### PR TITLE
FOLIO-972 Fix UUID pattern A-Z

### DIFF
--- a/ramls/request.json
+++ b/ramls/request.json
@@ -25,7 +25,7 @@
     "proxyUserId": {
       "description": "ID of the user representing a proxy for the patron",
       "type": "string",
-      "pattern": "^[a-fA-Z0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
     },    
     "itemId": {
       "description": "ID of the item being requested",


### PR DESCRIPTION
Fix regex typo. Was A-Z rather than A-F.

See #62. This was an additional one in another branch.