### PR TITLE
Circ 196 determine request policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 .vertx/
 metrics/
 *.log
+.antlr
 
 node_modules/
 

--- a/src/main/java/org/folio/circulation/CirculationVerticle.java
+++ b/src/main/java/org/folio/circulation/CirculationVerticle.java
@@ -8,7 +8,8 @@ import io.vertx.ext.web.Router;
 import org.folio.circulation.resources.CheckInByBarcodeResource;
 import org.folio.circulation.resources.CheckOutByBarcodeResource;
 import org.folio.circulation.resources.LoanCollectionResource;
-import org.folio.circulation.resources.CirculationRulesEngineResource;
+import org.folio.circulation.resources.LoanCirculationRulesEngineResource;
+import org.folio.circulation.resources.RequestCirculationRulesEngineResource;
 import org.folio.circulation.resources.CirculationRulesResource;
 import org.folio.circulation.resources.OverrideRenewalByBarcodeResource;
 import org.folio.circulation.resources.RenewByBarcodeResource;
@@ -46,11 +47,18 @@ public class CirculationVerticle extends AbstractVerticle {
     new RequestQueueResource(client).register(router);
     new OverrideRenewalByBarcodeResource(client).register(router);
 
-    new CirculationRulesResource         ("/circulation/rules", client)
+    new CirculationRulesResource("/circulation/rules", client)
       .register(router);
-    new CirculationRulesEngineResource   ("/circulation/rules/loan-policy",
-                                   "/circulation/rules/loan-policy-all", client)
-      .register(router);
+    new LoanCirculationRulesEngineResource(
+      "/circulation/rules/loan-policy",
+      "/circulation/rules/loan-policy-all",
+       client)
+        .register(router);
+    new RequestCirculationRulesEngineResource(
+      "/circulation/rules/request-policy",
+      "/circulation/rules/request-policy-all",
+       client)
+        .register(router);
 
     server.requestHandler(router::accept)
       .listen(config().getInteger("port"), result -> {

--- a/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
+++ b/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
@@ -110,7 +110,8 @@ public class CirculationRulesResource extends Resource {
       internalError(routingContext.response(), ExceptionUtils.getStackTrace(e));
       return;
     }
-    CirculationRulesEngineResource.clearCache(new WebContext(routingContext).getTenantId());
+    LoanCirculationRulesEngineResource.clearCache(new WebContext(routingContext).getTenantId());
+    RequestCirculationRulesEngineResource.clearCache(new WebContext(routingContext).getTenantId());
 
     loansRulesClient.put(rulesInput.copy()).thenAccept(response -> {
       if (response.getStatusCode() == 204) {

--- a/src/main/java/org/folio/circulation/resources/LoanCirculationRulesEngineResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCirculationRulesEngineResource.java
@@ -49,7 +49,7 @@ public class LoanCirculationRulesEngineResource extends AbstractCirculationRules
           .writeTo(routingContext.response());
       }
       catch (Exception e) {
-        log.error("apply", e);
+        log.error("apply loan policy", e);
         internalError(routingContext.response(), ExceptionUtils.getStackTrace(e));
       }
     });

--- a/src/main/java/org/folio/circulation/resources/LoanCirculationRulesEngineResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCirculationRulesEngineResource.java
@@ -1,0 +1,79 @@
+package org.folio.circulation.resources;
+
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.folio.circulation.rules.Drools;
+import org.folio.circulation.support.OkJsonHttpResult;
+
+import static org.folio.circulation.support.http.server.ServerErrorResponse.internalError;
+
+/**
+ * The circulation rules engine calculates the loan policy based on
+ * item type, loan type, patron type and shelving location.
+ */
+public class LoanCirculationRulesEngineResource extends AbstractCirculationRulesEngineResource {
+
+  private static final String LOAN_TYPE_ID_NAME = "loan_type_id";
+
+  public LoanCirculationRulesEngineResource(String applyPath, String applyAllPath, HttpClient client) {
+    super(applyPath, applyAllPath, client);
+  }
+
+  protected boolean invalidApplyParameters(HttpServerRequest request) {
+    return
+        invalidUuid(request, ITEM_TYPE_ID_NAME) ||
+        invalidUuid(request, LOAN_TYPE_ID_NAME) ||
+        invalidUuid(request, PATRON_TYPE_ID_NAME) ||
+        invalidUuid(request, SHELVING_LOCATION_ID_NAME);
+  }
+
+  void apply(RoutingContext routingContext) {
+    HttpServerRequest request = routingContext.request();
+    if (invalidApplyParameters(request)) {
+      return;
+    }
+    drools(routingContext, drools -> {
+      try {
+        String itemTypeId = request.getParam(ITEM_TYPE_ID_NAME);
+        String loanTypeId = request.getParam(LOAN_TYPE_ID_NAME);
+        String patronGroupId = request.getParam(PATRON_TYPE_ID_NAME);
+        String shelvingLocationId = request.getParam(SHELVING_LOCATION_ID_NAME);
+        String loanPolicyId = drools.loanPolicy(itemTypeId, loanTypeId, patronGroupId, shelvingLocationId);
+        JsonObject json = new JsonObject().put("loanPolicyId", loanPolicyId);
+
+        new OkJsonHttpResult(json)
+          .writeTo(routingContext.response());
+      }
+      catch (Exception e) {
+        log.error("apply", e);
+        internalError(routingContext.response(), ExceptionUtils.getStackTrace(e));
+      }
+    });
+  }
+
+  void applyAll(RoutingContext routingContext, Drools drools) {
+    HttpServerRequest request = routingContext.request();
+    if (invalidApplyParameters(request)) {
+      return;
+    }
+    try {
+      String itemTypeId = request.getParam(ITEM_TYPE_ID_NAME);
+      String loanTypeId = request.getParam(LOAN_TYPE_ID_NAME);
+      String patronGroupId = request.getParam(PATRON_TYPE_ID_NAME);
+      String shelvingLocationId = request.getParam(SHELVING_LOCATION_ID_NAME);
+      JsonArray matches = drools.loanPolicies(itemTypeId, loanTypeId, patronGroupId, shelvingLocationId);
+      JsonObject json = new JsonObject().put("circulationRuleMatches", matches);
+
+      new OkJsonHttpResult(json)
+        .writeTo(routingContext.response());
+    }
+    catch (Exception e) {
+      log.error("applyAll", e);
+      internalError(routingContext.response(), ExceptionUtils.getStackTrace(e));
+    }
+  }
+}

--- a/src/main/java/org/folio/circulation/resources/RequestCirculationRulesEngineResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCirculationRulesEngineResource.java
@@ -1,0 +1,79 @@
+package org.folio.circulation.resources;
+
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.folio.circulation.rules.Drools;
+import org.folio.circulation.support.OkJsonHttpResult;
+
+import static org.folio.circulation.support.http.server.ServerErrorResponse.internalError;
+
+/**
+ * The circulation rules engine calculates the request policy based on
+ * item type, request type, patron type and shelving location.
+ */
+public class RequestCirculationRulesEngineResource extends AbstractCirculationRulesEngineResource {
+
+  private static final String REQUEST_TYPE_ID_NAME = "request_type_id";
+
+  public RequestCirculationRulesEngineResource(String applyPath, String applyAllPath, HttpClient client) {
+    super(applyPath, applyAllPath, client);
+  }
+
+  protected boolean invalidApplyParameters(HttpServerRequest request) {
+    return
+        invalidUuid(request, ITEM_TYPE_ID_NAME) ||
+        invalidUuid(request, REQUEST_TYPE_ID_NAME) ||
+        invalidUuid(request, PATRON_TYPE_ID_NAME) ||
+        invalidUuid(request, SHELVING_LOCATION_ID_NAME);
+  }
+
+  void apply(RoutingContext routingContext) {
+    HttpServerRequest request = routingContext.request();
+    if (invalidApplyParameters(request)) {
+      return;
+    }
+    drools(routingContext, drools -> {
+      try {
+        String itemTypeId = request.getParam(ITEM_TYPE_ID_NAME);
+        String requestTypeId = request.getParam(REQUEST_TYPE_ID_NAME);
+        String patronGroupId = request.getParam(PATRON_TYPE_ID_NAME);
+        String shelvingLocationId = request.getParam(SHELVING_LOCATION_ID_NAME);
+        String requestPolicyId = drools.requestPolicy(itemTypeId, requestTypeId, patronGroupId, shelvingLocationId);
+        JsonObject json = new JsonObject().put("requestPolicyId", requestPolicyId);
+
+        new OkJsonHttpResult(json)
+          .writeTo(routingContext.response());
+      }
+      catch (Exception e) {
+        log.error("apply", e);
+        internalError(routingContext.response(), ExceptionUtils.getStackTrace(e));
+      }
+    });
+  }
+
+  void applyAll(RoutingContext routingContext, Drools drools) {
+    HttpServerRequest request = routingContext.request();
+    if (invalidApplyParameters(request)) {
+      return;
+    }
+    try {
+      String itemTypeId = request.getParam(ITEM_TYPE_ID_NAME);
+      String requestTypeId = request.getParam(REQUEST_TYPE_ID_NAME);
+      String patronGroupId = request.getParam(PATRON_TYPE_ID_NAME);
+      String shelvingLocationId = request.getParam(SHELVING_LOCATION_ID_NAME);
+      JsonArray matches = drools.requestPolicies(itemTypeId, requestTypeId, patronGroupId, shelvingLocationId);
+      JsonObject json = new JsonObject().put("circulationRuleMatches", matches);
+
+      new OkJsonHttpResult(json)
+        .writeTo(routingContext.response());
+    }
+    catch (Exception e) {
+      log.error("applyAll", e);
+      internalError(routingContext.response(), ExceptionUtils.getStackTrace(e));
+    }
+  }
+}

--- a/src/main/java/org/folio/circulation/resources/RequestCirculationRulesEngineResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCirculationRulesEngineResource.java
@@ -49,7 +49,7 @@ public class RequestCirculationRulesEngineResource extends AbstractCirculationRu
           .writeTo(routingContext.response());
       }
       catch (Exception e) {
-        log.error("apply", e);
+        log.error("apply request policy", e);
         internalError(routingContext.response(), ExceptionUtils.getStackTrace(e));
       }
     });

--- a/src/main/java/org/folio/circulation/resources/RequestCirculationRulesEngineResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCirculationRulesEngineResource.java
@@ -31,6 +31,28 @@ public class RequestCirculationRulesEngineResource extends AbstractCirculationRu
         invalidUuid(request, SHELVING_LOCATION_ID_NAME);
   }
 
+  void applyAll(RoutingContext routingContext, Drools drools) {
+    HttpServerRequest request = routingContext.request();
+    if (invalidApplyParameters(request)) {
+      return;
+    }
+    try {
+      String itemTypeId = request.getParam(ITEM_TYPE_ID_NAME);
+      String requestTypeId = request.getParam(REQUEST_TYPE_ID_NAME);
+      String patronGroupId = request.getParam(PATRON_TYPE_ID_NAME);
+      String shelvingLocationId = request.getParam(SHELVING_LOCATION_ID_NAME);
+      JsonArray matches = drools.requestPolicies(itemTypeId, requestTypeId, patronGroupId, shelvingLocationId);
+      JsonObject json = new JsonObject().put("circulationRuleMatches", matches);
+
+      new OkJsonHttpResult(json)
+        .writeTo(routingContext.response());
+    }
+    catch (Exception e) {
+      log.error("applyAll", e);
+      internalError(routingContext.response(), ExceptionUtils.getStackTrace(e));
+    }
+  }
+
   void apply(RoutingContext routingContext) {
     HttpServerRequest request = routingContext.request();
     if (invalidApplyParameters(request)) {
@@ -53,27 +75,5 @@ public class RequestCirculationRulesEngineResource extends AbstractCirculationRu
         internalError(routingContext.response(), ExceptionUtils.getStackTrace(e));
       }
     });
-  }
-
-  void applyAll(RoutingContext routingContext, Drools drools) {
-    HttpServerRequest request = routingContext.request();
-    if (invalidApplyParameters(request)) {
-      return;
-    }
-    try {
-      String itemTypeId = request.getParam(ITEM_TYPE_ID_NAME);
-      String requestTypeId = request.getParam(REQUEST_TYPE_ID_NAME);
-      String patronGroupId = request.getParam(PATRON_TYPE_ID_NAME);
-      String shelvingLocationId = request.getParam(SHELVING_LOCATION_ID_NAME);
-      JsonArray matches = drools.requestPolicies(itemTypeId, requestTypeId, patronGroupId, shelvingLocationId);
-      JsonObject json = new JsonObject().put("circulationRuleMatches", matches);
-
-      new OkJsonHttpResult(json)
-        .writeTo(routingContext.response());
-    }
-    catch (Exception e) {
-      log.error("applyAll", e);
-      internalError(routingContext.response(), ExceptionUtils.getStackTrace(e));
-    }
   }
 }

--- a/src/main/java/org/folio/circulation/rules/Drools.java
+++ b/src/main/java/org/folio/circulation/rules/Drools.java
@@ -138,6 +138,19 @@ public class Drools {
   }
 
   /**
+   * Return the request policy calculated using the drools rules and the item type and request type.
+   * @param droolsFile - rules to use
+   * @param itemType - item (material) type name
+   * @param requestType - request type name
+   * @param patronGroup group the patron belongs to
+   * @param shelvingLocation - item's shelving location
+   * @return request policy
+   */
+  public static String requestPolicy(String droolsFile, String itemType, String requestType, String patronGroup, String shelvingLocation) {
+    return new Drools(droolsFile).requestPolicy(itemType, requestType, patronGroup, shelvingLocation);
+  }
+
+  /**
    * Return all loan policies calculated using the drools rules and the item type and loan type
    * in the order they match.
    * @param droolsFile - rules to use

--- a/src/main/java/org/folio/circulation/rules/Drools.java
+++ b/src/main/java/org/folio/circulation/rules/Drools.java
@@ -66,6 +66,21 @@ public class Drools {
   }
 
   /**
+   * Calculate the request policy for itemTypeName and requestTypeName.
+   * @param itemType the name of the item type
+   * @param requestType the name of the request type
+   * @param patronGroup group the patron belongs to
+   * @param shelvingLocation - item's shelving location
+   * @return the name of the request policy
+   */
+  public String requestPolicy(String itemType, String requestType, String patronGroup, String shelvingLocation) {
+    KieSession kieSession = createSession(itemType, requestType, patronGroup, shelvingLocation);
+    kieSession.fireAllRules();
+    kieSession.dispose();
+    return match.requestPolicyId;
+  }
+
+  /**
    * Return all loan policies calculated using the drools rules
    * in the order they match.
    * @param itemType the item's material type
@@ -80,6 +95,28 @@ public class Drools {
     while (kieSession.fireAllRules() > 0) {
       JsonObject json = new JsonObject();
       json.put("loanPolicyId", match.loanPolicyId);
+      json.put("circulationRuleLine", match.lineNumber);
+      array.add(json);
+    }
+    kieSession.dispose();
+    return array;
+  }
+
+   /**
+   * Return all request policies calculated using the drools rules
+   * in the order they match.
+   * @param itemType the item's material type
+   * @param requestType the item's request type
+   * @param patronGroup group the patron belongs to
+   * @param shelvingLocation - item's shelving location
+   * @return matches, each match has a requestPolicyId and a circulationRuleLine field
+   */
+  public JsonArray requestPolicies(String itemType, String requestType, String patronGroup, String shelvingLocation) {
+    KieSession kieSession = createSession(itemType, requestType, patronGroup, shelvingLocation);
+    JsonArray array = new JsonArray();
+    while (kieSession.fireAllRules() > 0) {
+      JsonObject json = new JsonObject();
+      json.put("requestPolicyId", match.requestPolicyId);
       json.put("circulationRuleLine", match.lineNumber);
       array.add(json);
     }

--- a/src/test/java/api/CirculationRulesEngineAPITests.java
+++ b/src/test/java/api/CirculationRulesEngineAPITests.java
@@ -274,14 +274,14 @@ public class CirculationRulesEngineAPITests extends APITests {
     assertThat(applyLoanPolicy(m1, t1, g1, s2), is(lp3));
   }
 
-  private void matches(JsonArray array, int match, Policy policy, int line) {
+  private void matchesLoanPolicy(JsonArray array, int match, Policy policy, int line) {
     JsonObject o = array.getJsonObject(match);
     assertThat("["+match+"].loanPolicyId of "+o, o.getString("loanPolicyId"), is(policy.id));
     assertThat("["+match+"].circulationRuleLine of "+o, o.getInteger("circulationRuleLine"), is(line));
   }
 
   @Test
-  public void test1ApplyAll() throws Exception {
+  public void testLoanApplyAll() throws Exception {
     setRules(rules1);
     CompletableFuture<Response> completed = new CompletableFuture<>();
     URL url = circulationRulesUrl(
@@ -297,9 +297,38 @@ public class CirculationRulesEngineAPITests extends APITests {
         response.getStatusCode(), is(200));
     JsonObject json = new JsonObject(response.getBody());
     JsonArray array = json.getJsonArray("circulationRuleMatches");
-    matches(array, 0, lp4, 4);
-    matches(array, 1, lp3, 3);
-    matches(array, 2, lp2, 2);
+    matchesLoanPolicy(array, 0, lp4, 4);
+    matchesLoanPolicy(array, 1, lp3, 3);
+    matchesLoanPolicy(array, 2, lp2, 2);
+    assertThat(array.size(), is(3));
+  }
+
+  private void matchesRequestPolicy(JsonArray array, int match, Policy policy, int line) {
+    JsonObject o = array.getJsonObject(match);
+    assertThat("["+match+"].requestPolicyId of "+o, o.getString("requestPolicyId"), is(policy.id));
+    assertThat("["+match+"].circulationRuleLine of "+o, o.getInteger("circulationRuleLine"), is(line));
+  }
+
+  @Test
+  public void testRequestApplyAll() throws Exception {
+    setRules(rules1);
+    CompletableFuture<Response> completed = new CompletableFuture<>();
+    URL url = circulationRulesUrl(
+        "/request-policy-all"
+        + "?item_type_id="         + m2
+        + "&request_type_id="         + t2
+        + "&patron_type_id="       + g2
+        + "&shelving_location_id=" + s2
+        );
+    client.get(url, ResponseHandler.any(completed));
+    Response response = completed.get(10, TimeUnit.SECONDS);
+    assertThat(response.getStatusCode() + " " + response.getBody(),
+        response.getStatusCode(), is(200));
+    JsonObject json = new JsonObject(response.getBody());
+    JsonArray array = json.getJsonArray("circulationRuleMatches");
+    matchesRequestPolicy(array, 0, rp1, 4);
+    matchesRequestPolicy(array, 1, rp1, 3);
+    matchesRequestPolicy(array, 2, rp1, 2);
     assertThat(array.size(), is(3));
   }
 

--- a/src/test/java/api/CirculationRulesEngineAPITests.java
+++ b/src/test/java/api/CirculationRulesEngineAPITests.java
@@ -108,7 +108,7 @@ public class CirculationRulesEngineAPITests extends APITests {
   }
 
   @Test
-  public void applyWithoutParameters() throws Exception {
+  public void applyLoanWithoutParameters() throws Exception {
     CompletableFuture<Response> completed = new CompletableFuture<>();
     URL url = circulationRulesUrl("/loan-policy");
     client.get(url, ResponseHandler.any(completed));
@@ -116,7 +116,16 @@ public class CirculationRulesEngineAPITests extends APITests {
     assertThat(response.getStatusCode(), is(400));
   }
 
-  private void applyOneParameterMissing(String p1, String p2, String p3, String missing) throws Exception {
+  @Test
+  public void applyRequestWithoutParameters() throws Exception {
+    CompletableFuture<Response> completed = new CompletableFuture<>();
+    URL url = circulationRulesUrl("/request-policy");
+    client.get(url, ResponseHandler.any(completed));
+    Response response = completed.get(10, TimeUnit.SECONDS);
+    assertThat(response.getStatusCode(), is(400));
+  }
+
+  private void applyOneLoanParameterMissing(String p1, String p2, String p3, String missing) throws Exception {
     String name = missing.substring(0, missing.indexOf("="));
     CompletableFuture<Response> completed = new CompletableFuture<>();
     URL url = circulationRulesUrl("/loan-policy?" + p1 + "&" + p2 + "&" + p3);
@@ -126,8 +135,19 @@ public class CirculationRulesEngineAPITests extends APITests {
     assertThat(response.getBody(), containsString(name));
   }
 
+  private void applyOneRequestParameterMissing(String p1, String p2, String p3, String missing) throws Exception {
+    String name = missing.substring(0, missing.indexOf("="));
+    CompletableFuture<Response> completed = new CompletableFuture<>();
+    URL url = circulationRulesUrl("/request-policy?" + p1 + "&" + p2 + "&" + p3);
+    client.get(url, ResponseHandler.any(completed));
+    Response response = completed.get(10, TimeUnit.SECONDS);
+    assertThat(response.getStatusCode(), is(400));
+    assertThat(response.getBody(), containsString(name));
+  }
+
+
   @Test
-  public void applyOneParameterMissing() throws Exception {
+  public void applyOneLoanParameterMissing() throws Exception {
     String [] p = {
         "item_type_id=" + m1,
         "loan_type_id=" + t1,
@@ -135,10 +155,25 @@ public class CirculationRulesEngineAPITests extends APITests {
         "shelving_location_id=" + s1
     };
 
-    applyOneParameterMissing(p[1], p[2], p[3],  p[0]);
-    applyOneParameterMissing(p[0], p[2], p[3],  p[1]);
-    applyOneParameterMissing(p[0], p[1], p[3],  p[2]);
-    applyOneParameterMissing(p[0], p[1], p[2],  p[3]);
+    applyOneLoanParameterMissing(p[1], p[2], p[3],  p[0]);
+    applyOneLoanParameterMissing(p[0], p[2], p[3],  p[1]);
+    applyOneLoanParameterMissing(p[0], p[1], p[3],  p[2]);
+    applyOneLoanParameterMissing(p[0], p[1], p[2],  p[3]);
+  }
+
+  @Test
+  public void applyOneRequestParameterMissing() throws Exception {
+    String[] p = {
+        "item_type_id=" + m1,
+        "request_type_id=" + t1,
+        "patron_type_id=" + lp1,
+        "shelving_location_id=" + s1
+    };
+
+    applyOneRequestParameterMissing(p[1], p[2], p[3],  p[0]);
+    applyOneRequestParameterMissing(p[0], p[2], p[3],  p[1]);
+    applyOneRequestParameterMissing(p[0], p[1], p[3],  p[2]);
+    applyOneRequestParameterMissing(p[0], p[1], p[2],  p[3]);
   }
 
   private void applyInvalidUuid(String i, String l, String p, String s) {

--- a/src/test/java/api/CirculationRulesEngineAPITests.java
+++ b/src/test/java/api/CirculationRulesEngineAPITests.java
@@ -17,7 +17,7 @@ import org.folio.circulation.rules.Policy;
 import org.folio.circulation.rules.LoanType;
 import org.folio.circulation.rules.PatronGroup;
 import org.folio.circulation.rules.ShelvingLocation;
-import org.folio.circulation.resources.CirculationRulesEngineResource;
+import org.folio.circulation.resources.LoanCirculationRulesEngineResource;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.client.ResponseHandler;
 import org.junit.Before;
@@ -103,8 +103,8 @@ public class CirculationRulesEngineAPITests extends APITests {
 
   @Before
   public void setUp() {
-    CirculationRulesEngineResource.dropCache();
-    CirculationRulesEngineResource.setCacheTime(1000000, 1000000);  // 1000 seconds
+    LoanCirculationRulesEngineResource.dropCache();
+    LoanCirculationRulesEngineResource.setCacheTime(1000000, 1000000);  // 1000 seconds
   }
 
   @Test
@@ -256,7 +256,7 @@ public class CirculationRulesEngineAPITests extends APITests {
     assertThat(apply(m1, t1, g1, s1), is(lp6));
 
     // reduce cache time to trigger reload from storage backend
-    CirculationRulesEngineResource.setCacheTime(0, 0);
+    LoanCirculationRulesEngineResource.setCacheTime(0, 0);
 
     assertThat(apply(m1, t1, g1, s1), is(lp7));
   }

--- a/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
+++ b/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
@@ -88,6 +88,13 @@ public class Text2DroolsTest {
       testRequestPolicies(test1, requestTestCases);
   }
 
+  @Test public void testRequestPolicy() {
+    String drools = Text2Drools.convert(test1);
+    for (String[] s : requestTestCases) {
+      assertThat(first3(s), Drools.requestPolicy(drools, s[0], s[1], s[2], "shelf"), is(s[3]));
+    }
+  }
+
   /** s without the first 3 elements, converted to a String.
    * <p>
    * expected({"a", "b", "c", "d", "e", "f", "g"}) = "[d, e, f, g]"


### PR DESCRIPTION
Refactored CirculationRulesEngineResource into an AbstractRulesEngineResource with LoanCirculationRulesEngineResource and RequestCirculationRulesEngineResource to reduce code duplication.

Added new endpoints for `/circulation/rules/request-policy` and `/circulation/rules/request-policy-all`.