### PR TITLE
RMB-30 move raml util

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "raml-util"]
-	path = raml-util
+	path = ramls/raml-util
 	url = https://github.com/folio-org/raml

--- a/ramls/circulation.raml
+++ b/ramls/circulation.raml
@@ -13,14 +13,14 @@ schemas:
   - loans: !include schema/loans.json
 
 traits:
-  - secured: !include ../raml-util/traits/auth.raml
-  - language: !include ../raml-util/traits/language.raml
-  - pageable: !include ../raml-util/traits/pageable.raml
-  - searchable: !include ../raml-util/traits/searchable.raml
+  - secured: !include raml-util/traits/auth.raml
+  - language: !include raml-util/traits/language.raml
+  - pageable: !include raml-util/traits/pageable.raml
+  - searchable: !include raml-util/traits/searchable.raml
 
 resourceTypes:
-  - collection: !include ../raml-util/rtypes/collection.raml
-  - collection-item: !include ../raml-util/rtypes/item-collection.raml
+  - collection: !include raml-util/rtypes/collection.raml
+  - collection-item: !include raml-util/rtypes/item-collection.raml
 
 /circulation:
   /loans:

--- a/ramls/schema/README.md
+++ b/ramls/schema/README.md
@@ -1,1 +1,1 @@
-As a workaround to FOLIO-573, when any schema file refers to an additional schema file, then use the filename of that referenced second schema as the "key" name in the RAML "schemas" section, and wherever that schema is utilised in RAML and schema files.
+When any schema file refers to an additional schema file, then also use that pathname of the referenced second schema as the "key" name in the RAML "schemas" section, and wherever that schema is utilised in RAML files. Also ensure that all such referenced files are below the parent file.


### PR DESCRIPTION
Move raml-util to inside the ramls directory.
Enables reliable use of pathname for $ref in schema files.