### PR TITLE
CIRC-174 Implementing renewal overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules/
 
 #IntelliJ
 .idea/
+*.iml
 #netbeans
 nbproject/
 #eclipse

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "circulation",
-      "version": "5.3",
+      "version": "5.4",
       "handlers": [
         {
           "methods": [
@@ -84,6 +84,42 @@
           "pathPattern": "/circulation/renew-by-barcode",
           "permissionsRequired": [
             "circulation.renew-by-barcode.post"
+          ],
+          "modulePermissions": [
+            "circulation-storage.loans.item.put",
+            "circulation-storage.loans.item.get",
+            "circulation-storage.loans.collection.get",
+            "circulation.loan-rules.apply.get",
+            "circulation-storage.requests.collection.get",
+            "circulation-storage.requests.item.put",
+            "inventory-storage.items.item.put",
+            "inventory-storage.items.item.get",
+            "inventory-storage.items.collection.get",
+            "inventory-storage.locations.item.get",
+            "inventory-storage.locations.collection.get",
+            "inventory-storage.holdings.collection.get",
+            "inventory-storage.holdings.item.get",
+            "inventory-storage.instances.collection.get",
+            "inventory-storage.instances.item.get",
+            "inventory-storage.material-types.item.get",
+            "inventory-storage.material-types.collection.get",
+            "inventory-storage.service-points.collection.get",
+            "inventory-storage.service-points.item.get",
+            "users.item.get",
+            "users.collection.get",
+            "proxiesfor.collection.get",
+            "circulation-storage.loan-policies.item.get",
+            "circulation-storage.fixed-due-date-schedules.item.get",
+            "circulation-storage.fixed-due-date-schedules.collection.get"
+          ]
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/circulation/override-renewal-by-barcode",
+          "permissionsRequired": [
+            "circulation.override-renewal-by-barcode.post"
           ],
           "modulePermissions": [
             "circulation-storage.loans.item.put",
@@ -522,7 +558,7 @@
   "requires": [
     {
       "id": "loan-storage",
-      "version": "5.2"
+      "version": "5.3"
     },
     {
       "id": "loan-rules-storage",
@@ -589,6 +625,11 @@
       "permissionName": "circulation.renew-by-id.post",
       "displayName": "circulation - renew loan using id",
       "description": "renew a loan using IDs for item and loanee"
+    },
+    {
+      "permissionName": "circulation.override-renewal-by-barcode.post",
+      "displayName": "circulation - override renewal by barcode",
+      "description": "override renewal using barcodes for item and loanee"
     },
     {
       "permissionName": "circulation.loans.collection.get",
@@ -684,6 +725,7 @@
         "circulation.check-in-by-barcode.post",
         "circulation.renew-by-barcode.post",
         "circulation.renew-by-id.post",
+        "circulation.override-renewal-by-barcode.post",
         "circulation.loans.collection.get",
         "circulation.loans.item.get",
         "circulation.loans.item.post",

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>14.3.0-SNAPSHOT</version>
+  <version>14.2.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>14.2.0-SNAPSHOT</version>
+  <version>14.3.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/ramls/circulation.raml
+++ b/ramls/circulation.raml
@@ -108,6 +108,34 @@ resourceTypes:
           body:
             text/plain:
               example: "Internal server error"
+  /circulation/override-renewal-by-barcode:
+    displayName: Override renewal of an existing loan using barcode for item and loanee
+      post:
+        description: Updates the due date of an existing loan
+        is: [
+          language,
+          validate
+        ]
+        body:
+          application/json:
+            type: !include override-renewal-by-barcode-request.json
+            example: !include examples/override-renewal-by-barcode-request.json
+        responses:
+          200:
+            body:
+              application/json:
+                type: loan
+                example: !include examples/loan.json
+          201:
+            body:
+              application/json:
+                type: loan
+                example: !include examples/loan.json
+          500:
+            description: "Internal server error"
+            body:
+              text/plain:
+                example: "Internal server error"
   /check-in-by-barcode:
     displayName: Checkin an existing loan using barcode for item and loanee
     post:

--- a/ramls/circulation.raml
+++ b/ramls/circulation.raml
@@ -110,32 +110,32 @@ resourceTypes:
               example: "Internal server error"
   /circulation/override-renewal-by-barcode:
     displayName: Override renewal of an existing loan using barcode for item and loanee
-      post:
-        description: Updates the due date of an existing loan
-        is: [
-          language,
-          validate
-        ]
-        body:
-          application/json:
-            type: !include override-renewal-by-barcode-request.json
-            example: !include examples/override-renewal-by-barcode-request.json
-        responses:
-          200:
-            body:
-              application/json:
-                type: loan
-                example: !include examples/loan.json
-          201:
-            body:
-              application/json:
-                type: loan
-                example: !include examples/loan.json
-          500:
-            description: "Internal server error"
-            body:
-              text/plain:
-                example: "Internal server error"
+    post:
+      description: Updates the due date of an existing loan
+      is: [
+        language,
+        validate
+      ]
+      body:
+        application/json:
+          type: !include override-renewal-by-barcode-request.json
+          example: !include examples/override-renewal-by-barcode-request.json
+      responses:
+        200:
+          body:
+            application/json:
+              type: loan
+              example: !include examples/loan.json
+        201:
+          body:
+            application/json:
+              type: loan
+              example: !include examples/loan.json
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"
   /check-in-by-barcode:
     displayName: Checkin an existing loan using barcode for item and loanee
     post:

--- a/ramls/examples/override-renewal-by-barcode-request.json
+++ b/ramls/examples/override-renewal-by-barcode-request.json
@@ -1,0 +1,6 @@
+{
+  "userBarcode": "466983136459401",
+  "itemBarcode": "2887532577331",
+  "comment": "Renewal override",
+  "dueDate": "2018-12-21T13:30:00Z"
+}

--- a/ramls/override-renewal-by-barcode-request.json
+++ b/ramls/override-renewal-by-barcode-request.json
@@ -25,6 +25,7 @@
   "required": [
     "itemBarcode",
     "userBarcode",
+    "dueDate",
     "comment"
   ]
 }

--- a/ramls/override-renewal-by-barcode-request.json
+++ b/ramls/override-renewal-by-barcode-request.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Request to override renewal of an existing loan, found by barcodes of item and loanee",
+  "properties": {
+    "itemBarcode": {
+      "description": "Barcode of the item to be renewed",
+      "type": "string"
+    },
+    "userBarcode": {
+      "description": "Barcode of the user (representing the patron) the item has been loaned to",
+      "type": "string"
+    },
+    "dueDate": {
+      "description": "New due date for renewed loan",
+      "type": "date-time"
+    },
+    "comment": {
+      "description": "Comment to override action stored in loan history",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "itemBarcode",
+    "userBarcode",
+    "comment"
+  ]
+}

--- a/ramls/override-renewal-by-barcode-request.json
+++ b/ramls/override-renewal-by-barcode-request.json
@@ -13,7 +13,8 @@
     },
     "dueDate": {
       "description": "New due date for renewed loan",
-      "type": "date-time"
+      "type": "string",
+      "format": "date-time"
     },
     "comment": {
       "description": "Comment to override action stored in loan history",

--- a/ramls/override-renewal-by-barcode-request.json
+++ b/ramls/override-renewal-by-barcode-request.json
@@ -25,7 +25,6 @@
   "required": [
     "itemBarcode",
     "userBarcode",
-    "dueDate",
     "comment"
   ]
 }

--- a/src/main/java/org/folio/circulation/CirculationVerticle.java
+++ b/src/main/java/org/folio/circulation/CirculationVerticle.java
@@ -1,12 +1,16 @@
 package org.folio.circulation;
 
-import java.lang.invoke.MethodHandles;
-
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.web.Router;
 import org.folio.circulation.resources.CheckInByBarcodeResource;
 import org.folio.circulation.resources.CheckOutByBarcodeResource;
 import org.folio.circulation.resources.LoanCollectionResource;
 import org.folio.circulation.resources.LoanRulesEngineResource;
 import org.folio.circulation.resources.LoanRulesResource;
+import org.folio.circulation.resources.OverrideRenewalByBarcodeResource;
 import org.folio.circulation.resources.RenewByBarcodeResource;
 import org.folio.circulation.resources.RenewByIdResource;
 import org.folio.circulation.resources.RequestCollectionResource;
@@ -14,11 +18,7 @@ import org.folio.circulation.resources.RequestQueueResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpServer;
-import io.vertx.ext.web.Router;
+import java.lang.invoke.MethodHandles;
 
 public class CirculationVerticle extends AbstractVerticle {
   private HttpServer server;
@@ -44,6 +44,7 @@ public class CirculationVerticle extends AbstractVerticle {
     new LoanCollectionResource(client).register(router);
     new RequestCollectionResource(client).register(router);
     new RequestQueueResource(client).register(router);
+    new OverrideRenewalByBarcodeResource(client).register(router);
 
     new LoanRulesResource         ("/circulation/loan-rules", client)
       .register(router);

--- a/src/main/java/org/folio/circulation/domain/LoanRenewalService.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRenewalService.java
@@ -25,6 +25,6 @@ public class LoanRenewalService {
 
   public CompletableFuture<HttpResult<Loan>> overrideRenewal(Loan loan, DateTime dueDate, String comment) {
     return loanPolicyRepository.lookupLoanPolicy(loan)
-      .thenApply(r -> r.next(policy -> policy.overrideRenewal(loan, dueDate, comment)));
+      .thenApply(r -> r.next(policy -> policy.overrideRenewal(loan, DateTime.now(), dueDate, comment)));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/LoanRenewalService.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRenewalService.java
@@ -22,4 +22,9 @@ public class LoanRenewalService {
     return loanPolicyRepository.lookupLoanPolicy(loan)
       .thenApply(r -> r.next(policy -> policy.renew(loan, DateTime.now())));
   }
+
+  public CompletableFuture<HttpResult<Loan>> overrideRenewal(Loan loan, DateTime dueDate, String comment) {
+    return loanPolicyRepository.lookupLoanPolicy(loan)
+      .thenApply(r -> r.next(policy -> policy.overrideRenewal(loan, DateTime.now(), dueDate, comment)));
+  }
 }

--- a/src/main/java/org/folio/circulation/domain/LoanRenewalService.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRenewalService.java
@@ -25,6 +25,6 @@ public class LoanRenewalService {
 
   public CompletableFuture<HttpResult<Loan>> overrideRenewal(Loan loan, DateTime dueDate, String comment) {
     return loanPolicyRepository.lookupLoanPolicy(loan)
-      .thenApply(r -> r.next(policy -> policy.overrideRenewal(loan, DateTime.now(), dueDate, comment)));
+      .thenApply(r -> r.next(policy -> policy.overrideRenewal(loan, dueDate, comment)));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -105,7 +105,7 @@ public class LoanPolicy {
         return overrideRenewalForDueDate(loan, overrideDueDate, comment);
       }
       if (proposedDueDateResult.failed() && isRolling(loansPolicy)) {
-        DueDateStrategy dueDateStrategy = getRollingOverrideRenewalDueDateStrategy(systemDate);
+        DueDateStrategy dueDateStrategy = getRollingRenewalOverrideDueDateStrategy(systemDate);
         return dueDateStrategy.calculateDueDate(loan)
           .map(dueDate -> loan.overrideRenewal(dueDate, getId(), comment));
       }
@@ -127,7 +127,7 @@ public class LoanPolicy {
     return HttpResult.succeeded(loan.overrideRenewal(overrideDueDate, getId(), comment));
   }
 
-  private DueDateStrategy getRollingOverrideRenewalDueDateStrategy(DateTime systemDate) {
+  private DueDateStrategy getRollingRenewalOverrideDueDateStrategy(DateTime systemDate) {
     final JsonObject loansPolicy = getLoansPolicy();
     final JsonObject renewalsPolicy = getRenewalsPolicy();
     return new RollingRenewalOverrideDueDateStrategy(getId(), getName(),

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -91,27 +91,23 @@ public class LoanPolicy {
     }
   }
 
-  public HttpResult<Loan> overrideRenewal(Loan loan, DateTime systemDate,
+  public HttpResult<Loan> overrideRenewal(Loan loan,
                                           DateTime overrideDueDate, String comment) {
     try {
-      HttpResult<DateTime> proposedDueDateResult =
-        determineStrategy(true, systemDate).calculateDueDate(loan);
+      HttpResult<DateTime> proposedDueDateResult = null;
 
       List<ValidationError> errors = new ArrayList<>();
 
-      if (proposedDueDateResult.failed() &&
-        proposedDueDateResult.cause() instanceof ValidationErrorFailure) {
-        if (overrideDueDate == null) {
-          errors.add(errorForDueDate());
-        } else {
-          proposedDueDateResult = HttpResult.succeeded(overrideDueDate);
-        }
+      if (overrideDueDate == null) {
+        errors.add(errorForDueDate());
+      } else {
+        proposedDueDateResult = HttpResult.succeeded(overrideDueDate);
       }
-      if (proposedDueDateResult.succeeded()) {
+      if (proposedDueDateResult != null && proposedDueDateResult.succeeded()) {
         errorWhenEarlierOrSameDueDate(loan, proposedDueDateResult.value(), errors);
       }
 
-      if (errors.isEmpty()) {
+      if (proposedDueDateResult != null && errors.isEmpty()) {
         return proposedDueDateResult.map(dueDate -> loan.overrideRenewal(dueDate, getId(), comment));
       } else {
         return HttpResult.failed(new ValidationErrorFailure(errors));

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -130,7 +130,7 @@ public class LoanPolicy {
   private DueDateStrategy getRollingOverrideRenewalDueDateStrategy(DateTime systemDate) {
     final JsonObject loansPolicy = getLoansPolicy();
     final JsonObject renewalsPolicy = getRenewalsPolicy();
-    return new RollingOverrideRenewalDueDateStrategy(getId(), getName(),
+    return new RollingRenewalOverrideDueDateStrategy(getId(), getName(),
       systemDate, getRenewFrom(), getRenewalPeriod(loansPolicy, renewalsPolicy),
       getRenewalDueDateLimitSchedules(), this::errorForPolicy);
   }

--- a/src/main/java/org/folio/circulation/domain/policy/RollingOverrideRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingOverrideRenewalDueDateStrategy.java
@@ -1,0 +1,27 @@
+package org.folio.circulation.domain.policy;
+
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.http.server.ValidationError;
+import org.joda.time.DateTime;
+
+import java.util.function.Function;
+
+/**
+ * Overrides {@link #calculateDueDate(DateTime, DateTime)} in {@link RollingRenewalDueDateStrategy}
+ * to skip due date truncating
+ */
+class RollingOverrideRenewalDueDateStrategy extends RollingRenewalDueDateStrategy {
+
+  RollingOverrideRenewalDueDateStrategy(String loanPolicyId, String loanPolicyName, DateTime systemDate,
+                                        String renewFrom, Period period,
+                                        FixedDueDateSchedules dueDateLimitSchedules,
+                                        Function<String, ValidationError> errorForPolicy) {
+    super(loanPolicyId, loanPolicyName, systemDate, renewFrom, period, dueDateLimitSchedules, errorForPolicy);
+  }
+
+  @Override
+  protected HttpResult<DateTime> calculateDueDate(DateTime from, DateTime loanDate) {
+    return super.renewalDueDate(from);
+  }
+}
+

--- a/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
@@ -66,12 +66,12 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
     }
   }
 
-  private HttpResult<DateTime> calculateDueDate(DateTime from, DateTime loanDate) {
+  protected HttpResult<DateTime> calculateDueDate(DateTime from, DateTime loanDate) {
     return renewalDueDate(from)
       .next(dueDate -> truncateDueDateBySchedule(loanDate, dueDate));
   }
 
-  private HttpResult<DateTime> renewalDueDate(DateTime from) {
+  protected HttpResult<DateTime> renewalDueDate(DateTime from) {
     return period.addTo(from,
       () -> validationError(RENEWAL_UNRECOGNISED_PERIOD_MESSAGE),
       interval -> validationError(String.format(RENEWAL_UNRECOGNISED_INTERVAL_MESSAGE, interval)),

--- a/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
@@ -1,14 +1,14 @@
 package org.folio.circulation.domain.policy;
 
+import static org.folio.circulation.support.HttpResult.failed;
+
+import java.util.function.Function;
+
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
-
-import java.util.function.Function;
-
-import static org.folio.circulation.support.HttpResult.failed;
 
 class RollingRenewalDueDateStrategy extends DueDateStrategy {
   private static final String RENEW_FROM_SYSTEM_DATE = "SYSTEM_DATE";
@@ -71,7 +71,7 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
       .next(dueDate -> truncateDueDateBySchedule(loanDate, dueDate));
   }
 
-  protected HttpResult<DateTime> renewalDueDate(DateTime from) {
+  HttpResult<DateTime> renewalDueDate(DateTime from) {
     return period.addTo(from,
       () -> validationError(RENEWAL_UNRECOGNISED_PERIOD_MESSAGE),
       interval -> validationError(String.format(RENEWAL_UNRECOGNISED_INTERVAL_MESSAGE, interval)),

--- a/src/main/java/org/folio/circulation/domain/policy/RollingRenewalOverrideDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingRenewalOverrideDueDateStrategy.java
@@ -10,9 +10,9 @@ import java.util.function.Function;
  * Overrides {@link #calculateDueDate(DateTime, DateTime)} in {@link RollingRenewalDueDateStrategy}
  * to skip due date truncating
  */
-class RollingOverrideRenewalDueDateStrategy extends RollingRenewalDueDateStrategy {
+class RollingRenewalOverrideDueDateStrategy extends RollingRenewalDueDateStrategy {
 
-  RollingOverrideRenewalDueDateStrategy(String loanPolicyId, String loanPolicyName, DateTime systemDate,
+  RollingRenewalOverrideDueDateStrategy(String loanPolicyId, String loanPolicyName, DateTime systemDate,
                                         String renewFrom, Period period,
                                         FixedDueDateSchedules dueDateLimitSchedules,
                                         Function<String, ValidationError> errorForPolicy) {

--- a/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
@@ -12,4 +12,5 @@ public class LoanProperties {
   public static final String SYSTEM_RETURN_DATE = "systemReturnDate";
   public static final String CHECKIN_SERVICE_POINT_ID = "checkinServicePointId";
   public static final String CHECKOUT_SERVICE_POINT_ID = "checkoutServicePointId";
+  public static final String ACTION_COMMENT = "actionComment";
 }

--- a/src/main/java/org/folio/circulation/resources/OverrideByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/resources/OverrideByBarcodeRequest.java
@@ -5,8 +5,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.support.HttpResult;
 import org.joda.time.DateTime;
 
-import java.util.Optional;
-
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimeProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;

--- a/src/main/java/org/folio/circulation/resources/OverrideByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/resources/OverrideByBarcodeRequest.java
@@ -15,7 +15,7 @@ public class OverrideByBarcodeRequest {
 
   public static final String USER_BARCODE = "userBarcode";
   public static final String ITEM_BARCODE = "itemBarcode";
-  public static final String COMMENT = "comment";
+  public static final String COMMENT_PROPERTY = "comment";
   public static final String DUE_DATE = "dueDate";
 
   private final String itemBarcode;
@@ -57,9 +57,9 @@ public class OverrideByBarcodeRequest {
       return failedResult("Override renewal request must have a user barcode", USER_BARCODE, null);
     }
 
-    final String comment = getProperty(json, COMMENT);
+    final String comment = getProperty(json, COMMENT_PROPERTY);
     if(StringUtils.isBlank(comment)) {
-      return failedResult("Override renewal request must have a comment", COMMENT, null);
+      return failedResult("Override renewal request must have a comment", COMMENT_PROPERTY, null);
     }
     final Optional<String> dueDateProperty = Optional.ofNullable(getProperty(json, DUE_DATE));
     final DateTime dueDate = dueDateProperty.map(DateTime::parse).orElse(null);

--- a/src/main/java/org/folio/circulation/resources/OverrideByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/resources/OverrideByBarcodeRequest.java
@@ -1,0 +1,70 @@
+package org.folio.circulation.resources;
+
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.circulation.support.HttpResult;
+import org.joda.time.DateTime;
+
+import java.util.Optional;
+
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
+
+public class OverrideByBarcodeRequest {
+
+  public static final String USER_BARCODE = "userBarcode";
+  public static final String ITEM_BARCODE = "itemBarcode";
+  public static final String COMMENT = "comment";
+  public static final String DUE_DATE = "dueDate";
+
+  private final String itemBarcode;
+  private final String userBarcode;
+  private final String comment;
+  private final DateTime dueDate;
+
+  public OverrideByBarcodeRequest(String itemBarcode, String userBarcode, String comment, DateTime dueDate) {
+    this.itemBarcode = itemBarcode;
+    this.userBarcode = userBarcode;
+    this.comment = comment;
+    this.dueDate = dueDate;
+  }
+
+  public String getItemBarcode() {
+    return itemBarcode;
+  }
+
+  public String getUserBarcode() {
+    return userBarcode;
+  }
+
+  public String getComment() {
+    return comment;
+  }
+
+  public DateTime getDueDate() {
+    return dueDate;
+  }
+
+  public static HttpResult<OverrideByBarcodeRequest> from(JsonObject json) {
+    final String itemBarcode = getProperty(json, ITEM_BARCODE);
+    if(StringUtils.isBlank(itemBarcode)) {
+      return failedResult("Override renewal request must have an item barcode", ITEM_BARCODE, null);
+    }
+
+    final String userBarcode = getProperty(json, USER_BARCODE);
+    if(StringUtils.isBlank(userBarcode)) {
+      return failedResult("Override renewal request must have a user barcode", USER_BARCODE, null);
+    }
+
+    final String comment = getProperty(json, COMMENT);
+    if(StringUtils.isBlank(comment)) {
+      return failedResult("Override renewal request must have a comment", COMMENT, null);
+    }
+    final Optional<String> dueDateProperty = Optional.ofNullable(getProperty(json, DUE_DATE));
+    final DateTime dueDate = dueDateProperty.map(DateTime::parse).orElse(null);
+
+    return succeeded(new OverrideByBarcodeRequest(itemBarcode, userBarcode, comment, dueDate));
+  }
+
+}

--- a/src/main/java/org/folio/circulation/resources/OverrideByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/resources/OverrideByBarcodeRequest.java
@@ -8,6 +8,7 @@ import org.joda.time.DateTime;
 import java.util.Optional;
 
 import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimeProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
 
@@ -61,8 +62,7 @@ public class OverrideByBarcodeRequest {
     if(StringUtils.isBlank(comment)) {
       return failedResult("Override renewal request must have a comment", COMMENT_PROPERTY, null);
     }
-    final Optional<String> dueDateProperty = Optional.ofNullable(getProperty(json, DUE_DATE));
-    final DateTime dueDate = dueDateProperty.map(DateTime::parse).orElse(null);
+    final DateTime dueDate = getDateTimeProperty(json, DUE_DATE);
 
     return succeeded(new OverrideByBarcodeRequest(itemBarcode, userBarcode, comment, dueDate));
   }

--- a/src/main/java/org/folio/circulation/resources/OverrideRenewalByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/OverrideRenewalByBarcodeResource.java
@@ -1,35 +1,30 @@
 package org.folio.circulation.resources;
 
 import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanRenewalService;
 import org.folio.circulation.domain.LoanRepository;
 import org.folio.circulation.domain.LoanRepresentation;
 import org.folio.circulation.domain.UserRepository;
 import org.folio.circulation.domain.representations.LoanResponse;
+import org.folio.circulation.storage.SingleOpenLoanByUserAndItemBarcodeFinder;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ItemRepository;
 import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.server.WebContext;
 
-import java.util.concurrent.CompletableFuture;
+public class OverrideRenewalByBarcodeResource extends Resource {
 
-public abstract class RenewalResource extends Resource {
-  private final String rootPath;
-
-  RenewalResource(HttpClient client, String rootPath) {
+  public OverrideRenewalByBarcodeResource(HttpClient client) {
     super(client);
-    this.rootPath = rootPath;
   }
 
   @Override
   public void register(Router router) {
     RouteRegistration routeRegistration = new RouteRegistration(
-      rootPath, router);
+      "/circulation/override-renewal-by-barcode", router);
 
     routeRegistration.create(this::renew);
   }
@@ -44,20 +39,16 @@ public abstract class RenewalResource extends Resource {
 
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
     final LoanRenewalService loanRenewalService = LoanRenewalService.using(clients);
+    final SingleOpenLoanByUserAndItemBarcodeFinder loanFinder = new SingleOpenLoanByUserAndItemBarcodeFinder();
 
-    //TODO: Validation check for same user should be in the domain service
+    final HttpResult<OverrideByBarcodeRequest> request = OverrideByBarcodeRequest.from(routingContext.getBodyAsJson());
 
-    findLoan(routingContext.getBodyAsJson(), loanRepository, itemRepository, userRepository)
-      .thenComposeAsync(r -> r.after(loanRenewalService::renew))
-      .thenComposeAsync(r -> r.after(loanRepository::updateLoan))
+    request.after(overrideRequest ->
+      loanFinder.findLoan(routingContext.getBodyAsJson(), loanRepository, itemRepository, userRepository)
+        .thenComposeAsync(r -> r.after(loan -> loanRenewalService.overrideRenewal(loan, overrideRequest.getDueDate(), overrideRequest.getComment())))
+        .thenComposeAsync(r -> r.after(loanRepository::updateLoan)))
       .thenApply(r -> r.map(loanRepresentation::extendedLoan))
       .thenApply(LoanResponse::from)
       .thenAccept(result -> result.writeTo(routingContext.response()));
   }
-
-  protected abstract CompletableFuture<HttpResult<Loan>> findLoan(
-    JsonObject request,
-    LoanRepository loanRepository,
-    ItemRepository itemRepository,
-    UserRepository userRepository);
 }

--- a/src/main/java/org/folio/circulation/resources/OverrideRenewalByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/OverrideRenewalByBarcodeResource.java
@@ -38,14 +38,14 @@ public class OverrideRenewalByBarcodeResource extends Resource {
     final UserRepository userRepository = new UserRepository(clients);
 
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
-    final LoanRenewalService loanRenewalService = LoanRenewalService.using(clients);
+    final LoanRenewalService renewalService = LoanRenewalService.using(clients);
     final SingleOpenLoanByUserAndItemBarcodeFinder loanFinder = new SingleOpenLoanByUserAndItemBarcodeFinder();
 
     final HttpResult<OverrideByBarcodeRequest> request = OverrideByBarcodeRequest.from(routingContext.getBodyAsJson());
 
-    request.after(overrideRequest ->
+    request.after(override ->
       loanFinder.findLoan(routingContext.getBodyAsJson(), loanRepository, itemRepository, userRepository)
-        .thenComposeAsync(r -> r.after(loan -> loanRenewalService.overrideRenewal(loan, overrideRequest.getDueDate(), overrideRequest.getComment())))
+        .thenComposeAsync(r -> r.after(loan -> renewalService.overrideRenewal(loan, override.getDueDate(), override.getComment())))
         .thenComposeAsync(r -> r.after(loanRepository::updateLoan)))
       .thenApply(r -> r.map(loanRepresentation::extendedLoan))
       .thenApply(LoanResponse::from)

--- a/src/main/java/org/folio/circulation/resources/RenewByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByBarcodeRequest.java
@@ -1,17 +1,16 @@
 package org.folio.circulation.resources;
 
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.circulation.support.HttpResult;
+
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
 
-import org.apache.commons.lang3.StringUtils;
-import org.folio.circulation.support.HttpResult;
-
-import io.vertx.core.json.JsonObject;
-
 public class RenewByBarcodeRequest {
-  static final String USER_BARCODE = "userBarcode";
-  private static final String ITEM_BARCODE = "itemBarcode";
+  public static final String USER_BARCODE = "userBarcode";
+  public static final String ITEM_BARCODE = "itemBarcode";
 
   private final String itemBarcode;
   private final String userBarcode;

--- a/src/main/java/org/folio/circulation/resources/RenewByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByBarcodeResource.java
@@ -1,25 +1,15 @@
 package org.folio.circulation.resources;
 
-import static org.folio.circulation.domain.validation.CommonFailures.moreThanOneOpenLoanFailure;
-import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundForBarcodeFailure;
-import static org.folio.circulation.support.HttpResult.failed;
-import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
-
-import java.util.concurrent.CompletableFuture;
-
-import org.apache.commons.lang3.StringUtils;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonObject;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanRepository;
 import org.folio.circulation.domain.UserRepository;
-import org.folio.circulation.domain.validation.UserNotFoundValidator;
-import org.folio.circulation.storage.ItemByBarcodeInStorageFinder;
-import org.folio.circulation.storage.SingleOpenLoanForItemInStorageFinder;
+import org.folio.circulation.storage.SingleOpenLoanByUserAndItemBarcodeFinder;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ItemRepository;
 
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.JsonObject;
+import java.util.concurrent.CompletableFuture;
 
 public class RenewByBarcodeResource extends RenewalResource {
   public RenewByBarcodeResource(HttpClient client) {
@@ -33,47 +23,7 @@ public class RenewByBarcodeResource extends RenewalResource {
     ItemRepository itemRepository,
     UserRepository userRepository) {
 
-    final HttpResult<RenewByBarcodeRequest> requestResult
-      = RenewByBarcodeRequest.from(request);
-
-    final String itemBarcode = requestResult
-      .map(RenewByBarcodeRequest::getItemBarcode)
-      .orElse("unknown barcode");
-
-    final ItemByBarcodeInStorageFinder itemFinder = new ItemByBarcodeInStorageFinder(
-      itemRepository, noItemFoundForBarcodeFailure(itemBarcode));
-
-    final SingleOpenLoanForItemInStorageFinder singleOpenLoanFinder
-      = new SingleOpenLoanForItemInStorageFinder(loanRepository, userRepository,
-      moreThanOneOpenLoanFailure(itemBarcode), false);
-
-    //TODO: Possibly move this to single open loan finder?
-    final UserNotFoundValidator userNotFoundValidator = new UserNotFoundValidator(
-      userId -> failure("user is not found", "userId", userId));
-
-    return requestResult
-      .after(checkInRequest -> itemFinder.findItemByBarcode(itemBarcode))
-      .thenComposeAsync(itemResult ->
-        itemResult.after(singleOpenLoanFinder::findSingleOpenLoan))
-      .thenApply(userNotFoundValidator::refuseWhenUserNotFound)
-      .thenApply(loanResult -> loanResult.combineToResult(requestResult,
-        this::refuseWhenUserDoesNotMatch));
-  }
-
-  private HttpResult<Loan> refuseWhenUserDoesNotMatch(
-    Loan loan,
-    RenewByBarcodeRequest barcodeRequest) {
-
-    if(userMatches(loan, barcodeRequest.getUserBarcode())) {
-      return succeeded(loan);
-    }
-    else {
-      return failed(failure("Cannot renew item checked out to different user",
-        RenewByBarcodeRequest.USER_BARCODE, barcodeRequest.getUserBarcode()));
-    }
-  }
-
-  private boolean userMatches(Loan loan, String expectedUserBarcode) {
-    return StringUtils.equals(loan.getUser().getBarcode(), expectedUserBarcode);
+    SingleOpenLoanByUserAndItemBarcodeFinder finder = new SingleOpenLoanByUserAndItemBarcodeFinder();
+    return finder.findLoan(request, loanRepository, itemRepository, userRepository);
   }
 }

--- a/src/main/java/org/folio/circulation/resources/RenewByIdRequest.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByIdRequest.java
@@ -1,13 +1,12 @@
 package org.folio.circulation.resources;
 
-import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
-import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
-
+import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.support.HttpResult;
 
-import io.vertx.core.json.JsonObject;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
 
 public class RenewByIdRequest {
   static final String USER_ID = "userId";

--- a/src/main/java/org/folio/circulation/storage/SingleOpenLoanByUserAndItemBarcodeFinder.java
+++ b/src/main/java/org/folio/circulation/storage/SingleOpenLoanByUserAndItemBarcodeFinder.java
@@ -1,0 +1,71 @@
+package org.folio.circulation.storage;
+
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.LoanRepository;
+import org.folio.circulation.domain.UserRepository;
+import org.folio.circulation.domain.validation.UserNotFoundValidator;
+import org.folio.circulation.resources.RenewByBarcodeRequest;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ItemRepository;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.folio.circulation.domain.validation.CommonFailures.moreThanOneOpenLoanFailure;
+import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundForBarcodeFailure;
+import static org.folio.circulation.support.HttpResult.failed;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.ValidationErrorFailure.failure;
+
+public class SingleOpenLoanByUserAndItemBarcodeFinder {
+
+  public CompletableFuture<HttpResult<Loan>> findLoan(
+    JsonObject request,
+    LoanRepository loanRepository,
+    ItemRepository itemRepository,
+    UserRepository userRepository) {
+
+    final HttpResult<RenewByBarcodeRequest> requestResult
+      = RenewByBarcodeRequest.from(request);
+
+    final String itemBarcode = requestResult
+      .map(RenewByBarcodeRequest::getItemBarcode)
+      .orElse("unknown barcode");
+
+
+    final ItemByBarcodeInStorageFinder itemFinder = new ItemByBarcodeInStorageFinder(
+      itemRepository, noItemFoundForBarcodeFailure(itemBarcode));
+
+    final SingleOpenLoanForItemInStorageFinder singleOpenLoanFinder
+      = new SingleOpenLoanForItemInStorageFinder(loanRepository, userRepository,
+      moreThanOneOpenLoanFailure(itemBarcode), false);
+
+    final UserNotFoundValidator userNotFoundValidator = new UserNotFoundValidator(
+      userId -> failure("user is not found", "userId", userId));
+
+    return requestResult
+      .after(checkInRequest -> itemFinder.findItemByBarcode(itemBarcode))
+      .thenComposeAsync(itemResult ->
+        itemResult.after(singleOpenLoanFinder::findSingleOpenLoan))
+      .thenApply(userNotFoundValidator::refuseWhenUserNotFound)
+      .thenApply(loanResult -> loanResult.combineToResult(requestResult,
+        this::refuseWhenUserDoesNotMatch));
+  }
+
+  private HttpResult<Loan> refuseWhenUserDoesNotMatch(
+    Loan loan,
+    RenewByBarcodeRequest barcodeRequest) {
+
+    if (userMatches(loan, barcodeRequest.getUserBarcode())) {
+      return succeeded(loan);
+    } else {
+      return failed(failure("Cannot renew item checked out to different user",
+        RenewByBarcodeRequest.USER_BARCODE, barcodeRequest.getUserBarcode()));
+    }
+  }
+
+  private boolean userMatches(Loan loan, String expectedUserBarcode) {
+    return StringUtils.equals(loan.getUser().getBarcode(), expectedUserBarcode);
+  }
+}

--- a/src/test/java/api/APITestSuite.java
+++ b/src/test/java/api/APITestSuite.java
@@ -37,6 +37,7 @@ import api.loans.LoanAPIProxyTests;
 import api.loans.LoanAPIRelatedRecordsTests;
 import api.loans.LoanAPITests;
 import api.loans.LoanAPITitleTests;
+import api.loans.OverrideRenewByBarcodeTests;
 import api.loans.RenewByBarcodeTests;
 import api.loans.RenewByIdTests;
 import api.loans.scenarios.InTransitToHomeLocationTests;
@@ -81,6 +82,7 @@ import io.vertx.core.json.JsonObject;
   CheckOutByBarcodeTests.class,
   RenewByBarcodeTests.class,
   RenewByIdTests.class,
+  OverrideRenewByBarcodeTests.class,
   CheckInByBarcodeTests.class,
   CheckInByReplacingLoanTests.class,
   LoanAPITests.class,

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -58,11 +58,14 @@ public class OverrideRenewByBarcodeTests extends APITests {
       new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43))
       .getId();
 
+    DateTime newDueDate =
+      new DateTime(2019, DateTimeConstants.JANUARY, 1, 1, 1, 1);
+
     //TODO: Renewal based upon system date,
     // needs to be approximated, at least until we introduce a calendar and clock
     DateTime approximateRenewalDate = DateTime.now();
 
-    final JsonObject renewedLoan = loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null).getJson();
+    final JsonObject renewedLoan = loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, newDueDate.toString()).getJson();
 
     assertThat(renewedLoan.getString("id"), is(loanId.toString()));
 
@@ -88,9 +91,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
       renewedLoan.getString("loanPolicyId"),
       is(APITestSuite.canCirculateRollingLoanPolicyId().toString()));
 
-    assertThat("due date should be approximately 3 weeks after renewal date, based upon loan policy",
+    assertThat("due date should be 1st of Feb 2019",
       renewedLoan.getString("dueDate"),
-      withinSecondsAfter(Seconds.seconds(10), approximateRenewalDate.plusWeeks(3)));
+      isEquivalentTo(newDueDate));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 
@@ -110,6 +113,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
     final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
       new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43));
 
+    DateTime newDueDate =
+      new DateTime(2019, DateTimeConstants.JANUARY, 1, 1, 1, 1);
+
     final UUID loanId = loan.getId();
 
     LoanPolicyBuilder currentDueDateRollingPolicy = new LoanPolicyBuilder()
@@ -125,7 +131,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     useLoanPolicyAsFallback(dueDateLimitedPolicyId);
 
     final JsonObject renewedLoan =
-      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null).getJson();
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, newDueDate.toString()).getJson();
 
     assertThat(renewedLoan.getString("id"), is(loanId.toString()));
 
@@ -150,9 +156,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
     assertThat("last loan policy should be stored",
       renewedLoan.getString("loanPolicyId"), is(dueDateLimitedPolicyId.toString()));
 
-    assertThat("due date should be 2 months after initial due date date",
+    assertThat("due date should be 1st of Feb 2019",
       renewedLoan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, DateTimeConstants.JULY, 12, 11, 21, 43)));
+      isEquivalentTo(newDueDate));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 
@@ -169,6 +175,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
     FixedDueDateSchedulesBuilder dueDateLimitSchedule = new FixedDueDateSchedulesBuilder()
       .withName("March Only Due Date Limit")
       .addSchedule(wholeMonth(2018, DateTimeConstants.MARCH));
+
+    DateTime newDueDate =
+      new DateTime(2019, DateTimeConstants.JANUARY, 1, 1, 1, 1);
 
     final UUID dueDateLimitScheduleId = fixedDueDateScheduleClient.create(
       dueDateLimitSchedule).getId();
@@ -202,16 +211,16 @@ public class OverrideRenewByBarcodeTests extends APITests {
         .at(UUID.randomUUID()));
 
     final IndividualResource response =
-      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, steve, OVERRIDE_COMMENT, null);
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, steve, OVERRIDE_COMMENT, newDueDate.toString());
 
     final JsonObject loan = response.getJson();
 
     assertThat("last loan policy should be stored",
       loan.getString("loanPolicyId"), is(dueDateLimitedPolicyId.toString()));
 
-    assertThat("due date should be limited by schedule",
+    assertThat("due date should be 1st of Feb 2019",
       loan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, DateTimeConstants.MARCH, 31, 23, 59, 59, DateTimeZone.UTC)));
+      isEquivalentTo(newDueDate));
   }
 
   @Test
@@ -226,6 +235,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
       new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43));
+
+    DateTime newDueDate =
+      new DateTime(2019, DateTimeConstants.JANUARY, 1, 1, 1, 1);
 
     final UUID loanId = loan.getId();
 
@@ -243,7 +255,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     useLoanPolicyAsFallback(dueDateLimitedPolicyId);
 
     final JsonObject renewedLoan =
-      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null).getJson();
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, newDueDate.toString()).getJson();
 
     assertThat(renewedLoan.getString("id"), is(loanId.toString()));
 
@@ -268,9 +280,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
     assertThat("last loan policy should be stored",
       renewedLoan.getString("loanPolicyId"), is(dueDateLimitedPolicyId.toString()));
 
-    assertThat("due date should be 2 months after initial due date date",
+    assertThat("due date should be 1st of Feb 2019",
       renewedLoan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, DateTimeConstants.JUNE, 12, 11, 21, 43)));
+      isEquivalentTo(newDueDate));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 
@@ -290,6 +302,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     final UUID dueDateLimitScheduleId = fixedDueDateScheduleClient.create(
       dueDateLimitSchedule).getId();
+
+    DateTime newDueDate =
+      new DateTime(2019, DateTimeConstants.JANUARY, 1, 1, 1, 1);
 
     //Need to remember in order to delete after test
     schedulesToDelete.add(dueDateLimitScheduleId);
@@ -320,16 +335,16 @@ public class OverrideRenewByBarcodeTests extends APITests {
         .at(UUID.randomUUID()));
 
     final IndividualResource response =
-      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, steve, OVERRIDE_COMMENT, null);
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, steve, OVERRIDE_COMMENT, newDueDate.toString());
 
     final JsonObject loan = response.getJson();
 
     assertThat("last loan policy should be stored",
       loan.getString("loanPolicyId"), is(dueDateLimitedPolicyId.toString()));
 
-    assertThat("due date should be limited by schedule",
+    assertThat("due date should be 1st of Feb 2019",
       loan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, DateTimeConstants.MARCH, 31, 23, 59, 59, DateTimeZone.UTC)));
+      isEquivalentTo(newDueDate));
   }
 
   @Test
@@ -345,6 +360,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     final UUID dueDateLimitScheduleId = fixedDueDateScheduleClient.create(
       dueDateLimitSchedule).getId();
+
+    DateTime newDueDate =
+      new DateTime(2019, DateTimeConstants.JANUARY, 1, 1, 1, 1);
 
     //Need to remember in order to delete after test
     schedulesToDelete.add(dueDateLimitScheduleId);
@@ -376,16 +394,16 @@ public class OverrideRenewByBarcodeTests extends APITests {
         .at(UUID.randomUUID()));
 
     final IndividualResource response =
-      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, steve, OVERRIDE_COMMENT, null);
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, steve, OVERRIDE_COMMENT, newDueDate.toString());
 
     final JsonObject loan = response.getJson();
 
     assertThat("last loan policy should be stored",
       loan.getString("loanPolicyId"), is(dueDateLimitedPolicyId.toString()));
 
-    assertThat("due date should be limited by schedule",
+    assertThat("due date should be 1st of Feb 2019",
       loan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, DateTimeConstants.MARCH, 31, 23, 59, 59, DateTimeZone.UTC)));
+      isEquivalentTo(newDueDate));
   }
 
   @Test
@@ -406,6 +424,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     final UUID fixedDueDateSchedulesId = fixedDueDateScheduleClient.create(
       fixedDueDateSchedules).getId();
+
+    DateTime newDueDate =
+      new DateTime(2019, DateTimeConstants.JANUARY, 1, 1, 1, 1);
 
     //Need to remember in order to delete after test
     schedulesToDelete.add(fixedDueDateSchedulesId);
@@ -434,7 +455,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
         .on(loanDate)
         .at(UUID.randomUUID()));
 
-    final IndividualResource response = loansFixture.overrideRenewalByBarcode(smallAngryPlanet, steve, OVERRIDE_COMMENT, null);
+    final IndividualResource response = loansFixture.overrideRenewalByBarcode(smallAngryPlanet, steve, OVERRIDE_COMMENT, newDueDate.toString());
 
     final JsonObject loan = response.getJson();
 
@@ -444,14 +465,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
     assertThat("renewal count should be incremented",
       loan.getInteger("renewalCount"), is(1));
 
-    final DateTime endOfRenewalDate = renewalDate
-      .withTimeAtStartOfDay()
-      .withHourOfDay(23)
-      .withMinuteOfHour(59)
-      .withSecondOfMinute(59);
-
-    assertThat("due date should be defined by schedule",
-      loan.getString("dueDate"), isEquivalentTo(endOfRenewalDate));
+    assertThat("due date should be 1st of Feb 2019",
+      loan.getString("dueDate"),
+      isEquivalentTo(newDueDate));
   }
 
   @Test
@@ -480,14 +496,17 @@ public class OverrideRenewByBarcodeTests extends APITests {
     final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
       new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43, DateTimeZone.UTC));
 
+    DateTime newDueDate =
+      new DateTime(2019, DateTimeConstants.JANUARY, 1, 1, 1, 1);
+
     final UUID loanId = loan.getId();
 
-    loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null);
+    loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, newDueDate.toString());
 
-    loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null);
+    loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, newDueDate.plusDays(1).toString());
 
     final JsonObject renewedLoan =
-      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null).getJson();
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, newDueDate.plusDays(2).toString()).getJson();
 
     assertThat(renewedLoan.getString("id"), is(loanId.toString()));
 
@@ -506,9 +525,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
     assertThat("last loan policy should be stored",
       renewedLoan.getString("loanPolicyId"), is(limitedRenewalsPolicyId.toString()));
 
-    assertThat("due date should be 8 days after initial loan date date",
+    assertThat("due date should be 1st of Feb 2019",
       renewedLoan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, DateTimeConstants.APRIL, 29, 11, 21, 43, DateTimeZone.UTC)));
+      isEquivalentTo(newDueDate.plusDays(2)));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 
@@ -529,12 +548,15 @@ public class OverrideRenewByBarcodeTests extends APITests {
       new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43))
       .getId();
 
+    DateTime newDueDate =
+      new DateTime(2019, DateTimeConstants.JANUARY, 1, 1, 1, 1);
+
     //TODO: Renewal based upon system date,
     // needs to be approximated, at least until we introduce a calendar and clock
     DateTime approximateRenewalDate = DateTime.now();
 
     final IndividualResource response =
-      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null);
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, newDueDate.toString());
 
     final CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
@@ -571,9 +593,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
       renewedLoan.getString("loanPolicyId"),
       is(APITestSuite.canCirculateRollingLoanPolicyId().toString()));
 
-    assertThat("due date should be approximately 3 weeks after renewal date, based upon loan policy",
+    assertThat("due date should be 1st of Feb 2019",
       renewedLoan.getString("dueDate"),
-      withinSecondsAfter(Seconds.seconds(10), approximateRenewalDate.plusWeeks(3)));
+      isEquivalentTo(newDueDate));
   }
 
   @Test

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -108,7 +108,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43));
+      new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43));
 
     final UUID loanId = loan.getId();
 
@@ -152,7 +152,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     assertThat("due date should be 2 months after initial due date date",
       renewedLoan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, 7, 12, 11, 21, 43)));
+      isEquivalentTo(new DateTime(2018, DateTimeConstants.JULY, 12, 11, 21, 43)));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 
@@ -168,7 +168,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     FixedDueDateSchedulesBuilder dueDateLimitSchedule = new FixedDueDateSchedulesBuilder()
       .withName("March Only Due Date Limit")
-      .addSchedule(wholeMonth(2018, 3));
+      .addSchedule(wholeMonth(2018, DateTimeConstants.MARCH));
 
     final UUID dueDateLimitScheduleId = fixedDueDateScheduleClient.create(
       dueDateLimitSchedule).getId();
@@ -192,7 +192,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    final DateTime loanDate = new DateTime(2018, 3, 7, 11, 43, 54, DateTimeZone.UTC);
+    final DateTime loanDate = new DateTime(2018, DateTimeConstants.MARCH, 7, 11, 43, 54, DateTimeZone.UTC);
 
     loansFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -211,7 +211,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     assertThat("due date should be limited by schedule",
       loan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, 3, 31, 23, 59, 59, DateTimeZone.UTC)));
+      isEquivalentTo(new DateTime(2018, DateTimeConstants.MARCH, 31, 23, 59, 59, DateTimeZone.UTC)));
   }
 
   @Test
@@ -225,7 +225,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43));
+      new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43));
 
     final UUID loanId = loan.getId();
 
@@ -270,7 +270,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     assertThat("due date should be 2 months after initial due date date",
       renewedLoan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, 6, 12, 11, 21, 43)));
+      isEquivalentTo(new DateTime(2018, DateTimeConstants.JUNE, 12, 11, 21, 43)));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 
@@ -286,7 +286,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     FixedDueDateSchedulesBuilder dueDateLimitSchedule = new FixedDueDateSchedulesBuilder()
       .withName("March Only Due Date Limit")
-      .addSchedule(wholeMonth(2018, 3));
+      .addSchedule(wholeMonth(2018, DateTimeConstants.MARCH));
 
     final UUID dueDateLimitScheduleId = fixedDueDateScheduleClient.create(
       dueDateLimitSchedule).getId();
@@ -310,7 +310,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    final DateTime loanDate = new DateTime(2018, 3, 4, 11, 43, 54, DateTimeZone.UTC);
+    final DateTime loanDate = new DateTime(2018, DateTimeConstants.MARCH, 4, 11, 43, 54, DateTimeZone.UTC);
 
     loansFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -329,7 +329,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     assertThat("due date should be limited by schedule",
       loan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, 3, 31, 23, 59, 59, DateTimeZone.UTC)));
+      isEquivalentTo(new DateTime(2018, DateTimeConstants.MARCH, 31, 23, 59, 59, DateTimeZone.UTC)));
   }
 
   @Test
@@ -341,7 +341,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     FixedDueDateSchedulesBuilder dueDateLimitSchedule = new FixedDueDateSchedulesBuilder()
       .withName("March Only Due Date Limit")
-      .addSchedule(wholeMonth(2018, 3));
+      .addSchedule(wholeMonth(2018, DateTimeConstants.MARCH));
 
     final UUID dueDateLimitScheduleId = fixedDueDateScheduleClient.create(
       dueDateLimitSchedule).getId();
@@ -366,7 +366,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    final DateTime loanDate = new DateTime(2018, 3, 4, 11, 43, 54, DateTimeZone.UTC);
+    final DateTime loanDate = new DateTime(2018, DateTimeConstants.MARCH, 4, 11, 43, 54, DateTimeZone.UTC);
 
     loansFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -385,7 +385,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     assertThat("due date should be limited by schedule",
       loan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, 3, 31, 23, 59, 59, DateTimeZone.UTC)));
+      isEquivalentTo(new DateTime(2018, DateTimeConstants.MARCH, 31, 23, 59, 59, DateTimeZone.UTC)));
   }
 
   @Test
@@ -401,7 +401,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
       .withName("Kludgy Fixed Due Date Schedule")
-      .addSchedule(wholeMonth(2018, 2))
+      .addSchedule(wholeMonth(2018, DateTimeConstants.FEBRUARY))
       .addSchedule(forDay(renewalDate));
 
     final UUID fixedDueDateSchedulesId = fixedDueDateScheduleClient.create(
@@ -425,7 +425,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    final DateTime loanDate = new DateTime(2018, 2, 10, 11, 23, 12, DateTimeZone.UTC);
+    final DateTime loanDate = new DateTime(2018, DateTimeConstants.FEBRUARY, 10, 11, 23, 12, DateTimeZone.UTC);
 
     loansFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -478,7 +478,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     useLoanPolicyAsFallback(limitedRenewalsPolicyId);
 
     final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43, DateTimeZone.UTC));
 
     final UUID loanId = loan.getId();
 
@@ -508,7 +508,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     assertThat("due date should be 8 days after initial loan date date",
       renewedLoan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, 4, 29, 11, 21, 43, DateTimeZone.UTC)));
+      isEquivalentTo(new DateTime(2018, DateTimeConstants.APRIL, 29, 11, 21, 43, DateTimeZone.UTC)));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 
@@ -526,7 +526,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     final UUID loanId = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43))
+      new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43))
       .getId();
 
     //TODO: Renewal based upon system date,
@@ -589,7 +589,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     final UUID unknownLoanPolicyId = UUID.randomUUID();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43));
+      new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43));
 
     useLoanPolicyAsFallback(unknownLoanPolicyId);
 
@@ -656,7 +656,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43));
+      new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43));
 
     final Response response =
       loansFixture.attemptOverride(smallAngryPlanet, james, OVERRIDE_COMMENT, null);
@@ -678,13 +678,13 @@ public class OverrideRenewByBarcodeTests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43));
+      new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43));
 
     final UUID loanId = loan.getId();
 
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
       .withName("Kludgy Fixed Due Date Schedule")
-      .addSchedule(wholeMonth(2018, 2))
+      .addSchedule(wholeMonth(2018, DateTimeConstants.FEBRUARY))
       .addSchedule(forDay(renewalDate));
 
     final UUID fixedDueDateSchedulesId = fixedDueDateScheduleClient.create(
@@ -707,7 +707,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     useLoanPolicyAsFallback(dueDateLimitedPolicyId);
 
     DateTime newDueDate =
-      new DateTime(2025, 1, 1, 1, 1, 1);
+      new DateTime(2025, DateTimeConstants.JANUARY, 1, 1, 1, 1);
     final JsonObject renewedLoan =
       loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, newDueDate.toString()).getJson();
 
@@ -755,13 +755,13 @@ public class OverrideRenewByBarcodeTests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43));
+      new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43));
 
     final UUID loanId = loan.getId();
 
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
       .withName("Kludgy Fixed Due Date Schedule")
-      .addSchedule(wholeMonth(2018, 2))
+      .addSchedule(wholeMonth(2018, DateTimeConstants.FEBRUARY))
       .addSchedule(forDay(renewalDate));
 
     final UUID fixedDueDateSchedulesId = fixedDueDateScheduleClient.create(

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -147,7 +147,8 @@ public class OverrideRenewByBarcodeTests extends APITests {
   public void canOverrideRenewalWhenItemIsNotRenewableAndNewDueDateIsNotSpecified() throws
     InterruptedException,
     ExecutionException,
-    TimeoutException, MalformedURLException {
+    TimeoutException,
+    MalformedURLException {
 
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource jessica = usersFixture.jessica();
@@ -168,6 +169,8 @@ public class OverrideRenewByBarcodeTests extends APITests {
     policiesToDelete.add(nonRenewablePolicyId);
 
     useLoanPolicyAsFallback(nonRenewablePolicyId);
+
+    loansFixture.attemptRenewal(422, smallAngryPlanet, jessica);
 
     Response response =
       loansFixture.attemptOverride(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null);
@@ -180,7 +183,8 @@ public class OverrideRenewByBarcodeTests extends APITests {
   public void canOverrideRenewalWhenItemIsNotRenewableAndNewDueDateIsSpecified() throws
     InterruptedException,
     ExecutionException,
-    TimeoutException, MalformedURLException {
+    TimeoutException,
+    MalformedURLException {
 
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource jessica = usersFixture.jessica();
@@ -202,10 +206,13 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(nonRenewablePolicyId);
 
+    loansFixture.attemptRenewal(422, smallAngryPlanet, jessica);
+
     DateTime newDueDate = DateTime.now().plusWeeks(2);
 
     JsonObject renewedLoan =
-      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, newDueDate.toString()).getJson();
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica,
+        OVERRIDE_COMMENT, newDueDate.toString()).getJson();
 
     assertThat("user ID should match barcode",
       renewedLoan.getString("userId"), is(jessica.getId().toString()));
@@ -269,6 +276,8 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(dueDateLimitedPolicyId);
 
+    loansFixture.attemptRenewal(422, smallAngryPlanet, jessica);
+
     Response response =
       loansFixture.attemptOverride(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null);
 
@@ -287,7 +296,9 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     DateTime loanDueDate =
       new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43);
-    final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica, loanDueDate);
+
+    final IndividualResource loan = loansFixture.checkOutByBarcode(
+      smallAngryPlanet, jessica, loanDueDate);
 
     final UUID loanId = loan.getId();
 
@@ -312,6 +323,8 @@ public class OverrideRenewByBarcodeTests extends APITests {
     policiesToDelete.add(dueDateLimitedPolicyId);
 
     useLoanPolicyAsFallback(dueDateLimitedPolicyId);
+
+    loansFixture.attemptRenewal(422, smallAngryPlanet, jessica);
 
     DateTime newDueDate = DateTime.now().plusWeeks(1);
     final JsonObject renewedLoan =
@@ -390,6 +403,8 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(dueDateLimitedPolicyId);
 
+    loansFixture.attemptRenewal(422, smallAngryPlanet, jessica);
+
     final JsonObject renewedLoan =
       loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null)
         .getJson();
@@ -447,8 +462,11 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     loansFixture.renewLoan(smallAngryPlanet, jessica);
 
+    loansFixture.attemptRenewal(422, smallAngryPlanet, jessica);
+
     final JsonObject renewedLoan =
-      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null)
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica,
+        OVERRIDE_COMMENT, null)
         .getJson();
 
     assertThat("user ID should match barcode",

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -734,7 +734,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     assertThat("last loan policy should be stored",
       renewedLoan.getString("loanPolicyId"), is(dueDateLimitedPolicyId.toString()));
 
-    assertThat("due date should be 2 months after initial due date date",
+    assertThat("due date should be 1st of January 2025",
       renewedLoan.getString("dueDate"),
       isEquivalentTo(newDueDate));
 

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -1,0 +1,823 @@
+package api.loans;
+
+import api.APITestSuite;
+import api.support.APITests;
+import api.support.builders.CheckOutByBarcodeRequestBuilder;
+import api.support.builders.FixedDueDateSchedulesBuilder;
+import api.support.builders.LoanPolicyBuilder;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.http.client.ResponseHandler;
+import org.folio.circulation.support.http.server.ValidationError;
+import org.hamcrest.Matcher;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Seconds;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static api.support.builders.FixedDueDateSchedule.forDay;
+import static api.support.builders.FixedDueDateSchedule.wholeMonth;
+import static api.support.builders.ItemBuilder.CHECKED_OUT;
+import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
+import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
+import static api.support.matchers.TextDateTimeMatcher.withinSecondsAfter;
+import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
+import static api.support.matchers.ValidationErrorMatchers.hasMessage;
+import static api.support.matchers.ValidationErrorMatchers.hasParameter;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class OverrideRenewByBarcodeTests extends APITests {
+
+  private static final String OVERRIDE_COMMENT = "Comment to override";
+
+  @Test
+  public void canOverrideRenewalRollingLoanFromSystemDate()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final UUID loanId = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
+      new DateTime(2018, 4, 21, 11, 21, 43))
+      .getId();
+
+    //TODO: Renewal based upon system date,
+    // needs to be approximated, at least until we introduce a calendar and clock
+    DateTime approximateRenewalDate = DateTime.now();
+
+    final JsonObject renewedLoan = loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null).getJson();
+
+    assertThat(renewedLoan.getString("id"), is(loanId.toString()));
+
+    assertThat("user ID should match barcode",
+      renewedLoan.getString("userId"), is(jessica.getId().toString()));
+
+    assertThat("item ID should match barcode",
+      renewedLoan.getString("itemId"), is(smallAngryPlanet.getId().toString()));
+
+    assertThat("status should be open",
+      renewedLoan.getJsonObject("status").getString("name"), is("Open"));
+
+    assertThat("action should be renewed",
+      renewedLoan.getString("action"), is("Renewed through override"));
+
+    assertThat("'actionComment' field should contain comment specified for override",
+      renewedLoan.getString("actionComment"), is(OVERRIDE_COMMENT));
+
+    assertThat("renewal count should be incremented",
+      renewedLoan.getInteger("renewalCount"), is(1));
+
+    assertThat("last loan policy should be stored",
+      renewedLoan.getString("loanPolicyId"),
+      is(APITestSuite.canCirculateRollingLoanPolicyId().toString()));
+
+    assertThat("due date should be approximately 3 weeks after renewal date, based upon loan policy",
+      renewedLoan.getString("dueDate"),
+      withinSecondsAfter(Seconds.seconds(10), approximateRenewalDate.plusWeeks(3)));
+
+    smallAngryPlanet = itemsClient.get(smallAngryPlanet);
+
+    assertThat(smallAngryPlanet, hasItemStatus(CHECKED_OUT));
+  }
+
+  @Test
+  public void canOverrideRenewalRollingLoanFromCurrentDueDate()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
+      new DateTime(2018, 4, 21, 11, 21, 43));
+
+    final UUID loanId = loan.getId();
+
+    LoanPolicyBuilder currentDueDateRollingPolicy = new LoanPolicyBuilder()
+      .withName("Current Due Date Rolling Policy")
+      .rolling(Period.months(2))
+      .renewFromCurrentDueDate();
+
+    UUID dueDateLimitedPolicyId = loanPolicyClient.create(currentDueDateRollingPolicy).getId();
+
+    //Need to remember in order to delete after test
+    policiesToDelete.add(dueDateLimitedPolicyId);
+
+    useLoanPolicyAsFallback(dueDateLimitedPolicyId);
+
+    final JsonObject renewedLoan =
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null).getJson();
+
+    assertThat(renewedLoan.getString("id"), is(loanId.toString()));
+
+    assertThat("user ID should match barcode",
+      renewedLoan.getString("userId"), is(jessica.getId().toString()));
+
+    assertThat("item ID should match barcode",
+      renewedLoan.getString("itemId"), is(smallAngryPlanet.getId().toString()));
+
+    assertThat("status should be open",
+      renewedLoan.getJsonObject("status").getString("name"), is("Open"));
+
+    assertThat("action should be renewed",
+      renewedLoan.getString("action"), is("Renewed through override"));
+
+    assertThat("'actionComment' field should contain comment specified for override",
+      renewedLoan.getString("actionComment"), is(OVERRIDE_COMMENT));
+
+    assertThat("renewal count should be incremented",
+      renewedLoan.getInteger("renewalCount"), is(1));
+
+    assertThat("last loan policy should be stored",
+      renewedLoan.getString("loanPolicyId"), is(dueDateLimitedPolicyId.toString()));
+
+    assertThat("due date should be 2 months after initial due date date",
+      renewedLoan.getString("dueDate"),
+      isEquivalentTo(new DateTime(2018, 7, 12, 11, 21, 43)));
+
+    smallAngryPlanet = itemsClient.get(smallAngryPlanet);
+
+    assertThat(smallAngryPlanet, hasItemStatus(CHECKED_OUT));
+  }
+
+  @Test
+  public void canOverrideRenewalUsingDueDateLimitedRollingLoanPolicy()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    FixedDueDateSchedulesBuilder dueDateLimitSchedule = new FixedDueDateSchedulesBuilder()
+      .withName("March Only Due Date Limit")
+      .addSchedule(wholeMonth(2018, 3));
+
+    final UUID dueDateLimitScheduleId = fixedDueDateScheduleClient.create(
+      dueDateLimitSchedule).getId();
+
+    //Need to remember in order to delete after test
+    schedulesToDelete.add(dueDateLimitScheduleId);
+
+    LoanPolicyBuilder dueDateLimitedPolicy = new LoanPolicyBuilder()
+      .withName("Due Date Limited Rolling Policy")
+      .rolling(Period.weeks(2))
+      .limitedBySchedule(dueDateLimitScheduleId)
+      .renewFromCurrentDueDate();
+
+    UUID dueDateLimitedPolicyId = loanPolicyClient.create(dueDateLimitedPolicy).getId();
+
+    //Need to remember in order to delete after test
+    policiesToDelete.add(dueDateLimitedPolicyId);
+
+    useLoanPolicyAsFallback(dueDateLimitedPolicyId);
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource steve = usersFixture.steve();
+
+    final DateTime loanDate = new DateTime(2018, 3, 7, 11, 43, 54, DateTimeZone.UTC);
+
+    loansFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(smallAngryPlanet)
+        .to(steve)
+        .on(loanDate)
+        .at(UUID.randomUUID()));
+
+    final IndividualResource response =
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, steve, OVERRIDE_COMMENT, null);
+
+    final JsonObject loan = response.getJson();
+
+    assertThat("last loan policy should be stored",
+      loan.getString("loanPolicyId"), is(dueDateLimitedPolicyId.toString()));
+
+    assertThat("due date should be limited by schedule",
+      loan.getString("dueDate"),
+      isEquivalentTo(new DateTime(2018, 3, 31, 23, 59, 59, DateTimeZone.UTC)));
+  }
+
+  @Test
+  public void canOverrideRenewalRollingLoanUsingDifferentPeriod()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
+      new DateTime(2018, 4, 21, 11, 21, 43));
+
+    final UUID loanId = loan.getId();
+
+    LoanPolicyBuilder currentDueDateRollingPolicy = new LoanPolicyBuilder()
+      .withName("Current Due Date Different Period Rolling Policy")
+      .rolling(Period.months(2))
+      .renewFromCurrentDueDate()
+      .renewWith(Period.months(1));
+
+    UUID dueDateLimitedPolicyId = loanPolicyClient.create(currentDueDateRollingPolicy).getId();
+
+    //Need to remember in order to delete after test
+    policiesToDelete.add(dueDateLimitedPolicyId);
+
+    useLoanPolicyAsFallback(dueDateLimitedPolicyId);
+
+    final JsonObject renewedLoan =
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null).getJson();
+
+    assertThat(renewedLoan.getString("id"), is(loanId.toString()));
+
+    assertThat("user ID should match barcode",
+      renewedLoan.getString("userId"), is(jessica.getId().toString()));
+
+    assertThat("item ID should match barcode",
+      renewedLoan.getString("itemId"), is(smallAngryPlanet.getId().toString()));
+
+    assertThat("status should be open",
+      renewedLoan.getJsonObject("status").getString("name"), is("Open"));
+
+    assertThat("action should be renewed",
+      renewedLoan.getString("action"), is("Renewed through override"));
+
+    assertThat("'actionComment' field should contain comment specified for override",
+      renewedLoan.getString("actionComment"), is(OVERRIDE_COMMENT));
+
+    assertThat("renewal count should be incremented",
+      renewedLoan.getInteger("renewalCount"), is(1));
+
+    assertThat("last loan policy should be stored",
+      renewedLoan.getString("loanPolicyId"), is(dueDateLimitedPolicyId.toString()));
+
+    assertThat("due date should be 2 months after initial due date date",
+      renewedLoan.getString("dueDate"),
+      isEquivalentTo(new DateTime(2018, 6, 12, 11, 21, 43)));
+
+    smallAngryPlanet = itemsClient.get(smallAngryPlanet);
+
+    assertThat(smallAngryPlanet, hasItemStatus(CHECKED_OUT));
+  }
+
+  @Test
+  public void canOverrideRenewalUsingAlternateDueDateLimitedRollingLoanPolicy()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    FixedDueDateSchedulesBuilder dueDateLimitSchedule = new FixedDueDateSchedulesBuilder()
+      .withName("March Only Due Date Limit")
+      .addSchedule(wholeMonth(2018, 3));
+
+    final UUID dueDateLimitScheduleId = fixedDueDateScheduleClient.create(
+      dueDateLimitSchedule).getId();
+
+    //Need to remember in order to delete after test
+    schedulesToDelete.add(dueDateLimitScheduleId);
+
+    LoanPolicyBuilder dueDateLimitedPolicy = new LoanPolicyBuilder()
+      .withName("Due Date Limited Rolling Policy")
+      .rolling(Period.weeks(3))
+      .renewFromCurrentDueDate()
+      .renewWith(Period.days(8), dueDateLimitScheduleId);
+
+    UUID dueDateLimitedPolicyId = loanPolicyClient.create(dueDateLimitedPolicy).getId();
+
+    //Need to remember in order to delete after test
+    policiesToDelete.add(dueDateLimitedPolicyId);
+
+    useLoanPolicyAsFallback(dueDateLimitedPolicyId);
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource steve = usersFixture.steve();
+
+    final DateTime loanDate = new DateTime(2018, 3, 4, 11, 43, 54, DateTimeZone.UTC);
+
+    loansFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(smallAngryPlanet)
+        .to(steve)
+        .on(loanDate)
+        .at(UUID.randomUUID()));
+
+    final IndividualResource response =
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, steve, OVERRIDE_COMMENT, null);
+
+    final JsonObject loan = response.getJson();
+
+    assertThat("last loan policy should be stored",
+      loan.getString("loanPolicyId"), is(dueDateLimitedPolicyId.toString()));
+
+    assertThat("due date should be limited by schedule",
+      loan.getString("dueDate"),
+      isEquivalentTo(new DateTime(2018, 3, 31, 23, 59, 59, DateTimeZone.UTC)));
+  }
+
+  @Test
+  public void canOverrideRenewalUsingLoanDueDateLimitSchedulesWhenDifferentPeriodAndNotAlternateLimits()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    FixedDueDateSchedulesBuilder dueDateLimitSchedule = new FixedDueDateSchedulesBuilder()
+      .withName("March Only Due Date Limit")
+      .addSchedule(wholeMonth(2018, 3));
+
+    final UUID dueDateLimitScheduleId = fixedDueDateScheduleClient.create(
+      dueDateLimitSchedule).getId();
+
+    //Need to remember in order to delete after test
+    schedulesToDelete.add(dueDateLimitScheduleId);
+
+    LoanPolicyBuilder dueDateLimitedPolicy = new LoanPolicyBuilder()
+      .withName("Due Date Limited Rolling Policy")
+      .rolling(Period.weeks(3))
+      .limitedBySchedule(dueDateLimitScheduleId)
+      .renewFromCurrentDueDate()
+      .renewWith(Period.days(8));
+
+    UUID dueDateLimitedPolicyId = loanPolicyClient.create(dueDateLimitedPolicy).getId();
+
+    //Need to remember in order to delete after test
+    policiesToDelete.add(dueDateLimitedPolicyId);
+
+    useLoanPolicyAsFallback(dueDateLimitedPolicyId);
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource steve = usersFixture.steve();
+
+    final DateTime loanDate = new DateTime(2018, 3, 4, 11, 43, 54, DateTimeZone.UTC);
+
+    loansFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(smallAngryPlanet)
+        .to(steve)
+        .on(loanDate)
+        .at(UUID.randomUUID()));
+
+    final IndividualResource response =
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, steve, OVERRIDE_COMMENT, null);
+
+    final JsonObject loan = response.getJson();
+
+    assertThat("last loan policy should be stored",
+      loan.getString("loanPolicyId"), is(dueDateLimitedPolicyId.toString()));
+
+    assertThat("due date should be limited by schedule",
+      loan.getString("dueDate"),
+      isEquivalentTo(new DateTime(2018, 3, 31, 23, 59, 59, DateTimeZone.UTC)));
+  }
+
+  @Test
+  public void canOverrideRenewalUsingFixedDueDateLoanPolicy()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    //TODO: Need to be able to inject system date here
+    final DateTime renewalDate = DateTime.now();
+    //e.g. Clock.freeze(renewalDate)
+
+    FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
+      .withName("Kludgy Fixed Due Date Schedule")
+      .addSchedule(wholeMonth(2018, 2))
+      .addSchedule(forDay(renewalDate));
+
+    final UUID fixedDueDateSchedulesId = fixedDueDateScheduleClient.create(
+      fixedDueDateSchedules).getId();
+
+    //Need to remember in order to delete after test
+    schedulesToDelete.add(fixedDueDateSchedulesId);
+
+    LoanPolicyBuilder dueDateLimitedPolicy = new LoanPolicyBuilder()
+      .withName("Fixed Due Date Policy")
+      .fixed(fixedDueDateSchedulesId)
+      .renewFromSystemDate();
+
+    UUID fixedDueDatePolicyId = loanPolicyClient.create(dueDateLimitedPolicy).getId();
+
+    //Need to remember in order to delete after test
+    policiesToDelete.add(fixedDueDatePolicyId);
+
+    useLoanPolicyAsFallback(fixedDueDatePolicyId);
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource steve = usersFixture.steve();
+
+    final DateTime loanDate = new DateTime(2018, 2, 10, 11, 23, 12, DateTimeZone.UTC);
+
+    loansFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(smallAngryPlanet)
+        .to(steve)
+        .on(loanDate)
+        .at(UUID.randomUUID()));
+
+    final IndividualResource response = loansFixture.overrideRenewalByBarcode(smallAngryPlanet, steve, OVERRIDE_COMMENT, null);
+
+    final JsonObject loan = response.getJson();
+
+    assertThat("last loan policy should be stored",
+      loan.getString("loanPolicyId"), is(fixedDueDatePolicyId.toString()));
+
+    assertThat("renewal count should be incremented",
+      loan.getInteger("renewalCount"), is(1));
+
+    final DateTime endOfRenewalDate = renewalDate
+      .withTimeAtStartOfDay()
+      .withHourOfDay(23)
+      .withMinuteOfHour(59)
+      .withSecondOfMinute(59);
+
+    assertThat("due date should be defined by schedule",
+      loan.getString("dueDate"), isEquivalentTo(endOfRenewalDate));
+  }
+
+  @Test
+  public void canOverrideRenewalMultipleTimesUpToRenewalLimit()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    LoanPolicyBuilder limitedRenewalsPolicy = new LoanPolicyBuilder()
+      .withName("Limited Renewals Policy")
+      .rolling(Period.days(2))
+      .renewFromCurrentDueDate()
+      .limitedRenewals(3);
+
+    UUID limitedRenewalsPolicyId = loanPolicyClient.create(limitedRenewalsPolicy).getId();
+
+    //Need to remember in order to delete after test
+    policiesToDelete.add(limitedRenewalsPolicyId);
+
+    useLoanPolicyAsFallback(limitedRenewalsPolicyId);
+
+    final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
+      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+
+    final UUID loanId = loan.getId();
+
+    loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null);
+
+    loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null);
+
+    final JsonObject renewedLoan =
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null).getJson();
+
+    assertThat(renewedLoan.getString("id"), is(loanId.toString()));
+
+    assertThat("status should be open",
+      renewedLoan.getJsonObject("status").getString("name"), is("Open"));
+
+    assertThat("action should be renewed",
+      renewedLoan.getString("action"), is("Renewed through override"));
+
+    assertThat("'actionComment' field should contain comment specified for override",
+      renewedLoan.getString("actionComment"), is(OVERRIDE_COMMENT));
+
+    assertThat("renewal count should be incremented",
+      renewedLoan.getInteger("renewalCount"), is(3));
+
+    assertThat("last loan policy should be stored",
+      renewedLoan.getString("loanPolicyId"), is(limitedRenewalsPolicyId.toString()));
+
+    assertThat("due date should be 8 days after initial loan date date",
+      renewedLoan.getString("dueDate"),
+      isEquivalentTo(new DateTime(2018, 4, 29, 11, 21, 43, DateTimeZone.UTC)));
+
+    smallAngryPlanet = itemsClient.get(smallAngryPlanet);
+
+    assertThat(smallAngryPlanet, hasItemStatus(CHECKED_OUT));
+  }
+
+  @Test
+  public void canGetOverrideRenewaledLoan()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final UUID loanId = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
+      new DateTime(2018, 4, 21, 11, 21, 43))
+      .getId();
+
+    //TODO: Renewal based upon system date,
+    // needs to be approximated, at least until we introduce a calendar and clock
+    DateTime approximateRenewalDate = DateTime.now();
+
+    final IndividualResource response =
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null);
+
+    final CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+
+    client.get(APITestSuite.circulationModuleUrl(response.getLocation()),
+      ResponseHandler.json(getCompleted));
+
+    final Response getResponse = getCompleted.get(2, TimeUnit.SECONDS);
+
+    assertThat(getResponse.getStatusCode(), is(HTTP_OK));
+
+    JsonObject renewedLoan = getResponse.getJson();
+
+    assertThat(renewedLoan.getString("id"), is(loanId.toString()));
+
+    assertThat("user ID should match barcode",
+      renewedLoan.getString("userId"), is(jessica.getId().toString()));
+
+    assertThat("item ID should match barcode",
+      renewedLoan.getString("itemId"), is(smallAngryPlanet.getId().toString()));
+
+    assertThat("status should be open",
+      renewedLoan.getJsonObject("status").getString("name"), is("Open"));
+
+    assertThat("action should be renewed",
+      renewedLoan.getString("action"), is("Renewed through override"));
+
+    assertThat("'actionComment' field should contain comment specified for override",
+      renewedLoan.getString("actionComment"), is(OVERRIDE_COMMENT));
+
+    assertThat("renewal count should be incremented",
+      renewedLoan.getInteger("renewalCount"), is(1));
+
+    assertThat("last loan policy should be stored",
+      renewedLoan.getString("loanPolicyId"),
+      is(APITestSuite.canCirculateRollingLoanPolicyId().toString()));
+
+    assertThat("due date should be approximately 3 weeks after renewal date, based upon loan policy",
+      renewedLoan.getString("dueDate"),
+      withinSecondsAfter(Seconds.seconds(10), approximateRenewalDate.plusWeeks(3)));
+  }
+
+  @Test
+  public void cannotOverrideRenewalWhenLoanPolicyDoesNotExist()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final UUID unknownLoanPolicyId = UUID.randomUUID();
+
+    loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
+      new DateTime(2018, 4, 21, 11, 21, 43));
+
+    useLoanPolicyAsFallback(unknownLoanPolicyId);
+
+    final Response response = loansFixture.attemptRenewal(500, smallAngryPlanet, jessica);
+
+    assertThat(response.getBody(), is(String.format(
+      "Loan policy %s could not be found, please check loan rules", unknownLoanPolicyId)));
+  }
+
+  @Test
+  public void cannotOverrideRenewalWhenLoaneeCannotBeFound()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource steve = usersFixture.steve();
+
+    loansFixture.checkOut(smallAngryPlanet, steve);
+
+    usersClient.delete(steve.getId());
+
+    final Response response =
+      loansFixture.attemptOverride(smallAngryPlanet, steve, OVERRIDE_COMMENT, null);
+
+    //Occurs when current loanee is not found, so relates to loan rather than user in request
+    assertThat(response.getJson(), hasErrorWith(allOf(
+      hasMessage("user is not found"),
+      hasParameter("userId", steve.getId().toString()))));
+  }
+
+  @Test
+  public void cannotOverrideRenewalWhenItemCannotBeFound()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource steve = usersFixture.steve();
+
+    loansFixture.checkOut(smallAngryPlanet, steve);
+
+    itemsClient.delete(smallAngryPlanet.getId());
+
+    final Response response =
+      loansFixture.attemptOverride(smallAngryPlanet, steve, OVERRIDE_COMMENT, null);
+
+    assertThat(response.getJson(), hasErrorWith(allOf(
+      hasItemNotFoundMessage(smallAngryPlanet),
+      hasItemRelatedParameter(smallAngryPlanet))));
+  }
+
+  @Test
+  public void cannotOverrideRenewalLoanForDifferentUser()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    IndividualResource james = usersFixture.james();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
+      new DateTime(2018, 4, 21, 11, 21, 43));
+
+    final Response response =
+      loansFixture.attemptOverride(smallAngryPlanet, james, OVERRIDE_COMMENT, null);
+
+    assertThat(response.getJson(), hasErrorWith(allOf(
+      hasMessage("Cannot renew item checked out to different user"),
+      hasUserRelatedParameter(james))));
+  }
+
+  @Test
+  public void canOverrideRenewalToSpecifiedDateWhenDateFallsOutsideOfTheDateRangesInTheLoanPolicy() throws
+    InterruptedException,
+    ExecutionException,
+    TimeoutException, MalformedURLException {
+
+    final DateTime renewalDate = DateTime.now();
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
+      new DateTime(2018, 4, 21, 11, 21, 43));
+
+    final UUID loanId = loan.getId();
+
+    FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
+      .withName("Kludgy Fixed Due Date Schedule")
+      .addSchedule(wholeMonth(2018, 2))
+      .addSchedule(forDay(renewalDate));
+
+    final UUID fixedDueDateSchedulesId = fixedDueDateScheduleClient.create(
+      fixedDueDateSchedules).getId();
+
+    //Need to remember in order to delete after test
+    schedulesToDelete.add(fixedDueDateSchedulesId);
+
+    LoanPolicyBuilder currentDueDateRollingPolicy = new LoanPolicyBuilder()
+      .withName("Current Due Date Rolling Policy")
+      .rolling(Period.months(2))
+      .renewWith(fixedDueDateSchedulesId)
+      .renewFromCurrentDueDate();
+
+    UUID dueDateLimitedPolicyId = loanPolicyClient.create(currentDueDateRollingPolicy).getId();
+
+    //Need to remember in order to delete after test
+    policiesToDelete.add(dueDateLimitedPolicyId);
+
+    useLoanPolicyAsFallback(dueDateLimitedPolicyId);
+
+    DateTime newDueDate =
+      new DateTime(2025, 1, 1, 1, 1, 1);
+    final JsonObject renewedLoan =
+      loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica, OVERRIDE_COMMENT, newDueDate.toString()).getJson();
+
+    assertThat(renewedLoan.getString("id"), is(loanId.toString()));
+
+    assertThat("user ID should match barcode",
+      renewedLoan.getString("userId"), is(jessica.getId().toString()));
+
+    assertThat("item ID should match barcode",
+      renewedLoan.getString("itemId"), is(smallAngryPlanet.getId().toString()));
+
+    assertThat("status should be open",
+      renewedLoan.getJsonObject("status").getString("name"), is("Open"));
+
+    assertThat("action should be renewed",
+      renewedLoan.getString("action"), is("Renewed through override"));
+
+    assertThat("'actionComment' field should contain comment specified for override",
+      renewedLoan.getString("actionComment"), is(OVERRIDE_COMMENT));
+
+    assertThat("renewal count should be incremented",
+      renewedLoan.getInteger("renewalCount"), is(1));
+
+    assertThat("last loan policy should be stored",
+      renewedLoan.getString("loanPolicyId"), is(dueDateLimitedPolicyId.toString()));
+
+    assertThat("due date should be 2 months after initial due date date",
+      renewedLoan.getString("dueDate"),
+      isEquivalentTo(newDueDate));
+
+    smallAngryPlanet = itemsClient.get(smallAngryPlanet);
+
+    assertThat(smallAngryPlanet, hasItemStatus(CHECKED_OUT));
+  }
+
+  @Test
+  public void cannotOverrideRenewalWhenNewDueDateIsNotSpecifiedAndDateFallsOutsideOfTheDateRangesInTheLoanPolicy() throws
+    InterruptedException,
+    ExecutionException,
+    TimeoutException, MalformedURLException {
+
+    final DateTime renewalDate = DateTime.now();
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final IndividualResource loan = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
+      new DateTime(2018, 4, 21, 11, 21, 43));
+
+    final UUID loanId = loan.getId();
+
+    FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
+      .withName("Kludgy Fixed Due Date Schedule")
+      .addSchedule(wholeMonth(2018, 2))
+      .addSchedule(forDay(renewalDate));
+
+    final UUID fixedDueDateSchedulesId = fixedDueDateScheduleClient.create(
+      fixedDueDateSchedules).getId();
+
+    //Need to remember in order to delete after test
+    schedulesToDelete.add(fixedDueDateSchedulesId);
+
+    LoanPolicyBuilder currentDueDateRollingPolicy = new LoanPolicyBuilder()
+      .withName("Current Due Date Rolling Policy")
+      .rolling(Period.months(2))
+      .renewWith(fixedDueDateSchedulesId)
+      .renewFromCurrentDueDate();
+
+    UUID dueDateLimitedPolicyId = loanPolicyClient.create(currentDueDateRollingPolicy).getId();
+
+    //Need to remember in order to delete after test
+    policiesToDelete.add(dueDateLimitedPolicyId);
+
+    useLoanPolicyAsFallback(dueDateLimitedPolicyId);
+
+    final Response response =
+      loansFixture.attemptOverride(smallAngryPlanet, jessica, OVERRIDE_COMMENT, null);
+
+    assertThat(response.getJson(), hasErrorWith(allOf(
+      hasMessage("New due date must be specified when due date calculation fails"),
+      hasParameter("dueDate", null))));
+  }
+
+  @Test
+  public void cannotOverrideRenewalWhenCommentPropertyIsBlank() throws
+    InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final Response response =
+      loansFixture.attemptOverride(smallAngryPlanet, jessica, StringUtils.EMPTY, null);
+
+    assertThat(response.getJson(), hasErrorWith(allOf(
+      hasMessage("Override renewal request must have a comment"),
+      hasParameter("comment", null))));
+  }
+
+  private Matcher<ValidationError> hasUserRelatedParameter(IndividualResource user) {
+    return hasParameter("userBarcode", user.getJson().getString("barcode"));
+  }
+
+  private Matcher<ValidationError> hasItemRelatedParameter(IndividualResource item) {
+    return hasParameter("itemBarcode", item.getJson().getString("barcode"));
+  }
+
+  private Matcher<ValidationError> hasItemNotFoundMessage(IndividualResource item) {
+    return hasMessage(String.format("No item with barcode %s exists",
+      item.getJson().getString("barcode")));
+  }
+}

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -14,6 +14,7 @@ import org.folio.circulation.support.http.client.ResponseHandler;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeConstants;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Seconds;
 import org.junit.Test;
@@ -54,7 +55,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     final UUID loanId = loansFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43))
+      new DateTime(2018, DateTimeConstants.APRIL, 21, 11, 21, 43))
       .getId();
 
     //TODO: Renewal based upon system date,

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -696,7 +696,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     LoanPolicyBuilder currentDueDateRollingPolicy = new LoanPolicyBuilder()
       .withName("Current Due Date Rolling Policy")
       .rolling(Period.months(2))
-      .renewWith(fixedDueDateSchedulesId)
+      .renewOverrideWith(fixedDueDateSchedulesId)
       .renewFromCurrentDueDate();
 
     UUID dueDateLimitedPolicyId = loanPolicyClient.create(currentDueDateRollingPolicy).getId();
@@ -773,7 +773,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     LoanPolicyBuilder currentDueDateRollingPolicy = new LoanPolicyBuilder()
       .withName("Current Due Date Rolling Policy")
       .rolling(Period.months(2))
-      .renewWith(fixedDueDateSchedulesId)
+      .renewOverrideWith(fixedDueDateSchedulesId)
       .renewFromCurrentDueDate();
 
     UUID dueDateLimitedPolicyId = loanPolicyClient.create(currentDueDateRollingPolicy).getId();

--- a/src/test/java/api/support/builders/LoanPolicyBuilder.java
+++ b/src/test/java/api/support/builders/LoanPolicyBuilder.java
@@ -333,8 +333,18 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewable);
   }
 
-  public LoanPolicyBuilder renewWith(UUID fixedDueDateScheduleId) {
+  public Builder renewWith(UUID fixedDueDateScheduleId) {
+    if(!Objects.equals(profile, "Fixed")) {
+      throw new IllegalArgumentException("Can only be used with fixed profile");
+    }
+    return renew(fixedDueDateScheduleId);
+  }
 
+  public LoanPolicyBuilder renewOverrideWith(UUID fixedDueDateScheduleId) {
+    return renew(fixedDueDateScheduleId);
+  }
+
+  private LoanPolicyBuilder renew(UUID fixedDueDateScheduleId) {
     return new LoanPolicyBuilder(
       this.id,
       this.name,

--- a/src/test/java/api/support/builders/LoanPolicyBuilder.java
+++ b/src/test/java/api/support/builders/LoanPolicyBuilder.java
@@ -340,10 +340,6 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
     return renew(fixedDueDateScheduleId);
   }
 
-  public LoanPolicyBuilder renewOverrideWith(UUID fixedDueDateScheduleId) {
-    return renew(fixedDueDateScheduleId);
-  }
-
   private LoanPolicyBuilder renew(UUID fixedDueDateScheduleId) {
     return new LoanPolicyBuilder(
       this.id,

--- a/src/test/java/api/support/builders/LoanPolicyBuilder.java
+++ b/src/test/java/api/support/builders/LoanPolicyBuilder.java
@@ -333,10 +333,7 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewable);
   }
 
-  public Builder renewWith(UUID fixedDueDateScheduleId) {
-    if(!Objects.equals(profile, "Fixed")) {
-      throw new IllegalArgumentException("Can only be used with fixed profile");
-    }
+  public LoanPolicyBuilder renewWith(UUID fixedDueDateScheduleId) {
 
     return new LoanPolicyBuilder(
       this.id,

--- a/src/test/java/api/support/builders/OverrideRenewalByBarcodeRequestBuilder.java
+++ b/src/test/java/api/support/builders/OverrideRenewalByBarcodeRequestBuilder.java
@@ -1,0 +1,74 @@
+package api.support.builders;
+
+import io.vertx.core.json.JsonObject;
+import org.folio.circulation.support.http.client.IndividualResource;
+
+public class OverrideRenewalByBarcodeRequestBuilder extends JsonBuilder implements Builder {
+
+  private final String itemBarcode;
+  private final String userBarcode;
+  private final String comment;
+  private final String dueDate;
+
+  public OverrideRenewalByBarcodeRequestBuilder() {
+    this(null, null, null, null);
+  }
+
+  private OverrideRenewalByBarcodeRequestBuilder(
+    String itemBarcode,
+    String userBarcode, String comment, String dueDate) {
+
+    this.itemBarcode = itemBarcode;
+    this.userBarcode = userBarcode;
+    this.comment = comment;
+    this.dueDate = dueDate;
+  }
+
+  @Override
+  public JsonObject create() {
+    final JsonObject request = new JsonObject();
+
+    put(request, "itemBarcode", this.itemBarcode);
+    put(request, "userBarcode", this.userBarcode);
+    put(request, "comment", this.comment);
+    put(request, "dueDate", this.dueDate);
+
+    return request;
+  }
+
+  public OverrideRenewalByBarcodeRequestBuilder forItem(IndividualResource item) {
+    return new OverrideRenewalByBarcodeRequestBuilder(
+      getBarcode(item),
+      this.userBarcode,
+      this.comment,
+      this.dueDate);
+  }
+
+  public OverrideRenewalByBarcodeRequestBuilder forUser(IndividualResource loanee) {
+    return new OverrideRenewalByBarcodeRequestBuilder(
+      this.itemBarcode,
+      getBarcode(loanee),
+      this.comment,
+      this.dueDate);
+  }
+
+  public OverrideRenewalByBarcodeRequestBuilder withComment(String comment) {
+    return new OverrideRenewalByBarcodeRequestBuilder(
+      this.itemBarcode,
+      this.userBarcode,
+      comment,
+      this.dueDate);
+  }
+
+  public OverrideRenewalByBarcodeRequestBuilder withDueDate(String dueDate) {
+    return new OverrideRenewalByBarcodeRequestBuilder(
+      this.itemBarcode,
+      this.userBarcode,
+      this.comment,
+      dueDate);
+  }
+
+  private String getBarcode(IndividualResource record) {
+    return record.getJson().getString("barcode");
+  }
+}

--- a/src/test/java/api/support/http/InterfaceUrls.java
+++ b/src/test/java/api/support/http/InterfaceUrls.java
@@ -1,9 +1,9 @@
 package api.support.http;
 
+import api.APITestSuite;
+
 import java.net.URL;
 import java.util.UUID;
-
-import api.APITestSuite;
 
 public class InterfaceUrls {
   static URL materialTypesStorageUrl(String subPath) {
@@ -104,6 +104,10 @@ public class InterfaceUrls {
 
   public static URL renewByBarcodeUrl() {
     return APITestSuite.circulationModuleUrl("/circulation/renew-by-barcode");
+  }
+
+  public static URL overrideRenewalByBarcodeUrl() {
+    return APITestSuite.circulationModuleUrl("/circulation/override-renewal-by-barcode");
   }
 
   public static URL renewByIdUrl() {

--- a/test-via-okapi.sh
+++ b/test-via-okapi.sh
@@ -6,13 +6,13 @@ circulation_direct_address=http://localhost:9605
 circulation_instance_id=localhost-9605
 
 #Needs to be the specific version of mod-inventory-storage you want to use for testing
-inventory_storage_module_id="mod-inventory-storage-14.0.0-SNAPSHOT"
+inventory_storage_module_id="mod-inventory-storage-14.1.0-SNAPSHOT"
 
 #Needs to be the specific version of mod-circulation-storage you want to use for testing
 circulation_storage_module_id="mod-circulation-storage-6.3.0-SNAPSHOT"
 
 #Needs to be the specific version of mod-users you want to use for testing
-users_storage_module_id="mod-users-15.3.0-SNAPSHOT"
+users_storage_module_id="mod-users-15.3.1-SNAPSHOT"
 
 #remove log output
 rm test-via-okapi.log
@@ -70,7 +70,8 @@ echo "Run tests via Okapi"
 # to run a smaller set of tests
 mvn -Dokapi.address="${okapi_proxy_address}" \
 -Duse.okapi.initial.requests="true"  \
--Duse.okapi.storage.requests="true" clean test \
+-Duse.okapi.storage.requests="true" \
+clean test \
 | tee -a test-via-okapi.log
 
 test_results=$?


### PR DESCRIPTION
## Purpose
CIRC-174
New endpoint **POST /circulation/override-renewal-by-barcode** was implemented to give an ability to override renewal process in case it fails due to list of reasons (see story description).

Resolves: https://issues.folio.org/browse/CIRC-174
Requires updates in circulation-storage: [pull request](https://github.com/folio-org/mod-circulation-storage/pull/123)
Link to flow chart describing renewal override logic: [flow chart](https://drive.google.com/open?id=1MQqE3eJdcXlb-H8dSYul2-hyQmlANrPE)
## Approach
- new resource _OverrideRenewalByBarcodeResource_ was added;
- functionality for searching loan was moved from _RenewByBarcodeResource_ to _SingleOpenLoanByUserAndItemBarcodeFinder_ for reuse purposes;
- new method _overrideRenewal()_ was added to _LoanPolicy_ class to containing override logic;
- new method _overrideRenewal()_ was added to _Loan_ class that changes Loan state due to override action;
- updated 'circulation' interface version to '5.4';
- module now requires 'loan-storage' v5.3 interface (as a new filed 'actionComment' is saved after override action');
