### PR TITLE
Include item id for checked in item CIRC-176

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "circulation",
-      "version": "5.2",
+      "version": "5.3",
       "handlers": [
         {
           "methods": [

--- a/ramls/check-in-by-barcode-response.json
+++ b/ramls/check-in-by-barcode-response.json
@@ -11,6 +11,10 @@
       "description": "Additional information about the item",
       "type": "object",
       "properties": {
+        "id": {
+          "description": "ID of the item",
+          "type": "string"
+        },
         "title": {
           "description": "The title of the item lent to the patron",
           "type": "string"

--- a/ramls/circulation.raml
+++ b/ramls/circulation.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Circulation
-version: v5.2
+version: v5.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -29,6 +29,10 @@
       "description": "Additional information about the item",
       "type": "object",
       "properties": {
+        "id": {
+          "description": "ID of the item",
+          "type": "string"
+        },
         "title": {
           "description": "The title of the item lent to the patron",
           "type": "string"

--- a/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
@@ -22,6 +22,7 @@ public class ItemSummaryRepresentation {
 
     JsonObject itemSummary = new JsonObject();
 
+    write(itemSummary, "id", item.getItemId());
     write(itemSummary, "holdingsRecordId", item.getHoldingsRecordId());
     write(itemSummary, "instanceId", item.getInstanceId());
     write(itemSummary, "title", item.getTitle());

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -77,6 +77,9 @@ public class CheckInByBarcodeTests extends APITests {
     assertThat("action is not checkedin",
       loanRepresentation.getString("action"), is("checkedin"));
 
+    assertThat("ID should be included for item",
+      loanRepresentation.getJsonObject("item").getString("id"), is(nod.getId()));
+
     assertThat("title is taken from item",
       loanRepresentation.getJsonObject("item").getString("title"),
       is("Nod"));
@@ -95,6 +98,9 @@ public class CheckInByBarcodeTests extends APITests {
 
     assertThat("title is included for item",
       itemFromResponse.getString("title"), is("Nod"));
+
+    assertThat("ID should be included for item",
+      itemFromResponse.getString("id"), is(nod.getId()));
 
     assertThat("barcode is included for item",
       itemFromResponse.getString("barcode"), is("565578437802"));
@@ -235,6 +241,9 @@ public class CheckInByBarcodeTests extends APITests {
 
     final JsonObject itemFromResponse = checkInResponse.getItem();
 
+    assertThat("ID should be included for item",
+      itemFromResponse.getString("id"), is(nod.getId()));
+
     assertThat("title is included for item",
       itemFromResponse.getString("title"), is("Nod"));
 
@@ -278,6 +287,9 @@ public class CheckInByBarcodeTests extends APITests {
       checkInResponse.getJson().containsKey("item"), is(true));
 
     final JsonObject itemFromResponse = checkInResponse.getItem();
+
+    assertThat("ID should be included for item",
+      itemFromResponse.getString("id"), is(nod.getId()));
 
     assertThat("title is included for item",
       itemFromResponse.getString("title"), is("Nod"));

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -5,6 +5,7 @@ import static api.support.fixtures.UserExamples.basedUponStevenJones;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
 import static api.support.http.InterfaceUrls.loansUrl;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
+import static api.support.matchers.UUIDMatcher.is;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
@@ -92,6 +93,9 @@ public class LoanAPITests extends APITests {
 
     assertThat("last loan policy should be stored",
       loan.getString("loanPolicyId"), is(APITestSuite.canCirculateRollingLoanPolicyId().toString()));
+
+    assertThat("ID is taken from item",
+      loan.getJsonObject("item").getString("id"), is(itemId));
 
     assertThat("title is taken from instance",
       loan.getJsonObject("item").getString("title"),
@@ -756,6 +760,9 @@ public class LoanAPITests extends APITests {
 
     assertThat("last loan policy should be stored",
       loan.getString("loanPolicyId"), is(APITestSuite.canCirculateRollingLoanPolicyId().toString()));
+
+    assertThat("ID is taken from item",
+      loan.getJsonObject("item").getString("id"), is(itemId));
 
     assertThat("title is taken from item",
       loan.getJsonObject("item").getString("title"),
@@ -1556,6 +1563,7 @@ public class LoanAPITests extends APITests {
 
     JsonObject item = loan.getJsonObject("item");
 
+    hasProperty("id", item, "item");
     hasProperty("title", item, "item");
     hasProperty("barcode", item, "item");
     hasProperty("status", item, "item");

--- a/src/test/java/api/loans/scenarios/InTransitToHomeLocationTests.java
+++ b/src/test/java/api/loans/scenarios/InTransitToHomeLocationTests.java
@@ -54,6 +54,9 @@ public class InTransitToHomeLocationTests extends APITests {
     assertThat("item should be present in response",
       itemRepresentation, notNullValue());
 
+    assertThat("ID should be included for item",
+      itemRepresentation.getString("id"), is(nod.getId()));
+
     assertThat("title is included for item",
       itemRepresentation.getString("title"), is("Nod"));
 
@@ -147,6 +150,9 @@ public class InTransitToHomeLocationTests extends APITests {
     assertThat("item should be present in response",
       itemRepresentation, notNullValue());
 
+    assertThat("ID should be included for item",
+      itemRepresentation.getString("id"), is(nod.getId()));
+
     assertThat("title is included for item",
       itemRepresentation.getString("title"), is("Nod"));
 
@@ -225,6 +231,9 @@ public class InTransitToHomeLocationTests extends APITests {
     assertThat("item should be present in response",
       itemRepresentation, notNullValue());
 
+    assertThat("ID should be included for item",
+      itemRepresentation.getString("id"), is(nod.getId()));
+
     assertThat("title is included for item",
       itemRepresentation.getString("title"), is("Nod"));
 
@@ -293,6 +302,9 @@ public class InTransitToHomeLocationTests extends APITests {
 
     assertThat("item should be present in response",
       itemRepresentation, notNullValue());
+
+    assertThat("ID should be included for item",
+      itemRepresentation.getString("id"), is(nod.getId()));
 
     assertThat("title is included for item",
       itemRepresentation.getString("title"), is("Nod"));
@@ -368,6 +380,9 @@ public class InTransitToHomeLocationTests extends APITests {
 
     assertThat("item should be present in response",
       itemRepresentation, notNullValue());
+
+    assertThat("ID should be included for item",
+      itemRepresentation.getString("id"), is(nod.getId()));
 
     assertThat("title is included for item",
       itemRepresentation.getString("title"), is("Nod"));
@@ -450,6 +465,9 @@ public class InTransitToHomeLocationTests extends APITests {
 
     assertThat("item should be present in response",
       itemRepresentation, notNullValue());
+
+    assertThat("ID should be included for item",
+      itemRepresentation.getString("id"), is(nod.getId()));
 
     assertThat("title is included for item",
       itemRepresentation.getString("title"), is("Nod"));
@@ -538,6 +556,9 @@ public class InTransitToHomeLocationTests extends APITests {
 
     assertThat("item should be present in response",
       itemRepresentation, notNullValue());
+
+    assertThat("ID should be included for item",
+      itemRepresentation.getString("id"), is(nod.getId()));
 
     assertThat("title is included for item",
       itemRepresentation.getString("title"), is("Nod"));


### PR DESCRIPTION
*Purpose*
See https://issues.folio.org/browse/CIRC-176

As it is now possible for a check in to be for an item without an associated open loan, the check in API now responds with the item separately (in `circulation 5.2`). However this item representation did not include the `ID` of the item, as previously it was within the loan which had a property for that already.

*Learnings*
* Include the ID of a related record within a summary representation, even though it is mostly redundant. This helps with inspection checks that the correct record has been included and it makes the representation more versatile. With only a very minor increase in redundant information.