### PR TITLE
Split finding single open loan CIRC-146

### DIFF
--- a/src/main/java/org/folio/circulation/domain/FindByBarcodeQuery.java
+++ b/src/main/java/org/folio/circulation/domain/FindByBarcodeQuery.java
@@ -1,6 +1,6 @@
 package org.folio.circulation.domain;
 
-public interface FindByBarcodeQuery extends UserRelatedQuery {
+public interface FindByBarcodeQuery {
   String getItemBarcode();
   String getUserBarcode();
 }

--- a/src/main/java/org/folio/circulation/domain/FindByIdQuery.java
+++ b/src/main/java/org/folio/circulation/domain/FindByIdQuery.java
@@ -1,6 +1,0 @@
-package org.folio.circulation.domain;
-
-public interface FindByIdQuery {
-  String getItemId();
-  String getUserId();
-}

--- a/src/main/java/org/folio/circulation/domain/FindByIdQuery.java
+++ b/src/main/java/org/folio/circulation/domain/FindByIdQuery.java
@@ -1,6 +1,6 @@
 package org.folio.circulation.domain;
 
-public interface FindByIdQuery extends UserRelatedQuery {
+public interface FindByIdQuery {
   String getItemId();
   String getUserId();
 }

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -184,7 +184,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     return user;
   }
 
-  Loan withUser(User newUser) {
+  public Loan withUser(User newUser) {
     return new Loan(representation, item, newUser, proxy);
   }
 

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -211,7 +211,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     return this;
   }
 
-  Loan checkin(DateTime returnDate, UUID servicePointId) {
+  Loan checkIn(DateTime returnDate, UUID servicePointId) {
     changeAction("checkedin");
     changeStatus("Closed");
     changeReturnDate(returnDate);

--- a/src/main/java/org/folio/circulation/domain/LoanCheckInService.java
+++ b/src/main/java/org/folio/circulation/domain/LoanCheckInService.java
@@ -5,9 +5,10 @@ import static org.folio.circulation.support.HttpResult.of;
 import org.folio.circulation.domain.representations.CheckInByBarcodeRequest;
 import org.folio.circulation.support.HttpResult;
 
-public class LoanCheckinService {
-  public HttpResult<Loan> checkin(Loan loan, CheckInByBarcodeRequest request) {
-    return of(() -> loan.checkin(request.getCheckInDate(),
+public class LoanCheckInService {
+  public HttpResult<Loan> checkIn(Loan loan, CheckInByBarcodeRequest request) {
+    return of(() -> loan.checkIn(
+      request.getCheckInDate(),
       request.getServicePointId()));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepository.java
@@ -137,8 +137,7 @@ public class LoanRepository {
           }));
       }))
       .thenComposeAsync(this::fetchUser)
-      .thenApply(userNotFoundValidator::refuseWhenUserNotFound)
-      .thenApply(r -> r.next(loan -> refuseWhenDifferentUser(loan, query)));
+      .thenApply(userNotFoundValidator::refuseWhenUserNotFound);
   }
 
   /**
@@ -166,18 +165,6 @@ public class LoanRepository {
             String.format("More than one open loan for item %s", request.getItemId())));
         }
       }));
-  }
-
-  private HttpResult<Loan> refuseWhenDifferentUser(
-    Loan loan,
-    UserRelatedQuery query) {
-
-    if(query.userMatches(loan.getUser())) {
-      return succeeded(loan);
-    }
-    else {
-      return failed(query.userDoesNotMatchError());
-    }
   }
 
   public CompletableFuture<HttpResult<Loan>> getById(String id) {

--- a/src/main/java/org/folio/circulation/domain/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepository.java
@@ -239,7 +239,7 @@ public class LoanRepository {
       .thenApply(r -> r.map(loans -> !loans.getRecords().isEmpty()));
   }
 
-  private CompletableFuture<HttpResult<MultipleRecords<Loan>>> findOpenLoans(Item item) {
+  public CompletableFuture<HttpResult<MultipleRecords<Loan>>> findOpenLoans(Item item) {
     return findOpenLoans(item.getItemId());
   }
 

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -16,7 +16,7 @@ import org.folio.circulation.domain.representations.RequestProperties;
 
 import io.vertx.core.json.JsonObject;
 
-public class Request implements ItemRelatedRecord, UserRelatedRecord, FindByIdQuery {
+public class Request implements ItemRelatedRecord, UserRelatedRecord {
   private final JsonObject representation;
   private final Item item;
   private final User requester;

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -13,8 +13,6 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.representations.RequestProperties;
-import org.folio.circulation.support.ValidationErrorFailure;
-import org.folio.circulation.support.http.server.ValidationError;
 
 import io.vertx.core.json.JsonObject;
 
@@ -218,17 +216,6 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord, FindByIdQu
 
   ItemStatus checkedOutItemStatus() {
     return getRequestType().toCheckedOutItemStatus();
-  }
-
-  @Override
-  public boolean userMatches(User user) {
-    return user.getId().equals(requester.getId());
-  }
-
-  @Override
-  public ValidationErrorFailure userDoesNotMatchError() {
-    ValidationError error = new ValidationError("User does not match", "userId", requester.getId());
-    return new ValidationErrorFailure(error);
   }
 
   String getDeliveryAddressType() {

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -42,20 +42,6 @@ public class UpdateItem {
           loanAndRelatedRecords.getLoan().getItem(), prospectiveStatus));
   }
 
-  public CompletableFuture<HttpResult<Loan>> setLoansItemStatusAvaliable(Loan loan) {
-    Item item = loan.getItem();
-    item.changeStatus(ItemStatus.AVAILABLE);
-
-    return this.itemsStorageClient.put(item.getItemId(), item.getItem()).thenApply(putItemResponse -> {
-      if (putItemResponse.getStatusCode() == 204) {
-        return succeeded(loan);
-      } else {
-        return failed(
-            new ServerErrorFailure(String.format("Failed to update item status '%s'", putItemResponse.getBody())));
-      }
-    });
-  }
-
   CompletableFuture<HttpResult<RequestAndRelatedRecords>> onRequestCreation(
     RequestAndRelatedRecords requestAndRelatedRecords) {
 

--- a/src/main/java/org/folio/circulation/domain/UserRelatedQuery.java
+++ b/src/main/java/org/folio/circulation/domain/UserRelatedQuery.java
@@ -1,9 +1,0 @@
-package org.folio.circulation.domain;
-
-import org.folio.circulation.support.ValidationErrorFailure;
-
-public interface UserRelatedQuery {
-  boolean userMatches(User user);
-
-  ValidationErrorFailure userDoesNotMatchError();
-}

--- a/src/main/java/org/folio/circulation/domain/representations/CheckInByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/domain/representations/CheckInByBarcodeRequest.java
@@ -5,38 +5,30 @@ import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimePrope
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getUUIDProperty;
 import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
-import org.folio.circulation.domain.FindByBarcodeQuery;
-import org.folio.circulation.domain.User;
 import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
 import org.joda.time.DateTime;
 
 import io.vertx.core.json.JsonObject;
 
-public class CheckInByBarcodeRequest implements FindByBarcodeQuery {
-  private static final String USER_BARCODE = "userBarcode";
+public class CheckInByBarcodeRequest {
   private static final String ITEM_BARCODE = "itemBarcode";
   private static final String CHECK_IN_DATE = "checkInDate";
   private static final String SERVICE_POINT_ID = "servicePointId";
 
   private final String itemBarcode;
-  private final String userBarcode;
   private final UUID servicePointId;
   private final DateTime checkInDate;
 
   private CheckInByBarcodeRequest(
     String itemBarcode,
-    String userBarcode,
     UUID servicePointId,
     DateTime checkInDate) {
 
     this.itemBarcode = itemBarcode;
-    this.userBarcode = userBarcode;
     this.servicePointId = servicePointId;
     this.checkInDate = checkInDate;
   }
@@ -63,35 +55,16 @@ public class CheckInByBarcodeRequest implements FindByBarcodeQuery {
         CHECK_IN_DATE, null);
     }
 
-    //TODO: Remove unused user barcode field
-    // (needed for FindByBarcodeQuery interface)
-    return succeeded(new CheckInByBarcodeRequest(itemBarcode, null,
+    return succeeded(new CheckInByBarcodeRequest(itemBarcode,
       servicePointId, checkInDate));
   }
 
-  @Override
   public String getItemBarcode() {
     return itemBarcode;
   }
 
-  @Override
-  public String getUserBarcode() {
-    return userBarcode;
-  }
-
   public UUID getServicePointId() {
     return servicePointId;
-  }
-
-  @Override
-  public ValidationErrorFailure userDoesNotMatchError() {
-    return failure("Cannot checkin item checked out to different user",
-      USER_BARCODE, getUserBarcode());
-  }
-
-  @Override
-  public boolean userMatches(User user) {
-    return StringUtils.equals(user.getBarcode(), getUserBarcode());
   }
 
   public DateTime getCheckInDate() {

--- a/src/main/java/org/folio/circulation/domain/validation/CommonFailures.java
+++ b/src/main/java/org/folio/circulation/domain/validation/CommonFailures.java
@@ -1,5 +1,7 @@
 package org.folio.circulation.domain.validation;
 
+import static org.folio.circulation.support.ValidationErrorFailure.failure;
+
 import java.util.function.Supplier;
 
 import org.folio.circulation.support.HttpFailure;
@@ -11,5 +13,11 @@ public class CommonFailures {
   public static Supplier<HttpFailure> moreThanOneOpenLoanFailure(String itemBarcode) {
     return () -> new ServerErrorFailure(
       String.format("More than one open loan for item %s", itemBarcode));
+  }
+
+  public static Supplier<HttpFailure> noItemFoundFailure(String itemBarcode) {
+    return () -> failure(
+      String.format("No item with barcode %s exists", itemBarcode),
+      "itemBarcode", itemBarcode);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/validation/CommonFailures.java
+++ b/src/main/java/org/folio/circulation/domain/validation/CommonFailures.java
@@ -15,9 +15,15 @@ public class CommonFailures {
       String.format("More than one open loan for item %s", itemBarcode));
   }
 
-  public static Supplier<HttpFailure> noItemFoundFailure(String itemBarcode) {
+  public static Supplier<HttpFailure> noItemFoundForBarcodeFailure(String itemBarcode) {
     return () -> failure(
       String.format("No item with barcode %s exists", itemBarcode),
       "itemBarcode", itemBarcode);
+  }
+
+  public static Supplier<HttpFailure> noItemFoundForIdFailure(String itemId) {
+    return () -> failure(
+      String.format("No item with ID %s exists", itemId),
+      "itemId", itemId);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/validation/CommonFailures.java
+++ b/src/main/java/org/folio/circulation/domain/validation/CommonFailures.java
@@ -1,0 +1,15 @@
+package org.folio.circulation.domain.validation;
+
+import java.util.function.Supplier;
+
+import org.folio.circulation.support.HttpFailure;
+import org.folio.circulation.support.ServerErrorFailure;
+
+public class CommonFailures {
+  private CommonFailures() { }
+
+  public static Supplier<HttpFailure> moreThanOneOpenLoanFailure(String itemBarcode) {
+    return () -> new ServerErrorFailure(
+      String.format("More than one open loan for item %s", itemBarcode));
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/validation/MoreThanOneLoanValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/MoreThanOneLoanValidator.java
@@ -2,7 +2,6 @@ package org.folio.circulation.domain.validation;
 
 import static org.folio.circulation.support.HttpResult.of;
 
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -26,11 +25,6 @@ public class MoreThanOneLoanValidator {
   }
 
   private static Function<MultipleRecords<Loan>, HttpResult<Boolean>> moreThanOneLoan() {
-    return loans -> {
-      final Optional<Loan> first = loans.getRecords().stream()
-        .findFirst();
-
-      return of(() -> loans.getTotalRecords() != 1 || !first.isPresent());
-    };
+    return loans -> of(() -> loans.getTotalRecords() > 1);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/validation/MoreThanOneLoanValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/MoreThanOneLoanValidator.java
@@ -11,21 +11,21 @@ import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.HttpResult;
 
-public class MoreThanOneOpenLoanValidator {
+public class MoreThanOneLoanValidator {
   private final Supplier<HttpFailure> failureSupplier;
 
-  public MoreThanOneOpenLoanValidator(Supplier<HttpFailure> failureSupplier) {
+  public MoreThanOneLoanValidator(Supplier<HttpFailure> failureSupplier) {
     this.failureSupplier = failureSupplier;
   }
 
-  public HttpResult<MultipleRecords<Loan>> failWhenMoreThanOneOpenLoan(
+  public HttpResult<MultipleRecords<Loan>> failWhenMoreThanOneLoan(
     HttpResult<MultipleRecords<Loan>> result) {
 
-    return result.failWhen(moreThanOneOpenLoan(),
+    return result.failWhen(moreThanOneLoan(),
       loans -> failureSupplier.get());
   }
 
-  private static Function<MultipleRecords<Loan>, HttpResult<Boolean>> moreThanOneOpenLoan() {
+  private static Function<MultipleRecords<Loan>, HttpResult<Boolean>> moreThanOneLoan() {
     return loans -> {
       final Optional<Loan> first = loans.getRecords().stream()
         .findFirst();

--- a/src/main/java/org/folio/circulation/domain/validation/MoreThanOneOpenLoanValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/MoreThanOneOpenLoanValidator.java
@@ -1,0 +1,32 @@
+package org.folio.circulation.domain.validation;
+
+import static org.folio.circulation.support.HttpResult.of;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.folio.circulation.domain.FindByBarcodeQuery;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.MultipleRecords;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ServerErrorFailure;
+
+public class MoreThanOneOpenLoanValidator {
+  public HttpResult<MultipleRecords<Loan>> failWhenMoreThanOneOpenLoan(
+    HttpResult<MultipleRecords<Loan>> result,
+    FindByBarcodeQuery query) {
+
+    return result.failWhen(moreThanOneOpenLoan(),
+      loans -> new ServerErrorFailure(
+        String.format("More than one open loan for item %s", query.getItemBarcode())));
+  }
+
+  private static Function<MultipleRecords<Loan>, HttpResult<Boolean>> moreThanOneOpenLoan() {
+    return loans -> {
+      final Optional<Loan> first = loans.getRecords().stream()
+        .findFirst();
+
+      return of(() -> loans.getTotalRecords() != 1 || !first.isPresent());
+    };
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/validation/MoreThanOneOpenLoanValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/MoreThanOneOpenLoanValidator.java
@@ -4,21 +4,25 @@ import static org.folio.circulation.support.HttpResult.of;
 
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
-import org.folio.circulation.domain.FindByBarcodeQuery;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.MultipleRecords;
+import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ServerErrorFailure;
 
 public class MoreThanOneOpenLoanValidator {
+  private final Supplier<HttpFailure> failureSupplier;
+
+  public MoreThanOneOpenLoanValidator(Supplier<HttpFailure> failureSupplier) {
+    this.failureSupplier = failureSupplier;
+  }
+
   public HttpResult<MultipleRecords<Loan>> failWhenMoreThanOneOpenLoan(
-    HttpResult<MultipleRecords<Loan>> result,
-    FindByBarcodeQuery query) {
+    HttpResult<MultipleRecords<Loan>> result) {
 
     return result.failWhen(moreThanOneOpenLoan(),
-      loans -> new ServerErrorFailure(
-        String.format("More than one open loan for item %s", query.getItemBarcode())));
+      loans -> failureSupplier.get());
   }
 
   private static Function<MultipleRecords<Loan>, HttpResult<Boolean>> moreThanOneOpenLoan() {

--- a/src/main/java/org/folio/circulation/domain/validation/NoLoanValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/NoLoanValidator.java
@@ -1,0 +1,25 @@
+package org.folio.circulation.domain.validation;
+
+import static org.folio.circulation.support.HttpResult.of;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.support.HttpFailure;
+import org.folio.circulation.support.HttpResult;
+
+public class NoLoanValidator {
+  private final Supplier<HttpFailure> failureSupplier;
+
+  public NoLoanValidator(Supplier<HttpFailure> failureSupplier) {
+    this.failureSupplier = failureSupplier;
+  }
+
+  public HttpResult<Optional<Loan>> failWhenNoLoan(
+    HttpResult<Optional<Loan>> result) {
+
+    return result.failWhen(loan -> of(() -> !loan.isPresent()),
+      loans -> failureSupplier.get());
+  }
+}

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -1,21 +1,34 @@
 package org.folio.circulation.resources;
 
-import java.util.function.BiFunction;
+import static org.folio.circulation.support.HttpResult.of;
 
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.folio.circulation.domain.FindByBarcodeQuery;
+import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.domain.LoanCheckInService;
 import org.folio.circulation.domain.LoanRepository;
 import org.folio.circulation.domain.LoanRepresentation;
+import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.RequestQueue;
 import org.folio.circulation.domain.RequestQueueRepository;
 import org.folio.circulation.domain.UpdateItem;
 import org.folio.circulation.domain.UpdateRequestQueue;
+import org.folio.circulation.domain.UserRepository;
 import org.folio.circulation.domain.representations.CheckInByBarcodeRequest;
 import org.folio.circulation.domain.representations.CheckInByBarcodeResponse;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ItemRepository;
 import org.folio.circulation.support.RouteRegistration;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.server.WebContext;
 
 import io.vertx.core.http.HttpClient;
@@ -36,12 +49,13 @@ public class CheckInByBarcodeResource extends Resource {
   }
 
   private void checkin(RoutingContext routingContext) {
-
     final WebContext context = new WebContext(routingContext);
 
     final Clients clients = Clients.create(context, client);
 
     final LoanRepository loanRepository = new LoanRepository(clients);
+    final ItemRepository itemRepository = new ItemRepository(clients, true, true);
+    final UserRepository userRepository = new UserRepository(clients);
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
 
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
@@ -56,7 +70,8 @@ public class CheckInByBarcodeResource extends Resource {
       = CheckInByBarcodeRequest.from(routingContext.getBodyAsJson());
 
     checkInRequestResult
-      .after(loanRepository::findOpenLoanByBarcode)
+      .after(checkInRequest -> findOpenLoanByBarcode(checkInRequest,
+        itemRepository, loanRepository, userRepository))
       .thenApply(loanResult -> loanResult.combineToResult(checkInRequestResult,
         loanCheckInService::checkIn))
       .thenComposeAsync(loanResult -> loanResult.combineAfter(
@@ -75,5 +90,63 @@ public class CheckInByBarcodeResource extends Resource {
 
   private BiFunction<Loan, RequestQueue, LoanAndRelatedRecords> mapToRelatedRecords() {
     return (loan, requestQueue) -> new LoanAndRelatedRecords(loan).withRequestQueue(requestQueue);
+  }
+
+  private CompletableFuture<HttpResult<Loan>> findOpenLoanByBarcode(
+    FindByBarcodeQuery query,
+    ItemRepository itemRepository,
+    LoanRepository loanRepository,
+    UserRepository userRepository) {
+
+    return itemRepository.fetchByBarcode(query.getItemBarcode())
+      .thenComposeAsync(getOnlyLoan(query, loanRepository))
+      .thenComposeAsync(loanResult -> this.fetchUser(loanResult, userRepository));
+  }
+
+  private Function<HttpResult<Item>, CompletionStage<HttpResult<Loan>>> getOnlyLoan(
+    FindByBarcodeQuery query,
+    LoanRepository loanRepository) {
+
+    return itemResult -> failWhenNoItemFoundForBarcode(itemResult, query)
+      .after(loanRepository::findOpenLoans)
+      .thenApply(result -> failWhenMoreThanOneOpenLoan(result, query))
+      .thenApply(loanResult -> loanResult.map(this::getFirstLoan))
+      .thenApply(loanResult -> loanResult.combine(itemResult, Loan::withItem));
+  }
+
+  private HttpResult<Item> failWhenNoItemFoundForBarcode(
+    HttpResult<Item> itemResult,
+    FindByBarcodeQuery query) {
+
+    return itemResult.failWhen(item -> of(item::isNotFound),
+      item -> ValidationErrorFailure.failure(
+        String.format("No item with barcode %s exists", query.getItemBarcode()),
+        "itemBarcode", query.getItemBarcode()) );
+  }
+
+  private HttpResult<MultipleRecords<Loan>> failWhenMoreThanOneOpenLoan(
+    HttpResult<MultipleRecords<Loan>> result,
+    FindByBarcodeQuery query) {
+
+    return result.failWhen(loans -> {
+      final Optional<Loan> first = loans.getRecords().stream()
+        .findFirst();
+
+      return of(() -> loans.getTotalRecords() != 1 || !first.isPresent());
+    }, loans -> new ServerErrorFailure(
+      String.format("More than one open loan for item %s", query.getItemBarcode())));
+  }
+
+  private CompletableFuture<HttpResult<Loan>> fetchUser(
+    HttpResult<Loan> result,
+    UserRepository userRepository) {
+
+    return result.combineAfter(userRepository::getUser, Loan::withUser);
+  }
+
+  private Loan getFirstLoan(MultipleRecords<Loan> loans) {
+    return loans.getRecords().stream()
+      .findFirst()
+      .orElse(null);
   }
 }

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.resources;
 
 import static org.folio.circulation.domain.validation.CommonFailures.moreThanOneOpenLoanFailure;
-import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundFailure;
+import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundForBarcodeFailure;
 
 import java.util.function.BiFunction;
 
@@ -66,7 +66,7 @@ public class CheckInByBarcodeResource extends Resource {
       .orElse("unknown barcode");
 
     final ItemByBarcodeInStorageFinder itemFinder = new ItemByBarcodeInStorageFinder(
-      itemRepository, noItemFoundFailure(itemBarcode));
+      itemRepository, noItemFoundForBarcodeFailure(itemBarcode));
 
     final SingleOpenLoanForItemInStorageFinder singleOpenLoanFinder
       = new SingleOpenLoanForItemInStorageFinder(loanRepository, userRepository,

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -22,7 +22,7 @@ import org.folio.circulation.domain.UpdateRequestQueue;
 import org.folio.circulation.domain.UserRepository;
 import org.folio.circulation.domain.representations.CheckInByBarcodeRequest;
 import org.folio.circulation.domain.representations.CheckInByBarcodeResponse;
-import org.folio.circulation.domain.validation.MoreThanOneOpenLoanValidator;
+import org.folio.circulation.domain.validation.MoreThanOneLoanValidator;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ItemRepository;
@@ -107,13 +107,13 @@ public class CheckInByBarcodeResource extends Resource {
     FindByBarcodeQuery query,
     LoanRepository loanRepository) {
 
-    final MoreThanOneOpenLoanValidator moreThanOneOpenLoanValidator
-      = new MoreThanOneOpenLoanValidator(() -> new ServerErrorFailure(
+    final MoreThanOneLoanValidator moreThanOneLoanValidator
+      = new MoreThanOneLoanValidator(() -> new ServerErrorFailure(
       String.format("More than one open loan for item %s", query.getItemBarcode())));
 
     return itemResult -> failWhenNoItemFoundForBarcode(itemResult, query)
       .after(loanRepository::findOpenLoans)
-      .thenApply(moreThanOneOpenLoanValidator::failWhenMoreThanOneOpenLoan)
+      .thenApply(moreThanOneLoanValidator::failWhenMoreThanOneLoan)
       .thenApply(loanResult -> loanResult.map(this::getFirstLoan))
       .thenApply(loanResult -> loanResult.combine(itemResult, Loan::withItem));
   }

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.resources;
 
+import static org.folio.circulation.domain.validation.CommonFailures.moreThanOneOpenLoanFailure;
 import static org.folio.circulation.support.HttpResult.of;
 
 import java.util.Optional;
@@ -31,7 +32,6 @@ import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ItemRepository;
 import org.folio.circulation.support.RouteRegistration;
-import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.server.WebContext;
 
@@ -112,8 +112,8 @@ public class CheckInByBarcodeResource extends Resource {
     LoanRepository loanRepository) {
 
     //Use same error for no loans and more than one loan to maintain compatibility
-    final Supplier<HttpFailure> incorrectLoansFailure = () -> new ServerErrorFailure(
-      String.format("More than one open loan for item %s", query.getItemBarcode()));
+    final Supplier<HttpFailure> incorrectLoansFailure
+      = moreThanOneOpenLoanFailure(query.getItemBarcode());
 
     final MoreThanOneLoanValidator moreThanOneLoanValidator
       = new MoreThanOneLoanValidator(incorrectLoansFailure);

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.resources;
 
 import static org.folio.circulation.domain.validation.CommonFailures.moreThanOneOpenLoanFailure;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
+import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundFailure;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -25,6 +25,7 @@ import org.folio.circulation.domain.UpdateRequestQueue;
 import org.folio.circulation.domain.UserRepository;
 import org.folio.circulation.domain.representations.CheckInByBarcodeRequest;
 import org.folio.circulation.domain.representations.CheckInByBarcodeResponse;
+import org.folio.circulation.domain.validation.CommonFailures;
 import org.folio.circulation.domain.validation.MoreThanOneLoanValidator;
 import org.folio.circulation.domain.validation.NoLoanValidator;
 import org.folio.circulation.storage.ItemByBarcodeInStorageFinder;
@@ -103,9 +104,7 @@ public class CheckInByBarcodeResource extends Resource {
     UserRepository userRepository) {
 
     final ItemByBarcodeInStorageFinder itemFinder = new ItemByBarcodeInStorageFinder(
-      itemRepository, () -> failure(
-      String.format("No item with barcode %s exists", query.getItemBarcode()),
-      "itemBarcode", query.getItemBarcode()));
+      itemRepository, noItemFoundFailure(query.getItemBarcode()));
 
     return itemFinder.findItemByBarcode(query.getItemBarcode())
       .thenComposeAsync(getOnlyLoan(loanRepository, userRepository,

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -128,13 +128,18 @@ public class CheckInByBarcodeResource extends Resource {
     HttpResult<MultipleRecords<Loan>> result,
     FindByBarcodeQuery query) {
 
-    return result.failWhen(loans -> {
+    return result.failWhen(moreThanOneOpenLoan(),
+      loans -> new ServerErrorFailure(
+        String.format("More than one open loan for item %s", query.getItemBarcode())));
+  }
+
+  private Function<MultipleRecords<Loan>, HttpResult<Boolean>> moreThanOneOpenLoan() {
+    return loans -> {
       final Optional<Loan> first = loans.getRecords().stream()
         .findFirst();
 
       return of(() -> loans.getTotalRecords() != 1 || !first.isPresent());
-    }, loans -> new ServerErrorFailure(
-      String.format("More than one open loan for item %s", query.getItemBarcode())));
+    };
   }
 
   private CompletableFuture<HttpResult<Loan>> fetchUser(

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -4,7 +4,7 @@ import java.util.function.BiFunction;
 
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
-import org.folio.circulation.domain.LoanCheckinService;
+import org.folio.circulation.domain.LoanCheckInService;
 import org.folio.circulation.domain.LoanRepository;
 import org.folio.circulation.domain.LoanRepresentation;
 import org.folio.circulation.domain.RequestQueue;
@@ -45,7 +45,7 @@ public class CheckInByBarcodeResource extends Resource {
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
 
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
-    final LoanCheckinService loanCheckinService = new LoanCheckinService();
+    final LoanCheckInService loanCheckInService = new LoanCheckInService();
 
     final UpdateItem updateItem = new UpdateItem(clients);
     final UpdateRequestQueue requestQueueUpdate = UpdateRequestQueue.using(clients);
@@ -58,7 +58,7 @@ public class CheckInByBarcodeResource extends Resource {
     checkInRequestResult
       .after(loanRepository::findOpenLoanByBarcode)
       .thenApply(loanResult -> loanResult.combineToResult(checkInRequestResult,
-        loanCheckinService::checkin))
+        loanCheckInService::checkIn))
       .thenComposeAsync(loanResult -> loanResult.combineAfter(
         loan -> requestQueueRepository.get(loan.getItemId()), mapToRelatedRecords()))
       .thenComposeAsync(result -> result.after(requestQueueUpdate::onCheckIn))

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -102,11 +102,12 @@ public class CheckInByBarcodeResource extends Resource {
     LoanRepository loanRepository,
     UserRepository userRepository) {
 
-    final ItemByBarcodeInStorageFinder itemFinder = new ItemByBarcodeInStorageFinder();
-
-    return itemFinder.findItemByBarcode(query.getItemBarcode(), () -> failure(
+    final ItemByBarcodeInStorageFinder itemFinder = new ItemByBarcodeInStorageFinder(
+      itemRepository, () -> failure(
       String.format("No item with barcode %s exists", query.getItemBarcode()),
-      "itemBarcode", query.getItemBarcode()), itemRepository)
+      "itemBarcode", query.getItemBarcode()));
+
+    return itemFinder.findItemByBarcode(query.getItemBarcode())
       .thenComposeAsync(getOnlyLoan(loanRepository, userRepository,
         moreThanOneOpenLoanFailure(query.getItemBarcode())));
   }

--- a/src/main/java/org/folio/circulation/resources/RenewByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByBarcodeRequest.java
@@ -3,15 +3,13 @@ package org.folio.circulation.resources;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
 import org.apache.commons.lang3.StringUtils;
-import org.folio.circulation.domain.FindByBarcodeQuery;
 import org.folio.circulation.support.HttpResult;
 
 import io.vertx.core.json.JsonObject;
 
-public class RenewByBarcodeRequest implements FindByBarcodeQuery {
+public class RenewByBarcodeRequest {
   static final String USER_BARCODE = "userBarcode";
   private static final String ITEM_BARCODE = "itemBarcode";
 
@@ -39,14 +37,11 @@ public class RenewByBarcodeRequest implements FindByBarcodeQuery {
     return succeeded(new RenewByBarcodeRequest(itemBarcode, userBarcode));
   }
 
-  @Override
   public String getItemBarcode() {
     return itemBarcode;
   }
 
-  @Override
   public String getUserBarcode() {
     return userBarcode;
   }
-
 }

--- a/src/main/java/org/folio/circulation/resources/RenewByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByBarcodeRequest.java
@@ -1,19 +1,18 @@
 package org.folio.circulation.resources;
 
-import io.vertx.core.json.JsonObject;
-import org.apache.commons.lang3.StringUtils;
-import org.folio.circulation.domain.FindByBarcodeQuery;
-import org.folio.circulation.domain.User;
-import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
-
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
 import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
+import org.apache.commons.lang3.StringUtils;
+import org.folio.circulation.domain.FindByBarcodeQuery;
+import org.folio.circulation.support.HttpResult;
+
+import io.vertx.core.json.JsonObject;
+
 public class RenewByBarcodeRequest implements FindByBarcodeQuery {
-  private static final String USER_BARCODE = "userBarcode";
+  static final String USER_BARCODE = "userBarcode";
   private static final String ITEM_BARCODE = "itemBarcode";
 
   private final String itemBarcode;
@@ -50,14 +49,4 @@ public class RenewByBarcodeRequest implements FindByBarcodeQuery {
     return userBarcode;
   }
 
-  @Override
-  public ValidationErrorFailure userDoesNotMatchError() {
-    return failure("Cannot renew item checked out to different user",
-      USER_BARCODE, getUserBarcode());
-  }
-
-  @Override
-  public boolean userMatches(User user) {
-    return StringUtils.equals(user.getBarcode(), getUserBarcode());
-  }
 }

--- a/src/main/java/org/folio/circulation/resources/RenewByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByBarcodeResource.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.resources;
 
 import static org.folio.circulation.domain.validation.CommonFailures.moreThanOneOpenLoanFailure;
-import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundFailure;
+import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundForBarcodeFailure;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.failure;
@@ -41,7 +41,7 @@ public class RenewByBarcodeResource extends RenewalResource {
       .orElse("unknown barcode");
 
     final ItemByBarcodeInStorageFinder itemFinder = new ItemByBarcodeInStorageFinder(
-      itemRepository, noItemFoundFailure(itemBarcode));
+      itemRepository, noItemFoundForBarcodeFailure(itemBarcode));
 
     final SingleOpenLoanForItemInStorageFinder singleOpenLoanFinder
       = new SingleOpenLoanForItemInStorageFinder(loanRepository, userRepository,

--- a/src/main/java/org/folio/circulation/resources/RenewByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByBarcodeResource.java
@@ -1,5 +1,7 @@
 package org.folio.circulation.resources;
 
+import static org.folio.circulation.domain.validation.CommonFailures.moreThanOneOpenLoanFailure;
+import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundFailure;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.failure;
@@ -10,6 +12,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanRepository;
 import org.folio.circulation.domain.UserRepository;
+import org.folio.circulation.domain.validation.UserNotFoundValidator;
+import org.folio.circulation.storage.ItemByBarcodeInStorageFinder;
+import org.folio.circulation.storage.SingleOpenLoanForItemInStorageFinder;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ItemRepository;
 
@@ -31,8 +36,26 @@ public class RenewByBarcodeResource extends RenewalResource {
     final HttpResult<RenewByBarcodeRequest> requestResult
       = RenewByBarcodeRequest.from(request);
 
+    final String itemBarcode = requestResult
+      .map(RenewByBarcodeRequest::getItemBarcode)
+      .orElse("unknown barcode");
+
+    final ItemByBarcodeInStorageFinder itemFinder = new ItemByBarcodeInStorageFinder(
+      itemRepository, noItemFoundFailure(itemBarcode));
+
+    final SingleOpenLoanForItemInStorageFinder singleOpenLoanFinder
+      = new SingleOpenLoanForItemInStorageFinder(loanRepository, userRepository,
+      moreThanOneOpenLoanFailure(itemBarcode));
+
+    //TODO: Possibly move this to single open loan finder?
+    final UserNotFoundValidator userNotFoundValidator = new UserNotFoundValidator(
+      userId -> failure("user is not found", "userId", userId));
+
     return requestResult
-      .after(query -> loanRepository.findOpenLoanByBarcode(query.getItemBarcode()))
+      .after(checkInRequest -> itemFinder.findItemByBarcode(itemBarcode))
+      .thenComposeAsync(itemResult ->
+        itemResult.after(singleOpenLoanFinder::findSingleOpenLoan))
+      .thenApply(userNotFoundValidator::refuseWhenUserNotFound)
       .thenApply(loanResult -> loanResult.combineToResult(requestResult,
         this::refuseWhenUserDoesNotMatch));
   }

--- a/src/main/java/org/folio/circulation/resources/RenewByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByBarcodeResource.java
@@ -9,7 +9,9 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanRepository;
+import org.folio.circulation.domain.UserRepository;
 import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ItemRepository;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonObject;
@@ -22,7 +24,9 @@ public class RenewByBarcodeResource extends RenewalResource {
   @Override
   protected CompletableFuture<HttpResult<Loan>> findLoan(
     JsonObject request,
-    LoanRepository loanRepository) {
+    LoanRepository loanRepository,
+    ItemRepository itemRepository,
+    UserRepository userRepository) {
 
     final HttpResult<RenewByBarcodeRequest> requestResult
       = RenewByBarcodeRequest.from(request);

--- a/src/main/java/org/folio/circulation/resources/RenewByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByBarcodeResource.java
@@ -28,7 +28,7 @@ public class RenewByBarcodeResource extends RenewalResource {
       = RenewByBarcodeRequest.from(request);
 
     return requestResult
-      .after(loanRepository::findOpenLoanByBarcode)
+      .after(query -> loanRepository.findOpenLoanByBarcode(query.getItemBarcode()))
       .thenApply(loanResult -> loanResult.combineToResult(requestResult,
         this::refuseWhenUserDoesNotMatch));
   }

--- a/src/main/java/org/folio/circulation/resources/RenewByIdRequest.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByIdRequest.java
@@ -3,9 +3,7 @@ package org.folio.circulation.resources;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.FindByIdQuery;
-import org.folio.circulation.domain.User;
 import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
 
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
@@ -13,7 +11,7 @@ import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
 import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
 public class RenewByIdRequest implements FindByIdQuery {
-  private static final String USER_ID = "userId";
+  static final String USER_ID = "userId";
   private static final String ITEM_ID = "itemId";
 
   private final String itemId;
@@ -50,14 +48,4 @@ public class RenewByIdRequest implements FindByIdQuery {
     return userId;
   }
 
-  @Override
-  public ValidationErrorFailure userDoesNotMatchError() {
-    return failure("Cannot renew item checked out to different user",
-      USER_ID, getUserId());
-  }
-
-  @Override
-  public boolean userMatches(User user) {
-    return StringUtils.equals(user.getId(), getUserId());
-  }
 }

--- a/src/main/java/org/folio/circulation/resources/RenewByIdRequest.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByIdRequest.java
@@ -1,16 +1,15 @@
 package org.folio.circulation.resources;
 
-import io.vertx.core.json.JsonObject;
-import org.apache.commons.lang3.StringUtils;
-import org.folio.circulation.domain.FindByIdQuery;
-import org.folio.circulation.support.HttpResult;
-
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
-public class RenewByIdRequest implements FindByIdQuery {
+import org.apache.commons.lang3.StringUtils;
+import org.folio.circulation.support.HttpResult;
+
+import io.vertx.core.json.JsonObject;
+
+public class RenewByIdRequest {
   static final String USER_ID = "userId";
   private static final String ITEM_ID = "itemId";
 
@@ -38,12 +37,10 @@ public class RenewByIdRequest implements FindByIdQuery {
     return succeeded(new RenewByIdRequest(itemBarcode, userBarcode));
   }
 
-  @Override
   public String getItemId() {
     return itemId;
   }
 
-  @Override
   public String getUserId() {
     return userId;
   }

--- a/src/main/java/org/folio/circulation/resources/RenewByIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByIdResource.java
@@ -1,5 +1,7 @@
 package org.folio.circulation.resources;
 
+import static org.folio.circulation.domain.validation.CommonFailures.moreThanOneOpenLoanFailure;
+import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundForIdFailure;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.failure;
@@ -10,6 +12,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanRepository;
 import org.folio.circulation.domain.UserRepository;
+import org.folio.circulation.domain.validation.UserNotFoundValidator;
+import org.folio.circulation.storage.ItemByIdInStorageFinder;
+import org.folio.circulation.storage.SingleOpenLoanForItemInStorageFinder;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ItemRepository;
 
@@ -31,8 +36,25 @@ public class RenewByIdResource extends RenewalResource {
     final HttpResult<RenewByIdRequest> requestResult
       = RenewByIdRequest.from(request);
 
+    final String itemId = requestResult
+      .map(RenewByIdRequest::getItemId)
+      .orElse("unknown item ID");
+
+    final UserNotFoundValidator userNotFoundValidator = new UserNotFoundValidator(
+      userId -> failure("user is not found", "userId", userId));
+
+    final SingleOpenLoanForItemInStorageFinder singleOpenLoanFinder
+      = new SingleOpenLoanForItemInStorageFinder(loanRepository, userRepository,
+        moreThanOneOpenLoanFailure(itemId));
+
+    final ItemByIdInStorageFinder itemFinder = new ItemByIdInStorageFinder(
+      itemRepository, noItemFoundForIdFailure(itemId));
+
     return requestResult
-      .after(query -> loanRepository.findOpenLoanById(query.getItemId()))
+      .after(checkInRequest -> itemFinder.findItemById(itemId))
+      .thenComposeAsync(itemResult ->
+        itemResult.after(singleOpenLoanFinder::findSingleOpenLoan))
+      .thenApply(userNotFoundValidator::refuseWhenUserNotFound)
       .thenApply(loanResult -> loanResult.combineToResult(requestResult,
         this::refuseWhenUserDoesNotMatch));
   }

--- a/src/main/java/org/folio/circulation/resources/RenewByIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByIdResource.java
@@ -28,7 +28,7 @@ public class RenewByIdResource extends RenewalResource {
       = RenewByIdRequest.from(request);
 
     return requestResult
-      .after(loanRepository::findOpenLoanById)
+      .after(query -> loanRepository.findOpenLoanById(query.getItemId()))
       .thenApply(loanResult -> loanResult.combineToResult(requestResult,
         this::refuseWhenUserDoesNotMatch));
   }

--- a/src/main/java/org/folio/circulation/resources/RenewByIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByIdResource.java
@@ -9,7 +9,9 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanRepository;
+import org.folio.circulation.domain.UserRepository;
 import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ItemRepository;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonObject;
@@ -22,7 +24,9 @@ public class RenewByIdResource extends RenewalResource {
   @Override
   protected CompletableFuture<HttpResult<Loan>> findLoan(
     JsonObject request,
-    LoanRepository loanRepository) {
+    LoanRepository loanRepository,
+    ItemRepository itemRepository,
+    UserRepository userRepository) {
 
     final HttpResult<RenewByIdRequest> requestResult
       = RenewByIdRequest.from(request);

--- a/src/main/java/org/folio/circulation/resources/RenewByIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByIdResource.java
@@ -1,12 +1,18 @@
 package org.folio.circulation.resources;
 
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.JsonObject;
+import static org.folio.circulation.support.HttpResult.failed;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.ValidationErrorFailure.failure;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanRepository;
 import org.folio.circulation.support.HttpResult;
 
-import java.util.concurrent.CompletableFuture;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonObject;
 
 public class RenewByIdResource extends RenewalResource {
   public RenewByIdResource(HttpClient client) {
@@ -18,7 +24,29 @@ public class RenewByIdResource extends RenewalResource {
     JsonObject request,
     LoanRepository loanRepository) {
 
-    return RenewByIdRequest.from(request)
-      .after(loanRepository::findOpenLoanById);
+    final HttpResult<RenewByIdRequest> requestResult
+      = RenewByIdRequest.from(request);
+
+    return requestResult
+      .after(loanRepository::findOpenLoanById)
+      .thenApply(loanResult -> loanResult.combineToResult(requestResult,
+        this::refuseWhenUserDoesNotMatch));
+  }
+
+  private HttpResult<Loan> refuseWhenUserDoesNotMatch(
+    Loan loan,
+    RenewByIdRequest idRequest) {
+
+    if(userMatches(loan, idRequest.getUserId())) {
+      return succeeded(loan);
+    }
+    else {
+      return failed(failure("Cannot renew item checked out to different user",
+        RenewByIdRequest.USER_ID, idRequest.getUserId()));
+    }
+  }
+
+  private boolean userMatches(Loan loan, String expectedUserId) {
+    return StringUtils.equals(loan.getUser().getId(), expectedUserId);
   }
 }

--- a/src/main/java/org/folio/circulation/resources/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewalResource.java
@@ -1,20 +1,23 @@
 package org.folio.circulation.resources;
 
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.Router;
-import io.vertx.ext.web.RoutingContext;
+import java.util.concurrent.CompletableFuture;
+
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanRenewalService;
 import org.folio.circulation.domain.LoanRepository;
 import org.folio.circulation.domain.LoanRepresentation;
+import org.folio.circulation.domain.UserRepository;
 import org.folio.circulation.domain.representations.LoanResponse;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ItemRepository;
 import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.server.WebContext;
 
-import java.util.concurrent.CompletableFuture;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
 
 public abstract class RenewalResource extends Resource {
   private final String rootPath;
@@ -35,13 +38,17 @@ public abstract class RenewalResource extends Resource {
   private void renew(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
     final Clients clients = Clients.create(context, client);
+
     final LoanRepository loanRepository = new LoanRepository(clients);
+    final ItemRepository itemRepository = new ItemRepository(clients, true, true);
+    final UserRepository userRepository = new UserRepository(clients);
+
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
     final LoanRenewalService loanRenewalService = LoanRenewalService.using(clients);
 
     //TODO: Validation check for same user should be in the domain service
 
-    findLoan(routingContext.getBodyAsJson(), loanRepository)
+    findLoan(routingContext.getBodyAsJson(), loanRepository, itemRepository, userRepository)
       .thenComposeAsync(r -> r.after(loanRenewalService::renew))
       .thenComposeAsync(r -> r.after(loanRepository::updateLoan))
       .thenApply(r -> r.map(loanRepresentation::extendedLoan))
@@ -51,5 +58,7 @@ public abstract class RenewalResource extends Resource {
 
   protected abstract CompletableFuture<HttpResult<Loan>> findLoan(
     JsonObject request,
-    LoanRepository loanRepository);
+    LoanRepository loanRepository,
+    ItemRepository itemRepository,
+    UserRepository userRepository);
 }

--- a/src/main/java/org/folio/circulation/storage/ItemByBarcodeInStorageFinder.java
+++ b/src/main/java/org/folio/circulation/storage/ItemByBarcodeInStorageFinder.java
@@ -1,0 +1,31 @@
+package org.folio.circulation.storage;
+
+import static org.folio.circulation.support.HttpResult.of;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import org.folio.circulation.domain.Item;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ItemRepository;
+import org.folio.circulation.support.ValidationErrorFailure;
+
+public class ItemByBarcodeInStorageFinder {
+  public CompletableFuture<HttpResult<Item>> findItemByBarcode(
+    String itemBarcode,
+    Supplier<ValidationErrorFailure> itemNotFoundFailureSupplier,
+    ItemRepository itemRepository) {
+
+    return itemRepository.fetchByBarcode(itemBarcode)
+      .thenApply(itemResult -> failWhenNoItemFoundForBarcode(itemResult,
+        itemNotFoundFailureSupplier));
+  }
+
+  private static HttpResult<Item> failWhenNoItemFoundForBarcode(
+    HttpResult<Item> itemResult,
+    Supplier<ValidationErrorFailure> itemNotFoundFailureSupplier) {
+
+    return itemResult.failWhen(item -> of(item::isNotFound),
+      item -> itemNotFoundFailureSupplier.get());
+  }
+}

--- a/src/main/java/org/folio/circulation/storage/ItemByBarcodeInStorageFinder.java
+++ b/src/main/java/org/folio/circulation/storage/ItemByBarcodeInStorageFinder.java
@@ -6,16 +6,23 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 import org.folio.circulation.domain.Item;
+import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ItemRepository;
-import org.folio.circulation.support.ValidationErrorFailure;
 
 public class ItemByBarcodeInStorageFinder {
-  public CompletableFuture<HttpResult<Item>> findItemByBarcode(
-    String itemBarcode,
-    Supplier<ValidationErrorFailure> itemNotFoundFailureSupplier,
-    ItemRepository itemRepository) {
+  private final ItemRepository itemRepository;
+  private final Supplier<HttpFailure> itemNotFoundFailureSupplier;
 
+  public ItemByBarcodeInStorageFinder(
+    ItemRepository itemRepository,
+    Supplier<HttpFailure> itemNotFoundFailureSupplier) {
+
+    this.itemRepository = itemRepository;
+    this.itemNotFoundFailureSupplier = itemNotFoundFailureSupplier;
+  }
+
+  public CompletableFuture<HttpResult<Item>> findItemByBarcode(String itemBarcode) {
     return itemRepository.fetchByBarcode(itemBarcode)
       .thenApply(itemResult -> failWhenNoItemFoundForBarcode(itemResult,
         itemNotFoundFailureSupplier));
@@ -23,7 +30,7 @@ public class ItemByBarcodeInStorageFinder {
 
   private static HttpResult<Item> failWhenNoItemFoundForBarcode(
     HttpResult<Item> itemResult,
-    Supplier<ValidationErrorFailure> itemNotFoundFailureSupplier) {
+    Supplier<HttpFailure> itemNotFoundFailureSupplier) {
 
     return itemResult.failWhen(item -> of(item::isNotFound),
       item -> itemNotFoundFailureSupplier.get());

--- a/src/main/java/org/folio/circulation/storage/ItemByIdInStorageFinder.java
+++ b/src/main/java/org/folio/circulation/storage/ItemByIdInStorageFinder.java
@@ -1,0 +1,38 @@
+package org.folio.circulation.storage;
+
+import static org.folio.circulation.support.HttpResult.of;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import org.folio.circulation.domain.Item;
+import org.folio.circulation.support.HttpFailure;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ItemRepository;
+
+public class ItemByIdInStorageFinder {
+  private final ItemRepository itemRepository;
+  private final Supplier<HttpFailure> itemNotFoundFailureSupplier;
+
+  public ItemByIdInStorageFinder(
+    ItemRepository itemRepository,
+    Supplier<HttpFailure> itemNotFoundFailureSupplier) {
+
+    this.itemRepository = itemRepository;
+    this.itemNotFoundFailureSupplier = itemNotFoundFailureSupplier;
+  }
+
+  public CompletableFuture<HttpResult<Item>> findItemById(String itemId) {
+    return itemRepository.fetchById(itemId)
+      .thenApply(itemResult -> failWhenNoItemFoundForId(itemResult,
+        itemNotFoundFailureSupplier));
+  }
+
+  private static HttpResult<Item> failWhenNoItemFoundForId(
+    HttpResult<Item> itemResult,
+    Supplier<HttpFailure> itemNotFoundFailureSupplier) {
+
+    return itemResult.failWhen(item -> of(item::isNotFound),
+      item -> itemNotFoundFailureSupplier.get());
+  }
+}

--- a/src/main/java/org/folio/circulation/storage/SingleOpenLoanForItemInStorageFinder.java
+++ b/src/main/java/org/folio/circulation/storage/SingleOpenLoanForItemInStorageFinder.java
@@ -1,0 +1,58 @@
+package org.folio.circulation.storage;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import org.folio.circulation.domain.Item;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.LoanRepository;
+import org.folio.circulation.domain.MultipleRecords;
+import org.folio.circulation.domain.UserRepository;
+import org.folio.circulation.domain.validation.MoreThanOneLoanValidator;
+import org.folio.circulation.domain.validation.NoLoanValidator;
+import org.folio.circulation.support.HttpFailure;
+import org.folio.circulation.support.HttpResult;
+
+public class SingleOpenLoanForItemInStorageFinder {
+  private final LoanRepository loanRepository;
+  private final UserRepository userRepository;
+  private final Supplier<HttpFailure> incorrectNumberOfLoansFailureSupplier;
+
+  public SingleOpenLoanForItemInStorageFinder(
+    LoanRepository loanRepository,
+    UserRepository userRepository,
+    Supplier<HttpFailure> incorrectNumberOfLoansFailureSupplier) {
+
+    this.loanRepository = loanRepository;
+    this.userRepository = userRepository;
+    this.incorrectNumberOfLoansFailureSupplier = incorrectNumberOfLoansFailureSupplier;
+  }
+
+  public CompletableFuture<HttpResult<Loan>> findSingleOpenLoan(Item item) {
+    //Use same error for no loans and more than one loan to maintain compatibility
+    final MoreThanOneLoanValidator moreThanOneLoanValidator
+      = new MoreThanOneLoanValidator(incorrectNumberOfLoansFailureSupplier);
+
+    final NoLoanValidator noLoanValidator
+      = new NoLoanValidator(incorrectNumberOfLoansFailureSupplier);
+
+    return loanRepository.findOpenLoans(item)
+      .thenApply(moreThanOneLoanValidator::failWhenMoreThanOneLoan)
+      .thenApply(loanResult -> loanResult.map(this::getFirstLoan))
+      .thenApply(noLoanValidator::failWhenNoLoan)
+      .thenApply(loanResult -> loanResult.map(loan -> loan.orElse(null)))
+      .thenApply(loanResult -> loanResult.map(loan -> loan.withItem(item)))
+      .thenComposeAsync(this::fetchUser);
+  }
+
+  private CompletableFuture<HttpResult<Loan>> fetchUser(
+    HttpResult<Loan> result) {
+
+    return result.combineAfter(userRepository::getUser, Loan::withUser);
+  }
+
+  private Optional<Loan> getFirstLoan(MultipleRecords<Loan> loans) {
+    return loans.getRecords().stream().findFirst();
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/validation/MoreThanOneLoanValidatorTests.java
+++ b/src/test/java/org/folio/circulation/domain/validation/MoreThanOneLoanValidatorTests.java
@@ -1,0 +1,63 @@
+package org.folio.circulation.domain.validation;
+
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
+import static org.folio.circulation.support.HttpResult.of;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.MultipleRecords;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.junit.Test;
+
+import api.support.builders.LoanBuilder;
+
+public class MoreThanOneLoanValidatorTests {
+  @Test
+  public void allowSingleLoan() {
+    final MoreThanOneLoanValidator validator = new MoreThanOneLoanValidator(
+      () -> new ServerErrorFailure("More than one loan"));
+
+    final ArrayList<Loan> loans = new ArrayList<>();
+    loans.add(Loan.from(new LoanBuilder().create()));
+
+    final HttpResult<MultipleRecords<Loan>> result =
+      validator.failWhenMoreThanOneLoan(
+        of(() -> new MultipleRecords<>(loans, loans.size())));
+
+    assertThat(result.succeeded(), is(true));
+  }
+
+  @Test
+  public void failWhenMoreThanOneLoan() {
+    final MoreThanOneLoanValidator validator = new MoreThanOneLoanValidator(
+      () -> new ServerErrorFailure("More than one loan"));
+
+    final ArrayList<Loan> loans = new ArrayList<>();
+    loans.add(Loan.from(new LoanBuilder().create()));
+    loans.add(Loan.from(new LoanBuilder().create()));
+
+    final HttpResult<MultipleRecords<Loan>> result =
+      validator.failWhenMoreThanOneLoan(
+        of(() -> new MultipleRecords<>(loans, loans.size())));
+
+    assertThat(result, isErrorFailureContaining("More than one loan"));
+  }
+
+  @Test
+  public void failWhenNoLoans() {
+    final MoreThanOneLoanValidator validator = new MoreThanOneLoanValidator(
+      () -> new ServerErrorFailure("More than one loan"));
+
+    final ArrayList<Loan> loans = new ArrayList<>();
+
+    final HttpResult<MultipleRecords<Loan>> result =
+      validator.failWhenMoreThanOneLoan(
+        of(() -> new MultipleRecords<>(loans, loans.size())));
+
+    assertThat(result, isErrorFailureContaining("More than one loan"));
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/validation/MoreThanOneLoanValidatorTests.java
+++ b/src/test/java/org/folio/circulation/domain/validation/MoreThanOneLoanValidatorTests.java
@@ -5,7 +5,8 @@ import static org.folio.circulation.support.HttpResult.of;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.MultipleRecords;
@@ -21,12 +22,11 @@ public class MoreThanOneLoanValidatorTests {
     final MoreThanOneLoanValidator validator = new MoreThanOneLoanValidator(
       () -> new ServerErrorFailure("More than one loan"));
 
-    final ArrayList<Loan> loans = new ArrayList<>();
-    loans.add(Loan.from(new LoanBuilder().create()));
+    final HttpResult<MultipleRecords<Loan>> multipleLoans
+      = multipleLoansResult(generateLoan());
 
     final HttpResult<MultipleRecords<Loan>> result =
-      validator.failWhenMoreThanOneLoan(
-        of(() -> new MultipleRecords<>(loans, loans.size())));
+      validator.failWhenMoreThanOneLoan(multipleLoans);
 
     assertThat(result.succeeded(), is(true));
   }
@@ -36,13 +36,12 @@ public class MoreThanOneLoanValidatorTests {
     final MoreThanOneLoanValidator validator = new MoreThanOneLoanValidator(
       () -> new ServerErrorFailure("More than one loan"));
 
-    final ArrayList<Loan> loans = new ArrayList<>();
-    loans.add(Loan.from(new LoanBuilder().create()));
-    loans.add(Loan.from(new LoanBuilder().create()));
+    final HttpResult<MultipleRecords<Loan>> multipleLoans
+      = multipleLoansResult(generateLoan(), generateLoan());
 
     final HttpResult<MultipleRecords<Loan>> result =
       validator.failWhenMoreThanOneLoan(
-        of(() -> new MultipleRecords<>(loans, loans.size())));
+        multipleLoans);
 
     assertThat(result, isErrorFailureContaining("More than one loan"));
   }
@@ -52,12 +51,22 @@ public class MoreThanOneLoanValidatorTests {
     final MoreThanOneLoanValidator validator = new MoreThanOneLoanValidator(
       () -> new ServerErrorFailure("More than one loan"));
 
-    final ArrayList<Loan> loans = new ArrayList<>();
+    final HttpResult<MultipleRecords<Loan>> noLoans
+      = multipleLoansResult();
 
     final HttpResult<MultipleRecords<Loan>> result =
-      validator.failWhenMoreThanOneLoan(
-        of(() -> new MultipleRecords<>(loans, loans.size())));
+      validator.failWhenMoreThanOneLoan(noLoans);
 
     assertThat(result, isErrorFailureContaining("More than one loan"));
+  }
+
+  private Loan generateLoan() {
+    return Loan.from(new LoanBuilder().create());
+  }
+
+  private HttpResult<MultipleRecords<Loan>> multipleLoansResult(Loan... loans) {
+    final List<Loan> loansList = Arrays.asList(loans);
+
+    return of(() -> new MultipleRecords<>(loansList, loansList.size()));
   }
 }

--- a/src/test/java/org/folio/circulation/domain/validation/MoreThanOneLoanValidatorTests.java
+++ b/src/test/java/org/folio/circulation/domain/validation/MoreThanOneLoanValidatorTests.java
@@ -47,7 +47,7 @@ public class MoreThanOneLoanValidatorTests {
   }
 
   @Test
-  public void failWhenNoLoans() {
+  public void allowWhenNoLoans() {
     final MoreThanOneLoanValidator validator = new MoreThanOneLoanValidator(
       () -> new ServerErrorFailure("More than one loan"));
 
@@ -57,7 +57,7 @@ public class MoreThanOneLoanValidatorTests {
     final HttpResult<MultipleRecords<Loan>> result =
       validator.failWhenMoreThanOneLoan(noLoans);
 
-    assertThat(result, isErrorFailureContaining("More than one loan"));
+    assertThat(result.succeeded(), is(true));
   }
 
   private Loan generateLoan() {

--- a/src/test/java/org/folio/circulation/domain/validation/NoLoanValidatorTests.java
+++ b/src/test/java/org/folio/circulation/domain/validation/NoLoanValidatorTests.java
@@ -1,0 +1,46 @@
+package org.folio.circulation.domain.validation;
+
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
+import static org.folio.circulation.support.HttpResult.of;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Optional;
+
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.junit.Test;
+
+import api.support.builders.LoanBuilder;
+
+public class NoLoanValidatorTests {
+  @Test
+  public void allowSingleLoan() {
+    final NoLoanValidator validator = new NoLoanValidator(
+      () -> new ServerErrorFailure("No loan"));
+
+    final HttpResult<Optional<Loan>> singleLoan
+      = HttpResult.of(() -> Optional.of(generateLoan()));
+
+    final HttpResult<Optional<Loan>> result =
+      validator.failWhenNoLoan(singleLoan);
+
+    assertThat(result.succeeded(), is(true));
+  }
+
+  @Test
+  public void failWhenNoLoans() {
+    final NoLoanValidator validator = new NoLoanValidator(
+      () -> new ServerErrorFailure("No loan"));
+
+    final HttpResult<Optional<Loan>> result =
+      validator.failWhenNoLoan(of(Optional::empty));
+
+    assertThat(result, isErrorFailureContaining("No loan"));
+  }
+
+  private Loan generateLoan() {
+    return Loan.from(new LoanBuilder().create());
+  }
+}


### PR DESCRIPTION
*Purpose*

Preparation for https://issues.folio.org/browse/CIRC-146
As a check in will be allowed for item which do not have an open loan, it is necessary to be able to find the item and the loan separately, so that the send step can find no loan but allow the process to continue.

These changes are the first step in preparing for that change.