### PR TITLE
Require 2.0 or 3.0 of `locations` CIRC-143

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 12.1.0 Unreleased
 
+* Requires version 2.0 or 3.0 of `locations` (CIRC-143)
 * Requires version 5.3 or 6.0 of `item-storage` (CIRC-141)
 * Requires version 4.0 or 5.0 of `instance-storage` (CIRC-141)
 * Requires version 1.3 or 2.0 of `holdings-storage` (CIRC-141)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -450,7 +450,7 @@
     },
     {
       "id": "locations",
-      "version": "1.1 2.0"
+      "version": "2.0 3.0"
     },
     {
       "id": "material-types",


### PR DESCRIPTION
  The change to `locations` involves additions of mandatory
  fields, but mod-circulation only reads from the interface
  so no code changes should be necessary.