### PR TITLE
FOLIO-1213 update raml-util to remove schema id property

### DIFF
--- a/ramls/circulation.raml
+++ b/ramls/circulation.raml
@@ -13,9 +13,11 @@ schemas:
   - loans: !include loans.json
   - request.json: !include request.json
   - requests: !include requests.json
-  - errors: !include raml-util/schemas/errors.schema
   - raml-util/schemas/error.schema: !include raml-util/schemas/error.schema
   - raml-util/schemas/metadata.schema: !include raml-util/schemas/metadata.schema
+  - errors: !include raml-util/schemas/errors.schema
+  - error.schema: !include raml-util/schemas/error.schema
+  - parameters.schema: !include raml-util/schemas/parameters.schema
 
 traits:
   - secured: !include raml-util/traits/auth.raml


### PR DESCRIPTION
This moves the ramls/raml-util git submodule to 20d6bc5 (i.e. [pull/82](https://github.com/folio-org/raml/pull/82) which removed the experimental id property from error.schema and related ones. The raml2html for this repo has not been building the api docs since the id was added in [pull/77](https://github.com/folio-org/raml/pull/77).

There was one significant change between those points, being [pull/81](https://github.com/folio-org/raml/pull/81) "Make 'username' option for users. Add metadata to addressTypes"