### PR TITLE
Improve result exception handling CIRC-155 

### DIFF
--- a/src/main/java/org/folio/circulation/domain/validation/ExistingOpenLoanValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ExistingOpenLoanValidator.java
@@ -1,12 +1,14 @@
 package org.folio.circulation.domain.validation;
 
+import static org.folio.circulation.support.HttpResult.ofAsync;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
 import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.domain.LoanRepository;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ValidationErrorFailure;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 
 public class ExistingOpenLoanValidator {
   private final Function<String, ValidationErrorFailure> existingOpenLoanErrorFunction;
@@ -23,9 +25,10 @@ public class ExistingOpenLoanValidator {
   public CompletableFuture<HttpResult<LoanAndRelatedRecords>> refuseWhenHasOpenLoan(
     LoanAndRelatedRecords loanAndRelatedRecords) {
 
-    return loanRepository.hasOpenLoan(loanAndRelatedRecords.getLoan().getItemId())
-      .thenApply(r -> r.failWhen(r, existingOpenLoanErrorFunction.apply(
+    return ofAsync(() -> loanAndRelatedRecords.getLoan().getItemId())
+      .thenComposeAsync(result -> result.failAfter(loanRepository::hasOpenLoan,
+        v -> existingOpenLoanErrorFunction.apply(
           "Cannot check out item that already has an open loan")))
-      .thenApply(r -> r.map(v -> loanAndRelatedRecords));
+      .thenApply(result -> result.map(v -> loanAndRelatedRecords));
   }
 }

--- a/src/main/java/org/folio/circulation/support/CqlHelper.java
+++ b/src/main/java/org/folio/circulation/support/CqlHelper.java
@@ -1,15 +1,14 @@
 package org.folio.circulation.support;
 
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.UnsupportedEncodingException;
 import java.lang.invoke.MethodHandles;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CqlHelper {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -33,20 +32,15 @@ public class CqlHelper {
 
       String query = String.format("id==(%s)", String.join(" or ", filteredIds));
 
+      //TODO: Check if would be preferable to fail request with error?
       return encodeQuery(query).orElse(null);
     }
   }
 
   public static HttpResult<String> encodeQuery(String cqlQuery) {
-    try {
-      log.info("Encoding query {}", cqlQuery);
+    log.info("Encoding query {}", cqlQuery);
 
-      return HttpResult.succeeded(URLEncoder.encode(cqlQuery,
-        String.valueOf(StandardCharsets.UTF_8)));
-
-    } catch (UnsupportedEncodingException e) {
-      return HttpResult.failed(
-        new ServerErrorFailure("Failed to encode CQL query"));
-    }
+    return HttpResult.of(() -> URLEncoder.encode(cqlQuery,
+      String.valueOf(StandardCharsets.UTF_8)));
   }
 }

--- a/src/main/java/org/folio/circulation/support/HttpResult.java
+++ b/src/main/java/org/folio/circulation/support/HttpResult.java
@@ -237,12 +237,25 @@ public interface HttpResult<T> {
     return action.apply(value());
   }
 
+  /**
+   * Apply the next action to the value of the result
+   *
+   * Responds with the result of applying the next action to the current value
+   * unless current result is failed or the application of action fails e.g. throws an exception
+   *
+   * @param action action to take after this result
+   * @return success when result succeeded and action is applied successfully, failure otherwise
+   */
   default <R> HttpResult<R> next(Function<T, HttpResult<R>> action) {
     if(failed()) {
       return failed(cause());
     }
 
-    return action.apply(value());
+    try {
+      return action.apply(value());
+    } catch (Exception e) {
+      return failed(new ServerErrorFailure(e));
+    }
   }
 
   /**

--- a/src/main/java/org/folio/circulation/support/HttpResult.java
+++ b/src/main/java/org/folio/circulation/support/HttpResult.java
@@ -268,16 +268,7 @@ public interface HttpResult<T> {
    * @return success when result succeeded and map is applied successfully, failure otherwise
    */
   default <U> HttpResult<U> map(Function<T, U> map) {
-    if(failed()) {
-      return failed(cause());
-    }
-    
-    try {
-      return succeeded(map.apply(value()));
-    }
-    catch (Exception e) {
-      return failed(new ServerErrorFailure(e));
-    }
+    return next(value -> succeeded(map.apply(value)));
   }
 
   default T orElse(T other) {

--- a/src/main/java/org/folio/circulation/support/HttpResult.java
+++ b/src/main/java/org/folio/circulation/support/HttpResult.java
@@ -62,8 +62,8 @@ public interface HttpResult<T> {
    * or successful result with the values combined
    */
   default <U, V> CompletableFuture<HttpResult<V>> combineAfter(
-    Function<T, CompletableFuture<HttpResult<U>>> nextAction, BiFunction<
-    T, U, V> combiner) {
+    Function<T, CompletableFuture<HttpResult<U>>> nextAction,
+    BiFunction<T, U, V> combiner) {
 
     return this.after(nextAction)
       .thenApply(actionResult -> actionResult.map(r ->

--- a/src/main/java/org/folio/circulation/support/HttpResult.java
+++ b/src/main/java/org/folio/circulation/support/HttpResult.java
@@ -234,7 +234,11 @@ public interface HttpResult<T> {
       return completedFuture(failed(cause()));
     }
 
-    return action.apply(value());
+    try {
+      return action.apply(value());
+    } catch (Exception e) {
+      return completedFuture(failed(new ServerErrorFailure(e)));
+    }
   }
 
   /**

--- a/src/main/java/org/folio/circulation/support/HttpResult.java
+++ b/src/main/java/org/folio/circulation/support/HttpResult.java
@@ -25,6 +25,19 @@ public interface HttpResult<T> {
   }
 
   /**
+   * Creates a completed future with successful result with the supplied value
+   * unless an exception is thrown
+   *
+   * @param supplier of the result value
+   * @return completed future with successful result or failed result with error
+   */
+  static <T> CompletableFuture<HttpResult<T>> ofAsync(
+    ThrowingSupplier<T, Exception> supplier) {
+
+    return completedFuture(of(supplier));
+  }
+
+  /**
    * Combines two results together, if both succeed.
    * Otherwise, returns either failure, first result takes precedence
    *
@@ -173,27 +186,6 @@ public interface HttpResult<T> {
 
     return nextWhen(condition,
       value -> failed(failure.apply(value)),
-      HttpResult::succeeded);
-  }
-
-  /**
-   * Fail a result when a condition evaluates to true
-   *
-   * Responds with the result of the failure function when condition evaluates to true
-   * Responds with success of the prior result when condition evaluates to false
-   * Executes neither if the condition evaluation fails
-   * Forwards on failure if previous result failed
-   *
-   * @param condition on which to decide upon
-   * @param failure executed to create failure reason when condition evaluates to true
-   * @return success when condition is false, failure otherwise
-   */
-  default HttpResult<T> failWhen(
-    HttpResult<Boolean> condition,
-    HttpFailure failure) {
-
-    return nextWhen(v -> condition,
-      value -> failed(failure),
       HttpResult::succeeded);
   }
 

--- a/src/main/java/org/folio/circulation/support/HttpResult.java
+++ b/src/main/java/org/folio/circulation/support/HttpResult.java
@@ -139,9 +139,9 @@ public interface HttpResult<T> {
     Function<T, HttpResult<T>> whenFalse) {
 
     return next(value ->
-      condition.apply(value).next(result -> result
-          ? whenTrue.apply(value)
-          : whenFalse.apply(value)));
+      when(condition.apply(value),
+        () -> whenTrue.apply(value),
+        () -> whenFalse.apply(value)));
   }
 
   /**
@@ -162,10 +162,9 @@ public interface HttpResult<T> {
     Supplier<HttpResult<R>> whenTrue,
     Supplier<HttpResult<R>> whenFalse) {
 
-    return
-      condition.next(result -> result
-        ? whenTrue.get()
-        : whenFalse.get());
+    return condition.next(result -> result
+      ? whenTrue.get()
+      : whenFalse.get());
   }
 
   /**

--- a/src/main/java/org/folio/circulation/support/HttpResult.java
+++ b/src/main/java/org/folio/circulation/support/HttpResult.java
@@ -271,13 +271,12 @@ public interface HttpResult<T> {
     if(failed()) {
       return failed(cause());
     }
-    else {
-      try {
-        return succeeded(map.apply(value()));
-      }
-      catch (Exception e) {
-        return failed(new ServerErrorFailure(e));
-      }
+    
+    try {
+      return succeeded(map.apply(value()));
+    }
+    catch (Exception e) {
+      return failed(new ServerErrorFailure(e));
     }
   }
 

--- a/src/main/java/org/folio/circulation/support/HttpResult.java
+++ b/src/main/java/org/folio/circulation/support/HttpResult.java
@@ -20,7 +20,7 @@ public interface HttpResult<T> {
     try {
       return succeeded(supplier.get());
     } catch (Exception e) {
-      return failed(new ServerErrorFailure(e));
+      return failed(e);
     }
   }
 
@@ -206,6 +206,10 @@ public interface HttpResult<T> {
     return new FailedHttpResult<>(cause);
   }
 
+  static <T> HttpResult<T> failed(Throwable e) {
+    return failed(new ServerErrorFailure(e));
+  }
+
   default <R> CompletableFuture<HttpResult<R>> after(
     Function<T, CompletableFuture<HttpResult<R>>> action) {
 
@@ -214,7 +218,8 @@ public interface HttpResult<T> {
     }
 
     try {
-      return action.apply(value());
+      return action.apply(value())
+        .exceptionally(HttpResult::failed);
     } catch (Exception e) {
       return completedFuture(failed(new ServerErrorFailure(e)));
     }
@@ -237,7 +242,7 @@ public interface HttpResult<T> {
     try {
       return action.apply(value());
     } catch (Exception e) {
-      return failed(new ServerErrorFailure(e));
+      return failed(e);
     }
   }
 

--- a/src/main/java/org/folio/circulation/support/ServerErrorFailure.java
+++ b/src/main/java/org/folio/circulation/support/ServerErrorFailure.java
@@ -1,8 +1,9 @@
 package org.folio.circulation.support;
 
-import io.vertx.core.http.HttpServerResponse;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.folio.circulation.support.http.server.ServerErrorResponse;
+
+import io.vertx.core.http.HttpServerResponse;
 
 public class ServerErrorFailure implements HttpFailure {
   public final String reason;

--- a/src/test/java/org/folio/circulation/support/results/HttpResultAfterTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultAfterTests.java
@@ -2,16 +2,15 @@ package org.folio.circulation.support.results;
 
 import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
+import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.util.concurrent.ExecutionException;
 
 import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ServerErrorFailure;
-import org.folio.circulation.support.WritableHttpResult;
 import org.junit.Test;
 
 public class HttpResultAfterTests {
@@ -33,11 +32,11 @@ public class HttpResultAfterTests {
     throws ExecutionException,
     InterruptedException {
     
-    final HttpResult<Integer> result = failedResult()
+    final HttpResult<Integer> result = alreadyFailed()
       .after(value -> completedFuture(succeeded(value + 10)))
       .get();
 
-    assertThat(result, isErrorFailureContaining("Something went wrong"));
+    assertThat(result, isErrorFailureContaining("Already failed"));
   }
 
   @Test
@@ -46,17 +45,9 @@ public class HttpResultAfterTests {
     InterruptedException {
 
     final HttpResult<Integer> result = succeeded(10)
-      .<Integer>after(value -> { throw exampleException(); })
+      .<Integer>after(value -> { throw somethingWentWrong(); })
       .get();
 
     assertThat(result, isErrorFailureContaining("Something went wrong"));
-  }
-
-  private WritableHttpResult<Integer> failedResult() {
-    return failed(new ServerErrorFailure(exampleException()));
-  }
-
-  private RuntimeException exampleException() {
-    return new RuntimeException("Something went wrong");
   }
 }

--- a/src/test/java/org/folio/circulation/support/results/HttpResultAfterTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultAfterTests.java
@@ -1,0 +1,64 @@
+package org.folio.circulation.support.results;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.support.HttpResult.failed;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.WritableHttpResult;
+import org.junit.Test;
+
+public class HttpResultAfterTests {
+  @Test
+  public void shouldSucceedWhenNextStepIsSuccessful()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .after(value -> completedFuture(succeeded(value + 10)))
+      .get();
+
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(20));
+  }
+
+  @Test
+  public void shouldFailWhenAlreadyFailed()
+    throws ExecutionException,
+    InterruptedException {
+    
+    final HttpResult<Integer> result = failedResult()
+      .after(value -> completedFuture(succeeded(value + 10)))
+      .get();
+
+    assertThat(result.failed(), is(true));
+    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
+  }
+
+  @Test
+  public void shouldFailWhenExceptionThrownDuringNextStep()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .<Integer>after(value -> { throw exampleException(); })
+      .get();
+
+    assertThat(result.failed(), is(true));
+    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
+  }
+
+  private WritableHttpResult<Integer> failedResult() {
+    return failed(new ServerErrorFailure(exampleException()));
+  }
+
+  private RuntimeException exampleException() {
+    return new RuntimeException("Something went wrong");
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/HttpResultAfterTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultAfterTests.java
@@ -4,6 +4,7 @@ import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
+import static org.folio.circulation.support.results.ResultExamples.shouldNotExecute;
 import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -33,7 +34,7 @@ public class HttpResultAfterTests {
     InterruptedException {
     
     final HttpResult<Integer> result = alreadyFailed()
-      .after(value -> completedFuture(succeeded(value + 10)))
+      .<Integer>after(value -> { throw shouldNotExecute(); })
       .get();
 
     assertThat(result, isErrorFailureContaining("Already failed"));

--- a/src/test/java/org/folio/circulation/support/results/HttpResultAfterTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultAfterTests.java
@@ -2,6 +2,7 @@ package org.folio.circulation.support.results;
 
 import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
 import static org.folio.circulation.support.results.ResultExamples.shouldNotExecute;
@@ -47,6 +48,18 @@ public class HttpResultAfterTests {
 
     final HttpResult<Integer> result = succeeded(10)
       .<Integer>after(value -> { throw somethingWentWrong(); })
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
+  }
+
+  @Test
+  public void shouldFailWhenFutureFailsAsynchronously()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .<Integer>after(value -> supplyAsync(() -> { throw somethingWentWrong(); }))
       .get();
 
     assertThat(result, isErrorFailureContaining("Something went wrong"));

--- a/src/test/java/org/folio/circulation/support/results/HttpResultAfterTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultAfterTests.java
@@ -1,9 +1,9 @@
 package org.folio.circulation.support.results;
 
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -37,8 +37,7 @@ public class HttpResultAfterTests {
       .after(value -> completedFuture(succeeded(value + 10)))
       .get();
 
-    assertThat(result.failed(), is(true));
-    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
   }
 
   @Test
@@ -50,8 +49,7 @@ public class HttpResultAfterTests {
       .<Integer>after(value -> { throw exampleException(); })
       .get();
 
-    assertThat(result.failed(), is(true));
-    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
   }
 
   private WritableHttpResult<Integer> failedResult() {

--- a/src/test/java/org/folio/circulation/support/results/HttpResultAfterWhenTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultAfterWhenTests.java
@@ -1,0 +1,104 @@
+package org.folio.circulation.support.results;
+
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
+import static org.folio.circulation.support.results.ResultExamples.conditionFailed;
+import static org.folio.circulation.support.results.ResultExamples.shouldNotExecute;
+import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.folio.circulation.support.HttpResult;
+import org.junit.Test;
+
+public class HttpResultAfterWhenTests {
+  @Test
+  public void shouldApplyWhenTrueActionWhenConditionIsTrue()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .afterWhen(value -> completedFuture(succeeded(true)),
+        value -> completedFuture(succeeded(value + 10)),
+        value -> { throw shouldNotExecute(); })
+      .get();
+
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(20));
+  }
+
+  @Test
+  public void shouldApplyWhenFalseActionWhenConditionIsFalse()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .afterWhen(value -> completedFuture(succeeded(false)),
+        value -> { throw shouldNotExecute(); },
+        value -> completedFuture(succeeded(value + 10)))
+      .get();
+
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(20));
+  }
+
+  @Test
+  public void shouldFailWhenAlreadyFailed()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = alreadyFailed()
+      .afterWhen(value -> completedFuture(succeeded(true)),
+        value -> { throw shouldNotExecute(); },
+        value -> { throw shouldNotExecute(); })
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Already failed"));
+  }
+
+  @Test
+  public void shouldFailWhenConditionFailed()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .afterWhen(value -> completedFuture(conditionFailed()),
+        value -> { throw shouldNotExecute(); },
+        value -> { throw shouldNotExecute(); })
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Condition failed"));
+  }
+
+  @Test
+  public void shouldFailWhenTrueActionFailed()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .afterWhen(value -> completedFuture(succeeded(true)),
+        value -> { throw somethingWentWrong(); },
+        value -> {throw shouldNotExecute(); })
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
+  }
+
+  @Test
+  public void shouldFailWhenFalseActionFailed()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .afterWhen(value -> completedFuture(succeeded(false)),
+        value -> { throw shouldNotExecute(); },
+        value -> {throw somethingWentWrong(); })
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/HttpResultCombineAfterTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultCombineAfterTests.java
@@ -1,0 +1,85 @@
+package org.folio.circulation.support.results;
+
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.results.ResultExamples.actionFailed;
+import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
+import static org.folio.circulation.support.results.ResultExamples.shouldNotExecute;
+import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.folio.circulation.support.HttpResult;
+import org.junit.Test;
+
+public class HttpResultCombineAfterTests {
+  @Test
+  public void shouldSucceedWhenNextStepIsSuccessful()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .combineAfter(value -> completedFuture(succeeded(20)),
+        (v1, v2) -> v1 + v2)
+      .get();
+
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(30));
+  }
+
+  @Test
+  public void shouldFailWhenAlreadyFailed()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = alreadyFailed()
+      .combineAfter(value -> completedFuture(succeeded(20)),
+        (v1, v2) -> v1 + v2)
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Already failed"));
+  }
+
+  @Test
+  public void shouldFailWhenNextStepFails()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .<Integer, Integer>combineAfter(value -> completedFuture(actionFailed()),
+        (v1, v2) -> { throw shouldNotExecute(); })
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Action failed"));
+  }
+
+
+  @Test
+  public void shouldFailWhenExceptionThrownDuringNextStep()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .<Integer, Integer>combineAfter(value -> { throw somethingWentWrong(); },
+        (v1, v2) -> { throw shouldNotExecute(); })
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
+  }
+
+  @Test
+  public void shouldFailWhenExceptionThrownDuringCombination()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .<Integer, Integer>combineAfter(value -> completedFuture(succeeded(20)),
+        (v1, v2) -> { throw somethingWentWrong(); })
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/HttpResultFailAfterTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultFailAfterTests.java
@@ -2,6 +2,7 @@ package org.folio.circulation.support.results;
 
 import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
 import static org.folio.circulation.support.results.ResultExamples.conditionFailed;
@@ -67,6 +68,19 @@ public class HttpResultFailAfterTests {
       .get();
 
     assertThat(result, isErrorFailureContaining("Condition failed"));
+  }
+
+  @Test
+  public void shouldFailWhenConditionFailsAsynchronously()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .failAfter(value -> supplyAsync(() -> { throw somethingWentWrong(); }),
+        value -> exampleFailure("Specified failure"))
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
   }
 
   @Test

--- a/src/test/java/org/folio/circulation/support/results/HttpResultFailAfterTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultFailAfterTests.java
@@ -1,0 +1,84 @@
+package org.folio.circulation.support.results;
+
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
+import static org.folio.circulation.support.results.ResultExamples.conditionFailed;
+import static org.folio.circulation.support.results.ResultExamples.exampleFailure;
+import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.ExecutionException;
+
+import org.folio.circulation.support.HttpResult;
+import org.junit.Test;
+
+public class HttpResultFailAfterTests {
+  @Test
+  public void shouldPassThroughResultWhenConditionIsFalse()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .failAfter(value -> completedFuture(succeeded(false)),
+        value -> exampleFailure("Specified failure"))
+      .get();
+
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(10));
+  }
+
+  @Test
+  public void shouldApplyFailureWhenConditionIsTrue()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .failAfter(value -> completedFuture(succeeded(true)),
+        value -> exampleFailure("Specified failure"))
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Specified failure"));
+  }
+
+  @Test
+  public void shouldFailWhenAlreadyFailed()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = alreadyFailed()
+      .failAfter(value -> completedFuture(succeeded(false)),
+        value -> exampleFailure("Specified failure"))
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Already failed"));
+  }
+
+  @Test
+  public void shouldFailWhenConditionFailed()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .failAfter(value -> completedFuture(conditionFailed()),
+        value -> exampleFailure("Specified failure"))
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Condition failed"));
+  }
+
+  @Test
+  public void shouldFailWhenCreatingFailureFails()
+    throws ExecutionException,
+    InterruptedException {
+
+    final HttpResult<Integer> result = succeeded(10)
+      .failAfter(value -> completedFuture(succeeded(true)),
+        value -> { throw somethingWentWrong(); })
+      .get();
+
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/HttpResultFailWhenTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultFailWhenTests.java
@@ -1,0 +1,61 @@
+package org.folio.circulation.support.results;
+
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
+import static org.folio.circulation.support.results.ResultExamples.conditionFailed;
+import static org.folio.circulation.support.results.ResultExamples.exampleFailure;
+import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.folio.circulation.support.HttpResult;
+import org.junit.Test;
+
+public class HttpResultFailWhenTests {
+  @Test
+  public void shouldPassThroughResultWhenConditionIsFalse() {
+    final HttpResult<Integer> result = succeeded(10)
+      .failWhen(value -> succeeded(false),
+        value -> exampleFailure("Specified failure"));
+
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(10));
+  }
+
+  @Test
+  public void shouldApplyFailureWhenConditionIsTrue() {
+    final HttpResult<Integer> result = succeeded(10)
+      .failWhen(value -> succeeded(true),
+        value -> exampleFailure("Specified failure"));
+
+    assertThat(result, isErrorFailureContaining("Specified failure"));
+  }
+
+  @Test
+  public void shouldFailWhenAlreadyFailed() {
+    final HttpResult<Integer> result = alreadyFailed()
+      .failWhen(value -> succeeded(false),
+        value -> exampleFailure("Specified failure"));
+
+    assertThat(result, isErrorFailureContaining("Already failed"));
+  }
+
+  @Test
+  public void shouldFailWhenConditionFailed() {
+    final HttpResult<Integer> result = succeeded(10)
+      .failWhen(value -> conditionFailed(),
+        value -> exampleFailure("Specified failure"));
+
+    assertThat(result, isErrorFailureContaining("Condition failed"));
+  }
+
+  @Test
+  public void shouldFailWhenCreatingFailureFails() {
+    final HttpResult<Integer> result = succeeded(10)
+      .failWhen(value -> succeeded(true),
+        value -> { throw somethingWentWrong(); });
+
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/HttpResultGetValueTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultGetValueTests.java
@@ -1,0 +1,26 @@
+package org.folio.circulation.support.results;
+
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class HttpResultGetValueTests {
+  @Test
+  public void shouldBeValueWhenSucceeded() {
+    final Integer result = succeeded(10)
+      .orElse(5);
+
+    assertThat(result, is(10));
+  }
+
+  @Test
+  public void shouldBeAlternativeWhenFailed() {
+    final Integer result = alreadyFailed()
+      .orElse(5);
+
+    assertThat(result, is(5));
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/HttpResultInitialisationTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultInitialisationTests.java
@@ -1,12 +1,14 @@
-package org.folio.circulation.support;
-
-import org.junit.Test;
+package org.folio.circulation.support.results;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class HttpResultTests {
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.junit.Test;
+
+public class HttpResultInitialisationTests {
   @Test
   public void shouldSucceedWhenInitialValue() {
     final HttpResult<Integer> result = HttpResult.of(() -> 10);

--- a/src/test/java/org/folio/circulation/support/results/HttpResultInitialisationTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultInitialisationTests.java
@@ -5,6 +5,11 @@ import static org.folio.circulation.support.results.ResultExamples.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.folio.circulation.support.HttpResult;
 import org.junit.Test;
 
@@ -24,5 +29,19 @@ public class HttpResultInitialisationTests {
     });
 
     assertThat(result, isErrorFailureContaining("Initialisation failed"));
+  }
+
+  @Test
+  public void shouldSucceedWhenInitialValueAsync()
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    final CompletableFuture<HttpResult<Integer>> futureResult = HttpResult.ofAsync(() -> 10);
+
+    final HttpResult<Integer> result = futureResult.get(1, TimeUnit.SECONDS);
+
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(10));
   }
 }

--- a/src/test/java/org/folio/circulation/support/results/HttpResultInitialisationTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultInitialisationTests.java
@@ -1,11 +1,10 @@
 package org.folio.circulation.support.results;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ServerErrorFailure;
 import org.junit.Test;
 
 public class HttpResultInitialisationTests {
@@ -20,10 +19,9 @@ public class HttpResultInitialisationTests {
   @Test
   public void shouldFailWhenExceptionThrownForInitialValue() {
     final HttpResult<String> result = HttpResult.of(() -> {
-      throw new RuntimeException("Something went wrong");
+      throw new RuntimeException("Initialisation failed");
     });
 
-    assertThat(result.failed(), is(true));
-    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
+    assertThat(result, isErrorFailureContaining("Initialisation failed"));
   }
 }

--- a/src/test/java/org/folio/circulation/support/results/HttpResultInitialisationTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultInitialisationTests.java
@@ -1,6 +1,7 @@
 package org.folio.circulation.support.results;
 
 import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
+import static org.folio.circulation.support.results.ResultExamples.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -19,7 +20,7 @@ public class HttpResultInitialisationTests {
   @Test
   public void shouldFailWhenExceptionThrownForInitialValue() {
     final HttpResult<String> result = HttpResult.of(() -> {
-      throw new RuntimeException("Initialisation failed");
+      throw exampleException("Initialisation failed");
     });
 
     assertThat(result, isErrorFailureContaining("Initialisation failed"));

--- a/src/test/java/org/folio/circulation/support/results/HttpResultMappingTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultMappingTests.java
@@ -1,0 +1,49 @@
+package org.folio.circulation.support.results;
+
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.WritableHttpResult;
+import org.junit.Test;
+
+public class HttpResultMappingTests {
+  @Test
+  public void shouldSucceedWhenMapIsApplied() {
+    final HttpResult<Integer> mappedResult = succeeded(10)
+      .map(value -> value + 10);
+
+    assertThat(mappedResult.succeeded(), is(true));
+    assertThat(mappedResult.value(), is(20));
+  }
+
+  @Test
+  public void shouldFailWhenAlreadyFailed() {
+    final HttpResult<Integer> mappedResult = failedResult()
+      .map(value -> value + 10);
+
+    assertThat(mappedResult.succeeded(), is(false));
+    assertThat(mappedResult.cause(), instanceOf(ServerErrorFailure.class));
+  }
+
+  @Test
+  public void shouldFailWhenExceptionThrownDuringMapping() {
+    final HttpResult<Integer> mappedResult = succeeded(10)
+      .map(value -> { throw exampleException(); });
+
+    assertThat(mappedResult.failed(), is(true));
+    assertThat(mappedResult.cause(), instanceOf(ServerErrorFailure.class));
+  }
+
+  private WritableHttpResult<Integer> failedResult() {
+    return HttpResult.failed(new ServerErrorFailure(
+      exampleException()));
+  }
+
+  private RuntimeException exampleException() {
+    return new RuntimeException("Something went wrong");
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/HttpResultMappingTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultMappingTests.java
@@ -25,7 +25,7 @@ public class HttpResultMappingTests {
     final HttpResult<Integer> mappedResult = failedResult()
       .map(value -> value + 10);
 
-    assertThat(mappedResult.succeeded(), is(false));
+    assertThat(mappedResult.failed(), is(true));
     assertThat(mappedResult.cause(), instanceOf(ServerErrorFailure.class));
   }
 

--- a/src/test/java/org/folio/circulation/support/results/HttpResultMappingTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultMappingTests.java
@@ -1,14 +1,13 @@
 package org.folio.circulation.support.results;
 
 import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
-import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
+import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ServerErrorFailure;
-import org.folio.circulation.support.WritableHttpResult;
 import org.junit.Test;
 
 public class HttpResultMappingTests {
@@ -23,25 +22,17 @@ public class HttpResultMappingTests {
 
   @Test
   public void shouldFailWhenAlreadyFailed() {
-    final HttpResult<Integer> result = failedResult()
+    final HttpResult<Integer> result = alreadyFailed()
       .map(value -> value + 10);
 
-    assertThat(result, isErrorFailureContaining("Something went wrong"));
+    assertThat(result, isErrorFailureContaining("Already failed"));
   }
 
   @Test
   public void shouldFailWhenExceptionThrownDuringMapping() {
     final HttpResult<Integer> result = succeeded(10)
-      .map(value -> { throw exampleException(); });
+      .map(value -> { throw somethingWentWrong(); });
 
     assertThat(result, isErrorFailureContaining("Something went wrong"));
-  }
-
-  private WritableHttpResult<Integer> failedResult() {
-    return failed(new ServerErrorFailure(exampleException()));
-  }
-
-  private RuntimeException exampleException() {
-    return new RuntimeException("Something went wrong");
   }
 }

--- a/src/test/java/org/folio/circulation/support/results/HttpResultMappingTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultMappingTests.java
@@ -1,8 +1,8 @@
 package org.folio.circulation.support.results;
 
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -26,8 +26,7 @@ public class HttpResultMappingTests {
     final HttpResult<Integer> result = failedResult()
       .map(value -> value + 10);
 
-    assertThat(result.failed(), is(true));
-    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
   }
 
   @Test
@@ -35,8 +34,7 @@ public class HttpResultMappingTests {
     final HttpResult<Integer> result = succeeded(10)
       .map(value -> { throw exampleException(); });
 
-    assertThat(result.failed(), is(true));
-    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
   }
 
   private WritableHttpResult<Integer> failedResult() {

--- a/src/test/java/org/folio/circulation/support/results/HttpResultMappingTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultMappingTests.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.support.results;
 
+import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -22,25 +23,24 @@ public class HttpResultMappingTests {
 
   @Test
   public void shouldFailWhenAlreadyFailed() {
-    final HttpResult<Integer> mappedResult = failedResult()
+    final HttpResult<Integer> result = failedResult()
       .map(value -> value + 10);
 
-    assertThat(mappedResult.failed(), is(true));
-    assertThat(mappedResult.cause(), instanceOf(ServerErrorFailure.class));
+    assertThat(result.failed(), is(true));
+    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
   }
 
   @Test
   public void shouldFailWhenExceptionThrownDuringMapping() {
-    final HttpResult<Integer> mappedResult = succeeded(10)
+    final HttpResult<Integer> result = succeeded(10)
       .map(value -> { throw exampleException(); });
 
-    assertThat(mappedResult.failed(), is(true));
-    assertThat(mappedResult.cause(), instanceOf(ServerErrorFailure.class));
+    assertThat(result.failed(), is(true));
+    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
   }
 
   private WritableHttpResult<Integer> failedResult() {
-    return HttpResult.failed(new ServerErrorFailure(
-      exampleException()));
+    return failed(new ServerErrorFailure(exampleException()));
   }
 
   private RuntimeException exampleException() {

--- a/src/test/java/org/folio/circulation/support/results/HttpResultNextTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultNextTests.java
@@ -1,14 +1,13 @@
 package org.folio.circulation.support.results;
 
 import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
-import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
+import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ServerErrorFailure;
-import org.folio.circulation.support.WritableHttpResult;
 import org.junit.Test;
 
 public class HttpResultNextTests {
@@ -23,25 +22,17 @@ public class HttpResultNextTests {
 
   @Test
   public void shouldFailWhenAlreadyFailed() {
-    final HttpResult<Integer> result = failedResult()
+    final HttpResult<Integer> result = alreadyFailed()
       .next(value -> succeeded(value + 10));
 
-    assertThat(result, isErrorFailureContaining("Something went wrong"));
+    assertThat(result, isErrorFailureContaining("Already failed"));
   }
 
   @Test
   public void shouldFailWhenExceptionThrownDuringNextStep() {
     final HttpResult<Integer> result = succeeded(10)
-      .next(value -> { throw exampleException(); });
+      .next(value -> { throw somethingWentWrong(); });
 
     assertThat(result, isErrorFailureContaining("Something went wrong"));
-  }
-
-  private WritableHttpResult<Integer> failedResult() {
-    return failed(new ServerErrorFailure(exampleException()));
-  }
-
-  private RuntimeException exampleException() {
-    return new RuntimeException("Something went wrong");
   }
 }

--- a/src/test/java/org/folio/circulation/support/results/HttpResultNextTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultNextTests.java
@@ -1,0 +1,49 @@
+package org.folio.circulation.support.results;
+
+import static org.folio.circulation.support.HttpResult.failed;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.WritableHttpResult;
+import org.junit.Test;
+
+public class HttpResultNextTests {
+  @Test
+  public void shouldSucceedWhenNextStepIsSuccessful() {
+    final HttpResult<Integer> nextResult = succeeded(10)
+      .next(value -> succeeded(value + 10));
+
+    assertThat(nextResult.succeeded(), is(true));
+    assertThat(nextResult.value(), is(20));
+  }
+
+  @Test
+  public void shouldFailWhenAlreadyFailed() {
+    final HttpResult<Integer> nextResult = failedResult()
+      .next(value -> succeeded(value + 10));
+
+    assertThat(nextResult.failed(), is(true));
+    assertThat(nextResult.cause(), instanceOf(ServerErrorFailure.class));
+  }
+
+  @Test
+  public void shouldFailWhenExceptionThrownDuringNextStep() {
+    final HttpResult<Integer> nextResult = succeeded(10)
+      .next(value -> { throw exampleException(); });
+
+    assertThat(nextResult.failed(), is(true));
+    assertThat(nextResult.cause(), instanceOf(ServerErrorFailure.class));
+  }
+
+  private WritableHttpResult<Integer> failedResult() {
+    return failed(new ServerErrorFailure(exampleException()));
+  }
+
+  private RuntimeException exampleException() {
+    return new RuntimeException("Something went wrong");
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/HttpResultNextTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultNextTests.java
@@ -14,29 +14,29 @@ import org.junit.Test;
 public class HttpResultNextTests {
   @Test
   public void shouldSucceedWhenNextStepIsSuccessful() {
-    final HttpResult<Integer> nextResult = succeeded(10)
+    final HttpResult<Integer> result = succeeded(10)
       .next(value -> succeeded(value + 10));
 
-    assertThat(nextResult.succeeded(), is(true));
-    assertThat(nextResult.value(), is(20));
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(20));
   }
 
   @Test
   public void shouldFailWhenAlreadyFailed() {
-    final HttpResult<Integer> nextResult = failedResult()
+    final HttpResult<Integer> result = failedResult()
       .next(value -> succeeded(value + 10));
 
-    assertThat(nextResult.failed(), is(true));
-    assertThat(nextResult.cause(), instanceOf(ServerErrorFailure.class));
+    assertThat(result.failed(), is(true));
+    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
   }
 
   @Test
   public void shouldFailWhenExceptionThrownDuringNextStep() {
-    final HttpResult<Integer> nextResult = succeeded(10)
+    final HttpResult<Integer> result = succeeded(10)
       .next(value -> { throw exampleException(); });
 
-    assertThat(nextResult.failed(), is(true));
-    assertThat(nextResult.cause(), instanceOf(ServerErrorFailure.class));
+    assertThat(result.failed(), is(true));
+    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
   }
 
   private WritableHttpResult<Integer> failedResult() {

--- a/src/test/java/org/folio/circulation/support/results/HttpResultNextTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultNextTests.java
@@ -1,8 +1,8 @@
 package org.folio.circulation.support.results;
 
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -26,8 +26,7 @@ public class HttpResultNextTests {
     final HttpResult<Integer> result = failedResult()
       .next(value -> succeeded(value + 10));
 
-    assertThat(result.failed(), is(true));
-    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
   }
 
   @Test
@@ -35,8 +34,7 @@ public class HttpResultNextTests {
     final HttpResult<Integer> result = succeeded(10)
       .next(value -> { throw exampleException(); });
 
-    assertThat(result.failed(), is(true));
-    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
   }
 
   private WritableHttpResult<Integer> failedResult() {

--- a/src/test/java/org/folio/circulation/support/results/HttpResultNextWhenTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultNextWhenTests.java
@@ -1,0 +1,77 @@
+package org.folio.circulation.support.results;
+
+import static org.folio.circulation.support.HttpResult.failed;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.WritableHttpResult;
+import org.junit.Test;
+
+public class HttpResultNextWhenTests {
+  @Test
+  public void shouldApplyWhenTrueActionWhenConditionIsTrue() {
+    final HttpResult<Integer> result = succeeded(10)
+      .nextWhen(value -> succeeded(true),
+        value -> succeeded(value + 10),
+        value -> { throw exampleException(); });
+
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(20));
+  }
+
+  @Test
+  public void shouldApplyWhenFalseActionWhenConditionIsFalse() {
+    final HttpResult<Integer> result = succeeded(10)
+      .nextWhen(value -> succeeded(false),
+        value -> { throw exampleException(); },
+        value -> succeeded(value + 10));
+
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(20));
+  }
+
+  @Test
+  public void shouldFailWhenAlreadyFailed() {
+    final HttpResult<Integer> result = failedResult()
+      .nextWhen(value -> succeeded(true),
+        value -> succeeded(value + 10),
+        value -> succeeded(value + 10));
+
+    assertThat(result.failed(), is(true));
+    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
+
+    final ServerErrorFailure cause = (ServerErrorFailure) result.cause();
+    assertThat(cause.reason, containsString("Something went wrong"));
+  }
+
+  @Test
+  public void shouldFailWhenConditionFailed() {
+    final HttpResult<Integer> result = succeeded(10)
+      .nextWhen(value -> failed(exampleFailure()),
+        value -> succeeded(value + 10),
+        value -> succeeded(value + 10));
+
+    assertThat(result.failed(), is(true));
+    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
+
+    final ServerErrorFailure cause = (ServerErrorFailure) result.cause();
+    assertThat(cause.reason, containsString("Something went wrong"));
+  }
+
+  private WritableHttpResult<Integer> failedResult() {
+    return failed(exampleFailure());
+  }
+
+  private ServerErrorFailure exampleFailure() {
+    return new ServerErrorFailure(exampleException());
+  }
+
+  private RuntimeException exampleException() {
+    return new RuntimeException("Something went wrong");
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/HttpResultNextWhenTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultNextWhenTests.java
@@ -4,7 +4,7 @@ import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
 import static org.folio.circulation.support.results.ResultExamples.conditionFailed;
-import static org.folio.circulation.support.results.ResultExamples.shouldNotExecute;
+import static org.folio.circulation.support.results.ResultExamples.throwOnExecution;
 import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -18,7 +18,7 @@ public class HttpResultNextWhenTests {
     final HttpResult<Integer> result = succeeded(10)
       .nextWhen(value -> succeeded(true),
         value -> succeeded(value + 10),
-        value -> shouldNotExecute());
+        value -> throwOnExecution());
 
     assertThat(result.succeeded(), is(true));
     assertThat(result.value(), is(20));
@@ -28,7 +28,7 @@ public class HttpResultNextWhenTests {
   public void shouldApplyWhenFalseActionWhenConditionIsFalse() {
     final HttpResult<Integer> result = succeeded(10)
       .nextWhen(value -> succeeded(false),
-        value -> shouldNotExecute(),
+        value -> throwOnExecution(),
         value -> succeeded(value + 10));
 
     assertThat(result.succeeded(), is(true));
@@ -39,8 +39,8 @@ public class HttpResultNextWhenTests {
   public void shouldFailWhenAlreadyFailed() {
     final HttpResult<Integer> result = alreadyFailed()
       .nextWhen(value -> succeeded(true),
-        value -> shouldNotExecute(),
-        value -> shouldNotExecute());
+        value -> throwOnExecution(),
+        value -> throwOnExecution());
 
     assertThat(result, isErrorFailureContaining("Already failed"));
   }
@@ -60,7 +60,7 @@ public class HttpResultNextWhenTests {
     final HttpResult<Integer> result = succeeded(10)
       .nextWhen(value -> succeeded(true),
         value -> {throw somethingWentWrong(); },
-        value -> shouldNotExecute());
+        value -> throwOnExecution());
 
     assertThat(result, isErrorFailureContaining("Something went wrong"));
   }
@@ -69,7 +69,7 @@ public class HttpResultNextWhenTests {
   public void shouldFailWhenFalseActionFailed() {
     final HttpResult<Integer> result = succeeded(10)
       .nextWhen(value -> succeeded(false),
-        value -> shouldNotExecute(),
+        value -> throwOnExecution(),
         value -> {throw somethingWentWrong(); });
 
     assertThat(result, isErrorFailureContaining("Something went wrong"));

--- a/src/test/java/org/folio/circulation/support/results/HttpResultNextWhenTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultNextWhenTests.java
@@ -1,9 +1,8 @@
 package org.folio.circulation.support.results;
 
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -42,11 +41,7 @@ public class HttpResultNextWhenTests {
         value -> succeeded(value + 10),
         value -> succeeded(value + 10));
 
-    assertThat(result.failed(), is(true));
-    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
-
-    final ServerErrorFailure cause = (ServerErrorFailure) result.cause();
-    assertThat(cause.reason, containsString("Something went wrong"));
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
   }
 
   @Test
@@ -56,11 +51,7 @@ public class HttpResultNextWhenTests {
         value -> succeeded(value + 10),
         value -> succeeded(value + 10));
 
-    assertThat(result.failed(), is(true));
-    assertThat(result.cause(), instanceOf(ServerErrorFailure.class));
-
-    final ServerErrorFailure cause = (ServerErrorFailure) result.cause();
-    assertThat(cause.reason, containsString("Something went wrong"));
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
   }
 
   private WritableHttpResult<Integer> failedResult() {

--- a/src/test/java/org/folio/circulation/support/results/HttpResultNextWhenTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultNextWhenTests.java
@@ -17,7 +17,7 @@ public class HttpResultNextWhenTests {
     final HttpResult<Integer> result = succeeded(10)
       .nextWhen(value -> succeeded(true),
         value -> succeeded(value + 10),
-        value -> { throw exampleException(); });
+        value -> { throw exampleException("Should not execute"); });
 
     assertThat(result.succeeded(), is(true));
     assertThat(result.value(), is(20));
@@ -27,7 +27,7 @@ public class HttpResultNextWhenTests {
   public void shouldApplyWhenFalseActionWhenConditionIsFalse() {
     final HttpResult<Integer> result = succeeded(10)
       .nextWhen(value -> succeeded(false),
-        value -> { throw exampleException(); },
+        value -> { throw exampleException("Should not execute"); },
         value -> succeeded(value + 10));
 
     assertThat(result.succeeded(), is(true));
@@ -36,33 +36,33 @@ public class HttpResultNextWhenTests {
 
   @Test
   public void shouldFailWhenAlreadyFailed() {
-    final HttpResult<Integer> result = failedResult()
+    final HttpResult<Integer> result = alreadyFailed()
       .nextWhen(value -> succeeded(true),
         value -> succeeded(value + 10),
         value -> succeeded(value + 10));
 
-    assertThat(result, isErrorFailureContaining("Something went wrong"));
+    assertThat(result, isErrorFailureContaining("Already failed"));
   }
 
   @Test
   public void shouldFailWhenConditionFailed() {
     final HttpResult<Integer> result = succeeded(10)
-      .nextWhen(value -> failed(exampleFailure()),
+      .nextWhen(value -> failed(exampleFailure("Condition failed")),
         value -> succeeded(value + 10),
         value -> succeeded(value + 10));
 
-    assertThat(result, isErrorFailureContaining("Something went wrong"));
+    assertThat(result, isErrorFailureContaining("Condition failed"));
   }
 
-  private WritableHttpResult<Integer> failedResult() {
-    return failed(exampleFailure());
+  private WritableHttpResult<Integer> alreadyFailed() {
+    return failed(exampleFailure("Already failed"));
   }
 
-  private ServerErrorFailure exampleFailure() {
-    return new ServerErrorFailure(exampleException());
+  private ServerErrorFailure exampleFailure(String message) {
+    return new ServerErrorFailure(exampleException(message));
   }
 
-  private RuntimeException exampleException() {
-    return new RuntimeException("Something went wrong");
+  private RuntimeException exampleException(String message) {
+    return new RuntimeException(message);
   }
 }

--- a/src/test/java/org/folio/circulation/support/results/HttpResultNextWhenTests.java
+++ b/src/test/java/org/folio/circulation/support/results/HttpResultNextWhenTests.java
@@ -5,6 +5,7 @@ import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
 import static org.folio.circulation.support.results.ResultExamples.conditionFailed;
 import static org.folio.circulation.support.results.ResultExamples.shouldNotExecute;
+import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -52,5 +53,25 @@ public class HttpResultNextWhenTests {
         value -> succeeded(value + 10));
 
     assertThat(result, isErrorFailureContaining("Condition failed"));
+  }
+
+  @Test
+  public void shouldFailWhenTrueActionFailed() {
+    final HttpResult<Integer> result = succeeded(10)
+      .nextWhen(value -> succeeded(true),
+        value -> {throw somethingWentWrong(); },
+        value -> shouldNotExecute());
+
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
+  }
+
+  @Test
+  public void shouldFailWhenFalseActionFailed() {
+    final HttpResult<Integer> result = succeeded(10)
+      .nextWhen(value -> succeeded(false),
+        value -> shouldNotExecute(),
+        value -> {throw somethingWentWrong(); });
+
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
   }
 }

--- a/src/test/java/org/folio/circulation/support/results/ResultExamples.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultExamples.java
@@ -23,7 +23,7 @@ class ResultExamples {
     return new RuntimeException(message);
   }
 
-  private static ServerErrorFailure exampleFailure(String message) {
+  static ServerErrorFailure exampleFailure(String message) {
     return new ServerErrorFailure(exampleException(message));
   }
 

--- a/src/test/java/org/folio/circulation/support/results/ResultExamples.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultExamples.java
@@ -15,8 +15,12 @@ class ResultExamples {
     return failed(exampleFailure("Condition failed"));
   }
 
-  static HttpResult<Integer> shouldNotExecute() {
-    throw exampleException("Should not execute");
+  static <T> WritableHttpResult<T> actionFailed() {
+    return failed(exampleFailure("Action failed"));
+  }
+
+  static HttpResult<Integer> throwOnExecution() {
+    throw shouldNotExecute();
   }
 
   static RuntimeException exampleException(String message) {
@@ -25,6 +29,10 @@ class ResultExamples {
 
   static ServerErrorFailure exampleFailure(String message) {
     return new ServerErrorFailure(exampleException(message));
+  }
+
+  static RuntimeException shouldNotExecute() {
+    return exampleException("Should not execute");
   }
 
   static RuntimeException somethingWentWrong() {

--- a/src/test/java/org/folio/circulation/support/results/ResultExamples.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultExamples.java
@@ -1,0 +1,33 @@
+package org.folio.circulation.support.results;
+
+import static org.folio.circulation.support.HttpResult.failed;
+
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.WritableHttpResult;
+
+class ResultExamples {
+  static WritableHttpResult<Integer> alreadyFailed() {
+    return failed(exampleFailure("Already failed"));
+  }
+
+  static WritableHttpResult<Boolean> conditionFailed() {
+    return failed(exampleFailure("Condition failed"));
+  }
+
+  static HttpResult<Integer> shouldNotExecute() {
+    throw exampleException("Should not execute");
+  }
+
+  static RuntimeException exampleException(String message) {
+    return new RuntimeException(message);
+  }
+
+  private static ServerErrorFailure exampleFailure(String message) {
+    return new ServerErrorFailure(exampleException(message));
+  }
+
+  static RuntimeException somethingWentWrong() {
+    return exampleException("Something went wrong");
+  }
+}


### PR DESCRIPTION
There are some circumstances where exceptions are thrown when undertaking an asynchronous activity that never gets captured and reported, meaning that it is possible for some requests to never get a response.

This pull request aims to remove most of the opportunities for this by adding exception handling into the HttpResult class. In future, each endpoint can also include a final `exceptionally` method in the future chain as a precaution.

This also adds more tests for the HttpResult (to be renamed to Result), which should hopefully provide more examples of usage to ease familiarity.