### PR TITLE
CIRC-192 Change renewal failure messages to match requirements

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/FixedScheduleRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/FixedScheduleRenewalDueDateStrategy.java
@@ -12,7 +12,8 @@ import static org.folio.circulation.support.HttpResult.failed;
 
 class FixedScheduleRenewalDueDateStrategy extends DueDateStrategy {
   private static final String NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE =
-    "renewal date falls outside of the date ranges in the loan policy";
+    "Renewal date falls outside of the date ranges " +
+      "in the fixed schedule of fixed loan policy";
 
   private final FixedDueDateSchedules fixedDueDateSchedules;
   private final DateTime systemDate;
@@ -29,10 +30,9 @@ class FixedScheduleRenewalDueDateStrategy extends DueDateStrategy {
     this.systemDate = systemDate;
 
     //TODO: Find a better way to fail
-    if(fixedDueDateSchedules != null) {
+    if (fixedDueDateSchedules != null) {
       this.fixedDueDateSchedules = fixedDueDateSchedules;
-    }
-    else {
+    } else {
       this.fixedDueDateSchedules = new NoFixedDueDateSchedules();
     }
   }
@@ -46,8 +46,7 @@ class FixedScheduleRenewalDueDateStrategy extends DueDateStrategy {
         .map(HttpResult::succeeded)
         .orElseGet(() -> failed(
           validationError(NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE)));
-    }
-    catch(Exception e) {
+    } catch (Exception e) {
       logException(e, "Error occurred during fixed schedule renewal due date calculation");
       return failed(new ServerErrorFailure(e));
     }

--- a/src/main/java/org/folio/circulation/domain/policy/FixedScheduleRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/FixedScheduleRenewalDueDateStrategy.java
@@ -12,7 +12,7 @@ import static org.folio.circulation.support.HttpResult.failed;
 
 class FixedScheduleRenewalDueDateStrategy extends DueDateStrategy {
   private static final String NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE =
-    "Renewal date falls outside of the date ranges " +
+    "renewal date falls outside of the date ranges " +
       "in the fixed schedule of fixed loan policy";
 
   private final FixedDueDateSchedules fixedDueDateSchedules;

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -56,7 +56,7 @@ public class LoanPolicy {
     //TODO: Create HttpResult wrapper that traps exceptions
     try {
       if(isNotRenewable()) {
-        return failedResult(errorForPolicy("Loan is not renewable"));
+        return failedResult(errorForPolicy("loan is not renewable"));
       }
 
       final HttpResult<DateTime> proposedDueDateResult =
@@ -180,7 +180,7 @@ public class LoanPolicy {
 
     if(isSameOrBefore(loan, proposedDueDate)) {
       errors.add(errorForPolicy(
-        "Renewal would not change the due date"));
+        "renewal would not change the due date"));
     }
   }
 

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -1,18 +1,6 @@
 package org.folio.circulation.domain.policy;
 
-import static org.folio.circulation.support.HttpResult.failed;
-import static org.folio.circulation.support.JsonPropertyFetcher.getBooleanProperty;
-import static org.folio.circulation.support.JsonPropertyFetcher.getIntegerProperty;
-import static org.folio.circulation.support.JsonPropertyFetcher.getNestedIntegerProperty;
-import static org.folio.circulation.support.JsonPropertyFetcher.getNestedStringProperty;
-import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
-import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Objects;
-
+import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.support.HttpResult;
@@ -21,7 +9,18 @@ import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
 
-import io.vertx.core.json.JsonObject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+import static org.folio.circulation.support.HttpResult.failed;
+import static org.folio.circulation.support.JsonPropertyFetcher.getBooleanProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getIntegerProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getNestedIntegerProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getNestedStringProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
 
 public class LoanPolicy {
   private final JsonObject representation;
@@ -57,7 +56,7 @@ public class LoanPolicy {
     //TODO: Create HttpResult wrapper that traps exceptions
     try {
       if(isNotRenewable()) {
-        return failedResult(errorForPolicy("items with this loan policy cannot be renewed"));
+        return failedResult(errorForPolicy("Loan is not renewable"));
       }
 
       final HttpResult<DateTime> proposedDueDateResult =
@@ -181,7 +180,7 @@ public class LoanPolicy {
 
     if(isSameOrBefore(loan, proposedDueDate)) {
       errors.add(errorForPolicy(
-        "renewal at this time would not change the due date"));
+        "Renewal would not change the due date"));
     }
   }
 

--- a/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
@@ -1,21 +1,22 @@
 package org.folio.circulation.domain.policy;
 
-import static org.folio.circulation.support.HttpResult.failed;
-
-import java.util.function.Function;
-
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
 
+import java.util.function.Function;
+
+import static org.folio.circulation.support.HttpResult.failed;
+
 class RollingRenewalDueDateStrategy extends DueDateStrategy {
   private static final String RENEW_FROM_SYSTEM_DATE = "SYSTEM_DATE";
   private static final String RENEW_FROM_DUE_DATE = "CURRENT_DUE_DATE";
 
   private static final String NO_APPLICABLE_DUE_DATE_LIMIT_SCHEDULE_MESSAGE =
-    "renewal date falls outside of the date ranges in the loan policy";
+    "Renewal date falls outside of the date ranges " +
+      "in the limit schedule of rolling policy";
 
   private static final String RENEWAL_UNRECOGNISED_INTERVAL_MESSAGE =
     "the interval \"%s\" in the loan policy is not recognised";

--- a/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
@@ -16,7 +16,7 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
 
   private static final String NO_APPLICABLE_DUE_DATE_LIMIT_SCHEDULE_MESSAGE =
     "Renewal date falls outside of the date ranges " +
-      "in the limit schedule of rolling policy";
+      "in the limit schedule of rolling loan policy";
 
   private static final String RENEWAL_UNRECOGNISED_INTERVAL_MESSAGE =
     "the interval \"%s\" in the loan policy is not recognised";

--- a/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
@@ -15,7 +15,7 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
   private static final String RENEW_FROM_DUE_DATE = "CURRENT_DUE_DATE";
 
   private static final String NO_APPLICABLE_DUE_DATE_LIMIT_SCHEDULE_MESSAGE =
-    "Renewal date falls outside of the date ranges " +
+    "renewal date falls outside of the date ranges " +
       "in the limit schedule of rolling loan policy";
 
   private static final String RENEWAL_UNRECOGNISED_INTERVAL_MESSAGE =

--- a/src/main/java/org/folio/circulation/support/http/server/ValidationError.java
+++ b/src/main/java/org/folio/circulation/support/http/server/ValidationError.java
@@ -1,13 +1,12 @@
 package org.folio.circulation.support.http.server;
 
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringUtils;
-
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 
 public class ValidationError {
   private final String message;

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -1,5 +1,30 @@
 package api.loans;
 
+import api.APITestSuite;
+import api.support.APITests;
+import api.support.builders.CheckOutByBarcodeRequestBuilder;
+import api.support.builders.FixedDueDateSchedule;
+import api.support.builders.FixedDueDateSchedulesBuilder;
+import api.support.builders.LoanPolicyBuilder;
+import io.vertx.core.json.JsonObject;
+import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.http.client.ResponseHandler;
+import org.folio.circulation.support.http.server.ValidationError;
+import org.hamcrest.Matcher;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Seconds;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import static api.support.builders.FixedDueDateSchedule.forDay;
 import static api.support.builders.FixedDueDateSchedule.wholeMonth;
 import static api.support.builders.ItemBuilder.CHECKED_OUT;
@@ -14,32 +39,6 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-
-import java.net.MalformedURLException;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import org.folio.circulation.domain.policy.Period;
-import org.folio.circulation.support.http.client.IndividualResource;
-import org.folio.circulation.support.http.client.Response;
-import org.folio.circulation.support.http.client.ResponseHandler;
-import org.folio.circulation.support.http.server.ValidationError;
-import org.hamcrest.Matcher;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.Seconds;
-import org.junit.Test;
-
-import api.APITestSuite;
-import api.support.APITests;
-import api.support.builders.CheckOutByBarcodeRequestBuilder;
-import api.support.builders.FixedDueDateSchedule;
-import api.support.builders.FixedDueDateSchedulesBuilder;
-import api.support.builders.LoanPolicyBuilder;
-import io.vertx.core.json.JsonObject;
 
 abstract class RenewalAPITests extends APITests {
   abstract Response attemptRenewal(IndividualResource user, IndividualResource item);
@@ -666,7 +665,7 @@ abstract class RenewalAPITests extends APITests {
       hasLoanPolicyNameParameter("Limited Renewals And Limited Due Date Policy"))));
 
     assertThat(response.getJson(), hasErrorWith(allOf(
-      hasMessage("Renewal would not change the due date"),
+      hasMessage("renewal would not change the due date"),
       hasLoanPolicyIdParameter(limitedRenewalsPolicyId),
       hasLoanPolicyNameParameter("Limited Renewals And Limited Due Date Policy"))));
   }
@@ -699,7 +698,7 @@ abstract class RenewalAPITests extends APITests {
     final Response response = attemptRenewal(smallAngryPlanet, jessica);
 
     assertThat(response.getJson(), hasErrorWith(allOf(
-      hasMessage("Loan is not renewable"),
+      hasMessage("loan is not renewable"),
       hasLoanPolicyIdParameter(notRenewablePolicyId),
       hasLoanPolicyNameParameter("Non Renewable Policy"))));
   }
@@ -743,7 +742,7 @@ abstract class RenewalAPITests extends APITests {
     final Response response = attemptRenewal(smallAngryPlanet, jessica);
 
     assertThat(response.getJson(), hasErrorWith(allOf(
-      hasMessage("Loan is not renewable"),
+      hasMessage("loan is not renewable"),
       hasLoanPolicyIdParameter(notRenewablePolicyId),
       hasLoanPolicyNameParameter("Non Renewable Policy"))));
   }

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -666,7 +666,7 @@ abstract class RenewalAPITests extends APITests {
       hasLoanPolicyNameParameter("Limited Renewals And Limited Due Date Policy"))));
 
     assertThat(response.getJson(), hasErrorWith(allOf(
-      hasMessage("renewal at this time would not change the due date"),
+      hasMessage("Renewal would not change the due date"),
       hasLoanPolicyIdParameter(limitedRenewalsPolicyId),
       hasLoanPolicyNameParameter("Limited Renewals And Limited Due Date Policy"))));
   }
@@ -699,7 +699,7 @@ abstract class RenewalAPITests extends APITests {
     final Response response = attemptRenewal(smallAngryPlanet, jessica);
 
     assertThat(response.getJson(), hasErrorWith(allOf(
-      hasMessage("items with this loan policy cannot be renewed"),
+      hasMessage("Loan is not renewable"),
       hasLoanPolicyIdParameter(notRenewablePolicyId),
       hasLoanPolicyNameParameter("Non Renewable Policy"))));
   }
@@ -743,7 +743,7 @@ abstract class RenewalAPITests extends APITests {
     final Response response = attemptRenewal(smallAngryPlanet, jessica);
 
     assertThat(response.getJson(), hasErrorWith(allOf(
-      hasMessage("items with this loan policy cannot be renewed"),
+      hasMessage("Loan is not renewable"),
       hasLoanPolicyIdParameter(notRenewablePolicyId),
       hasLoanPolicyNameParameter("Non Renewable Policy"))));
   }

--- a/src/test/java/org/folio/circulation/domain/policy/FixedLoanPolicyRenewalDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/FixedLoanPolicyRenewalDueDateCalculationTests.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertThat;
 public class FixedLoanPolicyRenewalDueDateCalculationTests {
 
   private static final String EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES =
-    "Renewal date falls outside of the date ranges " +
+    "renewal date falls outside of the date ranges " +
       "in the fixed schedule of fixed loan policy";
   @Test
   public void shouldFailWhenLoanDateIsBeforeOnlyScheduleAvailable() {
@@ -219,7 +219,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result,
-      hasValidationFailure("Renewal would not change the due date"));
+      hasValidationFailure("renewal would not change the due date"));
   }
 
   @Test
@@ -243,7 +243,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result,
-      hasValidationFailure("Renewal would not change the due date"));
+      hasValidationFailure("renewal would not change the due date"));
   }
 
   @Test

--- a/src/test/java/org/folio/circulation/domain/policy/FixedLoanPolicyRenewalDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/FixedLoanPolicyRenewalDueDateCalculationTests.java
@@ -216,7 +216,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result,
-      hasValidationFailure("renewal at this time would not change the due date"));
+      hasValidationFailure("Renewal would not change the due date"));
   }
 
   @Test
@@ -240,7 +240,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result,
-      hasValidationFailure("renewal at this time would not change the due date"));
+      hasValidationFailure("Renewal would not change the due date"));
   }
 
   @Test

--- a/src/test/java/org/folio/circulation/domain/policy/FixedLoanPolicyRenewalDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/FixedLoanPolicyRenewalDueDateCalculationTests.java
@@ -1,11 +1,9 @@
 package org.folio.circulation.domain.policy;
 
-import static api.support.matchers.FailureMatcher.hasValidationFailure;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.util.UUID;
-
+import api.support.builders.FixedDueDateSchedule;
+import api.support.builders.FixedDueDateSchedulesBuilder;
+import api.support.builders.LoanBuilder;
+import api.support.builders.LoanPolicyBuilder;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.http.server.ValidationError;
@@ -13,12 +11,17 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
-import api.support.builders.FixedDueDateSchedule;
-import api.support.builders.FixedDueDateSchedulesBuilder;
-import api.support.builders.LoanBuilder;
-import api.support.builders.LoanPolicyBuilder;
+import java.util.UUID;
+
+import static api.support.matchers.FailureMatcher.hasValidationFailure;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public class FixedLoanPolicyRenewalDueDateCalculationTests {
+
+  private static final String EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES =
+    "Renewal date falls outside of the date ranges " +
+      "in the fixed schedule of fixed loan policy";
   @Test
   public void shouldFailWhenLoanDateIsBeforeOnlyScheduleAvailable() {
     LoanPolicy loanPolicy = LoanPolicy.from(new LoanPolicyBuilder()
@@ -36,7 +39,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result, hasValidationFailure(
-      "renewal date falls outside of the date ranges in the loan policy"));
+      EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
   }
 
   @Test
@@ -56,7 +59,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result, hasValidationFailure(
-      "renewal date falls outside of the date ranges in the loan policy"));
+      EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
   }
 
   @Test
@@ -192,7 +195,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result, hasValidationFailure(
-      "renewal date falls outside of the date ranges in the loan policy"));
+      EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
   }
 
   @Test
@@ -269,7 +272,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result, hasValidationFailure(
-      "renewal date falls outside of the date ranges in the loan policy"));
+      EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
 
     assertThat(result, hasValidationFailure(
       "loan has reached its maximum number of renewals"));
@@ -295,7 +298,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result, hasValidationFailure(
-      "renewal date falls outside of the date ranges in the loan policy"));
+      EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
   }
 
   @Test
@@ -316,7 +319,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result, hasValidationFailure(
-      "renewal date falls outside of the date ranges in the loan policy"));
+      EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
   }
 
   @Test
@@ -335,7 +338,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result, hasValidationFailure(
-      "renewal date falls outside of the date ranges in the loan policy"));
+      EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
   }
 
   @Test
@@ -352,7 +355,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<DateTime> result = calculator.calculateDueDate(loan);
 
     assertThat(result, hasValidationFailure(
-      "renewal date falls outside of the date ranges in the loan policy"));
+      EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
   }
 
   @Test
@@ -369,7 +372,7 @@ public class FixedLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<DateTime> result = calculator.calculateDueDate(loan);
 
     assertThat(result, hasValidationFailure(
-      "renewal date falls outside of the date ranges in the loan policy"));
+      EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
   }
 
   private Loan existingLoan() {

--- a/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyRenewalDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyRenewalDueDateCalculationTests.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertThat;
 public class RollingLoanPolicyRenewalDueDateCalculationTests {
 
   private static final String EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES =
-    "Renewal date falls outside of the date ranges " +
+    "renewal date falls outside of the date ranges " +
       "in the limit schedule of rolling loan policy";
 
   @Test
@@ -380,7 +380,7 @@ public class RollingLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result,
-      hasValidationFailure("Renewal would not change the due date"));
+      hasValidationFailure("renewal would not change the due date"));
   }
 
   @Test
@@ -405,7 +405,7 @@ public class RollingLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result,
-      hasValidationFailure("Renewal would not change the due date"));
+      hasValidationFailure("renewal would not change the due date"));
   }
 
   private Loan loanFor(DateTime loanDate) {

--- a/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyRenewalDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyRenewalDueDateCalculationTests.java
@@ -377,7 +377,7 @@ public class RollingLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result,
-      hasValidationFailure("renewal at this time would not change the due date"));
+      hasValidationFailure("Renewal would not change the due date"));
   }
 
   @Test
@@ -402,7 +402,7 @@ public class RollingLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, renewalDate);
 
     assertThat(result,
-      hasValidationFailure("renewal at this time would not change the due date"));
+      hasValidationFailure("Renewal would not change the due date"));
   }
 
   private Loan loanFor(DateTime loanDate) {

--- a/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyRenewalDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyRenewalDueDateCalculationTests.java
@@ -1,18 +1,5 @@
 package org.folio.circulation.domain.policy;
 
-import static api.support.matchers.FailureMatcher.hasValidationFailure;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.util.UUID;
-
-import org.folio.circulation.domain.Loan;
-import org.folio.circulation.support.HttpResult;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import api.support.builders.FixedDueDateSchedule;
 import api.support.builders.FixedDueDateSchedulesBuilder;
 import api.support.builders.LoanBuilder;
@@ -20,9 +7,24 @@ import api.support.builders.LoanPolicyBuilder;
 import io.vertx.core.json.JsonObject;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.support.HttpResult;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.UUID;
+
+import static api.support.matchers.FailureMatcher.hasValidationFailure;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 @RunWith(JUnitParamsRunner.class)
 public class RollingLoanPolicyRenewalDueDateCalculationTests {
+
+  private static final String EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES = "Renewal date falls outside of the date ranges " +
+    "in the limit schedule of rolling policy";
 
   @Test
   @Parameters({
@@ -330,7 +332,7 @@ public class RollingLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, DateTime.now());
 
     assertThat(result, hasValidationFailure(
-      "renewal date falls outside of the date ranges in the loan policy"));
+      EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
   }
 
   @Test
@@ -352,7 +354,7 @@ public class RollingLoanPolicyRenewalDueDateCalculationTests {
     final HttpResult<Loan> result = loanPolicy.renew(loan, DateTime.now());
 
     assertThat(result, hasValidationFailure(
-      "renewal date falls outside of the date ranges in the loan policy"));
+      EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
   }
 
   @Test

--- a/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyRenewalDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyRenewalDueDateCalculationTests.java
@@ -23,8 +23,9 @@ import static org.junit.Assert.assertThat;
 @RunWith(JUnitParamsRunner.class)
 public class RollingLoanPolicyRenewalDueDateCalculationTests {
 
-  private static final String EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES = "Renewal date falls outside of the date ranges " +
-    "in the limit schedule of rolling policy";
+  private static final String EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES =
+    "Renewal date falls outside of the date ranges " +
+      "in the limit schedule of rolling loan policy";
 
   @Test
   @Parameters({


### PR DESCRIPTION
## Purpose
CIRC-192
Change renewal failure messages to match requirements.
Resolves: [CIRC-192](https://issues.folio.org/browse/CIRC-192)

Additional changes:
Replacing "outside of date ranges" message with different ones for fixed and rolling loan polices.
This was done to make failures distinguishable on UI. 