### PR TITLE
Only update loan once during check in CIRC-154

### DIFF
--- a/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
@@ -123,6 +123,9 @@ public class LoanCollectionResource extends CollectionResource {
       .thenCombineAsync(requestQueueRepository.get(loan.getItemId()), this::addRequestQueue)
       .thenComposeAsync(result -> result.after(requestQueueUpdate::onCheckIn))
       .thenComposeAsync(result -> result.after(updateItem::onLoanUpdate))
+      // Loan must be updated after item
+      // due to snapshot of item status stored with the loan
+      // as this is how the loan action history is populated
       .thenComposeAsync(result -> result.after(loanRepository::updateLoan))
       .thenApply(NoContentHttpResult::from)
       .thenAccept(result -> result.writeTo(routingContext.response()));


### PR DESCRIPTION
*Purpose*
At the moment the loan is updated in storage twice during the check in API. This is incorrect, and should only be done once. Not least because only one entry in the loan action history should be created, and this is currently done via storage of the loan (with a trigger in mod-circulation-storage)

The loan must be updated after the item status is determined, as a snapshot of the status is stored with the loan, in order for it to appear in the loan action history.