### PR TITLE
Incorrect current loan query for multiple requests CIRC-165

### DIFF
--- a/src/main/java/org/folio/circulation/domain/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepository.java
@@ -1,16 +1,19 @@
 package org.folio.circulation.domain;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
 import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.folio.circulation.domain.validation.UserNotFoundValidator;
 import org.folio.circulation.support.Clients;
@@ -96,7 +99,7 @@ public class LoanRepository {
     return itemRepository.fetchByBarcode(query.getItemBarcode())
       .thenComposeAsync(itemResult -> itemResult.after(item -> {
         if(item.isNotFound()) {
-          return CompletableFuture.completedFuture(ValidationErrorFailure.failedResult(
+          return completedFuture(ValidationErrorFailure.failedResult(
             String.format("No item with barcode %s exists", query.getItemBarcode()),
             "itemBarcode", query.getItemBarcode()));
         }
@@ -129,7 +132,7 @@ public class LoanRepository {
     return itemRepository.fetchById(query.getItemId())
       .thenComposeAsync(itemResult -> itemResult.after(item -> {
         if(item.isNotFound()) {
-          return CompletableFuture.completedFuture(ValidationErrorFailure.failedResult(
+          return completedFuture(ValidationErrorFailure.failedResult(
             String.format("No item with ID %s exists", query.getItemId()),
             "itemId", query.getItemId()));
         }
@@ -164,7 +167,7 @@ public class LoanRepository {
       .thenApply(loansResult -> loansResult.next(loans -> {
         //TODO: Consider introducing an unknown loan class, instead of null
         if (loans.getTotalRecords() == 0) {
-          return HttpResult.succeeded(null);
+          return succeeded(null);
         }
         else if(loans.getTotalRecords() == 1) {
           final Optional<Loan> firstLoan = loans.getRecords().stream().findFirst();
@@ -270,57 +273,50 @@ public class LoanRepository {
   }
 
   CompletableFuture<HttpResult<MultipleRecords<Request>>> findOpenLoansFor(
-    //TODO: Need to handle multiple open loans for same item (with failure?)
     MultipleRecords<Request> multipleRequests) {
 
-    //CQL to return a list of loans
+    //TODO: Need to handle multiple open loans for same item (with failure?)
+
     Collection<Request> requests = multipleRequests.getRecords();
-    List<String> clauses = new ArrayList<>();
 
-    for(Request request : requests) {
-      if(request.getItemId() != null) {
-        String clause = String.format("id==%s", request.getItemId());
-        clauses.add(clause);
-      }
+    //TODO: Extract this repeated getting of a collection of property values
+    final List<String> itemsToFetchLoansFor = requests.stream()
+      .filter(Objects::nonNull)
+      .map(Request::getItemId)
+      .filter(Objects::nonNull)
+      .distinct()
+      .collect(Collectors.toList());
+
+    if(itemsToFetchLoansFor.isEmpty()) {
+      log.info("No items to search for current loans for");
+      return completedFuture(succeeded(multipleRequests));
     }
 
-    if(clauses.isEmpty()) {
-      return CompletableFuture.completedFuture(HttpResult.succeeded(multipleRequests));
-    }
+    HttpResult<String> queryResult = CqlHelper.multipleRecordsCqlQuery(
+      String.format("status.name==\"%s\" and ", "Open"),
+      "itemId", itemsToFetchLoansFor);
 
-    final String itemClause = String.join(" OR ", clauses);
-    final String openLoansQuery = String.format("status.name==\"Open\" AND (%s)",
-        itemClause);
-
-    log.info("Querying open loans with query {}", openLoansQuery);
-
-    HttpResult<String> queryResult = CqlHelper.encodeQuery(openLoansQuery);
-    
     return queryResult.after(query -> loansStorageClient.getMany(query, requests.size(), 0)
         .thenApply(this::mapResponseToLoans)
-        .thenApply(multipleLoansResult -> multipleLoansResult.next(
-          multipleLoans -> {
-            List<Request> newRequestList = new ArrayList<>();
-            Collection<Loan> loanColl = multipleLoans.getRecords();
+      .thenApply(multipleLoansResult -> multipleLoansResult.next(
+        loans -> matchLoansToRequests(multipleRequests, loans))));
+  }
 
-            for(Request req : requests) {
-              Request newReq = null;
-              Boolean foundLoan = false;
-              for(Loan loan : loanColl) {
-                if(req.getItemId().equals(loan.getItemId())) {
-                  newReq = req.withLoan(loan);
-                  foundLoan = true;
-                  break;
-                }
-              }
-              if(!foundLoan) {
-                newReq = req;
-              }
-              newRequestList.add(newReq);
-            }
+  private HttpResult<MultipleRecords<Request>> matchLoansToRequests(
+    MultipleRecords<Request> requests,
+    MultipleRecords<Loan> loans) {
 
-            return HttpResult.succeeded(
-              new MultipleRecords<>(newRequestList, multipleRequests.getTotalRecords()));
-    })));
+    return HttpResult.of(() ->
+      requests.mapRecords(request -> matchLoansToRequest(request, loans)));
+  }
+
+  private Request matchLoansToRequest(
+    Request request,
+    MultipleRecords<Loan> loans) {
+
+    final Map<String, Loan> loanMap = loans.toMap(Loan::getItemId);
+
+    return request
+      .withLoan(loanMap.getOrDefault(request.getItemId(), null));
   }
 }

--- a/src/main/java/org/folio/circulation/support/CqlHelper.java
+++ b/src/main/java/org/folio/circulation/support/CqlHelper.java
@@ -17,26 +17,7 @@ public class CqlHelper {
   private CqlHelper() { }
 
   public static String multipleRecordsCqlQuery(Collection<String> recordIds) {
-    if(recordIds.isEmpty()) {
-      return null;
-    }
-    else {
-      final Collection<String> filteredIds = recordIds.stream()
-        .filter(Objects::nonNull)
-        .map(String::toString)
-        .filter(StringUtils::isNotBlank)
-        .distinct()
-        .collect(Collectors.toList());
-
-      if(filteredIds.isEmpty()) {
-        return null;
-      }
-
-      String query = String.format("id==(%s)", String.join(" or ", filteredIds));
-
-      //TODO: Check if would be preferable to fail request with error?
-      return encodeQuery(query).orElse(null);
-    }
+    return multipleRecordsCqlQuery(null, "id", recordIds).orElse(null);
   }
 
   public static HttpResult<String> encodeQuery(String cqlQuery) {

--- a/src/main/java/org/folio/circulation/support/CqlHelper.java
+++ b/src/main/java/org/folio/circulation/support/CqlHelper.java
@@ -45,4 +45,47 @@ public class CqlHelper {
     return HttpResult.of(() -> URLEncoder.encode(cqlQuery,
       String.valueOf(StandardCharsets.UTF_8)));
   }
+
+  /**
+   *
+   * Creates a CQL query for matching a property to one of multiple values
+   * intended to return multiple records. Typically used when fetching related
+   * records e.g. fetching all groups for users, or items for loans
+   *
+   * @param prefixQueryFragment fragment of CQL to include at the beginning
+   *                            e.g. status.name=="Open" AND
+   * @param indexName Name of the index (property) to match values to
+   * @param valuesToSearchFor Values to search for, query should match any
+   *                          against the index
+   * @return null if there are no values to search for, otherwise a CQL
+   * query that includes a fragment if provided and a clause for matching any
+   * of the values
+   */
+  public static HttpResult<String> multipleRecordsCqlQuery(
+    String prefixQueryFragment,
+    String indexName,
+    Collection<String> valuesToSearchFor) {
+
+    final Collection<String> filteredValues = valuesToSearchFor.stream()
+      .filter(Objects::nonNull)
+      .map(String::toString)
+      .filter(StringUtils::isNotBlank)
+      .distinct()
+      .collect(Collectors.toList());
+
+    if(filteredValues.isEmpty()) {
+      return HttpResult.of(() -> null);
+    }
+
+    String valueQuery = String.format("%s==(%s)",
+      indexName, String.join(" or ", filteredValues));
+
+    if(StringUtils.isBlank(prefixQueryFragment)) {
+      return encodeQuery(valueQuery);
+    }
+    else {
+      return encodeQuery(
+        String.format("%s %s", prefixQueryFragment, valueQuery));
+    }
+  }
 }

--- a/src/test/java/api/requests/RequestsAPIRetrievalTests.java
+++ b/src/test/java/api/requests/RequestsAPIRetrievalTests.java
@@ -5,6 +5,7 @@ import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static api.support.matchers.UUIDMatcher.is;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -111,19 +112,21 @@ public class RequestsAPIRetrievalTests extends APITests {
     assertThat(representation.getString("pickupServicePointId"),
         is(pickupServicePointId.toString()));
     assertThat(representation.getString("status"), is("Open - Not yet filled"));
-    assertThat(representation.containsKey("loan"), is(true));
+
     assertThat(representation.containsKey("proxy"), is(true));
     assertThat(representation.getJsonObject("proxy").containsKey("patronGroup"), is (true));
     assertThat(representation.getJsonObject("proxy").getString("patronGroupId"),
         is(staffGroupId.toString()));
     assertThat(representation.getJsonObject("proxy").getJsonObject("patronGroup").getString("id"),
         is(staffGroupId.toString()));
+
     assertThat(representation.containsKey("requester"), is(true));
     assertThat(representation.getJsonObject("requester").containsKey("patronGroup"), is (true));
     assertThat(representation.getJsonObject("requester").getString("patronGroupId"),
         is(facultyGroupId.toString()));
     assertThat(representation.getJsonObject("requester").getJsonObject("patronGroup").getString("id"),
         is(facultyGroupId.toString()));
+
     assertThat(representation.containsKey("pickupServicePoint"), is(true));
     assertThat(representation.getJsonObject("pickupServicePoint").getString("name"),
         is(cd1.getJson().getString("name")));
@@ -133,6 +136,7 @@ public class RequestsAPIRetrievalTests extends APITests {
         is(cd1.getJson().getString("discoveryDisplayName")));
     assertThat(representation.getJsonObject("pickupServicePoint").getBoolean("pickupLocation"),
         is(cd1.getJson().getBoolean("pickupLocation")));
+
     assertThat("has information taken from item",
       representation.containsKey("item"), is(true));
 
@@ -168,6 +172,20 @@ public class RequestsAPIRetrievalTests extends APITests {
     assertThat("barcode is taken from requesting user",
       representation.getJsonObject("requester").getString("barcode"),
       is("6059539205"));
+
+    assertThat("barcode is taken from requesting user",
+      representation.getJsonObject("requester").getString("barcode"),
+      is("6059539205"));
+
+    assertThat("current loan is present",
+      representation.containsKey("loan"), is(true));
+
+    assertThat("current loan has a due date",
+      representation.getJsonObject("loan").containsKey("dueDate"), is(true));
+
+    //TODO: Improve this by checking actual date
+    assertThat("current loan has non-null due date",
+      representation.getJsonObject("loan").getString("dueDate"), notNullValue());
   }
 
   @Test

--- a/src/test/java/api/requests/RequestsAPIRetrievalTests.java
+++ b/src/test/java/api/requests/RequestsAPIRetrievalTests.java
@@ -270,6 +270,9 @@ public class RequestsAPIRetrievalTests extends APITests {
     UUID staffGroupId = patronGroupsFixture.staff().getId();
     groupsToDelete.add(staffGroupId);
 
+    final IndividualResource jessica = usersFixture.jessica();
+    final IndividualResource charlotte = usersFixture.charlotte();
+
     final IndividualResource sponsor = usersFixture.rebecca(
         builder -> builder.withPatronGroupId(facultyGroupId));
 
@@ -284,44 +287,56 @@ public class RequestsAPIRetrievalTests extends APITests {
     servicePointsToDelete.add(cd1.getId());
     servicePointsToDelete.add(cd2.getId());
 
+    final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource nod = itemsFixture.basedUponNod();
+    final IndividualResource interestingTimes = itemsFixture.basedUponInterestingTimes();
+    final IndividualResource temeraire = itemsFixture.basedUponTemeraire();
+    final IndividualResource uprooted = itemsFixture.basedUponUprooted();
+
+    loansFixture.checkOut(smallAngryPlanet, jessica);
+    loansFixture.checkOut(nod, charlotte);
+    loansFixture.checkOut(interestingTimes, charlotte);
+    loansFixture.checkOut(temeraire, jessica);
+    loansFixture.checkOut(uprooted, jessica);
+
     requestsClient.create(new RequestBuilder()
-      .withItemId(itemsFixture.basedUponSmallAngryPlanet(ItemBuilder::checkOut).getId())
+      .withItemId(smallAngryPlanet.getId())
       .withRequesterId(requesterId)
       .withUserProxyId(proxyId)
       .withPickupServicePointId(pickupServicePointId));
 
     requestsClient.create(new RequestBuilder()
-      .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withItemId(nod.getId())
       .withRequesterId(requesterId)
       .withUserProxyId(proxyId)
       .withPickupServicePointId(pickupServicePointId2));
 
     requestsClient.create(new RequestBuilder()
-      .withItemId(itemsFixture.basedUponInterestingTimes(ItemBuilder::checkOut).getId())
+      .withItemId(interestingTimes.getId())
       .withRequesterId(requesterId)
       .withUserProxyId(proxyId)
       .withPickupServicePointId(pickupServicePointId));
 
     requestsClient.create(new RequestBuilder()
-      .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withItemId(temeraire.getId())
       .withRequesterId(requesterId)
       .withUserProxyId(proxyId)
       .withPickupServicePointId(pickupServicePointId2));
 
     requestsClient.create(new RequestBuilder()
-      .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withItemId(nod.getId())
       .withRequesterId(requesterId)
       .withUserProxyId(proxyId)
       .withPickupServicePointId(pickupServicePointId));
 
     requestsClient.create(new RequestBuilder()
-      .withItemId(itemsFixture.basedUponUprooted(ItemBuilder::checkOut).getId())
+      .withItemId(uprooted.getId())
       .withRequesterId(requesterId)
       .withUserProxyId(proxyId)
       .withPickupServicePointId(pickupServicePointId));
 
     requestsClient.create(new RequestBuilder()
-      .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withItemId(temeraire.getId())
       .withRequesterId(requesterId)
       .withUserProxyId(proxyId)
       .withPickupServicePointId(pickupServicePointId2));
@@ -339,6 +354,7 @@ public class RequestsAPIRetrievalTests extends APITests {
     List<JsonObject> requestList = getRequests(getResponse.getJson());
     
     requestList.forEach(this::requestHasExpectedProperties);
+    requestList.forEach(this::requestHasExpectedLoanProperties);
     requestList.forEach(this::requestHasServicePointProperties);
     requestList.forEach(this::requestHasPatronGroupProperties);
   }
@@ -674,6 +690,10 @@ public class RequestsAPIRetrievalTests extends APITests {
     hasProperty("requester", request, "request");
     hasProperty("status", request, "request");
   }
+
+  private void requestHasExpectedLoanProperties(JsonObject request) {
+    hasProperty("dueDate", request.getJsonObject("loan"), "loan");
+  }
   
   private void requestHasServicePointProperties(JsonObject request) {
     hasProperty("pickupServicePointId", request, "request");
@@ -701,6 +721,10 @@ public class RequestsAPIRetrievalTests extends APITests {
   }
 
   private void hasProperty(String property, JsonObject resource, String type) {
+    assertThat(String.format("%s should have %s: %s: is missing outer property",
+      type, property, resource),
+      resource, notNullValue());
+
     assertThat(String.format("%s should have %s: %s",
       type, property, resource),
       resource.containsKey(property), is(true));

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -22,6 +22,7 @@ import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.client.ResponseHandler;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
 import api.support.builders.LoanBuilder;
@@ -73,7 +74,8 @@ public class LoansFixture {
     return loansClient.create(new LoanBuilder()
       .withId(loanId)
       .open()
-      .withItemId(itemId));
+      .withItemId(itemId)
+      .withDueDate(new DateTime(2018, 12, 3, 11, 22, 43, DateTimeZone.UTC)));
   }
   
   public IndividualResource checkOutItem(UUID itemId)


### PR DESCRIPTION
*Purpose*
Searching for the current loan for requested items was not working. The previous fix for the structure of the query was necessary however wasn't sufficient

*Approach*
* Check out items, in order to create open loans, in test for fetching multiple requests
* Add test that closed loans are not included when fetching multiple requests
* Introduce way of searching for any of multiple values using CQL for an index other than {{id}}
and including a prefix fragment of CQL in order to search for loans by {{itemId}} and only in the open status.