### PR TITLE
fix invalid queries for request related records CIRC-165

### DIFF
--- a/src/main/java/org/folio/circulation/domain/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepository.java
@@ -226,7 +226,7 @@ public class LoanRepository {
 
   public CompletableFuture<HttpResult<MultipleRecords<Loan>>> findBy(String query) {
     //TODO: Should fetch users for all loans
-    return loansStorageClient.getMany(query)
+    return loansStorageClient.getManyWithRawQueryStringParameters(query)
       .thenApply(this::mapResponseToLoans)
       .thenComposeAsync(loans -> itemRepository.fetchItemsFor(loans, Loan::withItem));
   }

--- a/src/main/java/org/folio/circulation/domain/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepository.java
@@ -296,7 +296,7 @@ public class LoanRepository {
 
     HttpResult<String> queryResult = CqlHelper.encodeQuery(openLoansQuery);
     
-    return queryResult.after(query -> loansStorageClient.getMany(query)
+    return queryResult.after(query -> loansStorageClient.getMany(query, requests.size(), 0)
         .thenApply(this::mapResponseToLoans)
         .thenApply(multipleLoansResult -> multipleLoansResult.next(
           multipleLoans -> {

--- a/src/main/java/org/folio/circulation/domain/PatronGroupRepository.java
+++ b/src/main/java/org/folio/circulation/domain/PatronGroupRepository.java
@@ -29,7 +29,7 @@ class PatronGroupRepository {
 
       final String query = CqlHelper.multipleRecordsCqlQuery(groupsToFetch);
 
-      return patronGroupsStorageClient.getMany(query)
+      return patronGroupsStorageClient.getMany(query, groupsToFetch.size(), 0)
         .thenApply(this::mapResponseToPatronGroups)
         .thenApply(multiplePatronGroupsResult -> multiplePatronGroupsResult.next(
           patronGroups -> HttpResult.of(() -> matchGroupsToUsers(request, patronGroups))));
@@ -49,7 +49,7 @@ class PatronGroupRepository {
 
     final String query = CqlHelper.multipleRecordsCqlQuery(groupsToFetch);
 
-    return patronGroupsStorageClient.getMany(query)
+    return patronGroupsStorageClient.getMany(query, groupsToFetch.size(), 0)
       .thenApply(this::mapResponseToPatronGroups)
       .thenApply(multiplePatronGroupsResult -> multiplePatronGroupsResult.next(
         patronGroups -> matchGroupsToUsers(multipleRequests, patronGroups)));

--- a/src/main/java/org/folio/circulation/domain/RequestRepository.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepository.java
@@ -49,7 +49,7 @@ public class RequestRepository {
   }
 
   public CompletableFuture<HttpResult<MultipleRecords<Request>>> findBy(String query) {
-    return requestsStorageClient.getMany(query)
+    return requestsStorageClient.getManyWithRawQueryStringParameters(query)
       .thenApply(this::mapResponseToRequests)
       .thenComposeAsync(result -> itemRepository.fetchItemsFor(result, Request::withItem))
       .thenComposeAsync(result -> result.after(loanRepository::findOpenLoansFor))

--- a/src/main/java/org/folio/circulation/domain/ServicePointRepository.java
+++ b/src/main/java/org/folio/circulation/domain/ServicePointRepository.java
@@ -54,7 +54,7 @@ class ServicePointRepository {
     
     HttpResult<String> queryResult = CqlHelper.encodeQuery(spQuery);
     
-    return queryResult.after(query -> servicePointsStorageClient.getMany(query)
+    return queryResult.after(query -> servicePointsStorageClient.getMany(query, requests.size(), 0)
         .thenApply(this::mapResponseToServicePoints)
         .thenApply(multipleServicePointsResult -> multipleServicePointsResult.next(
           multipleServicePoints -> {

--- a/src/main/java/org/folio/circulation/domain/ServicePointRepository.java
+++ b/src/main/java/org/folio/circulation/domain/ServicePointRepository.java
@@ -4,7 +4,10 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.CqlHelper;
@@ -34,27 +37,24 @@ class ServicePointRepository {
   
   CompletableFuture<HttpResult<MultipleRecords<Request>>> findServicePointsForRequests(
     MultipleRecords<Request> multipleRequests) {
+
     Collection<Request> requests = multipleRequests.getRecords();
-    List<String> clauses = new ArrayList<>();
-    
-    for(Request request : requests) {
-      if(request.getPickupServicePointId() != null) {
-        String clause = String.format("id==%s", request.getPickupServicePointId());
-        clauses.add(clause);
-      }
-    }
-    
-    if(clauses.isEmpty()) {
+
+    final List<String> servicePointsToFetch = requests.stream()
+      .filter(Objects::nonNull)
+      .map(Request::getPickupServicePointId)
+      .filter(Objects::nonNull)
+      .distinct()
+      .collect(Collectors.toList());
+
+    if(servicePointsToFetch.isEmpty()) {
       log.info("No service points to query");
       return CompletableFuture.completedFuture(HttpResult.succeeded(multipleRequests));
     }
     
-    final String spQuery = String.join(" OR ", clauses);
-    log.info("Querying service points with query {}", spQuery);
-    
-    HttpResult<String> queryResult = CqlHelper.encodeQuery(spQuery);
-    
-    return queryResult.after(query -> servicePointsStorageClient.getMany(query, requests.size(), 0)
+    String query = CqlHelper.multipleRecordsCqlQuery(servicePointsToFetch);
+
+    return servicePointsStorageClient.getMany(query, requests.size(), 0)
         .thenApply(this::mapResponseToServicePoints)
         .thenApply(multipleServicePointsResult -> multipleServicePointsResult.next(
           multipleServicePoints -> {
@@ -78,9 +78,10 @@ class ServicePointRepository {
               }
               newRequestList.add(newRequest);
             }
+
             return HttpResult.succeeded(
               new MultipleRecords<>(newRequestList, multipleRequests.getTotalRecords()));
-          })));    
+          }));
   }
   
   private HttpResult<MultipleRecords<ServicePoint>> mapResponseToServicePoints(Response response) {

--- a/src/main/java/org/folio/circulation/domain/UpdateLoanActionHistory.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateLoanActionHistory.java
@@ -1,19 +1,24 @@
 package org.folio.circulation.domain;
 
-import io.vertx.core.json.JsonObject;
-import org.apache.commons.lang3.StringUtils;
-import org.folio.circulation.support.*;
-import org.folio.circulation.support.http.client.Response;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.support.HttpResult.failed;
+import static org.folio.circulation.support.HttpResult.succeeded;
 
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.folio.circulation.support.HttpResult.failed;
-import static org.folio.circulation.support.HttpResult.succeeded;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.CollectionResourceClient;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.JsonArrayHelper;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.http.client.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.json.JsonObject;
 
 public class UpdateLoanActionHistory {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -44,11 +49,13 @@ public class UpdateLoanActionHistory {
 
     String itemId = requestAndRelatedRecords.getRequest().getItemId();
 
+    //TODO: Replace this with CQL Helper and explicit query parameter
     String queryTemplate = "query=itemId=%s+and+status.name=Open";
     String query = String.format(queryTemplate, itemId);
 
-    return this.loansStorageClient.getMany(query).thenComposeAsync(
-      getLoansResponse -> updateLatestLoan(requestAndRelatedRecords, action,
+    return this.loansStorageClient.getManyWithRawQueryStringParameters(query)
+      .thenComposeAsync(
+        getLoansResponse -> updateLatestLoan(requestAndRelatedRecords, action,
         itemStatus, itemId, getLoansResponse));
   }
 

--- a/src/main/java/org/folio/circulation/domain/UserRepository.java
+++ b/src/main/java/org/folio/circulation/domain/UserRepository.java
@@ -93,7 +93,7 @@ public class UserRepository {
 
     final String query = CqlHelper.multipleRecordsCqlQuery(usersToFetch);
 
-    return usersStorageClient.getMany(query)
+    return usersStorageClient.getMany(query, requests.size(), 0)
       .thenApply(this::mapResponseToUsers)
       .thenApply(multipleUsersResult -> multipleUsersResult.next(
         multipleUsers -> HttpResult.of(() ->

--- a/src/main/java/org/folio/circulation/support/CollectionResourceClient.java
+++ b/src/main/java/org/folio/circulation/support/CollectionResourceClient.java
@@ -1,9 +1,10 @@
 package org.folio.circulation.support;
 
-import io.vertx.core.Handler;
-import io.vertx.core.http.HttpClientResponse;
+import java.lang.invoke.MethodHandles;
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
-import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.entity.ContentType;
@@ -12,10 +13,9 @@ import org.folio.circulation.support.http.client.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.invoke.MethodHandles;
-import java.net.URL;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.json.JsonObject;
 
 public class CollectionResourceClient {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -103,11 +103,22 @@ public class CollectionResourceClient {
     return future;
   }
 
-  public CompletableFuture<Response> getMany(String urlEncodedQuery) {
+  /**
+   * Make a get request for multiple records using raw query string parameters
+   * Should only be used when passing on entire query string from a client request
+   * Is deprecated, and will be removed when all use replaced by explicit parsing
+   * of request parameters
+   *
+   * @param rawQueryString raw query string to append to the URL
+   * @return response from the server
+   */
+  public CompletableFuture<Response> getManyWithRawQueryStringParameters(
+    String rawQueryString) {
+
     final CompletableFuture<Response> future = new CompletableFuture<>();
 
-    String url = isProvided(urlEncodedQuery)
-      ? String.format("%s?%s", collectionRoot, urlEncodedQuery)
+    String url = isProvided(rawQueryString)
+      ? String.format("%s?%s", collectionRoot, rawQueryString)
       : collectionRoot.toString();
 
     client.get(url, responseConversationHandler(future::complete));

--- a/src/main/java/org/folio/circulation/support/CqlHelper.java
+++ b/src/main/java/org/folio/circulation/support/CqlHelper.java
@@ -4,6 +4,7 @@ import java.lang.invoke.MethodHandles;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -21,6 +22,7 @@ public class CqlHelper {
     }
     else {
       final Collection<String> filteredIds = recordIds.stream()
+        .filter(Objects::nonNull)
         .map(String::toString)
         .filter(StringUtils::isNotBlank)
         .distinct()

--- a/src/test/java/api/requests/RequestsAPIDeletionTests.java
+++ b/src/test/java/api/requests/RequestsAPIDeletionTests.java
@@ -1,14 +1,10 @@
 package api.requests;
 
-import io.vertx.core.json.JsonObject;
-import api.support.APITests;
-import api.support.builders.RequestBuilder;
-import api.support.builders.UserBuilder;
-import api.support.http.InterfaceUrls;
-import org.folio.circulation.support.JsonArrayHelper;
-import org.folio.circulation.support.http.client.Response;
-import org.folio.circulation.support.http.client.ResponseHandler;
-import org.junit.Test;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
@@ -19,9 +15,16 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static java.net.HttpURLConnection.*;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import org.folio.circulation.support.JsonArrayHelper;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.http.client.ResponseHandler;
+import org.junit.Test;
+
+import api.support.APITests;
+import api.support.builders.RequestBuilder;
+import api.support.builders.UserBuilder;
+import api.support.http.InterfaceUrls;
+import io.vertx.core.json.JsonObject;
 
 public class RequestsAPIDeletionTests extends APITests {
 
@@ -138,7 +141,8 @@ public class RequestsAPIDeletionTests extends APITests {
 
     Response getAllResponse = getAllCompleted.get(5, TimeUnit.SECONDS);
 
-    assertThat(getAllResponse.getStatusCode(), is(HTTP_OK));
+    assertThat(String.format("Get all requests failed: \"%s\"", getAllResponse.getBody()),
+      getAllResponse.getStatusCode(), is(HTTP_OK));
 
     JsonObject allRequests = getAllResponse.getJson();
 

--- a/src/test/java/api/requests/RequestsAPIRetrievalTests.java
+++ b/src/test/java/api/requests/RequestsAPIRetrievalTests.java
@@ -255,8 +255,8 @@ public class RequestsAPIRetrievalTests extends APITests {
     final IndividualResource sponsor = usersFixture.rebecca(
         builder -> builder.withPatronGroupId(facultyGroupId));
 
-    final IndividualResource proxy = usersFixture.steve(builder ->
-      builder.withPatronGroupId(staffGroupId));
+    final IndividualResource proxy = usersFixture.steve(
+      builder -> builder.withPatronGroupId(staffGroupId));
 
     UUID proxyId = proxy.getId();
     UUID requesterId = sponsor.getId();
@@ -640,6 +640,8 @@ public class RequestsAPIRetrievalTests extends APITests {
   }
 
   private List<JsonObject> getRequests(JsonObject page) {
+    System.out.println("Found requests");
+    System.out.println(page.getJsonArray("requests").encodePrettily());
     return JsonArrayHelper.toList(page.getJsonArray("requests"));
   }
 
@@ -664,11 +666,16 @@ public class RequestsAPIRetrievalTests extends APITests {
   
   private void requestHasPatronGroupProperties(JsonObject request) {
     hasProperty("proxy", request, "proxy");
+
+    hasProperty("patronGroupId", request.getJsonObject("proxy"), "proxy");
     hasProperty("patronGroup", request.getJsonObject("proxy"), "patronGroup");
     hasProperty("id", request.getJsonObject("proxy").getJsonObject("patronGroup"), "id");
     hasProperty("group", request.getJsonObject("proxy").getJsonObject("patronGroup"), "group");
     hasProperty("desc", request.getJsonObject("proxy").getJsonObject("patronGroup"), "desc");
+
     hasProperty("requester", request, "requester");
+
+    hasProperty("patronGroupId", request.getJsonObject("requester"), "requester");
     hasProperty("patronGroup", request.getJsonObject("requester"), "patronGroup");
     hasProperty("id", request.getJsonObject("requester").getJsonObject("patronGroup"), "id");
     hasProperty("group", request.getJsonObject("requester").getJsonObject("patronGroup"), "desc");


### PR DESCRIPTION
See https://issues.folio.org/browse/CIRC-165

*Purpose*
Some related record queries when fetching requests do not provide a named query CQL parameter, instead this is provided as the whole query string itself.

FOLIO collection endpoints typically ignore unexpected query string parameters, and hence treat this as a request for all records. Within small record sets, this makes this difficult to identify, as the expected records are likely found within the first page of all records, and so don't demonstrate unintended behaviour.

*Learning*
This is compounded by the CollectionResourceClient providing a method that accepts a raw query parameter string in it's entirety. This is intended for forwarding of the query string parameters sent by the client directly to storage without needing to parse and re-encode them.

*Approach*
* Refuse unexpected query string parameters when fake storage module handles collection endpoint
* Replace usage of raw query string variant of `getMany` with parameterised version, for all affected related record requests
* Rename raw query string variant of `getMany` and add documentation to reduce change of future usage

*Further Changes*
* Replace all usage of raw query string variant, with parsing of incoming parameters and use of parameterised version
* Remove raw query string variant