### PR TITLE
Remove loan from request before storage CIRC-161

### DIFF
--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -76,6 +76,7 @@ class RequestFromRepresentationService {
     request.remove("requester");
     request.remove("proxy");
     request.remove("loan");
+    request.remove("pickupServicePoint");
 
     return request;
   }

--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -1,17 +1,23 @@
 package org.folio.circulation.resources;
 
-import io.vertx.core.json.JsonObject;
-import org.folio.circulation.domain.*;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.support.HttpResult.failed;
+import static org.folio.circulation.support.HttpResult.succeeded;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.circulation.domain.LoanRepository;
+import org.folio.circulation.domain.Request;
+import org.folio.circulation.domain.RequestAndRelatedRecords;
+import org.folio.circulation.domain.RequestQueueRepository;
+import org.folio.circulation.domain.RequestStatus;
+import org.folio.circulation.domain.UserRepository;
 import org.folio.circulation.domain.validation.ProxyRelationshipValidator;
 import org.folio.circulation.support.BadRequestFailure;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ItemRepository;
 
-import java.util.concurrent.CompletableFuture;
-
-import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.folio.circulation.support.HttpResult.failed;
-import static org.folio.circulation.support.HttpResult.succeeded;
+import io.vertx.core.json.JsonObject;
 
 class RequestFromRepresentationService {
   private final ItemRepository itemRepository;
@@ -69,6 +75,7 @@ class RequestFromRepresentationService {
     request.remove("item");
     request.remove("requester");
     request.remove("proxy");
+    request.remove("loan");
 
     return request;
   }

--- a/src/test/java/api/requests/RequestsAPIUpdatingTests.java
+++ b/src/test/java/api/requests/RequestsAPIUpdatingTests.java
@@ -50,6 +50,7 @@ public class RequestsAPIUpdatingTests extends APITests {
 
     DateTime requestDate = new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC);
 
+    //TODO: Should include pickup service point
     IndividualResource createdRequest = requestsClient.create(
       new RequestBuilder()
       .recall()
@@ -66,7 +67,8 @@ public class RequestsAPIUpdatingTests extends APITests {
       .withBarcode("679231693475"))
       .getId();
 
-    JsonObject updatedRequest = createdRequest.copyJson();
+    JsonObject updatedRequest = requestsClient.getById(createdRequest.getId())
+      .getJson();
 
     updatedRequest
       .put("requestType", "Hold")
@@ -161,7 +163,8 @@ public class RequestsAPIUpdatingTests extends APITests {
         .withRequestExpiration(new LocalDate(2017, 7, 30))
         .withHoldShelfExpiration(new LocalDate(2017, 8, 31)));
 
-    JsonObject updatedRequest = createdRequest.copyJson();
+    JsonObject updatedRequest = requestsClient.getById(createdRequest.getId())
+      .getJson();
 
     itemsClient.delete(itemId);
 
@@ -229,7 +232,8 @@ public class RequestsAPIUpdatingTests extends APITests {
 
     usersClient.delete(requester);
 
-    JsonObject updatedRequest = createdRequest.copyJson();
+    JsonObject updatedRequest = requestsClient.getById(createdRequest.getId())
+      .getJson();
 
     updatedRequest
       .put("requestType", "Hold");
@@ -297,7 +301,8 @@ public class RequestsAPIUpdatingTests extends APITests {
       .withNoBarcode())
       .getId();
 
-    JsonObject updatedRequest = createdRequest.copyJson();
+    JsonObject updatedRequest = requestsClient.getById(createdRequest.getId())
+      .getJson();
 
     updatedRequest
       .put("requestType", "Hold")
@@ -379,7 +384,8 @@ public class RequestsAPIUpdatingTests extends APITests {
       .withName("Campbell", "Fiona", "Stella")
       .withBarcode("679231693475")).getId();
 
-    JsonObject updatedRequest = createdRequest.copyJson();
+    JsonObject updatedRequest = requestsClient.getById(createdRequest.getId())
+      .getJson();
 
     updatedRequest
       .put("requestType", "Hold")
@@ -477,7 +483,8 @@ public class RequestsAPIUpdatingTests extends APITests {
     UUID updatedItemId = itemsFixture.basedUponSmallAngryPlanet(ItemBuilder::withNoBarcode)
       .getId();
 
-    JsonObject updatedRequest = createdRequest.copyJson();
+    JsonObject updatedRequest = requestsClient.getById(createdRequest.getId())
+      .getJson();
 
     updatedRequest
       .put("itemId", updatedItemId.toString());

--- a/src/test/java/api/requests/RequestsAPIUpdatingTests.java
+++ b/src/test/java/api/requests/RequestsAPIUpdatingTests.java
@@ -50,6 +50,9 @@ public class RequestsAPIUpdatingTests extends APITests {
 
     DateTime requestDate = new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC);
 
+    final IndividualResource exampleServicePoint = servicePointsFixture.cd1();
+    servicePointsToDelete.add(exampleServicePoint.getId());
+
     //TODO: Should include pickup service point
     IndividualResource createdRequest = requestsClient.create(
       new RequestBuilder()
@@ -59,6 +62,7 @@ public class RequestsAPIUpdatingTests extends APITests {
       .withItemId(itemId)
       .withRequesterId(originalRequesterId)
       .fulfilToHoldShelf()
+      .withPickupServicePointId(exampleServicePoint.getId())
       .withRequestExpiration(new LocalDate(2017, 7, 30))
       .withHoldShelfExpiration(new LocalDate(2017, 8, 31)));
 

--- a/src/test/java/api/requests/RequestsAPIUpdatingTests.java
+++ b/src/test/java/api/requests/RequestsAPIUpdatingTests.java
@@ -1,18 +1,8 @@
 package api.requests;
 
-import io.vertx.core.json.JsonObject;
-import api.support.APITests;
-import api.support.builders.ItemBuilder;
-import api.support.builders.RequestBuilder;
-import api.support.builders.UserBuilder;
-import api.support.http.InterfaceUrls;
-import org.folio.circulation.support.http.client.IndividualResource;
-import org.folio.circulation.support.http.client.Response;
-import org.folio.circulation.support.http.client.ResponseHandler;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDate;
-import org.junit.Test;
+import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -22,9 +12,20 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.http.client.ResponseHandler;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.junit.Test;
+
+import api.support.APITests;
+import api.support.builders.ItemBuilder;
+import api.support.builders.RequestBuilder;
+import api.support.builders.UserBuilder;
+import api.support.http.InterfaceUrls;
+import io.vertx.core.json.JsonObject;
 
 public class RequestsAPIUpdatingTests extends APITests {
   @Test

--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -136,7 +136,7 @@ public class FakeOkapi extends AbstractVerticle {
       .withRootPath("/request-storage/requests")
       .withRequiredProperties("itemId", "requesterId", "requestType",
         "requestDate", "fulfilmentPreference")
-      .withDisallowedProperties("pickupServicePoint")
+      .withDisallowedProperties("pickupServicePoint", "loan")
       .withChangeMetadata()
       .create().register(router);
 

--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -136,6 +136,7 @@ public class FakeOkapi extends AbstractVerticle {
       .withRootPath("/request-storage/requests")
       .withRequiredProperties("itemId", "requesterId", "requestType",
         "requestDate", "fulfilmentPreference")
+      .withDisallowedProperties("pickupServicePoint")
       .withChangeMetadata()
       .create().register(router);
 

--- a/src/test/java/api/support/fakes/FakeStorageModule.java
+++ b/src/test/java/api/support/fakes/FakeStorageModule.java
@@ -1,5 +1,29 @@
 package api.support.fakes;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.folio.circulation.support.CreatedJsonHttpResult;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ValidationErrorFailure;
+import org.folio.circulation.support.http.server.ClientErrorResponse;
+import org.folio.circulation.support.http.server.SuccessResponse;
+import org.folio.circulation.support.http.server.ValidationError;
+import org.folio.circulation.support.http.server.WebContext;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
+
 import api.APITestSuite;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.buffer.Buffer;
@@ -10,18 +34,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
-import org.apache.commons.lang3.StringUtils;
-import org.folio.circulation.support.CreatedJsonHttpResult;
-import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
-import org.folio.circulation.support.http.server.*;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.ISODateTimeFormat;
-
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class FakeStorageModule extends AbstractVerticle {
   private static final Set<String> queries = Collections.synchronizedSet(new HashSet<>());
@@ -33,6 +45,7 @@ public class FakeStorageModule extends AbstractVerticle {
   private final Map<String, Map<String, JsonObject>> storedResourcesByTenant;
   private final String recordTypeName;
   private final Collection<String> uniqueProperties;
+  private final Collection<String> disallowedProperties;
   private final Boolean includeChangeMetadata;
   private final String changeMetadataPropertyName = "metadata";
 
@@ -48,6 +61,7 @@ public class FakeStorageModule extends AbstractVerticle {
     boolean hasCollectionDelete,
     String recordTypeName,
     Collection<String> uniqueProperties,
+    Collection<String> disallowedProperties,
     Boolean includeChangeMetadata) {
 
     this.rootPath = rootPath;
@@ -56,6 +70,7 @@ public class FakeStorageModule extends AbstractVerticle {
     this.hasCollectionDelete = hasCollectionDelete;
     this.recordTypeName = recordTypeName;
     this.uniqueProperties = uniqueProperties;
+    this.disallowedProperties = disallowedProperties;
     this.includeChangeMetadata = includeChangeMetadata;
 
     storedResourcesByTenant = new HashMap<>();
@@ -73,12 +88,14 @@ public class FakeStorageModule extends AbstractVerticle {
 
     router.post(rootPath).handler(this::checkRequiredProperties);
     router.post(rootPath).handler(this::checkUniqueProperties);
+    router.post(rootPath).handler(this::checkDisallowedProperties);
     router.post(rootPath).handler(this::create);
 
     router.get(rootPath).handler(this::getMany);
     router.delete(rootPath).handler(this::empty);
 
     router.put(rootPath + "/:id").handler(this::checkRequiredProperties);
+    router.put(rootPath + "/:id").handler(this::checkDisallowedProperties);
     router.put(rootPath + "/:id").handler(this::replace);
 
     router.get(rootPath + "/:id").handler(this::get);
@@ -330,7 +347,7 @@ public class FakeStorageModule extends AbstractVerticle {
 
     ArrayList<ValidationError> errors = new ArrayList<>();
 
-    requiredProperties.stream().forEach(requiredProperty -> {
+    requiredProperties.forEach(requiredProperty -> {
       if(!body.getMap().containsKey(requiredProperty)) {
         errors.add(new ValidationError("Required property missing", requiredProperty, ""));
       }
@@ -355,7 +372,7 @@ public class FakeStorageModule extends AbstractVerticle {
 
     ArrayList<ValidationError> errors = new ArrayList<>();
 
-    uniqueProperties.stream().forEach(uniqueProperty -> {
+    uniqueProperties.forEach(uniqueProperty -> {
       String proposedValue = body.getString(uniqueProperty);
 
       Map<String, JsonObject> records = getResourcesForTenant(new WebContext(routingContext));
@@ -367,6 +384,32 @@ public class FakeStorageModule extends AbstractVerticle {
         errors.add(new ValidationError(
           String.format("%s with this %s already exists", recordTypeName, uniqueProperty),
           uniqueProperty, proposedValue));
+
+        HttpResult.failed(ValidationErrorFailure.failure(errors))
+          .writeTo(routingContext.response());
+      }
+    });
+
+    if(errors.isEmpty()) {
+      routingContext.next();
+    }
+  }
+
+  private void checkDisallowedProperties(RoutingContext routingContext) {
+    if(uniqueProperties.isEmpty()) {
+      routingContext.next();
+      return;
+    }
+
+    JsonObject body = getJsonFromBody(routingContext);
+
+    ArrayList<ValidationError> errors = new ArrayList<>();
+
+    disallowedProperties.forEach(disallowedProperty -> {
+      if(body.containsKey(disallowedProperty)) {
+        errors.add(new ValidationError(
+          String.format("Unrecognised field \"%s\"", disallowedProperty),
+          disallowedProperty, null));
 
         HttpResult.failed(ValidationErrorFailure.failure(errors))
           .writeTo(routingContext.response());

--- a/src/test/java/api/support/fakes/FakeStorageModule.java
+++ b/src/test/java/api/support/fakes/FakeStorageModule.java
@@ -396,7 +396,7 @@ public class FakeStorageModule extends AbstractVerticle {
   }
 
   private void checkDisallowedProperties(RoutingContext routingContext) {
-    if(uniqueProperties.isEmpty()) {
+    if(disallowedProperties.isEmpty()) {
       routingContext.next();
       return;
     }

--- a/src/test/java/api/support/fakes/FakeStorageModuleBuilder.java
+++ b/src/test/java/api/support/fakes/FakeStorageModuleBuilder.java
@@ -1,10 +1,10 @@
 package api.support.fakes;
 
-import api.APITestSuite;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+
+import api.APITestSuite;
 
 public class FakeStorageModuleBuilder {
   private final String rootPath;
@@ -12,13 +12,22 @@ public class FakeStorageModuleBuilder {
   private final String tenantId;
   private final Collection<String> requiredProperties;
   private final Collection<String> uniqueProperties;
+  private final Collection<String> disallowedProperties;
   private final Boolean hasCollectionDelete;
   private final String recordName;
   private final Boolean includeChangeMetadata;
 
-  public FakeStorageModuleBuilder() {
-    this(null, null, APITestSuite.TENANT_ID, new ArrayList<>(), true, "",
-      new ArrayList<>(), false);
+  FakeStorageModuleBuilder() {
+    this(
+      null,
+      null,
+      APITestSuite.TENANT_ID,
+      new ArrayList<>(),
+      new ArrayList<>(),
+      true,
+      "",
+      new ArrayList<>(),
+      false);
   }
 
   private FakeStorageModuleBuilder(
@@ -26,6 +35,7 @@ public class FakeStorageModuleBuilder {
     String collectionPropertyName,
     String tenantId,
     Collection<String> requiredProperties,
+    Collection<String> disallowedProperties,
     Boolean hasCollectionDelete,
     String recordName,
     Collection<String> uniqueProperties,
@@ -35,6 +45,7 @@ public class FakeStorageModuleBuilder {
     this.collectionPropertyName = collectionPropertyName;
     this.tenantId = tenantId;
     this.requiredProperties = requiredProperties;
+    this.disallowedProperties = disallowedProperties;
     this.hasCollectionDelete = hasCollectionDelete;
     this.recordName = recordName;
     this.uniqueProperties = uniqueProperties;
@@ -44,10 +55,10 @@ public class FakeStorageModuleBuilder {
   public FakeStorageModule create() {
     return new FakeStorageModule(rootPath, collectionPropertyName, tenantId,
       requiredProperties, hasCollectionDelete, recordName, uniqueProperties,
-      includeChangeMetadata);
+      disallowedProperties, includeChangeMetadata);
   }
 
-  public FakeStorageModuleBuilder withRootPath(String rootPath) {
+  FakeStorageModuleBuilder withRootPath(String rootPath) {
 
     String newCollectionPropertyName = collectionPropertyName == null
       ? rootPath.substring(rootPath.lastIndexOf("/") + 1)
@@ -58,86 +69,118 @@ public class FakeStorageModuleBuilder {
       newCollectionPropertyName,
       this.tenantId,
       this.requiredProperties,
+      this.disallowedProperties,
       this.hasCollectionDelete,
       this.recordName,
       this.uniqueProperties,
       this.includeChangeMetadata);
   }
 
-  public FakeStorageModuleBuilder withCollectionPropertyName(String collectionPropertyName) {
+  FakeStorageModuleBuilder withCollectionPropertyName(
+    String collectionPropertyName) {
+
     return new FakeStorageModuleBuilder(
       this.rootPath,
       collectionPropertyName,
       this.tenantId,
       this.requiredProperties,
+      this.disallowedProperties,
       this.hasCollectionDelete,
       this.recordName,
       this.uniqueProperties,
       this.includeChangeMetadata);
   }
 
-  public FakeStorageModuleBuilder withRecordName(String recordName) {
+  FakeStorageModuleBuilder withRecordName(String recordName) {
     return new FakeStorageModuleBuilder(
       this.rootPath,
       this.collectionPropertyName,
       this.tenantId,
       this.requiredProperties,
+      this.disallowedProperties,
       this.hasCollectionDelete,
       recordName,
       this.uniqueProperties,
       this.includeChangeMetadata);
   }
 
-  public FakeStorageModuleBuilder withRequiredProperties(Collection<String> requiredProperties) {
+  private FakeStorageModuleBuilder withRequiredProperties(
+    Collection<String> requiredProperties) {
+
     return new FakeStorageModuleBuilder(
       this.rootPath,
       this.collectionPropertyName,
       this.tenantId,
       requiredProperties,
+      this.disallowedProperties,
       this.hasCollectionDelete,
       this.recordName,
       this.uniqueProperties,
       this.includeChangeMetadata);
     }
 
-  public FakeStorageModuleBuilder withRequiredProperties(String... requiredProperties) {
+  FakeStorageModuleBuilder withRequiredProperties(String... requiredProperties) {
     return withRequiredProperties(Arrays.asList(requiredProperties));
   }
 
-  public FakeStorageModuleBuilder withUniqueProperties(Collection<String> uniqueProperties) {
+  private FakeStorageModuleBuilder withUniqueProperties(
+    Collection<String> uniqueProperties) {
+
     return new FakeStorageModuleBuilder(
       this.rootPath,
       this.collectionPropertyName,
       this.tenantId,
       this.requiredProperties,
+      this.disallowedProperties,
       this.hasCollectionDelete,
       this.recordName,
       uniqueProperties,
       this.includeChangeMetadata);
   }
 
-  public FakeStorageModuleBuilder withUniqueProperties(String... uniqueProperties) {
+  FakeStorageModuleBuilder withUniqueProperties(String... uniqueProperties) {
     return withUniqueProperties(Arrays.asList(uniqueProperties));
   }
 
-  public FakeStorageModuleBuilder disallowCollectionDelete() {
+  private FakeStorageModuleBuilder withDisallowedProperties(
+    Collection<String> disallowedProperties) {
+
     return new FakeStorageModuleBuilder(
       this.rootPath,
       this.collectionPropertyName,
       this.tenantId,
       this.requiredProperties,
+      disallowedProperties,
+      this.hasCollectionDelete,
+      this.recordName,
+      this.uniqueProperties,
+      this.includeChangeMetadata);
+  }
+
+  FakeStorageModuleBuilder withDisallowedProperties(String... disallowedProperties) {
+    return withDisallowedProperties(Arrays.asList(disallowedProperties));
+  }
+
+  FakeStorageModuleBuilder disallowCollectionDelete() {
+    return new FakeStorageModuleBuilder(
+      this.rootPath,
+      this.collectionPropertyName,
+      this.tenantId,
+      this.requiredProperties,
+      this.disallowedProperties,
       false,
       this.recordName,
       this.uniqueProperties,
       this.includeChangeMetadata);
   }
 
-  public FakeStorageModuleBuilder withChangeMetadata() {
+  FakeStorageModuleBuilder withChangeMetadata() {
     return new FakeStorageModuleBuilder(
       this.rootPath,
       this.collectionPropertyName,
       this.tenantId,
       this.requiredProperties,
+      this.disallowedProperties,
       this.hasCollectionDelete,
       this.recordName,
       this.uniqueProperties,


### PR DESCRIPTION
See https://issues.folio.org/browse/CIRC-161

Request representations are augmented with information from related records. The current loan for an item is a recent addition to these.

As this information is fetched on demand and not stored, it needs to be removed from the request representation before it can be stored using the request-storage interface

This change also changes the request updating API tests to better reflect expected client behaviour (by fetching the request via `GET /circulation/requests/id` prior to attempting to update. This also helped to recreate the issue, as the request representation following creation does not include the properties that cause issues (which is a related, yet different, issue)