### PR TITLE
CIRC-243 Require service point for Hold Requests

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -155,7 +155,7 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
     return representation.getString("id");
   }
 
-  RequestType getRequestType() {
+  public RequestType getRequestType() {
     return RequestType.from(representation.getString("requestType"));
   }
 

--- a/src/main/java/org/folio/circulation/domain/validation/ServicePointPickupLocationValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ServicePointPickupLocationValidator.java
@@ -7,6 +7,7 @@ import java.lang.invoke.MethodHandles;
 
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestAndRelatedRecords;
+import org.folio.circulation.domain.RequestType;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.slf4j.Logger;
@@ -14,7 +15,7 @@ import org.slf4j.LoggerFactory;
 
 public class ServicePointPickupLocationValidator {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  
+
   public HttpResult<RequestAndRelatedRecords> checkServicePointPickupLocation(
       HttpResult<RequestAndRelatedRecords> requestAndRelatedRecordsResult) {
 
@@ -37,8 +38,15 @@ public class ServicePointPickupLocationValidator {
     }
 
     if(request.getPickupServicePointId() == null) {
-      log.info("No pickup service point specified for request");
-      return succeeded(requestAndRelatedRecords);
+      if(request.getRequestType() == RequestType.HOLD) {
+        log.info("Hold Requests require a Pickup Service Point");
+        return failed(ValidationErrorFailure.failure(
+                "Hold Requests require a Pickup Service Point", "id",
+                request.getId()));
+      } else {
+        log.info("No pickup service point specified for request");
+        return succeeded(requestAndRelatedRecords);
+      }
     }
 
     if(request.getPickupServicePointId() != null && request.getPickupServicePoint() == null) {

--- a/src/test/java/api/requests/RequestsAPICreateMultipleRequestsTests.java
+++ b/src/test/java/api/requests/RequestsAPICreateMultipleRequestsTests.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -31,16 +32,19 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
     final IndividualResource firstRequest = requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.jessica()));
 
     final IndividualResource secondRequest = requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.rebecca()));
 
     final IndividualResource thirdRequest = requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.charlotte()));
 
     assertThat(firstRequest.getJson().getInteger("position"), is(1));
@@ -62,11 +66,13 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
     final IndividualResource firstRequest = requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.james()));
 
     final IndividualResource secondRequest = requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.charlotte()));
 
     final IndividualResource thirdRequest = requestsClient.create(new RequestBuilder()
@@ -93,6 +99,7 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
     final IndividualResource firstRequest = requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.james()));
 
     final IndividualResource secondRequest = requestsClient.create(new RequestBuilder()
@@ -130,6 +137,7 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
         .open()
         .hold()
         .forItem(smallAngryPlanet)
+        .withPickupServicePointId(servicePointsFixture.cd1().getId())
         .by(usersFixture.jessica()));
 
     final IndividualResource secondRequest = requestsClient.createAtSpecificLocation(
@@ -137,6 +145,7 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
         .open()
         .hold()
         .forItem(smallAngryPlanet)
+        .withPickupServicePointId(servicePointsFixture.cd1().getId())
         .by(usersFixture.rebecca()));
 
     final IndividualResource thirdRequest = requestsClient.createAtSpecificLocation(
@@ -144,6 +153,7 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
         .open()
         .hold()
         .forItem(smallAngryPlanet)
+        .withPickupServicePointId(servicePointsFixture.cd1().getId())
         .by(usersFixture.charlotte()));
 
     assertThat("First request should have position",

--- a/src/test/java/api/requests/RequestsAPIDeletionTests.java
+++ b/src/test/java/api/requests/RequestsAPIDeletionTests.java
@@ -46,16 +46,19 @@ public class RequestsAPIDeletionTests extends APITests {
 
     requestsClient.create(new RequestBuilder()
       .withItemId(nod.getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId))
       .getId();
 
     requestsClient.create(new RequestBuilder()
       .withItemId(smallAngryPlanet.getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId))
       .getId();
 
     requestsClient.create(new RequestBuilder()
       .withItemId(temeraire.getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId))
       .getId();
 
@@ -103,16 +106,19 @@ public class RequestsAPIDeletionTests extends APITests {
 
     final UUID firstRequestId = requestsClient.create(new RequestBuilder()
       .withItemId(nod.getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId))
       .getId();
 
     final UUID secondRequestId = requestsClient.create(new RequestBuilder()
       .withItemId(smallAngryPlanet.getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId))
       .getId();
 
     final UUID thirdRequestId = requestsClient.create(new RequestBuilder()
       .withItemId(temeraire.getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId))
       .getId();
 

--- a/src/test/java/api/requests/RequestsAPILoanHistoryTests.java
+++ b/src/test/java/api/requests/RequestsAPILoanHistoryTests.java
@@ -31,6 +31,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(usersFixture.charlotte().getId()));
 
     JsonObject loanFromStorage = loansStorageClient.getById(loanId).getJson();
@@ -82,6 +83,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.charlotte()));
 
     JsonObject closedLoanFromStorage = loansStorageClient.getById(closedLoanId)
@@ -141,6 +143,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.james()));
 
     JsonObject storageLoanForOtherItem = loansStorageClient
@@ -200,6 +203,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.charlotte()));
   }
 

--- a/src/test/java/api/requests/RequestsAPILocationTests.java
+++ b/src/test/java/api/requests/RequestsAPILocationTests.java
@@ -47,6 +47,7 @@ public class RequestsAPILocationTests extends APITests {
       .open()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(requester));
 
     JsonObject representation = request.getJson();
@@ -95,6 +96,7 @@ public class RequestsAPILocationTests extends APITests {
       .open()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.rebecca()));
 
     final InventoryItemResource temeraire = itemsFixture.basedUponTemeraire(
@@ -111,6 +113,7 @@ public class RequestsAPILocationTests extends APITests {
       .open()
       .hold()
       .forItem(temeraire)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.steve()));
 
     List<JsonObject> fetchedRequestsResponse = requestsClient.getAll();

--- a/src/test/java/api/requests/RequestsAPIProxyTests.java
+++ b/src/test/java/api/requests/RequestsAPIProxyTests.java
@@ -45,6 +45,7 @@ public class RequestsAPIProxyTests extends APITests {
       .forItem(smallAngryPlanet)
       .by(sponsor)
       .proxiedBy(proxy)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .create();
 
     CompletableFuture<Response> postCompleted = new CompletableFuture<>();
@@ -100,6 +101,7 @@ public class RequestsAPIProxyTests extends APITests {
       .forItem(item)
       .by(sponsor)
       .proxiedBy(proxy)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .create();
 
     CompletableFuture<Response> postCompleted = new CompletableFuture<>();
@@ -134,6 +136,7 @@ public class RequestsAPIProxyTests extends APITests {
       .forItem(smallAngryPlanet)
       .by(jessica)
       .proxiedBy(james)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .create();
 
     CompletableFuture<Response> postCompleted = new CompletableFuture<>();
@@ -156,7 +159,7 @@ public class RequestsAPIProxyTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
 
     final IndividualResource steve = usersFixture.steve();
-    
+
     loansFixture.checkOutByBarcode(smallAngryPlanet, steve);
 
     IndividualResource jessica = usersFixture.jessica();
@@ -168,6 +171,7 @@ public class RequestsAPIProxyTests extends APITests {
       .forItem(smallAngryPlanet)
       .by(jessica)
       .proxiedBy(james)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .create();
 
     CompletableFuture<Response> postCompleted = new CompletableFuture<>();
@@ -201,6 +205,7 @@ public class RequestsAPIProxyTests extends APITests {
       .forItem(smallAngryPlanet)
       .by(charlotte)
       .proxiedBy(james)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .create();
 
     CompletableFuture<Response> postCompleted = new CompletableFuture<>();

--- a/src/test/java/api/requests/RequestsAPIRelatedRecordsTests.java
+++ b/src/test/java/api/requests/RequestsAPIRelatedRecordsTests.java
@@ -39,6 +39,7 @@ public class RequestsAPIRelatedRecordsTests extends APITests {
 
     IndividualResource response = requestsClient.create(new RequestBuilder()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.charlotte()));
 
     JsonObject createdRequest = response.getJson();
@@ -98,11 +99,13 @@ public class RequestsAPIRelatedRecordsTests extends APITests {
 
     UUID firstRequestId = requestsClient.create(new RequestBuilder()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(charlotte))
       .getId();
 
     UUID secondRequestId = requestsClient.create(new RequestBuilder()
       .forItem(temeraire)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(charlotte))
       .getId();
 

--- a/src/test/java/api/requests/RequestsAPIRetrievalTests.java
+++ b/src/test/java/api/requests/RequestsAPIRetrievalTests.java
@@ -489,30 +489,37 @@ public class RequestsAPIRetrievalTests extends APITests {
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponSmallAngryPlanet(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponInterestingTimes(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponUprooted(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     CompletableFuture<Response> getFirstPageCompleted = new CompletableFuture<>();
@@ -562,30 +569,37 @@ public class RequestsAPIRetrievalTests extends APITests {
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponSmallAngryPlanet(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(firstRequester));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(firstRequester));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponInterestingTimes(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(secondRequester));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(firstRequester));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(firstRequester));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponUprooted(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(secondRequester));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(secondRequester));
 
     CompletableFuture<Response> getRequestsCompleted = new CompletableFuture<>();
@@ -625,26 +639,31 @@ public class RequestsAPIRetrievalTests extends APITests {
 
     requestsClient.create(new RequestBuilder()
       .forItem(itemsFixture.basedUponSmallAngryPlanet(ItemBuilder::checkOut))
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(sponsor)
       .proxiedBy(firstProxy));
 
     requestsClient.create(new RequestBuilder()
       .forItem(itemsFixture.basedUponNod(ItemBuilder::checkOut))
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(sponsor)
       .proxiedBy(secondProxy));
 
     requestsClient.create(new RequestBuilder()
       .forItem(itemsFixture.basedUponNod(ItemBuilder::checkOut))
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(sponsor)
       .proxiedBy(secondProxy));
 
     requestsClient.create(new RequestBuilder()
       .forItem(itemsFixture.basedUponUprooted(ItemBuilder::checkOut))
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(sponsor)
       .proxiedBy(firstProxy));
 
     requestsClient.create(new RequestBuilder()
       .forItem(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut))
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(sponsor)
       .proxiedBy(secondProxy));
 
@@ -679,30 +698,37 @@ public class RequestsAPIRetrievalTests extends APITests {
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponSmallAngryPlanet(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponInterestingTimes(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponUprooted(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(requesterId));
 
     CompletableFuture<Response> getRequestsCompleted = new CompletableFuture<>();

--- a/src/test/java/api/requests/RequestsAPITitleTests.java
+++ b/src/test/java/api/requests/RequestsAPITitleTests.java
@@ -34,6 +34,7 @@ public class RequestsAPITitleTests extends APITests {
 
     IndividualResource response = requestsClient.create(new RequestBuilder()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.james()));
 
     JsonObject createdRequest = response.getJson();
@@ -72,6 +73,7 @@ public class RequestsAPITitleTests extends APITests {
 
     IndividualResource response = requestsClient.create(new RequestBuilder()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.steve()));
 
     JsonObject createdRequest = response.getJson();
@@ -111,6 +113,7 @@ public class RequestsAPITitleTests extends APITests {
 
     UUID firstRequestId = requestsClient.create(new RequestBuilder()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.james()))
       .getId();
 
@@ -118,6 +121,7 @@ public class RequestsAPITitleTests extends APITests {
 
     UUID secondRequestId = requestsClient.create(new RequestBuilder()
       .forItem(temeraire)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.james()))
       .getId();
 

--- a/src/test/java/api/requests/RequestsAPIUpdatingTests.java
+++ b/src/test/java/api/requests/RequestsAPIUpdatingTests.java
@@ -66,6 +66,7 @@ public class RequestsAPIUpdatingTests extends APITests {
     requestsClient.replace(createdRequest.getId(),
       RequestBuilder.from(createdRequest)
         .hold()
+        .withPickupServicePointId(servicePointsFixture.cd1().getId())
         .by(charlotte)
         .withTags(new RequestBuilder.Tags(Arrays.asList("new", "important")))
     );
@@ -210,6 +211,7 @@ public class RequestsAPIUpdatingTests extends APITests {
 
     requestsClient.replace(createdRequest.getId(),
       RequestBuilder.from(createdRequest)
+        .withPickupServicePointId(servicePointsFixture.cd1().getId())
         .hold());
 
     Response getResponse = requestsClient.getById(createdRequest.getId());

--- a/src/test/java/api/requests/scenarios/RequestsForDifferentItemsTests.java
+++ b/src/test/java/api/requests/scenarios/RequestsForDifferentItemsTests.java
@@ -32,6 +32,7 @@ public class RequestsForDifferentItemsTests extends APITests {
       new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.jessica())
       .create());
 
@@ -40,6 +41,7 @@ public class RequestsForDifferentItemsTests extends APITests {
       .hold()
       .forItem(nod)
       .by(usersFixture.rebecca())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .create());
 
     final IndividualResource secondRequestForNod = requestsClient.create(
@@ -47,12 +49,14 @@ public class RequestsForDifferentItemsTests extends APITests {
         .hold()
         .forItem(nod)
         .by(usersFixture.james())
+        .withPickupServicePointId(servicePointsFixture.cd1().getId())
         .create());
 
     final IndividualResource secondRequestForSmallAngryPlannet = requestsClient.create(
       new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.charlotte())
       .create());
 

--- a/src/test/java/api/requests/scenarios/SingleClosedRequestTests.java
+++ b/src/test/java/api/requests/scenarios/SingleClosedRequestTests.java
@@ -39,6 +39,7 @@ public class SingleClosedRequestTests extends APITests {
       .withRequestDate(new DateTime(2018, 1, 10, 15, 34, 21, DateTimeZone.UTC))
       .fulfilled() //TODO: Replace with closed cancelled when introduced
       .withItemId(smallAngryPlanet.getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(jessica.getId()));
 
     loansFixture.checkInByBarcode(smallAngryPlanet);
@@ -74,6 +75,7 @@ public class SingleClosedRequestTests extends APITests {
       .withRequestDate(new DateTime(2018, 1, 10, 15, 34, 21, DateTimeZone.UTC))
       .fulfilled() //TODO: Replace with closed cancelled when introduced
       .withItemId(smallAngryPlanet.getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withRequesterId(jessica.getId()));
 
     loansFixture.checkInByBarcode(smallAngryPlanet);

--- a/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
+++ b/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
@@ -17,6 +17,7 @@ import java.net.MalformedURLException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import org.folio.circulation.domain.RequestType;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
@@ -200,7 +201,7 @@ public class SingleOpenHoldShelfRequestTests extends APITests {
         .forItem(smallAngryPlanet)
         .by(jessica)
         .withRequestDate(new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC))
-        .hold());
+        .recall());
 
     Response response = loansFixture.attemptCheckInByBarcode(new CheckInByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)

--- a/src/test/java/api/support/fixtures/RequestsFixture.java
+++ b/src/test/java/api/support/fixtures/RequestsFixture.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 import org.folio.circulation.domain.MultipleRecords;
+import org.folio.circulation.domain.RequestType;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.joda.time.DateTime;
 
@@ -72,7 +73,8 @@ public class RequestsFixture {
       .deliverToAddress(UUID.randomUUID())
       .withRequestDate(on)
       .withItemId(item.getId())
-      .withRequesterId(by.getId()));
+      .withRequesterId(by.getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId()));
   }
 
   public IndividualResource placeHoldShelfRequest(
@@ -126,12 +128,15 @@ public class RequestsFixture {
     TimeoutException,
     ExecutionException {
 
-    return place(new RequestBuilder()
+      IndividualResource resource = place(new RequestBuilder()
       .withRequestType(type)
       .deliverToAddress(UUID.randomUUID())
       .withRequestDate(on)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .withItemId(item.getId())
       .withRequesterId(by.getId()));
+
+      return resource;
   }
 
   public void cancelRequest(IndividualResource request)


### PR DESCRIPTION
Updates the ServicePointPickUpLocationValidator to check that any Request of type Hold has a PickupServicePoint.

Also updates tests to meet the new requirement.

https://issues.folio.org/browse/CIRC-243