### PR TITLE
CIRC-194 - populate hold shelf expiration date

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "circulation",
-      "version": "6.0",
+      "version": "7.0",
       "handlers": [
         {
           "methods": [
@@ -580,7 +580,7 @@
     },
     {
       "id": "request-storage",
-      "version": "2.5"
+      "version": "3.0"
     },
     {
       "id": "users",

--- a/ramls/circulation.raml
+++ b/ramls/circulation.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Circulation
-version: v6.0
+version: v7.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/examples/request.json
+++ b/ramls/examples/request.json
@@ -5,7 +5,7 @@
   "requesterId": "21932a85-bd00-446b-9565-46e0c1a5490b",
   "itemId": "195efae1-588f-47bd-a181-13a2eb437701",
   "fulfilmentPreference": "Hold Shelf",
-  "requestExpirationDate": "2017-07-25",
+  "requestExpirationDate": "2017-07-25T22:25:37Z",
   "position": 1,
   "item": {
     "location": {

--- a/ramls/examples/requests.json
+++ b/ramls/examples/requests.json
@@ -16,8 +16,8 @@
       "requesterId": "61d939e4-f2ae-4c53-95d2-224a802fa2a6",
       "itemId": "3e5d5433-a271-499c-94f4-5f3e4652e537",
       "fulfilmentPreference": "Delivery",
-      "requestExpirationDate": "2017-08-31",
-      "holdShelfExpirationDate": "2017-09-01",
+      "requestExpirationDate": "2017-08-31T22:25:37Z",
+      "holdShelfExpirationDate": "2017-09-01T22:25:37Z",
       "position": 1,
       "item": {
         "title": "Children of Time",

--- a/ramls/request.json
+++ b/ramls/request.json
@@ -267,12 +267,12 @@
     "requestExpirationDate": {
       "description": "Date when the request expires",
       "type": "string",
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+      "format": "date-time"
     },
     "holdShelfExpirationDate": {
       "description": "Date when an item returned to the hold shelf expires",
       "type": "string",
-      "pattern": "[0-9]{4}-[0-9]{2}-[0-9]{2}"
+      "format": "date-time"
     },
     "pickupServicePointId": {
       "description": "The ID of the Service Point where this request can be picked up",

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -8,6 +8,7 @@ import static org.folio.circulation.domain.RequestStatus.CLOSED_PICKUP_EXPIRED;
 import static org.folio.circulation.domain.RequestStatus.OPEN_AWAITING_PICKUP;
 import static org.folio.circulation.domain.RequestStatus.OPEN_NOT_YET_FILLED;
 import static org.folio.circulation.domain.representations.RequestProperties.STATUS;
+import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimeProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getIntegerProperty;
 import static org.folio.circulation.support.JsonPropertyWriter.write;
 
@@ -15,6 +16,7 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.representations.RequestProperties;
+import org.joda.time.DateTime;
 
 import io.vertx.core.json.JsonObject;
 
@@ -230,5 +232,20 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
 
   String getDeliveryAddressType() {
     return representation.getString("deliveryAddressTypeId");
+  }
+
+  Request changeHoldShelfExpirationDate(DateTime holdShelfExpirationDate) {
+    write(representation, RequestProperties.HOLD_SHELF_EXPIRATION_DATE,
+        holdShelfExpirationDate);
+
+    return this;
+  }
+
+  void removeHoldShelfExpirationDate() {
+    representation.remove(RequestProperties.HOLD_SHELF_EXPIRATION_DATE);
+  }
+
+  public DateTime getHoldShelfExpirationDate() {
+    return getDateTimeProperty(representation, RequestProperties.HOLD_SHELF_EXPIRATION_DATE);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -7,6 +7,8 @@ import static org.folio.circulation.domain.RequestStatus.CLOSED_UNFILLED;
 import static org.folio.circulation.domain.RequestStatus.CLOSED_PICKUP_EXPIRED;
 import static org.folio.circulation.domain.RequestStatus.OPEN_AWAITING_PICKUP;
 import static org.folio.circulation.domain.RequestStatus.OPEN_NOT_YET_FILLED;
+import static org.folio.circulation.domain.representations.RequestProperties.HOLD_SHELF_EXPIRATION_DATE;
+import static org.folio.circulation.domain.representations.RequestProperties.POSITION;
 import static org.folio.circulation.domain.representations.RequestProperties.STATUS;
 import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimeProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getIntegerProperty;
@@ -15,7 +17,6 @@ import static org.folio.circulation.support.JsonPropertyWriter.write;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
-import org.folio.circulation.domain.representations.RequestProperties;
 import org.joda.time.DateTime;
 
 import io.vertx.core.json.JsonObject;
@@ -201,7 +202,7 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
 
   Request changePosition(Integer newPosition) {
     if(!Objects.equals(getPosition(), newPosition)) {
-      write(representation, RequestProperties.POSITION, newPosition);
+      write(representation, POSITION, newPosition);
       changedPosition = true;
     }
 
@@ -209,12 +210,12 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   void removePosition() {
-    representation.remove(RequestProperties.POSITION);
+    representation.remove(POSITION);
     changedPosition = true;
   }
 
   public Integer getPosition() {
-    return getIntegerProperty(representation, RequestProperties.POSITION, null);
+    return getIntegerProperty(representation, POSITION, null);
   }
 
   boolean hasChangedPosition() {
@@ -234,17 +235,17 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   Request changeHoldShelfExpirationDate(DateTime holdShelfExpirationDate) {
-    write(representation, RequestProperties.HOLD_SHELF_EXPIRATION_DATE,
+    write(representation, HOLD_SHELF_EXPIRATION_DATE,
         holdShelfExpirationDate);
 
     return this;
   }
 
   void removeHoldShelfExpirationDate() {
-    representation.remove(RequestProperties.HOLD_SHELF_EXPIRATION_DATE);
+    representation.remove(HOLD_SHELF_EXPIRATION_DATE);
   }
 
   public DateTime getHoldShelfExpirationDate() {
-    return getDateTimeProperty(representation, RequestProperties.HOLD_SHELF_EXPIRATION_DATE);
+    return getDateTimeProperty(representation, HOLD_SHELF_EXPIRATION_DATE);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/ServicePoint.java
+++ b/src/main/java/org/folio/circulation/domain/ServicePoint.java
@@ -4,6 +4,7 @@ import io.vertx.core.json.JsonObject;
 
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getIntegerProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getObjectProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getBooleanProperty;
 
 public class ServicePoint {
@@ -43,6 +44,10 @@ public class ServicePoint {
   
   public Boolean getPickupLocation() {
     return getBooleanProperty(representation, "pickupLocation");
+  }
+  
+  public TimePeriod getHoldShelfExpiryPeriod() {
+    return TimePeriod.from(getObjectProperty(representation, "holdShelfExpiryPeriod"));
   }
   
   public static ServicePoint from(JsonObject representation) {

--- a/src/main/java/org/folio/circulation/domain/TimePeriod.java
+++ b/src/main/java/org/folio/circulation/domain/TimePeriod.java
@@ -1,12 +1,11 @@
 package org.folio.circulation.domain;
 
-import io.vertx.core.json.JsonObject;
-
+import static org.folio.circulation.support.JsonPropertyFetcher.getIntegerProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 
 import java.time.temporal.ChronoUnit;
 
-import static org.folio.circulation.support.JsonPropertyFetcher.getIntegerProperty;
+import io.vertx.core.json.JsonObject;
 
 public class TimePeriod {
   private final JsonObject representation;

--- a/src/main/java/org/folio/circulation/domain/TimePeriod.java
+++ b/src/main/java/org/folio/circulation/domain/TimePeriod.java
@@ -1,0 +1,39 @@
+package org.folio.circulation.domain;
+
+import io.vertx.core.json.JsonObject;
+
+import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
+
+import java.time.temporal.ChronoUnit;
+
+import static org.folio.circulation.support.JsonPropertyFetcher.getIntegerProperty;
+
+public class TimePeriod {
+  private final JsonObject representation;
+  
+  public TimePeriod(JsonObject representation) {
+    this.representation = representation;
+  }
+  
+  public Integer getDuration() {
+    return getIntegerProperty(representation, "duration", null);
+  }
+
+  public String getIntervalId() {
+    return getProperty(representation, "intervalId");
+  }
+
+  public ChronoUnit getInterval() {
+    final String id = getIntervalId();
+    if (id != null) {
+      return ChronoUnit.valueOf(id.toUpperCase());
+    } else {
+      // Default is days
+      return ChronoUnit.DAYS;
+    }
+  }
+
+  public static TimePeriod from(JsonObject representation) {
+    return new TimePeriod(representation);
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -44,9 +44,8 @@ public class UpdateItem {
 
     if (requestQueue.hasOutstandingFulfillableRequests()) {
       Request request = requestQueue.getHighestPriorityFulfillableRequest();
-      String pickupServicePointIdString = request.getPickupServicePointId();
-      UUID pickUpServicePointId = pickupServicePointIdString == null ? null : UUID.fromString(request.getPickupServicePointId());
-      if (pickUpServicePointId == null || checkInServicePointId == null || checkInServicePointId.equals(pickUpServicePointId)) {
+      UUID pickUpServicePointId = UUID.fromString(request.getPickupServicePointId());
+      if (checkInServicePointId.equals(pickUpServicePointId)) {
         return item.changeStatus(requestQueue.getHighestPriorityFulfillableRequest()
           .checkedInItemStatus());
       } else {

--- a/src/main/java/org/folio/circulation/domain/representations/RequestProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/RequestProperties.java
@@ -6,4 +6,5 @@ public class RequestProperties {
   public static final String STATUS = "status";
   public static final String PROXY_USER_ID = "proxyUserId";
   public static final String POSITION = "position";
+  public static final String HOLD_SHELF_EXPIRATION_DATE = "holdShelfExpirationDate";
 }

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -144,7 +144,7 @@ public class RequestCollectionResource extends CollectionResource {
 
     final RequestRepository requestRepository = RequestRepository.using(clients);
     final UpdateRequestQueue updateRequestQueue = new UpdateRequestQueue(
-      RequestQueueRepository.using(clients), requestRepository);
+      RequestQueueRepository.using(clients), requestRepository, new ServicePointRepository(clients));
 
     requestRepository.getById(id)
       .thenComposeAsync(r -> r.after(requestRepository::delete))

--- a/src/main/java/org/folio/circulation/support/ClockManager.java
+++ b/src/main/java/org/folio/circulation/support/ClockManager.java
@@ -1,0 +1,31 @@
+package org.folio.circulation.support;
+
+import java.time.Clock;
+
+// This class allows for unit tests to replace the clock used by the module.
+// Ideally, we'd use dependency injection for this.
+public class ClockManager {
+  private static final ClockManager INSTANCE = new ClockManager();
+
+  private Clock clock = Clock.systemUTC();
+
+  private ClockManager() {
+    super();
+  }
+
+  public void setClock(Clock clock) {
+    if (clock == null) {
+      throw new IllegalArgumentException("clock cannot be null");
+    }
+
+    this.clock = clock;
+  }
+
+  public Clock getClock() {
+    return clock;
+  }
+
+  public static ClockManager getClockManager() {
+    return INSTANCE;
+  }
+}

--- a/src/test/java/api/loans/scenarios/InTransitToHomeLocationTests.java
+++ b/src/test/java/api/loans/scenarios/InTransitToHomeLocationTests.java
@@ -545,7 +545,7 @@ public class InTransitToHomeLocationTests extends APITests {
     final IndividualResource loan = loansFixture.checkOut(nod, james);
 
     requestsFixture.placeHoldShelfRequest(
-      nod, jessica, DateTime.now(DateTimeZone.UTC));
+      nod, jessica, DateTime.now(DateTimeZone.UTC), otherServicePoint.getId());
 
     final CheckInByBarcodeResponse checkInResponse = loansFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()

--- a/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
+++ b/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
@@ -1,0 +1,188 @@
+package api.requests.scenarios;
+
+import static api.support.builders.RequestBuilder.OPEN_AWAITING_PICKUP;
+import static api.support.builders.RequestBuilder.OPEN_IN_TRANSIT;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
+
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.circulation.support.ClockManager;
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import api.support.APITests;
+import api.support.builders.CheckInByBarcodeRequestBuilder;
+import io.vertx.core.json.JsonObject;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@RunWith(JUnitParamsRunner.class)
+public class HoldShelfExpirationDateTests extends APITests{
+  private static Clock clock;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    ClockManager.getClockManager().setClock(clock);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    // reset the clock before each test (just in case)
+    ClockManager.getClockManager().setClock(clock);
+  }
+
+  @Test
+  @Parameters({
+    "cd5|MINUTES|42",
+    "cd6|HOURS|9",
+    "cd1|DAYS|30",
+    "cd2|MONTHS|6",
+    "cd4|WEEKS|2"
+  })
+  public void requestWithHoldShelfExpirationDateTest(String servicePoint, ChronoUnit interval, int amount)
+      throws MalformedURLException, InterruptedException, TimeoutException,
+      ExecutionException {
+    final IndividualResource checkInServicePoint;
+    try {
+      Method m = servicePointsFixture.getClass().getMethod(servicePoint);
+      checkInServicePoint = (IndividualResource) m.invoke(servicePointsFixture);
+    } catch(Exception e) {
+      throw new IllegalArgumentException("no such service point: " + servicePoint);
+    }
+
+    final IndividualResource james = usersFixture.james();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final IndividualResource nod = itemsFixture.basedUponNod();
+
+    final IndividualResource requestServicePoint = checkInServicePoint;
+
+    loansFixture.checkOut(nod, james);
+
+    final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId());
+
+    loansFixture.checkInByBarcode(
+      new CheckInByBarcodeRequestBuilder()
+        .forItem(nod)
+        .at(checkInServicePoint.getId()));
+
+    final JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
+        storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
+
+    assertThat("request hold shelf expiration date is " + amount + " " + interval.toString() + " in the future",
+        storedRequest.getString("holdShelfExpirationDate"), is(new DateTime(interval.addTo(ZonedDateTime.now(clock), amount).toInstant().toEpochMilli(), DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime())));
+  }
+
+  @Test
+  public void requestWithHoldShelfExpirationDateAlreadySetTest()
+      throws MalformedURLException, InterruptedException, TimeoutException,
+      ExecutionException {
+    final IndividualResource checkInServicePoint = servicePointsFixture.cd1();
+
+    final IndividualResource james = usersFixture.james();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final IndividualResource nod = itemsFixture.basedUponNod();
+
+    final IndividualResource requestServicePoint = checkInServicePoint;
+
+    loansFixture.checkOut(nod, james);
+
+    final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId());
+
+    loansFixture.checkInByBarcode(
+      new CheckInByBarcodeRequestBuilder()
+        .forItem(nod)
+        .at(checkInServicePoint.getId()));
+
+    final JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
+        storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
+
+    assertThat("request hold shelf expiration date is 30 days in the future",
+        storedRequest.getString("holdShelfExpirationDate"), is(new DateTime(ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30).toInstant().toEpochMilli(), DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime())));
+
+    Clock not30Days = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC);
+    ClockManager.getClockManager().setClock(not30Days);
+
+    loansFixture.checkInByBarcode(
+        new CheckInByBarcodeRequestBuilder()
+          .forItem(nod)
+          .at(checkInServicePoint.getId()));
+
+    final JsonObject storedSecondCheckInRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
+        storedSecondCheckInRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
+
+    assertThat("request hold shelf expiration date is 30 days in the future and has not been updated",
+        storedRequest.getString("holdShelfExpirationDate"), is(new DateTime(ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30).toInstant().toEpochMilli(), DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime())));
+  }
+  @Test
+  public void requestRemoveHoldShelfExpirationDateWhenItemIsInTransitTest()
+      throws MalformedURLException, InterruptedException, TimeoutException,
+      ExecutionException {
+    final IndividualResource checkInServicePoint = servicePointsFixture.cd1();
+    final IndividualResource alternateCheckInServicePoint = servicePointsFixture.cd2();
+
+    final IndividualResource james = usersFixture.james();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final IndividualResource nod = itemsFixture.basedUponNod();
+
+    final IndividualResource requestServicePoint = checkInServicePoint;
+
+    loansFixture.checkOut(nod, james);
+
+    final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId());
+
+    loansFixture.checkInByBarcode(
+      new CheckInByBarcodeRequestBuilder()
+        .forItem(nod)
+        .at(checkInServicePoint.getId()));
+
+    final JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
+        storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
+
+    assertThat("request hold shelf expiration date is 30 days in the future",
+        storedRequest.getString("holdShelfExpirationDate"), is(new DateTime(ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30).toInstant().toEpochMilli(), DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime())));
+
+    loansFixture.checkInByBarcode(
+        new CheckInByBarcodeRequestBuilder()
+          .forItem(nod)
+          .at(alternateCheckInServicePoint.getId()));
+
+    final JsonObject storedSecondCheckInRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("request status snapshot in storage is " + OPEN_IN_TRANSIT,
+        storedSecondCheckInRequest.getString("status"), is(OPEN_IN_TRANSIT));
+
+    assertThat("request hold shelf expiration date is not set",
+        storedSecondCheckInRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
+  }
+}

--- a/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
+++ b/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
@@ -1,7 +1,13 @@
 package api.requests.scenarios;
 
+import static api.support.builders.ItemBuilder.AWAITING_PICKUP;
+import static api.support.builders.ItemBuilder.CHECKED_OUT;
+import static api.support.builders.ItemBuilder.IN_TRANSIT;
+import static api.support.builders.ItemBuilder.PAGED;
 import static api.support.builders.RequestBuilder.OPEN_AWAITING_PICKUP;
 import static api.support.builders.RequestBuilder.OPEN_IN_TRANSIT;
+import static api.support.builders.RequestBuilder.OPEN_NOT_YET_FILLED;
+import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
@@ -56,7 +62,7 @@ public class HoldShelfExpirationDateTests extends APITests{
     "cd2|MONTHS|6",
     "cd4|WEEKS|2"
   })
-  public void requestWithHoldShelfExpirationDateTest(String servicePoint, ChronoUnit interval, int amount)
+  public void requestWithHoldShelfExpirationDate(String servicePoint, ChronoUnit interval, int amount)
       throws MalformedURLException, InterruptedException, TimeoutException,
       ExecutionException {
     final IndividualResource checkInServicePoint;
@@ -94,7 +100,7 @@ public class HoldShelfExpirationDateTests extends APITests{
   }
 
   @Test
-  public void requestWithHoldShelfExpirationDateAlreadySetTest()
+  public void requestWithHoldShelfExpirationDateAlreadySet()
       throws MalformedURLException, InterruptedException, TimeoutException,
       ExecutionException {
     final IndividualResource checkInServicePoint = servicePointsFixture.cd1();
@@ -140,8 +146,9 @@ public class HoldShelfExpirationDateTests extends APITests{
     assertThat("request hold shelf expiration date is 30 days in the future and has not been updated",
         storedRequest.getString("holdShelfExpirationDate"), is(new DateTime(ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30).toInstant().toEpochMilli(), DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime())));
   }
+
   @Test
-  public void requestRemoveHoldShelfExpirationDateWhenItemIsInTransitTest()
+  public void requestRemoveHoldShelfExpirationDateWhenItemIsInTransit()
       throws MalformedURLException, InterruptedException, TimeoutException,
       ExecutionException {
     final IndividualResource checkInServicePoint = servicePointsFixture.cd1();
@@ -150,7 +157,7 @@ public class HoldShelfExpirationDateTests extends APITests{
     final IndividualResource james = usersFixture.james();
     final IndividualResource jessica = usersFixture.jessica();
 
-    final IndividualResource nod = itemsFixture.basedUponNod();
+    IndividualResource nod = itemsFixture.basedUponNod();
 
     final IndividualResource requestServicePoint = checkInServicePoint;
 
@@ -164,7 +171,12 @@ public class HoldShelfExpirationDateTests extends APITests{
         .forItem(nod)
         .at(checkInServicePoint.getId()));
 
-    final JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+    nod = itemsClient.get(nod);
+
+    JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("Item status snapshot in storage is " + AWAITING_PICKUP,
+        nod, hasItemStatus(AWAITING_PICKUP));
 
     assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
         storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
@@ -184,5 +196,174 @@ public class HoldShelfExpirationDateTests extends APITests{
 
     assertThat("request hold shelf expiration date is not set",
         storedSecondCheckInRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
+  }
+
+  @Test
+  public void pageRequestWithHoldShelfExpirationDate()
+      throws MalformedURLException, InterruptedException, TimeoutException,
+      ExecutionException {
+    final IndividualResource checkInServicePoint = servicePointsFixture.cd1();
+
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final IndividualResource nod = itemsFixture.basedUponNod();
+
+    final IndividualResource requestServicePoint = checkInServicePoint;
+
+    final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId(), "Page");
+
+    loansFixture.checkInByBarcode(
+      new CheckInByBarcodeRequestBuilder()
+        .forItem(nod)
+        .at(checkInServicePoint.getId()));
+
+    final JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
+        storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
+
+    assertThat("request hold shelf expiration date is 30 days in the future",
+        storedRequest.getString("holdShelfExpirationDate"), is(new DateTime(ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30).toInstant().toEpochMilli(), DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime())));
+  }
+
+  @Test
+  public void requestHoldShelfExpirationDateWhenItemIsInTransit()
+      throws MalformedURLException, InterruptedException, TimeoutException,
+      ExecutionException {
+    final IndividualResource checkInServicePoint = servicePointsFixture.cd1();
+    final IndividualResource alternateCheckInServicePoint = servicePointsFixture.cd2();
+
+    final IndividualResource james = usersFixture.james();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    IndividualResource nod = itemsFixture.basedUponNod();
+
+    final IndividualResource requestServicePoint = alternateCheckInServicePoint;
+
+    loansFixture.checkOut(nod, james);
+
+    final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId());
+
+    nod = itemsClient.get(nod);
+
+    JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("Item status snapshot in storage is " + CHECKED_OUT,
+        nod, hasItemStatus(CHECKED_OUT));
+
+    assertThat("request status snapshot in storage is " + OPEN_NOT_YET_FILLED,
+        storedRequest.getString("status"), is(OPEN_NOT_YET_FILLED));
+
+    loansFixture.checkInByBarcode(
+      new CheckInByBarcodeRequestBuilder()
+        .forItem(nod)
+        .at(checkInServicePoint.getId()));
+
+    storedRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("request status snapshot in storage is " + OPEN_IN_TRANSIT,
+        storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
+
+    assertThat("request hold shelf expiration date is not set",
+        storedRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
+  }
+
+  @Test
+  public void pageRequestInTransitWithHoldShelfExpirationDate()
+      throws MalformedURLException, InterruptedException, TimeoutException,
+      ExecutionException {
+    final IndividualResource checkInServicePoint = servicePointsFixture.cd1();
+    final IndividualResource alternateServicePoint = servicePointsFixture.cd2();
+
+    final IndividualResource jessica = usersFixture.jessica();
+
+    IndividualResource nod = itemsFixture.basedUponNod();
+
+    final IndividualResource requestServicePoint = alternateServicePoint;
+
+    final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId(), "Page");
+
+    nod = itemsClient.get(nod);
+
+    JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("Item status snapshot in storage is " + PAGED,
+        nod, hasItemStatus(PAGED));
+
+    assertThat("request status snapshot in storage is " + OPEN_NOT_YET_FILLED,
+        storedRequest.getString("status"), is(OPEN_NOT_YET_FILLED));
+
+    loansFixture.checkInByBarcode(
+      new CheckInByBarcodeRequestBuilder()
+        .forItem(nod)
+        .at(checkInServicePoint.getId()));
+
+    storedRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("request status snapshot in storage is " + OPEN_IN_TRANSIT,
+        storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
+
+    assertThat("request hold shelf expiration date is not set",
+        storedRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
+  }
+
+  @Test
+  public void requestInTransitRemainsInTransit()
+      throws MalformedURLException, InterruptedException, TimeoutException,
+      ExecutionException {
+    final IndividualResource checkInServicePoint = servicePointsFixture.cd1();
+    final IndividualResource alternateCheckInServicePoint = servicePointsFixture.cd2();
+    final IndividualResource transitCheckInServicePoint = servicePointsFixture.cd4();
+
+    final IndividualResource james = usersFixture.james();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    IndividualResource nod = itemsFixture.basedUponNod();
+
+    final IndividualResource requestServicePoint = alternateCheckInServicePoint;
+
+    loansFixture.checkOut(nod, james);
+
+    final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId());
+
+    loansFixture.checkInByBarcode(
+      new CheckInByBarcodeRequestBuilder()
+        .forItem(nod)
+        .at(checkInServicePoint.getId()));
+
+    nod = itemsClient.get(nod);
+
+    JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("Item status snapshot in storage is " + IN_TRANSIT,
+        nod, hasItemStatus(IN_TRANSIT));
+
+    assertThat("request status snapshot in storage is " + OPEN_IN_TRANSIT,
+        storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
+
+    assertThat("request hold shelf expiration date is not set",
+        storedRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
+
+    loansFixture.checkInByBarcode(
+        new CheckInByBarcodeRequestBuilder()
+          .forItem(nod)
+          .at(transitCheckInServicePoint.getId()));
+
+    nod = itemsClient.get(nod);
+
+    storedRequest = requestsClient.getById(request.getId()).getJson();
+
+    assertThat("Item status snapshot in storage is " + IN_TRANSIT,
+        nod, hasItemStatus(IN_TRANSIT));
+
+    assertThat("request status snapshot in storage is " + OPEN_IN_TRANSIT,
+        storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
+
+    assertThat("request hold shelf expiration date is not set",
+        storedRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
   }
 }

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -139,7 +139,7 @@ public abstract class APITests {
     = new CancellationReasonsFixture(ResourceClient.forCancellationReasons(client));
 
   protected final RequestsFixture requestsFixture = new RequestsFixture(
-    requestsClient, cancellationReasonsFixture);
+    requestsClient, cancellationReasonsFixture, servicePointsFixture);
 
   protected APITests() {
     this(true);

--- a/src/test/java/api/support/builders/ItemBuilder.java
+++ b/src/test/java/api/support/builders/ItemBuilder.java
@@ -11,6 +11,8 @@ public class ItemBuilder extends JsonBuilder implements Builder {
   public static final String AVAILABLE = "Available";
   public static final String CHECKED_OUT = "Checked out";
   public static final String AWAITING_PICKUP = "Awaiting pickup";
+  public static final String IN_TRANSIT = "In transit";
+  public static final String PAGED = "Paged";
 
   private final UUID id;
   private final UUID holdingId;

--- a/src/test/java/api/support/builders/RequestBuilder.java
+++ b/src/test/java/api/support/builders/RequestBuilder.java
@@ -18,6 +18,7 @@ import io.vertx.core.json.JsonObject;
 public class RequestBuilder extends JsonBuilder implements Builder {
   public static final String OPEN_NOT_YET_FILLED = "Open - Not yet filled";
   public static final String OPEN_AWAITING_PICKUP = "Open - Awaiting pickup";
+  public static final String OPEN_IN_TRANSIT = "Open - In transit";
   public static final String CLOSED_FILLED = "Closed - Filled";
   public static final String CLOSED_CANCELLED = "Closed - Cancelled";
 

--- a/src/test/java/api/support/builders/ServicePointBuilder.java
+++ b/src/test/java/api/support/builders/ServicePointBuilder.java
@@ -14,7 +14,8 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
   private final String description;
   private final Integer shelvingLagTime;
   private final Boolean pickupLocation;
-    
+  private final JsonObject holdShelfExpiryPeriod;
+
   public ServicePointBuilder(
       UUID id, 
       String name,
@@ -22,7 +23,8 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
       String discoveryDisplayName,
       String description,
       Integer shelvingLagTime,
-      Boolean pickupLocation) {
+      Boolean pickupLocation,
+      JsonObject holdShelfExpiryPeriod) {
     this.id = id;
     this.name = name;
     this.code = code;
@@ -30,6 +32,7 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
     this.description = description;
     this.shelvingLagTime = shelvingLagTime;
     this.pickupLocation = pickupLocation;
+    this.holdShelfExpiryPeriod = holdShelfExpiryPeriod;
   }
   
   public ServicePointBuilder(String name, String code, String discoveryDisplayName) {
@@ -40,7 +43,8 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
         discoveryDisplayName,
         null,
         null,
-        false);
+        false,
+        null);
   }
   
   public static ServicePointBuilder from(IndividualResource response) {
@@ -52,7 +56,8 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
         getProperty(representation, "discoveryDisplayName"),
         getProperty(representation, "description"),
         getIntegerProperty(representation, "shelvingLagTime", null),
-        getBooleanProperty(representation, "pickupLocation")
+        getBooleanProperty(representation, "pickupLocation"),
+        getObjectProperty(representation, "holdShelfExpiryPeriod")
     );
   }
 
@@ -66,7 +71,8 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
     put(servicePoint, "description", this.description);
     put(servicePoint, "shelvingLagTime", this.shelvingLagTime);
     put(servicePoint, "pickupLocation", this.pickupLocation);
-    
+    put(servicePoint, "holdShelfExpiryPeriod", this.holdShelfExpiryPeriod);
+
     return servicePoint;
   }
   
@@ -78,7 +84,8 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
       this.discoveryDisplayName,
       this.description,
       this.shelvingLagTime,
-      this.pickupLocation);
+      this.pickupLocation,
+      this.holdShelfExpiryPeriod);
   }
   
   public ServicePointBuilder withName(String newName) {
@@ -89,7 +96,8 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
       this.discoveryDisplayName,
       this.description,
       this.shelvingLagTime,
-      this.pickupLocation);
+      this.pickupLocation,
+      this.holdShelfExpiryPeriod);
   }
 
   public ServicePointBuilder withCode(String newCode) {
@@ -100,7 +108,8 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
       this.discoveryDisplayName,
       this.description,
       this.shelvingLagTime,
-      this.pickupLocation);
+      this.pickupLocation,
+      this.holdShelfExpiryPeriod);
   }  
   
   public ServicePointBuilder withDiscoveryDisplayName(String newDiscoveryDisplayName) {
@@ -111,7 +120,8 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
       newDiscoveryDisplayName,
       this.description,
       this.shelvingLagTime,
-      this.pickupLocation);
+      this.pickupLocation,
+      this.holdShelfExpiryPeriod);
   }  
   
   public ServicePointBuilder withDescription(String newDescription) {
@@ -122,7 +132,8 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
       this.discoveryDisplayName,
       newDescription,
       this.shelvingLagTime,
-      this.pickupLocation);
+      this.pickupLocation,
+      this.holdShelfExpiryPeriod);
   }  
   
   public ServicePointBuilder withShelvingLagTime(Integer newShelvingLagTime) {
@@ -133,7 +144,8 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
       this.discoveryDisplayName,
       this.description,
       newShelvingLagTime,
-      this.pickupLocation);
+      this.pickupLocation,
+      this.holdShelfExpiryPeriod);
   }  
   
   public ServicePointBuilder withPickupLocation(Boolean newPickupLocation) {
@@ -144,6 +156,24 @@ public class ServicePointBuilder extends JsonBuilder implements Builder {
       this.discoveryDisplayName,
       this.description,
       this.shelvingLagTime,
-      newPickupLocation);
+      newPickupLocation,
+      this.holdShelfExpiryPeriod);
+  }
+
+  public ServicePointBuilder withHoldShelfExpriyPeriod(int duration, String intervalId) {
+    final JsonObject holdShelfExpiryPeriod = new JsonObject();
+
+    put(holdShelfExpiryPeriod, "duration", duration);
+    put(holdShelfExpiryPeriod, "intervalId", intervalId);
+
+    return new ServicePointBuilder(
+      this.id,
+      this.name,
+      this.code,
+      this.discoveryDisplayName,
+      this.description,
+      this.shelvingLagTime,
+      this.pickupLocation,
+      holdShelfExpiryPeriod);
   }
 }

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -337,7 +337,7 @@ public class LoansFixture {
     return checkInByBarcode(new CheckInByBarcodeRequestBuilder()
       .forItem(item)
       .on(DateTime.now(DateTimeZone.UTC))
-      .at(servicePointsFixture.fake()));
+      .at(servicePointsFixture.cd1()));
   }
 
   public CheckInByBarcodeResponse checkInByBarcode(

--- a/src/test/java/api/support/fixtures/LocationsFixture.java
+++ b/src/test/java/api/support/fixtures/LocationsFixture.java
@@ -117,7 +117,7 @@ public class LocationsFixture {
       jubileeCampus().getId(),
       businessLibrary().getId(),
       djanoglyLibrary().getId(),
-      servicePointsFixture.fake().getId());
+      servicePointsFixture.cd1().getId());
   }
 
   private IndividualResource djanoglyLibrary()

--- a/src/test/java/api/support/fixtures/RequestsFixture.java
+++ b/src/test/java/api/support/fixtures/RequestsFixture.java
@@ -94,6 +94,28 @@ public class RequestsFixture {
         .withPickupServicePointId(pickupServicePointId));
   }
 
+
+  public IndividualResource placeHoldShelfRequest(
+      IndividualResource item,
+      IndividualResource by,
+      DateTime on,
+      UUID pickupServicePointId,
+      String type)
+          throws InterruptedException,
+          MalformedURLException,
+          TimeoutException,
+          ExecutionException {
+
+    return place(new RequestBuilder()
+        .hold()
+        .withRequestType(type)
+        .fulfilToHoldShelf()
+        .withItemId(item.getId())
+        .withRequestDate(on)
+        .withRequesterId(by.getId())
+        .withPickupServicePointId(pickupServicePointId));
+  }
+
   public IndividualResource placeHoldShelfRequest(
     IndividualResource item,
     IndividualResource by,

--- a/src/test/java/api/support/fixtures/RequestsFixture.java
+++ b/src/test/java/api/support/fixtures/RequestsFixture.java
@@ -19,13 +19,16 @@ import io.vertx.core.json.JsonObject;
 public class RequestsFixture {
   private final ResourceClient requestsClient;
   private final CancellationReasonsFixture cancellationReasonsFixture;
+  private final ServicePointsFixture servicePointsFixture;
 
   public RequestsFixture(
     ResourceClient requestsClient,
-    CancellationReasonsFixture cancellationReasonsFixture) {
+    CancellationReasonsFixture cancellationReasonsFixture,
+    ServicePointsFixture servicePointsFixture) {
 
     this.requestsClient = requestsClient;
     this.cancellationReasonsFixture = cancellationReasonsFixture;
+    this.servicePointsFixture = servicePointsFixture;
   }
 
   public IndividualResource place(RequestBuilder requestToBuild)
@@ -51,7 +54,8 @@ public class RequestsFixture {
       .fulfilToHoldShelf()
       .withItemId(item.getId())
       .withRequestDate(on)
-      .withRequesterId(by.getId()));
+      .withRequesterId(by.getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId()));
   }
 
   public IndividualResource placeDeliveryRequest(

--- a/src/test/java/api/support/fixtures/ServicePointExamples.java
+++ b/src/test/java/api/support/fixtures/ServicePointExamples.java
@@ -5,21 +5,36 @@ import api.support.builders.ServicePointBuilder;
 class ServicePointExamples {
   static ServicePointBuilder basedUponCircDesk1() {
     return new ServicePointBuilder("Circ Desk 1", "cd1",
-        "Circulation Desk -- Hallway").withPickupLocation(Boolean.TRUE);
+        "Circulation Desk -- Hallway").withPickupLocation(Boolean.TRUE)
+        .withHoldShelfExpriyPeriod(30, "Days");
   }
-  
+
   static ServicePointBuilder basedUponCircDesk2() {
     return new ServicePointBuilder("Circ Desk 2", "cd2",
-        "Circulation Desk -- Back Entrance").withPickupLocation(Boolean.TRUE);
+        "Circulation Desk -- Back Entrance").withPickupLocation(Boolean.TRUE)
+        .withHoldShelfExpriyPeriod(6, "Months");
   }
-  
+
   static ServicePointBuilder basedUponCircDesk3() {
     return new ServicePointBuilder("Circ Desk 3", "cd3",
         "Circulation Desk -- Dumpster").withPickupLocation(Boolean.FALSE);
   }
-  
+
   static ServicePointBuilder basedUponCircDesk4() {
     return new ServicePointBuilder("Circ Desk 4", "cd4",
-        "Circulation Desk -- Basement").withPickupLocation(Boolean.TRUE);
+        "Circulation Desk -- Basement").withPickupLocation(Boolean.TRUE)
+        .withHoldShelfExpriyPeriod(2, "Weeks");
+  }
+
+  static ServicePointBuilder basedUponCircDesk5() {
+    return new ServicePointBuilder("Circ Desk 5", "cd5",
+        "Circulation Desk -- Rooftop").withPickupLocation(Boolean.TRUE)
+        .withHoldShelfExpriyPeriod(42, "Minutes");
+  }
+
+  static ServicePointBuilder basedUponCircDesk6() {
+    return new ServicePointBuilder("Circ Desk 6", "cd6",
+        "Circulation Desk -- Igloo").withPickupLocation(Boolean.TRUE)
+        .withHoldShelfExpriyPeriod(9, "Hours");
   }
 }

--- a/src/test/java/api/support/fixtures/ServicePointsFixture.java
+++ b/src/test/java/api/support/fixtures/ServicePointsFixture.java
@@ -4,6 +4,8 @@ import static api.support.fixtures.ServicePointExamples.basedUponCircDesk1;
 import static api.support.fixtures.ServicePointExamples.basedUponCircDesk2;
 import static api.support.fixtures.ServicePointExamples.basedUponCircDesk3;
 import static api.support.fixtures.ServicePointExamples.basedUponCircDesk4;
+import static api.support.fixtures.ServicePointExamples.basedUponCircDesk5;
+import static api.support.fixtures.ServicePointExamples.basedUponCircDesk6;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 
 import java.net.MalformedURLException;
@@ -12,7 +14,6 @@ import java.util.concurrent.TimeoutException;
 
 import org.folio.circulation.support.http.client.IndividualResource;
 
-import api.support.builders.ServicePointBuilder;
 import api.support.http.ResourceClient;
 
 public class ServicePointsFixture {
@@ -32,49 +33,57 @@ public class ServicePointsFixture {
     servicePointRecordCreator.cleanUp();
   }
 
-  public IndividualResource cd1() 
-      throws InterruptedException, 
-      MalformedURLException, 
-      TimeoutException, 
+  public IndividualResource cd1()
+      throws InterruptedException,
+      MalformedURLException,
+      TimeoutException,
       ExecutionException {
 
     return servicePointRecordCreator.createIfAbsent(basedUponCircDesk1());
   }
   
-  public IndividualResource cd2() 
-      throws InterruptedException, 
-      MalformedURLException, 
-      TimeoutException, 
+  public IndividualResource cd2()
+      throws InterruptedException,
+      MalformedURLException,
+      TimeoutException,
       ExecutionException {
 
     return servicePointRecordCreator.createIfAbsent(basedUponCircDesk2());
   } 
   
-  public IndividualResource cd3() 
-      throws InterruptedException, 
-      MalformedURLException, 
-      TimeoutException, 
+  public IndividualResource cd3()
+      throws InterruptedException,
+      MalformedURLException,
+      TimeoutException,
       ExecutionException {
 
     return servicePointRecordCreator.createIfAbsent(basedUponCircDesk3());
   }
 
-  public IndividualResource cd4() 
-      throws InterruptedException, 
-      MalformedURLException, 
-      TimeoutException, 
+  public IndividualResource cd4()
+      throws InterruptedException,
+      MalformedURLException,
+      TimeoutException,
       ExecutionException {
 
     return servicePointRecordCreator.createIfAbsent(basedUponCircDesk4());
   }
 
-  public IndividualResource fake()
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+  public IndividualResource cd5()
+      throws InterruptedException,
+      MalformedURLException,
+      TimeoutException,
+      ExecutionException {
 
-    return servicePointRecordCreator.createIfAbsent(
-      new ServicePointBuilder("Fake service point", "FAKE", "Fake service point"));
+    return servicePointRecordCreator.createIfAbsent(basedUponCircDesk5());
+  }
+
+  public IndividualResource cd6()
+      throws InterruptedException,
+      MalformedURLException,
+      TimeoutException,
+      ExecutionException {
+
+    return servicePointRecordCreator.createIfAbsent(basedUponCircDesk6());
   }
 }


### PR DESCRIPTION
In order to complete this story, we needed to expand the `holdShelfExpirationDate` to include a time component. We also took this opportunity to update the `requestExpirationDate` to include a time component. The hold shelf expiration date is calculated using the UTC time zone.