### PR TITLE
Implemented CIRC-230 Apply request policies on recreating requests

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -42,7 +42,8 @@
             "circulation-storage.loan-policies.item.get",
             "circulation-storage.request-policies.item.get",
             "circulation-storage.fixed-due-date-schedules.item.get",
-            "circulation-storage.fixed-due-date-schedules.collection.get"
+            "circulation-storage.fixed-due-date-schedules.collection.get",
+            "configuration.entries.collection.get"
           ]
         },
         {
@@ -156,7 +157,8 @@
             "circulation-storage.loan-policies.item.get",
             "circulation-storage.request-policies.item.get",
             "circulation-storage.fixed-due-date-schedules.item.get",
-            "circulation-storage.fixed-due-date-schedules.collection.get"
+            "circulation-storage.fixed-due-date-schedules.collection.get",
+            "configuration.entries.collection.get"
           ]
         },
         {
@@ -674,6 +676,10 @@
     },
     {
       "id": "calendar",
+      "version": "2.0"
+    },
+    {
+      "id": "configuration",
       "version": "2.0"
     }
   ],

--- a/src/main/java/org/folio/circulation/domain/CirculationActionType.java
+++ b/src/main/java/org/folio/circulation/domain/CirculationActionType.java
@@ -1,0 +1,6 @@
+package org.folio.circulation.domain;
+
+public enum CirculationActionType {
+    LOAN,
+    REQUEST
+  }

--- a/src/main/java/org/folio/circulation/domain/CirculationActionType.java
+++ b/src/main/java/org/folio/circulation/domain/CirculationActionType.java
@@ -1,6 +1,0 @@
-package org.folio.circulation.domain;
-
-public enum CirculationActionType {
-    LOAN,
-    REQUEST
-  }

--- a/src/main/java/org/folio/circulation/domain/ConfigurationRepository.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationRepository.java
@@ -1,0 +1,47 @@
+package org.folio.circulation.domain;
+
+import static org.folio.circulation.domain.MultipleRecords.from;
+import static org.folio.circulation.support.CqlHelper.encodeQuery;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.CollectionResourceClient;
+import org.folio.circulation.support.HttpResult;
+import org.joda.time.DateTimeZone;
+
+public class ConfigurationRepository {
+
+  private static final String QUERY_PARAMETERS = "module==%s and configName==%s";
+  private static final String MODULE_VAL = "ORG";
+  private static final String LOCALE_SETTINGS_VAL = "localeSettings";
+  private static final String RECORDS_NAME = "configs";
+
+  private final CollectionResourceClient configurationClient;
+
+  public ConfigurationRepository(Clients clients) {
+    configurationClient = clients.configurationStorageClient();
+  }
+
+  public CompletableFuture<HttpResult<LoanAndRelatedRecords>> lookupTimeZone(LoanAndRelatedRecords relatedRecords) {
+    return findTimeZoneConfiguration()
+      .thenApply(result -> result.map(relatedRecords::withTimeZone));
+  }
+
+  private CompletableFuture<HttpResult<DateTimeZone>> findTimeZoneConfiguration() {
+
+    final ConfigurationService configurationService = new ConfigurationService();
+    String unEncodedQuery = String.format(QUERY_PARAMETERS, MODULE_VAL, LOCALE_SETTINGS_VAL);
+
+    return encodeQuery(unEncodedQuery)
+      .after(query -> findBy(query)
+        .thenApply(result -> result.map(configurations ->
+          configurationService.findDateTimeZone(configurations.getRecords()))));
+  }
+
+  private CompletableFuture<HttpResult<MultipleRecords<TimeZoneConfig>>> findBy(String query) {
+    return configurationClient.getMany(query, 1, 0)
+      .thenApply(response -> from(response, TimeZoneConfig::new, RECORDS_NAME));
+  }
+
+}

--- a/src/main/java/org/folio/circulation/domain/ConfigurationService.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationService.java
@@ -1,0 +1,54 @@
+package org.folio.circulation.domain;
+
+import static org.folio.circulation.domain.MultipleRecords.from;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.vertx.core.json.JsonObject;
+
+class ConfigurationService {
+
+  private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final DateTimeZone DEFAULT_DATE_TIME_ZONE = DateTimeZone.UTC;
+  private static final String TIMEZONE_KEY = "timezone";
+  private static final String RECORDS_NAME = "configs";
+
+  DateTimeZone findDateTimeZone(JsonObject representation) {
+    return from(representation, TimeZoneConfig::new, RECORDS_NAME)
+      .map(MultipleRecords::getRecords)
+      .map(this::findDateTimeZone)
+      .orElse(DEFAULT_DATE_TIME_ZONE);
+  }
+
+  DateTimeZone findDateTimeZone(Collection<TimeZoneConfig> timeZoneConfigs) {
+    final DateTimeZone chosenTimeZone = timeZoneConfigs.stream()
+      .map(this::applyTimeZone)
+      .findFirst()
+      .orElse(DEFAULT_DATE_TIME_ZONE);
+
+    log.info("Chosen timezone: `{}`", chosenTimeZone);
+
+    return chosenTimeZone;
+  }
+
+  private DateTimeZone applyTimeZone(TimeZoneConfig item) {
+    String value = item.getValue();
+    return StringUtils.isBlank(value)
+      ? DEFAULT_DATE_TIME_ZONE
+      : parseDateTimeZone(value);
+  }
+
+  private DateTimeZone parseDateTimeZone(String value) {
+    String timezone = new JsonObject(value).getString(TIMEZONE_KEY);
+    return StringUtils.isBlank(timezone)
+      ? DEFAULT_DATE_TIME_ZONE
+      : DateTimeZone.forID(timezone);
+  }
+
+}

--- a/src/main/java/org/folio/circulation/domain/CreateRequestService.java
+++ b/src/main/java/org/folio/circulation/domain/CreateRequestService.java
@@ -7,32 +7,39 @@ import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.folio.circulation.domain.policy.RequestPolicy;
+import org.folio.circulation.domain.policy.RequestPolicyRepository;
 import org.folio.circulation.support.HttpResult;
 
 public class CreateRequestService {
   private final RequestRepository requestRepository;
   private final UpdateItem updateItem;
   private final UpdateLoanActionHistory updateLoanActionHistory;
+  private final RequestPolicyRepository requestPolicyRepository;
   private final UpdateLoan updateLoan;
 
   public CreateRequestService(
     RequestRepository requestRepository,
     UpdateItem updateItem,
     UpdateLoanActionHistory updateLoanActionHistory,
-    UpdateLoan updateLoan) {
+    UpdateLoan updateLoan,
+    RequestPolicyRepository requestPolicyRepository) {
 
     this.requestRepository = requestRepository;
     this.updateItem = updateItem;
     this.updateLoanActionHistory = updateLoanActionHistory;
     this.updateLoan = updateLoan;
+    this.requestPolicyRepository = requestPolicyRepository;
   }
 
   public CompletableFuture<HttpResult<RequestAndRelatedRecords>> createRequest(
     RequestAndRelatedRecords requestAndRelatedRecords) {
 
     return completedFuture(refuseWhenItemIsNotValid(requestAndRelatedRecords)
-      .next(CreateRequestService::refuseWhenItemDoesNotExist)
-      .map(CreateRequestService::setRequestQueuePosition))
+      .next(CreateRequestService::refuseWhenItemDoesNotExist))
+      .thenComposeAsync( r-> r.after(requestPolicyRepository::lookupRequestPolicy)) //get policy
+      .thenApply( r -> r.next(CreateRequestService::refuseWhenRequestCannotBeFulfilled)) //check policy here
+      .thenApply(r -> r.map(CreateRequestService::setRequestQueuePosition))
       .thenComposeAsync(r -> r.after(updateItem::onRequestCreation))
       .thenComposeAsync(r -> r.after(updateLoanActionHistory::onRequestCreation))
       .thenComposeAsync(r -> r.after(updateLoan::onRequestCreation))
@@ -56,6 +63,22 @@ public class CreateRequestService {
       return failed(failure(
         "Item does not exist", "itemId",
         requestAndRelatedRecords.getRequest().getItemId()));
+    }
+    else {
+      return succeeded(requestAndRelatedRecords);
+    }
+  }
+
+  private static HttpResult<RequestAndRelatedRecords> refuseWhenRequestCannotBeFulfilled(
+    RequestAndRelatedRecords requestAndRelatedRecords) {
+
+    RequestPolicy requestPolicy = requestAndRelatedRecords.getRequestPolicy();
+    RequestType requestType =  requestAndRelatedRecords.getRequest().getRequestType();
+
+    if(!requestPolicy.containsType(requestType)) {
+      return failed(failure(
+        "Request Type is not valid", "requestType",
+        requestType.getValue()));
     }
     else {
       return succeeded(requestAndRelatedRecords);

--- a/src/main/java/org/folio/circulation/domain/CreateRequestService.java
+++ b/src/main/java/org/folio/circulation/domain/CreateRequestService.java
@@ -13,15 +13,18 @@ public class CreateRequestService {
   private final RequestRepository requestRepository;
   private final UpdateItem updateItem;
   private final UpdateLoanActionHistory updateLoanActionHistory;
+  private final UpdateLoan updateLoan;
 
   public CreateRequestService(
     RequestRepository requestRepository,
     UpdateItem updateItem,
-    UpdateLoanActionHistory updateLoanActionHistory) {
+    UpdateLoanActionHistory updateLoanActionHistory,
+    UpdateLoan updateLoan) {
 
     this.requestRepository = requestRepository;
     this.updateItem = updateItem;
     this.updateLoanActionHistory = updateLoanActionHistory;
+    this.updateLoan = updateLoan;
   }
 
   public CompletableFuture<HttpResult<RequestAndRelatedRecords>> createRequest(
@@ -32,6 +35,7 @@ public class CreateRequestService {
       .map(CreateRequestService::setRequestQueuePosition))
       .thenComposeAsync(r -> r.after(updateItem::onRequestCreation))
       .thenComposeAsync(r -> r.after(updateLoanActionHistory::onRequestCreation))
+      .thenComposeAsync(r -> r.after(updateLoan::onRequestCreation))
       .thenComposeAsync(r -> r.after(requestRepository::create));
   }
 

--- a/src/main/java/org/folio/circulation/domain/CreateRequestService.java
+++ b/src/main/java/org/folio/circulation/domain/CreateRequestService.java
@@ -76,9 +76,9 @@ public class CreateRequestService {
     RequestPolicy requestPolicy = requestAndRelatedRecords.getRequestPolicy();
     RequestType requestType =  requestAndRelatedRecords.getRequest().getRequestType();
 
-    if(!requestPolicy.containsType(requestType)) {
+    if(!requestPolicy.allowsType(requestType)) {
       return failed(failure(
-        "Request Type " + requestType.getValue() + " is not valid", "requestType",
+        requestType.getValue() + " requests are not allowed for this patron and item combination", "requestType",
         requestType.getValue()));
     }
     else {
@@ -93,8 +93,9 @@ public class CreateRequestService {
 
     if (!request.allowedForItem()) {
       return failed(failure(
-        String.format("Item is %s", request.getItem().getStatus()),
-        "itemId", request.getItemId()
+        String.format("%s requests are not allowed for %s item status combination", request.getRequestType().getValue() , request.getItem().getStatus().getValue()),
+        request.getRequestType().getValue(),
+        request.getItemId()
       ));
     }
     else {

--- a/src/main/java/org/folio/circulation/domain/CreateRequestService.java
+++ b/src/main/java/org/folio/circulation/domain/CreateRequestService.java
@@ -38,8 +38,8 @@ public class CreateRequestService {
     return completedFuture(refuseWhenItemIsNotValid(requestAndRelatedRecords)
       .next(CreateRequestService::refuseWhenItemDoesNotExist)
       .next(CreateRequestService::refuseWhenInvalidUserAndPatronGroup))
-      .thenComposeAsync( r-> r.after(requestPolicyRepository::lookupRequestPolicy)) //get policy
-      .thenApply( r -> r.next(CreateRequestService::refuseWhenRequestCannotBeFulfilled)) //check policy here
+      .thenComposeAsync( r-> r.after(requestPolicyRepository::lookupRequestPolicy))
+      .thenApply( r -> r.next(CreateRequestService::refuseWhenRequestCannotBeFulfilled))
       .thenApply(r -> r.map(CreateRequestService::setRequestQueuePosition))
       .thenComposeAsync(r -> r.after(updateItem::onRequestCreation))
       .thenComposeAsync(r -> r.after(updateLoanActionHistory::onRequestCreation))
@@ -78,7 +78,7 @@ public class CreateRequestService {
 
     if(!requestPolicy.allowsType(requestType)) {
       return failed(failure(
-        requestType.getValue() + " requests are not allowed for this patron and item combination", "requestType",
+        requestType.getValue() + " requests are not allowed for this patron and item combination", Request.REQUEST_TYPE,
         requestType.getValue()));
     }
     else {

--- a/src/main/java/org/folio/circulation/domain/CreateRequestService.java
+++ b/src/main/java/org/folio/circulation/domain/CreateRequestService.java
@@ -36,7 +36,8 @@ public class CreateRequestService {
     RequestAndRelatedRecords requestAndRelatedRecords) {
 
     return completedFuture(refuseWhenItemIsNotValid(requestAndRelatedRecords)
-      .next(CreateRequestService::refuseWhenItemDoesNotExist))
+      .next(CreateRequestService::refuseWhenItemDoesNotExist)
+      .next(CreateRequestService::refuseWhenInvalidUserAndPatronGroup))
       .thenComposeAsync( r-> r.after(requestPolicyRepository::lookupRequestPolicy)) //get policy
       .thenApply( r -> r.next(CreateRequestService::refuseWhenRequestCannotBeFulfilled)) //check policy here
       .thenApply(r -> r.map(CreateRequestService::setRequestQueuePosition))
@@ -77,7 +78,7 @@ public class CreateRequestService {
 
     if(!requestPolicy.containsType(requestType)) {
       return failed(failure(
-        "Request Type is not valid", "requestType",
+        "Request Type " + requestType.getValue() + " is not valid", "requestType",
         requestType.getValue()));
     }
     else {
@@ -94,6 +95,28 @@ public class CreateRequestService {
       return failed(failure(
         String.format("Item is %s", request.getItem().getStatus()),
         "itemId", request.getItemId()
+      ));
+    }
+    else {
+      return succeeded(requestAndRelatedRecords);
+    }
+  }
+
+  private static HttpResult<RequestAndRelatedRecords> refuseWhenInvalidUserAndPatronGroup(
+    RequestAndRelatedRecords requestAndRelatedRecords) {
+
+    Request request = requestAndRelatedRecords.getRequest();
+    User requester = request.getRequester();
+
+    if (requester == null){
+      return failed(failure(
+        "A valid user and patron group are required. User is null",
+        "User", null
+      ));
+    } else if (requester.getPatronGroupId() == null) {
+      return failed(failure(
+        "A valid patron group is required. PatronGroup ID is null",
+        "PatronGroupId", null
       ));
     }
     else {

--- a/src/main/java/org/folio/circulation/domain/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepository.java
@@ -100,7 +100,7 @@ public class LoanRepository {
    * success with null if the no open loan is found,
    * failure if more than one open loan for the item found
    */
-  CompletableFuture<HttpResult<Loan>> findOpenLoanForRequest(Request request) {
+  public CompletableFuture<HttpResult<Loan>> findOpenLoanForRequest(Request request) {
     return findOpenLoans(request.getItemId())
       .thenApply(loansResult -> loansResult.next(loans -> {
         //TODO: Consider introducing an unknown loan class, instead of null

--- a/src/main/java/org/folio/circulation/domain/MultipleRecords.java
+++ b/src/main/java/org/folio/circulation/domain/MultipleRecords.java
@@ -48,15 +48,7 @@ public class MultipleRecords<T> {
             recordsPropertyName, response.getStatusCode(), response.getBody())));
       }
 
-      final JsonObject json = response.getJson();
-
-      List<T> wrappedRecords = mapToList(json,
-        recordsPropertyName, mapper);
-
-      Integer totalRecords = json.getInteger(TOTAL_RECORDS_PROPERTY_NAME);
-
-      return succeeded(new MultipleRecords<>(
-        wrappedRecords, totalRecords));
+      return from(response.getJson(), mapper, recordsPropertyName);
     }
     else {
       log.warn("Did not receive response to request");
@@ -64,6 +56,17 @@ public class MultipleRecords<T> {
         String.format("Did not receive response to request for multiple %s",
           recordsPropertyName)));
     }
+  }
+
+  public static <T> HttpResult<MultipleRecords<T>> from(JsonObject representation,
+                                                        Function<JsonObject, T> mapper,
+                                                        String recordsPropertyName) {
+
+    List<T> wrappedRecords = mapToList(representation, recordsPropertyName, mapper);
+    Integer totalRecords = representation.getInteger(TOTAL_RECORDS_PROPERTY_NAME);
+
+    return succeeded(new MultipleRecords<>(
+      wrappedRecords, totalRecords));
   }
 
   Map<String, T> toMap(Function<T, String> keyMapper) {
@@ -79,7 +82,7 @@ public class MultipleRecords<T> {
    * @return new multiple records collection with mapped records
    * and same total record count
    */
-  public <R> MultipleRecords<R> mapRecords(Function<T, R> mapper) {
+   <R> MultipleRecords<R> mapRecords(Function<T, R> mapper) {
     return new MultipleRecords<>(
       getRecords().stream().map(mapper).collect(Collectors.toList()),
         getTotalRecords());

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -124,7 +124,7 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
         pickupServicePoint);
   }
 
-  Request withLoan(Loan newLoan) {
+  public Request withLoan(Loan newLoan) {
     return new Request(representation, item, requester, proxy, newLoan,
         pickupServicePoint);
   }

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -29,6 +29,8 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   private final Loan loan;
   private final ServicePoint pickupServicePoint;
 
+  public static final String REQUEST_TYPE = "requestType";
+
   private boolean changedPosition = false;
 
   public Request(
@@ -156,7 +158,7 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   RequestType getRequestType() {
-    return RequestType.from(representation.getString("requestType"));
+    return RequestType.from(representation.getString(REQUEST_TYPE));
   }
 
   Boolean allowedForItem() {

--- a/src/main/java/org/folio/circulation/domain/RequestAndRelatedRecords.java
+++ b/src/main/java/org/folio/circulation/domain/RequestAndRelatedRecords.java
@@ -1,38 +1,53 @@
 package org.folio.circulation.domain;
 
+import org.folio.circulation.domain.policy.RequestPolicy;
+
 public class RequestAndRelatedRecords implements UserRelatedRecord, ItemRelatedRecord {
   private final Request request;
   private final RequestQueue requestQueue;
+  private final RequestPolicy requestPolicy;
 
   private RequestAndRelatedRecords(
     Request request,
-    RequestQueue requestQueue) {
+    RequestQueue requestQueue,
+    RequestPolicy requestPolicy) {
 
     this.request = request;
     this.requestQueue = requestQueue;
+    this.requestPolicy = requestPolicy;
   }
 
   public RequestAndRelatedRecords(Request request) {
-    this(request, null);
+    this(request, null, null);
   }
 
   RequestAndRelatedRecords withRequest(Request newRequest) {
     return new RequestAndRelatedRecords(newRequest.withItem(request.getItem()),
-      this.requestQueue
+      this.requestQueue, null
+    );
+  }
+
+  public RequestAndRelatedRecords withRequestPolicy(RequestPolicy newRequestPolicy) {
+    return new RequestAndRelatedRecords(
+      this.request,
+      this.requestQueue,
+      newRequestPolicy
     );
   }
 
   public RequestAndRelatedRecords withRequestQueue(RequestQueue newRequestQueue) {
     return new RequestAndRelatedRecords(
       this.request,
-      newRequestQueue
+      newRequestQueue,
+      this.requestPolicy
     );
   }
 
   public RequestAndRelatedRecords withItem(Item newItem) {
     return new RequestAndRelatedRecords(
       this.request.withItem(newItem),
-      this.requestQueue
+      this.requestQueue,
+      this.requestPolicy
     );
   }
 
@@ -43,6 +58,8 @@ public class RequestAndRelatedRecords implements UserRelatedRecord, ItemRelatedR
   RequestQueue getRequestQueue() {
     return requestQueue;
   }
+
+  RequestPolicy getRequestPolicy() {return requestPolicy; }
 
   @Override
   public String getUserId() {

--- a/src/main/java/org/folio/circulation/domain/RequestType.java
+++ b/src/main/java/org/folio/circulation/domain/RequestType.java
@@ -33,7 +33,7 @@ public enum RequestType {
     return value;
   }
 
-  private boolean nameMatches(String value) {
+  public boolean nameMatches(String value) {
     return equalsIgnoreCase(getValue(), value);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/TimeZoneConfig.java
+++ b/src/main/java/org/folio/circulation/domain/TimeZoneConfig.java
@@ -1,0 +1,32 @@
+package org.folio.circulation.domain;
+
+import io.vertx.core.json.JsonObject;
+
+public class TimeZoneConfig {
+
+  private static final String MODULE_KEY = "module";
+  private static final String CONFIG_NAME_KEY = "configName";
+  private static final String VALUE_KEY = "value";
+
+  private String module;
+  private String configName;
+  private String value;
+
+  TimeZoneConfig(JsonObject jsonObject) {
+    module = jsonObject.getString(MODULE_KEY);
+    configName = jsonObject.getString(CONFIG_NAME_KEY);
+    value = jsonObject.getString(VALUE_KEY);
+  }
+
+  public String getModule() {
+    return module;
+  }
+
+  public String getConfigName() {
+    return configName;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/UpdateLoan.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateLoan.java
@@ -1,0 +1,61 @@
+package org.folio.circulation.domain;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.applyCLDDMForLoanAndRelatedRecords;
+import static org.folio.circulation.support.HttpResult.succeeded;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.circulation.domain.policy.LoanPolicy;
+import org.folio.circulation.domain.policy.LoanPolicyRepository;
+import org.folio.circulation.domain.policy.library.ClosedLibraryStrategyService;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.HttpResult;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+public class UpdateLoan {
+  private final ClosedLibraryStrategyService closedLibraryStrategyService;
+  private final LoanRepository loanRepository;
+  private final LoanPolicyRepository loanPolicyRepository;
+
+  public UpdateLoan(Clients clients,
+      LoanRepository loanRepository,
+      LoanPolicyRepository loanPolicyRepository) {
+    closedLibraryStrategyService = ClosedLibraryStrategyService.using(clients,
+        DateTime.now(DateTimeZone.UTC), false);
+    this.loanPolicyRepository = loanPolicyRepository;
+    this.loanRepository = loanRepository;
+  }
+
+  /**
+   * Updates the loan due date for the loan associated with this newly created
+   * recall request. No modifications are made if the request is not a recall.
+   * Depending on loan/request policies, the loan date may not be updated.
+   * 
+   * @param requestAndRelatedRecords request and related records. 
+   * @return the request and related records with the possibly updated loan.
+   */
+  CompletableFuture<HttpResult<RequestAndRelatedRecords>> onRequestCreation(
+      RequestAndRelatedRecords requestAndRelatedRecords) {
+    Request request = requestAndRelatedRecords.getRequest();
+    Loan loan = request.getLoan();
+    if (request.getRequestType() == RequestType.RECALL && loan != null) {
+      return loanRepository.getById(loan.getId())
+          .thenApply(r -> r.map(LoanAndRelatedRecords::new))
+          .thenComposeAsync(r -> r.after(loanPolicyRepository::lookupLoanPolicy))
+          .thenApply(r -> r.next(this::recall))
+          .thenComposeAsync(r -> r.after(records -> applyCLDDMForLoanAndRelatedRecords(closedLibraryStrategyService, records)))
+          .thenComposeAsync(r -> r.after(loanRepository::updateLoan))
+          .thenApply(r -> r.map(v -> requestAndRelatedRecords));
+    } else {
+      return completedFuture(succeeded(requestAndRelatedRecords));
+    }
+  }
+
+  private HttpResult<LoanAndRelatedRecords> recall(LoanAndRelatedRecords loanAndRelatedRecords) {
+    LoanPolicy loanPolicy = loanAndRelatedRecords.getLoanPolicy();
+    return loanPolicy.recall(loanAndRelatedRecords.getLoan())
+        .map(loanAndRelatedRecords::withLoan);
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/policy/FixedDueDateSchedules.java
+++ b/src/main/java/org/folio/circulation/domain/policy/FixedDueDateSchedules.java
@@ -5,13 +5,11 @@ import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.JsonArrayHelper;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static org.folio.circulation.support.HttpResult.failed;
 
@@ -23,7 +21,6 @@ public class FixedDueDateSchedules {
   }
 
   static FixedDueDateSchedules from(JsonObject representation) {
-    //TODO: Replace this with better check
     if (representation == null) {
       return new NoFixedDueDateSchedules();
     } else {
@@ -55,16 +52,6 @@ public class FixedDueDateSchedules {
 
   private DateTime getDueDate(JsonObject schedule) {
     return DateTime.parse(schedule.getString("due"));
-  }
-
-  List<DateTime> getDueDates() {
-    return schedules.stream()
-      .map(schedule ->
-        new DateTime(schedule.getString("due"))
-          .millisOfDay()
-          .withMaximumValue()
-          .withZone(DateTimeZone.UTC))
-      .collect(Collectors.toList());
   }
 
   public boolean isEmpty() {

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicyRepository.java
@@ -25,12 +25,12 @@ import static org.folio.circulation.support.HttpResult.succeeded;
 public class LoanPolicyRepository {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private final CirculationRulesClient circulationRulesClient;
+  private final CirculationRulesClient circulationLoanRulesClient;
   private final CollectionResourceClient loanPoliciesStorageClient;
   private final CollectionResourceClient fixedDueDateSchedulesStorageClient;
 
   public LoanPolicyRepository(Clients clients) {
-    circulationRulesClient = clients.circulationRules();
+    circulationLoanRulesClient = clients.circulationLoanRules();
     loanPoliciesStorageClient = clients.loanPoliciesStorage();
     fixedDueDateSchedulesStorageClient = clients.fixedDueDateSchedules();
   }
@@ -157,7 +157,7 @@ public class LoanPolicyRepository {
       "Applying circulation rules for material type: {}, patron group: {}, loan type: {}, location: {}",
       materialTypeId, patronGroupId, loanTypeId, locationId);
 
-    circulationRulesClient.applyRules(loanTypeId, locationId, materialTypeId,
+      circulationLoanRulesClient.applyRules(loanTypeId, locationId, materialTypeId,
       patronGroupId, ResponseHandler.any(circulationRulesResponse));
 
     circulationRulesResponse.thenAcceptAsync(response -> {

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicyRepository.java
@@ -67,15 +67,15 @@ public class LoanPolicyRepository {
     final String loanScheduleId = loanPolicy.getLoansFixedDueDateScheduleId();
     final String alternateRenewalsSchedulesId = loanPolicy.getAlternateRenewalsFixedDueDateScheduleId();
 
-    if(loanScheduleId != null) {
+    if (loanScheduleId != null) {
       scheduleIds.add(loanScheduleId);
     }
 
-    if(alternateRenewalsSchedulesId != null) {
+    if (alternateRenewalsSchedulesId != null) {
       scheduleIds.add(alternateRenewalsSchedulesId);
     }
 
-    if(scheduleIds.isEmpty()) {
+    if (scheduleIds.isEmpty()) {
       return CompletableFuture.completedFuture(succeeded(loanPolicy));
     }
 
@@ -101,7 +101,7 @@ public class LoanPolicyRepository {
     return fixedDueDateSchedulesStorageClient.getMany(schedulesQuery,
       schedulesIds.size(), 0)
       .thenApply(schedulesResponse -> {
-        if(schedulesResponse.getStatusCode() != 200) {
+        if (schedulesResponse.getStatusCode() != 200) {
           return HttpResult.failed(new ServerErrorFailure(
             String.format("Fixed due date schedules request (%s) failed %s: %s",
               schedulesQuery, schedulesResponse.getStatusCode(),
@@ -134,12 +134,12 @@ public class LoanPolicyRepository {
     CompletableFuture<HttpResult<String>> findLoanPolicyCompleted
       = new CompletableFuture<>();
 
-    if(item.isNotFound()) {
+    if (item.isNotFound()) {
       return CompletableFuture.completedFuture(HttpResult.failed(
         new ServerErrorFailure("Unable to apply circulation rules for unknown item")));
     }
 
-    if(item.doesNotHaveHolding()) {
+    if (item.doesNotHaveHolding()) {
       return CompletableFuture.completedFuture(HttpResult.failed(
         new ServerErrorFailure("Unable to apply circulation rules for unknown holding")));
     }
@@ -157,10 +157,10 @@ public class LoanPolicyRepository {
       "Applying circulation rules for material type: {}, patron group: {}, loan type: {}, location: {}",
       materialTypeId, patronGroupId, loanTypeId, locationId);
 
-      circulationRulesClient.applyRules(loanTypeId, locationId, materialTypeId,
+    circulationRulesClient.applyRules(loanTypeId, locationId, materialTypeId,
       patronGroupId, ResponseHandler.any(circulationRulesResponse));
 
-      circulationRulesResponse.thenAcceptAsync(response -> {
+    circulationRulesResponse.thenAcceptAsync(response -> {
       if (response.getStatusCode() == 404) {
         findLoanPolicyCompleted.complete(HttpResult.failed(
           new ServerErrorFailure("Unable to apply circulation rules")));

--- a/src/main/java/org/folio/circulation/domain/policy/RequestPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RequestPolicy.java
@@ -11,10 +11,8 @@ import io.vertx.core.json.JsonObject;
 public class RequestPolicy {
 
   private List<String> requestTypes;
-  private final JsonObject representation;
 
   public RequestPolicy(JsonObject representation){
-    this.representation = representation;
     this.requestTypes = JsonStringArrayHelper
       .toStream(representation, "requestTypes")
       .collect(Collectors.toList());

--- a/src/main/java/org/folio/circulation/domain/policy/RequestPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RequestPolicy.java
@@ -1,0 +1,41 @@
+package org.folio.circulation.domain.policy;
+
+import java.util.ArrayList;
+
+import org.folio.circulation.domain.RequestType;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class RequestPolicy {
+
+  private ArrayList<String> requestTypes;
+  private final JsonObject representation;
+
+  public RequestPolicy(JsonObject representation){
+    this.representation = representation;
+    populateRequestTypes();
+  }
+
+  static RequestPolicy from(JsonObject representation) {
+    return new RequestPolicy(representation);
+  }
+
+  public boolean containsType(RequestType type){
+    for (String requestType : requestTypes) {
+      if (type.nameMatches(requestType))
+        return true;
+    }
+    return false;
+  }
+
+  private void populateRequestTypes(){
+
+    requestTypes = new ArrayList<>();
+    JsonArray requestTypesJson = representation.getJsonArray("requestTypes");
+
+    for ( Object type : requestTypesJson) {
+      this.requestTypes.add(type.toString());
+    }
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/policy/RequestPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RequestPolicy.java
@@ -1,41 +1,34 @@
 package org.folio.circulation.domain.policy;
 
-import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.folio.circulation.domain.RequestType;
+import org.folio.circulation.support.JsonStringArrayHelper;
 
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class RequestPolicy {
 
-  private ArrayList<String> requestTypes;
+  private List<String> requestTypes;
   private final JsonObject representation;
 
   public RequestPolicy(JsonObject representation){
     this.representation = representation;
-    populateRequestTypes();
+    this.requestTypes = JsonStringArrayHelper
+      .toStream(representation, "requestTypes")
+      .collect(Collectors.toList());
   }
 
   static RequestPolicy from(JsonObject representation) {
     return new RequestPolicy(representation);
   }
 
-  public boolean containsType(RequestType type){
+  public boolean allowsType(RequestType type){
     for (String requestType : requestTypes) {
       if (type.nameMatches(requestType))
         return true;
     }
     return false;
-  }
-
-  private void populateRequestTypes(){
-
-    requestTypes = new ArrayList<>();
-    JsonArray requestTypesJson = representation.getJsonArray("requestTypes");
-
-    for ( Object type : requestTypesJson) {
-      this.requestTypes.add(type.toString());
-    }
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/RequestPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RequestPolicyRepository.java
@@ -100,8 +100,7 @@ public class RequestPolicyRepository {
         findRequestPolicyCompleted.complete(HttpResult.failed(
           new ForwardOnFailure(response)));
       } else {
-        String policyId = response.getJson().getString("RequestPolicyId");
-        findRequestPolicyCompleted.complete(succeeded(policyId));
+        findRequestPolicyCompleted.complete(succeeded(response.getJson().getString("requestPolicyId")));
       }
     });
 

--- a/src/main/java/org/folio/circulation/domain/policy/RequestPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RequestPolicyRepository.java
@@ -1,0 +1,111 @@
+package org.folio.circulation.domain.policy;
+
+import static org.folio.circulation.support.HttpResult.succeeded;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.circulation.domain.Item;
+import org.folio.circulation.domain.Request;
+import org.folio.circulation.domain.RequestAndRelatedRecords;
+import org.folio.circulation.domain.User;
+import org.folio.circulation.support.CirculationRulesClient;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.CollectionResourceClient;
+import org.folio.circulation.support.ForwardOnFailure;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.SingleRecordFetcher;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.http.client.ResponseHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.json.JsonObject;
+
+public class RequestPolicyRepository {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final CirculationRulesClient circulationRequestRulesClient;
+  private final CollectionResourceClient requestPoliciesStorageClient;
+
+  public RequestPolicyRepository(Clients clients) {
+    this.circulationRequestRulesClient = clients.circulationRequestRules();
+    this.requestPoliciesStorageClient = clients.requestPoliciesStorage();
+  }
+
+  public CompletableFuture<HttpResult<RequestAndRelatedRecords>> lookupRequestPolicy(
+    RequestAndRelatedRecords relatedRecords) {
+
+    Request request = relatedRecords.getRequest();
+
+    return lookupRequestPolicy(request.getItem(), request.getRequester())
+      .thenApply(result -> result.map(relatedRecords::withRequestPolicy));
+  }
+
+  private CompletableFuture<HttpResult<RequestPolicy>> lookupRequestPolicy(
+    Item item,
+    User user) {
+
+    return lookupRequestPolicyId(item, user)
+      .thenComposeAsync(r -> r.after(this::lookupRequestPolicy))
+      .thenApply(result -> result.map(this::toRequestPolicy));
+  }
+
+  private RequestPolicy toRequestPolicy(JsonObject representation) {
+    return new RequestPolicy(representation);
+  }
+
+
+  private CompletableFuture<HttpResult<JsonObject>> lookupRequestPolicy(
+    String requestPolicyId) {
+
+    return SingleRecordFetcher.json(requestPoliciesStorageClient, "request policy",
+      response -> HttpResult.failed(new ServerErrorFailure(
+        String.format("Request policy %s could not be found, please check circulation rules", requestPolicyId))))
+      .fetch(requestPolicyId);
+  }
+
+  private CompletableFuture<HttpResult<String>> lookupRequestPolicyId(
+    Item item,
+    User user) {
+
+    CompletableFuture<HttpResult<String>> findRequestPolicyCompleted
+      = new CompletableFuture<>();
+
+    if(item.isNotFound()) {
+      return CompletableFuture.completedFuture(HttpResult.failed(
+        new ServerErrorFailure("Unable to find matching request rules for unknown item")));
+    }
+
+    String materialTypeId = item.getMaterialTypeId();
+    String patronGroupId = user.getPatronGroupId();
+    String loanTypeId = item.determineLoanTypeForItem();
+    String locationId = item.getLocationId();
+
+    CompletableFuture<Response> circulationRulesResponse = new CompletableFuture<>();
+
+    log.info(
+      "Applying request rules for material type: {}, patron group: {}, loan type: {}, location: {}",
+      materialTypeId, patronGroupId, loanTypeId, locationId);
+
+    circulationRequestRulesClient.applyRules(loanTypeId, locationId, materialTypeId,
+      patronGroupId, ResponseHandler.any(circulationRulesResponse));
+
+    circulationRulesResponse.thenAcceptAsync(response -> {
+      if (response.getStatusCode() == 404) {
+        findRequestPolicyCompleted.complete(HttpResult.failed(
+          new ServerErrorFailure("Unable to find matching request rules")));
+      } else if (response.getStatusCode() != 200) {
+        findRequestPolicyCompleted.complete(HttpResult.failed(
+          new ForwardOnFailure(response)));
+      } else {
+        String policyId = response.getJson().getString("RequestPolicyId");
+        findRequestPolicyCompleted.complete(succeeded(policyId));
+      }
+    });
+
+    return findRequestPolicyCompleted;
+  }
+
+}

--- a/src/main/java/org/folio/circulation/domain/policy/RequestPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RequestPolicyRepository.java
@@ -100,7 +100,8 @@ public class RequestPolicyRepository {
         findRequestPolicyCompleted.complete(HttpResult.failed(
           new ForwardOnFailure(response)));
       } else {
-        findRequestPolicyCompleted.complete(succeeded(response.getJson().getString("requestPolicyId")));
+        findRequestPolicyCompleted.complete(
+          succeeded(response.getJson().getString("requestPolicyId")));
       }
     });
 

--- a/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyService.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyService.java
@@ -59,7 +59,7 @@ public class ClosedLibraryStrategyService {
 
     DateTime dueDateLimit = optionalDueDateLimit.get();
     Comparator<DateTime> dateComparator =
-      Comparator.comparing(dateTime -> dateTime.withZone(DateTimeZone.UTC).toLocalDate());
+      Comparator.comparing(dateTime -> dateTime.withZone(timeZone).toLocalDate());
     if (dateComparator.compare(dueDate, dueDateLimit) <= 0) {
       return HttpResult.succeeded(dueDate);
     }

--- a/src/main/java/org/folio/circulation/resources/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewalResource.java
@@ -4,6 +4,7 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import org.folio.circulation.domain.ConfigurationRepository;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.domain.LoanRenewalService;
@@ -52,6 +53,7 @@ public abstract class RenewalResource extends Resource {
 
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
     final LoanRenewalService loanRenewalService = LoanRenewalService.using(clients);
+    final ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
     final ClosedLibraryStrategyService strategyService =
       ClosedLibraryStrategyService.using(clients, DateTime.now(DateTimeZone.UTC), true);
 
@@ -60,6 +62,7 @@ public abstract class RenewalResource extends Resource {
 
     findLoan(routingContext.getBodyAsJson(), loanRepository, itemRepository, userRepository)
       .thenApply(r -> r.map(LoanAndRelatedRecords::new))
+      .thenComposeAsync(r -> r.after(configurationRepository::lookupTimeZone))
       .thenComposeAsync(r -> r.after(loanPolicyRepository::lookupLoanPolicy))
       .thenApply(r -> r.next(loanRenewalService::renew))
       .thenComposeAsync(r -> r.after(records -> applyCLDDMForLoanAndRelatedRecords(strategyService, records)))

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -11,10 +11,12 @@ import org.folio.circulation.domain.RequestRepository;
 import org.folio.circulation.domain.RequestRepresentation;
 import org.folio.circulation.domain.ServicePointRepository;
 import org.folio.circulation.domain.UpdateItem;
+import org.folio.circulation.domain.UpdateLoan;
 import org.folio.circulation.domain.UpdateLoanActionHistory;
 import org.folio.circulation.domain.UpdateRequestQueue;
 import org.folio.circulation.domain.UpdateRequestService;
 import org.folio.circulation.domain.UserRepository;
+import org.folio.circulation.domain.policy.LoanPolicyRepository;
 import org.folio.circulation.domain.representations.RequestProperties;
 import org.folio.circulation.domain.validation.ClosedRequestValidator;
 import org.folio.circulation.domain.validation.ProxyRelationshipValidator;
@@ -48,8 +50,10 @@ public class RequestCollectionResource extends CollectionResource {
     final RequestRepository requestRepository = RequestRepository.using(clients);
     final UserRepository userRepository = new UserRepository(clients);
     final LoanRepository loanRepository = new LoanRepository(clients);
+    final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final UpdateItem updateItem = new UpdateItem(clients);
     final UpdateLoanActionHistory updateLoanActionHistory = new UpdateLoanActionHistory(clients);
+    final UpdateLoan updateLoan = new UpdateLoan(clients, loanRepository, loanPolicyRepository);
     final ServicePointPickupLocationValidator servicePointPickupLocationValidator
         = new ServicePointPickupLocationValidator();
 
@@ -57,7 +61,7 @@ public class RequestCollectionResource extends CollectionResource {
       createProxyRelationshipValidator(representation, clients);
 
     final CreateRequestService createRequestService = new CreateRequestService(
-      requestRepository, updateItem, updateLoanActionHistory);
+      requestRepository, updateItem, updateLoanActionHistory, updateLoan);
 
     final RequestRepresentation requestRepresentation = new RequestRepresentation();
 
@@ -87,8 +91,10 @@ public class RequestCollectionResource extends CollectionResource {
     final LoanRepository loanRepository = new LoanRepository(clients);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
+    final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final UpdateRequestQueue updateRequestQueue = UpdateRequestQueue.using(clients);
     final UpdateItem updateItem = new UpdateItem(clients);
+    final UpdateLoan updateLoan = new UpdateLoan(clients, loanRepository, loanPolicyRepository);
     final UpdateLoanActionHistory updateLoanActionHistory = new UpdateLoanActionHistory(clients);
     final ServicePointPickupLocationValidator servicePointPickupLocationValidator
         = new ServicePointPickupLocationValidator();
@@ -100,7 +106,7 @@ public class RequestCollectionResource extends CollectionResource {
       RequestRepository.using(clients));
 
     final CreateRequestService createRequestService = new CreateRequestService(
-      requestRepository, updateItem, updateLoanActionHistory);
+      requestRepository, updateItem, updateLoanActionHistory, updateLoan);
 
 
     final UpdateRequestService updateRequestService = new UpdateRequestService(

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -16,6 +16,7 @@ import org.folio.circulation.domain.UpdateLoanActionHistory;
 import org.folio.circulation.domain.UpdateRequestQueue;
 import org.folio.circulation.domain.UpdateRequestService;
 import org.folio.circulation.domain.UserRepository;
+import org.folio.circulation.domain.policy.RequestPolicyRepository;
 import org.folio.circulation.domain.policy.LoanPolicyRepository;
 import org.folio.circulation.domain.representations.RequestProperties;
 import org.folio.circulation.domain.validation.ClosedRequestValidator;
@@ -51,6 +52,7 @@ public class RequestCollectionResource extends CollectionResource {
     final UserRepository userRepository = new UserRepository(clients);
     final LoanRepository loanRepository = new LoanRepository(clients);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
+    final RequestPolicyRepository requestPolicyRepository = new RequestPolicyRepository(clients);
     final UpdateItem updateItem = new UpdateItem(clients);
     final UpdateLoanActionHistory updateLoanActionHistory = new UpdateLoanActionHistory(clients);
     final UpdateLoan updateLoan = new UpdateLoan(clients, loanRepository, loanPolicyRepository);
@@ -61,7 +63,7 @@ public class RequestCollectionResource extends CollectionResource {
       createProxyRelationshipValidator(representation, clients);
 
     final CreateRequestService createRequestService = new CreateRequestService(
-      requestRepository, updateItem, updateLoanActionHistory, updateLoan);
+      requestRepository, updateItem, updateLoanActionHistory, updateLoan, requestPolicyRepository);
 
     final RequestRepresentation requestRepresentation = new RequestRepresentation();
 
@@ -91,6 +93,7 @@ public class RequestCollectionResource extends CollectionResource {
     final LoanRepository loanRepository = new LoanRepository(clients);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
+    final RequestPolicyRepository requestPolicyRepository =  new RequestPolicyRepository(clients);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final UpdateRequestQueue updateRequestQueue = UpdateRequestQueue.using(clients);
     final UpdateItem updateItem = new UpdateItem(clients);
@@ -106,7 +109,7 @@ public class RequestCollectionResource extends CollectionResource {
       RequestRepository.using(clients));
 
     final CreateRequestService createRequestService = new CreateRequestService(
-      requestRepository, updateItem, updateLoanActionHistory, updateLoan);
+      requestRepository, updateItem, updateLoanActionHistory, updateLoan, requestPolicyRepository);
 
 
     final UpdateRequestService updateRequestService = new UpdateRequestService(

--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -56,11 +56,11 @@ class RequestFromRepresentationService {
       .thenApply(r -> r.next(this::validateStatus))
       .thenApply(r -> r.map(this::removeRelatedRecordInformation))
       .thenApply(r -> r.map(Request::from))
-      //.thenComposeAsync(r -> r.combineAfter(loanRepository::findOpenLoanById, Request::withLoan))
       .thenComposeAsync(r -> r.combineAfter(itemRepository::fetchFor, Request::withItem))
       .thenComposeAsync(r -> r.combineAfter(userRepository::getUser, Request::withRequester))
       .thenComposeAsync(r -> r.combineAfter(userRepository::getProxyUser, Request::withProxy))
       .thenComposeAsync(r -> r.combineAfter(servicePointRepository::getServicePointForRequest, Request::withPickupServicePoint))
+      .thenComposeAsync(r -> r.combineAfter(loanRepository::findOpenLoanForRequest, Request::withLoan))
       .thenApply(r -> r.map(RequestAndRelatedRecords::new))
       .thenComposeAsync(r -> r.combineAfter(requestQueueRepository::get,
         RequestAndRelatedRecords::withRequestQueue))

--- a/src/main/java/org/folio/circulation/support/CirculationRulesClient.java
+++ b/src/main/java/org/folio/circulation/support/CirculationRulesClient.java
@@ -4,6 +4,7 @@ import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import org.folio.circulation.domain.CirculationActionType;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.server.WebContext;
 import org.slf4j.Logger;
@@ -16,22 +17,26 @@ public class CirculationRulesClient {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final OkapiHttpClient client;
   private final URL root;
+  private final String loanPolicyPath = "/circulation/rules/loan-policy";
+  private final String requestPolicyPath = "/circulation/rules/request-policy";
 
-  CirculationRulesClient(OkapiHttpClient client, WebContext context)
+  CirculationRulesClient(OkapiHttpClient client, WebContext context, CirculationActionType circulationType)
     throws MalformedURLException {
 
     this.client = client;
-    root = context.getOkapiBasedUrl("/circulation/rules/loan-policy");
+    root = context.getOkapiBasedUrl(
+      circulationType == CirculationActionType.LOAN ? loanPolicyPath : requestPolicyPath
+    );
   }
 
   public void applyRules(
-    String loanTypeId,
+    String circulationTypeId,
     String locationId,
     String materialTypeId,
     String patronGroup,
     Handler<HttpClientResponse> responseHandler) {
 
-    String circulationRulesQuery = queryParameters(loanTypeId, locationId,
+    String circulationRulesQuery = queryParameters(circulationTypeId, locationId,
       materialTypeId, patronGroup);
 
     log.info("Applying circulation rules for {}", circulationRulesQuery);
@@ -41,13 +46,13 @@ public class CirculationRulesClient {
   }
 
   private String queryParameters(
-    String loanTypeId,
+    String circulationTypeId,
     String locationId,
     String materialTypeId,
     String patronGroup) {
 
     return String.format(
       "item_type_id=%s&loan_type_id=%s&patron_type_id=%s&shelving_location_id=%s",
-      materialTypeId, loanTypeId, patronGroup, locationId);
+      materialTypeId, circulationTypeId, patronGroup, locationId);
   }
 }

--- a/src/main/java/org/folio/circulation/support/CirculationRulesClient.java
+++ b/src/main/java/org/folio/circulation/support/CirculationRulesClient.java
@@ -4,7 +4,6 @@ import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.folio.circulation.domain.CirculationActionType;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.server.WebContext;
 import org.slf4j.Logger;
@@ -17,16 +16,12 @@ public class CirculationRulesClient {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final OkapiHttpClient client;
   private final URL root;
-  private static final String LOAN_POLICY_PATH = "/circulation/rules/loan-policy";
-  private static final String REQUEST_POLICY_PATH = "/circulation/rules/request-policy";
 
-  CirculationRulesClient(OkapiHttpClient client, WebContext context, CirculationActionType circulationType)
+  CirculationRulesClient(OkapiHttpClient client, WebContext context, String policyPath)
     throws MalformedURLException {
 
     this.client = client;
-    root = context.getOkapiBasedUrl(
-      circulationType == CirculationActionType.LOAN ? LOAN_POLICY_PATH : REQUEST_POLICY_PATH
-    );
+    root = context.getOkapiBasedUrl(policyPath);
   }
 
   public void applyRules(

--- a/src/main/java/org/folio/circulation/support/CirculationRulesClient.java
+++ b/src/main/java/org/folio/circulation/support/CirculationRulesClient.java
@@ -25,13 +25,13 @@ public class CirculationRulesClient {
   }
 
   public void applyRules(
-    String circulationTypeId,
+    String loanTypeId,
     String locationId,
     String materialTypeId,
     String patronGroup,
     Handler<HttpClientResponse> responseHandler) {
 
-    String circulationRulesQuery = queryParameters(circulationTypeId, locationId,
+    String circulationRulesQuery = queryParameters(loanTypeId, locationId,
       materialTypeId, patronGroup);
 
     log.info("Applying circulation rules for {}", circulationRulesQuery);
@@ -41,13 +41,13 @@ public class CirculationRulesClient {
   }
 
   private String queryParameters(
-    String circulationTypeId,
+    String loanTypeId,
     String locationId,
     String materialTypeId,
     String patronGroup) {
 
     return String.format(
       "item_type_id=%s&loan_type_id=%s&patron_type_id=%s&shelving_location_id=%s",
-      materialTypeId, circulationTypeId, patronGroup, locationId);
+      materialTypeId, loanTypeId, patronGroup, locationId);
   }
 }

--- a/src/main/java/org/folio/circulation/support/CirculationRulesClient.java
+++ b/src/main/java/org/folio/circulation/support/CirculationRulesClient.java
@@ -17,15 +17,15 @@ public class CirculationRulesClient {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final OkapiHttpClient client;
   private final URL root;
-  private static final String loanPolicyPath = "/circulation/rules/loan-policy";
-  private static final String requestPolicyPath = "/circulation/rules/request-policy";
+  private static final String LOAN_POLICY_PATH = "/circulation/rules/loan-policy";
+  private static final String REQUEST_POLICY_PATH = "/circulation/rules/request-policy";
 
   CirculationRulesClient(OkapiHttpClient client, WebContext context, CirculationActionType circulationType)
     throws MalformedURLException {
 
     this.client = client;
     root = context.getOkapiBasedUrl(
-      circulationType == CirculationActionType.LOAN ? loanPolicyPath : requestPolicyPath
+      circulationType == CirculationActionType.LOAN ? LOAN_POLICY_PATH : REQUEST_POLICY_PATH
     );
   }
 

--- a/src/main/java/org/folio/circulation/support/CirculationRulesClient.java
+++ b/src/main/java/org/folio/circulation/support/CirculationRulesClient.java
@@ -17,8 +17,8 @@ public class CirculationRulesClient {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final OkapiHttpClient client;
   private final URL root;
-  private final String loanPolicyPath = "/circulation/rules/loan-policy";
-  private final String requestPolicyPath = "/circulation/rules/request-policy";
+  private static final String loanPolicyPath = "/circulation/rules/loan-policy";
+  private static final String requestPolicyPath = "/circulation/rules/request-policy";
 
   CirculationRulesClient(OkapiHttpClient client, WebContext context, CirculationActionType circulationType)
     throws MalformedURLException {

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -18,8 +18,10 @@ public class Clients {
   private final CollectionResourceClient proxiesForClient;
   private final CollectionResourceClient loanPoliciesStorageClient;
   private final CollectionResourceClient fixedDueDateSchedulesStorageClient;
-  private final CirculationRulesClient circulationRulesClient;
+  private final CirculationRulesClient circulationLoanRulesClient;
+  private final CirculationRulesClient circulationRequestRulesClient;
   private final CollectionResourceClient circulationRulesStorageClient;
+  private final CollectionResourceClient requestPoliciesStorageClient;
   private final CollectionResourceClient servicePointsStorageClient;
   private final CollectionResourceClient calendarStorageClient;
   private final CollectionResourceClient patronGroupsStorageClient;
@@ -40,9 +42,11 @@ public class Clients {
       locationsStorageClient = createLocationsStorageClient(client, context);
       materialTypesStorageClient = createMaterialTypesStorageClient(client, context);
       proxiesForClient = createProxyUsersStorageClient(client, context);
-      circulationRulesClient = new CirculationRulesClient(client, context);
+      circulationLoanRulesClient = new CirculationRulesClient(client, context, CirculationActionType.LOAN);
+      circulationRequestRulesClient = new CirculationRulesClient(client, context, CirculationActionType.REQUEST);
       circulationRulesStorageClient = createCirculationRulesStorageClient(client, context);
       loanPoliciesStorageClient = createLoanPoliciesStorageClient(client, context);
+      requestPoliciesStorageClient = createRequestPoliciesStorageClient(client, context);
       fixedDueDateSchedulesStorageClient = createFixedDueDateSchedulesStorageClient(client, context);
       servicePointsStorageClient = createServicePointsStorageClient(client, context);
       patronGroupsStorageClient = createPatronGroupsStorageClient(client, context);
@@ -57,6 +61,8 @@ public class Clients {
   public CollectionResourceClient requestsStorage() {
     return requestsStorageClient;
   }
+
+  public CollectionResourceClient requestPoliciesStorage() { return requestPoliciesStorageClient; }
 
   public CollectionResourceClient itemsStorage() {
     return itemsStorageClient;
@@ -93,11 +99,11 @@ public class Clients {
   public CollectionResourceClient fixedDueDateSchedules() {
     return fixedDueDateSchedulesStorageClient;
   }
-  
+
   public CollectionResourceClient servicePointsStorage() {
     return servicePointsStorageClient;
   }
-  
+
   public CollectionResourceClient patronGroupsStorage() {
     return patronGroupsStorageClient;
   }
@@ -114,8 +120,12 @@ public class Clients {
     return proxiesForClient;
   }
 
-  public CirculationRulesClient circulationRules() {
-    return circulationRulesClient;
+  public CirculationRulesClient circulationLoanRules() {
+    return circulationLoanRulesClient;
+  }
+
+  public CirculationRulesClient circulationRequestRules(){
+    return circulationRequestRulesClient;
   }
 
   public CollectionResourceClient circulationRulesStorage() {
@@ -214,6 +224,15 @@ public class Clients {
       "/loan-policy-storage/loan-policies");
   }
 
+  private CollectionResourceClient createRequestPoliciesStorageClient(
+    OkapiHttpClient client,
+    WebContext context)
+    throws MalformedURLException {
+
+    return getCollectionResourceClient(client, context,
+      "/request-policy-storage/request-policies");
+  }
+
   private CollectionResourceClient createFixedDueDateSchedulesStorageClient(
     OkapiHttpClient client,
     WebContext context)
@@ -238,7 +257,7 @@ public class Clients {
       throws MalformedURLException {
     return getCollectionResourceClient(client, context, "/service-points");
   }
-  
+
   private CollectionResourceClient createPatronGroupsStorageClient(
       OkapiHttpClient client,
       WebContext context)
@@ -259,5 +278,6 @@ public class Clients {
     throws MalformedURLException {
     return getCollectionResourceClient(client, context, "/configurations/entries");
   }
-  
+
+
 }

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -279,6 +279,4 @@ public class Clients {
     throws MalformedURLException {
     return getCollectionResourceClient(client, context, "/configurations/entries");
   }
-
-
 }

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -43,8 +43,8 @@ public class Clients {
       locationsStorageClient = createLocationsStorageClient(client, context);
       materialTypesStorageClient = createMaterialTypesStorageClient(client, context);
       proxiesForClient = createProxyUsersStorageClient(client, context);
-      circulationLoanRulesClient = new CirculationRulesClient(client, context, "/circulation/rules/loan-policy");
-      circulationRequestRulesClient = new CirculationRulesClient(client, context, "/circulation/rules/request-policy");
+      circulationLoanRulesClient = createCirculationLoanRulesClient(client, context);
+      circulationRequestRulesClient = createCirculationRequestRulesClient(client, context);
       circulationRulesStorageClient = createCirculationRulesStorageClient(client, context);
       loanPoliciesStorageClient = createLoanPoliciesStorageClient(client, context);
       requestPoliciesStorageClient = createRequestPoliciesStorageClient(client, context);
@@ -140,6 +140,22 @@ public class Clients {
     throws MalformedURLException {
 
     return new CollectionResourceClient(client, context.getOkapiBasedUrl(path));
+  }
+
+  private static CirculationRulesClient createCirculationLoanRulesClient(
+    OkapiHttpClient client,
+    WebContext context)
+    throws MalformedURLException {
+
+    return new CirculationRulesClient(client, context, "/circulation/rules/loan-policy");
+  }
+
+  private static CirculationRulesClient createCirculationRequestRulesClient(
+    OkapiHttpClient client,
+    WebContext context)
+    throws MalformedURLException {
+
+    return new CirculationRulesClient(client, context, "/circulation/rules/request-policy");
   }
 
   private static CollectionResourceClient createRequestsStorageClient(

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -2,8 +2,6 @@ package org.folio.circulation.support;
 
 import java.net.MalformedURLException;
 
-import org.folio.circulation.domain.CirculationActionType;
-
 import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.server.WebContext;
 
@@ -45,8 +43,8 @@ public class Clients {
       locationsStorageClient = createLocationsStorageClient(client, context);
       materialTypesStorageClient = createMaterialTypesStorageClient(client, context);
       proxiesForClient = createProxyUsersStorageClient(client, context);
-      circulationLoanRulesClient = new CirculationRulesClient(client, context, CirculationActionType.LOAN);
-      circulationRequestRulesClient = new CirculationRulesClient(client, context, CirculationActionType.REQUEST);
+      circulationLoanRulesClient = new CirculationRulesClient(client, context, "/circulation/rules/loan-policy");
+      circulationRequestRulesClient = new CirculationRulesClient(client, context, "/circulation/rules/request-policy");
       circulationRulesStorageClient = createCirculationRulesStorageClient(client, context);
       loanPoliciesStorageClient = createLoanPoliciesStorageClient(client, context);
       requestPoliciesStorageClient = createRequestPoliciesStorageClient(client, context);

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -1,10 +1,13 @@
 package org.folio.circulation.support;
 
-import io.vertx.core.http.HttpClient;
+import java.net.MalformedURLException;
+
+import org.folio.circulation.domain.CirculationActionType;
+
 import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.server.WebContext;
 
-import java.net.MalformedURLException;
+import io.vertx.core.http.HttpClient;
 
 public class Clients {
   private final CollectionResourceClient requestsStorageClient;

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -23,6 +23,7 @@ public class Clients {
   private final CollectionResourceClient servicePointsStorageClient;
   private final CollectionResourceClient calendarStorageClient;
   private final CollectionResourceClient patronGroupsStorageClient;
+  private final CollectionResourceClient configurationStorageClient;
 
   public static Clients create(WebContext context, HttpClient httpClient) {
     return new Clients(context.createHttpClient(httpClient), context);
@@ -46,6 +47,7 @@ public class Clients {
       servicePointsStorageClient = createServicePointsStorageClient(client, context);
       patronGroupsStorageClient = createPatronGroupsStorageClient(client, context);
       calendarStorageClient = createCalendarStorageClient(client, context);
+      configurationStorageClient = createConfigurationStorageClient(client, context);
     }
     catch(MalformedURLException e) {
       throw new InvalidOkapiLocationException(context.getOkapiLocation(), e);
@@ -104,6 +106,9 @@ public class Clients {
     return calendarStorageClient;
   }
 
+  public CollectionResourceClient configurationStorageClient() {
+    return configurationStorageClient;
+  }
 
   public CollectionResourceClient userProxies() {
     return proxiesForClient;
@@ -246,6 +251,13 @@ public class Clients {
     WebContext context)
     throws MalformedURLException {
     return getCollectionResourceClient(client, context, "/calendar/periods");
+  }
+
+  private CollectionResourceClient createConfigurationStorageClient(
+    OkapiHttpClient client,
+    WebContext context)
+    throws MalformedURLException {
+    return getCollectionResourceClient(client, context, "/configurations/entries");
   }
   
 }

--- a/src/main/java/org/folio/circulation/support/ClockManager.java
+++ b/src/main/java/org/folio/circulation/support/ClockManager.java
@@ -1,6 +1,10 @@
 package org.folio.circulation.support;
 
 import java.time.Clock;
+import java.time.ZonedDateTime;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 // This class allows for unit tests to replace the clock used by the module.
 // Ideally, we'd use dependency injection for this.
@@ -11,6 +15,10 @@ public class ClockManager {
 
   private ClockManager() {
     super();
+  }
+
+  public static ClockManager getClockManager() {
+    return INSTANCE;
   }
 
   public void setClock(Clock clock) {
@@ -25,7 +33,8 @@ public class ClockManager {
     return clock;
   }
 
-  public static ClockManager getClockManager() {
-    return INSTANCE;
+  public DateTime getDateTime() {
+    return new DateTime(ZonedDateTime.now(clock).toInstant().toEpochMilli(),
+        DateTimeZone.UTC);
   }
 }

--- a/src/test/java/api/loans/CheckOutByBarcodeFixedDueDateScenariosTest.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeFixedDueDateScenariosTest.java
@@ -62,7 +62,7 @@ public class CheckOutByBarcodeFixedDueDateScenariosTest extends APITests {
       .limitedBySchedule(fixedDueDateSchedulesId);
 
     UUID loanPolicyId = loanPolicyClient.create(loanPolicy).getId();
-    UUID requestPolicyId = requestPoliciesFixture.noAllowedTypes().getId();
+    UUID requestPolicyId = requestPoliciesFixture.allowAllRequestPolicy().getId();
     UUID noticePolicyId = noticePoliciesFixture.activeNotice().getId();
     useLoanPolicyAsFallback(loanPolicyId, requestPolicyId, noticePolicyId);
 
@@ -111,7 +111,7 @@ public class CheckOutByBarcodeFixedDueDateScenariosTest extends APITests {
 
 
     UUID loanPolicyId = loanPolicyClient.create(loanPolicy).getId();
-    UUID requestPolicyId = requestPoliciesFixture.noAllowedTypes().getId();
+    UUID requestPolicyId = requestPoliciesFixture.allowAllRequestPolicy().getId();
     UUID noticePolicyId = noticePoliciesFixture.activeNotice().getId();
     useLoanPolicyAsFallback(loanPolicyId, requestPolicyId, noticePolicyId);
 
@@ -161,7 +161,7 @@ public class CheckOutByBarcodeFixedDueDateScenariosTest extends APITests {
       .limitedBySchedule(fixedDueDateSchedulesId);
 
     UUID loanPolicyId = loanPolicyClient.create(loanPolicy).getId();
-    UUID requestPolicyId = requestPoliciesFixture.noAllowedTypes().getId();
+    UUID requestPolicyId = requestPoliciesFixture.allowAllRequestPolicy().getId();
     UUID noticePolicyId = noticePoliciesFixture.activeNotice().getId();
     useLoanPolicyAsFallback(loanPolicyId, requestPolicyId, noticePolicyId);
 

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -212,7 +212,7 @@ public class CheckOutByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(
       dueDateLimitedPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -559,7 +559,7 @@ public class CheckOutByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(
       nonExistentloanPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 

--- a/src/test/java/api/loans/CheckOutCalculateDueDateShortTermTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateDueDateShortTermTests.java
@@ -184,7 +184,7 @@ public class CheckOutCalculateDueDateShortTermTests extends APITests {
     ExecutionException {
 
     IndividualResource loanPolicy = loanPoliciesFixture.create(loanPolicyEntry);
-    UUID requestPolicyId = requestPoliciesFixture.noAllowedTypes().getId();
+    UUID requestPolicyId = requestPoliciesFixture.allowAllRequestPolicy().getId();
     UUID noticePolicyId = noticePoliciesFixture.activeNotice().getId();
     useLoanPolicyAsFallback(loanPolicy.getId(), requestPolicyId, noticePolicyId);
 

--- a/src/test/java/api/loans/CheckOutCalculateDueDateShortTermTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateDueDateShortTermTests.java
@@ -3,11 +3,13 @@ package api.loans;
 import api.support.APITests;
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
 import api.support.builders.LoanPolicyBuilder;
+import api.support.fixtures.ConfigurationExample;
 import io.vertx.core.json.JsonObject;
 import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.LoansPolicyProfile;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
@@ -26,6 +28,7 @@ import static api.support.fixtures.CalendarExamples.CASE_FRI_SAT_MON_DAY_ALL_SER
 import static api.support.fixtures.CalendarExamples.CASE_FRI_SAT_MON_SERVICE_POINT_ID;
 import static api.support.fixtures.CalendarExamples.CASE_FRI_SAT_MON_SERVICE_POINT_PREV_DAY;
 import static api.support.fixtures.CalendarExamples.END_TIME_FIRST_PERIOD;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -45,10 +48,41 @@ public class CheckOutCalculateDueDateShortTermTests extends APITests {
   private static final String POLICY_PROFILE_NAME = LoansPolicyProfile.ROLLING.name();
   private static final String INTERVAL_HOURS = "Hours";
   private static final String INTERVAL_MINUTES = "Minutes";
-  public static final LocalTime TEST_TIME_MORNING = new LocalTime(11, 0);
+  private static final LocalTime TEST_TIME_MORNING = new LocalTime(11, 0);
 
   private final String dueDateManagement =
     DueDateManagement.MOVE_TO_END_OF_CURRENT_SERVICE_POINT_HOURS.getValue();
+
+  @Test
+  public void testRespectSelectedTimezoneForDueDateCalculations() throws Exception {
+    String expectedTimeZone = "America/New_York";
+    int duration = 24;
+
+    Response response = configClient.create(ConfigurationExample.newYorkTimezoneConfiguration())
+      .getResponse();
+    assertThat(response.getBody(), containsString(expectedTimeZone));
+
+    DateTime loanDate = CASE_FRI_SAT_MON_DAY_ALL_PREV_DATE.toDateTime(TEST_TIME_MORNING, DateTimeZone.forID(expectedTimeZone));
+    DateTime expectedDueDate = CASE_FRI_SAT_MON_DAY_ALL_PREV_DATE.plusDays(1)
+      .toDateTime(LocalTime.MIDNIGHT, DateTimeZone.forID(expectedTimeZone));
+
+    checkOffsetTime(loanDate, expectedDueDate, CASE_FRI_SAT_MON_DAY_ALL_SERVICE_POINT_ID, INTERVAL_HOURS, duration);
+  }
+
+  @Test
+  public void testRespectUtcTimezoneForDueDateCalculations() throws Exception {
+    int duration = 24;
+
+    Response response = configClient.create(ConfigurationExample.utcTimezoneConfiguration())
+      .getResponse();
+    assertThat(response.getBody(), containsString(DateTimeZone.UTC.toString()));
+
+    DateTime loanDate = CASE_FRI_SAT_MON_DAY_ALL_PREV_DATE.toDateTime(TEST_TIME_MORNING, DateTimeZone.UTC);
+    DateTime expectedDueDate = CASE_FRI_SAT_MON_DAY_ALL_PREV_DATE.plusDays(1)
+      .toDateTime(LocalTime.MIDNIGHT, DateTimeZone.UTC);
+
+    checkOffsetTime(loanDate, expectedDueDate, CASE_FRI_SAT_MON_DAY_ALL_SERVICE_POINT_ID, INTERVAL_HOURS, duration);
+  }
 
   /**
    * Loan period: Hours
@@ -58,14 +92,13 @@ public class CheckOutCalculateDueDateShortTermTests extends APITests {
    */
   @Test
   public void testHoursLoanPeriodIfCurrentDayIsClosedAndNextAllDayOpen() throws Exception {
-    String servicePointId = CASE_FRI_SAT_MON_DAY_ALL_SERVICE_POINT_ID;
     int duration = 24;
 
     DateTime loanDate = CASE_FRI_SAT_MON_DAY_ALL_PREV_DATE.toDateTime(TEST_TIME_MORNING, DateTimeZone.UTC);
     DateTime expectedDueDate = CASE_FRI_SAT_MON_DAY_ALL_PREV_DATE.plusDays(1)
       .toDateTime(LocalTime.MIDNIGHT, DateTimeZone.UTC);
 
-    checkOffsetTime(loanDate, expectedDueDate, servicePointId, INTERVAL_HOURS, duration);
+    checkOffsetTime(loanDate, expectedDueDate, CASE_FRI_SAT_MON_DAY_ALL_SERVICE_POINT_ID, INTERVAL_HOURS, duration);
   }
 
   /**
@@ -110,7 +143,7 @@ public class CheckOutCalculateDueDateShortTermTests extends APITests {
 
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
-    ;
+
     final UUID checkoutServicePointId = UUID.fromString(servicePointId);
 
     JsonObject loanPolicyEntry = createLoanPolicyEntry(duration, interval);
@@ -144,7 +177,6 @@ public class CheckOutCalculateDueDateShortTermTests extends APITests {
     return dateTime.withSecondOfMinute(0).withMillisOfSecond(0);
   }
 
-
   private String createLoanPolicy(JsonObject loanPolicyEntry)
     throws InterruptedException,
     MalformedURLException,
@@ -172,6 +204,5 @@ public class CheckOutCalculateDueDateShortTermTests extends APITests {
       .renewFromCurrentDueDate()
       .create();
   }
-
 
 }

--- a/src/test/java/api/loans/CheckOutCalculateDueDateTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateDueDateTests.java
@@ -1061,7 +1061,7 @@ public class CheckOutCalculateDueDateTests extends APITests {
 
     useLoanPolicyAsFallback(
       loanPolicy.getId(),
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 

--- a/src/test/java/api/loans/CheckOutCalculateOffsetTimeTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateOffsetTimeTests.java
@@ -497,7 +497,7 @@ public class CheckOutCalculateOffsetTimeTests extends APITests {
 
     IndividualResource loanPolicy = loanPoliciesFixture.create(loanPolicyEntry);
 
-    UUID requestPolicyId = requestPoliciesFixture.noAllowedTypes().getId();
+    UUID requestPolicyId = requestPoliciesFixture.allowAllRequestPolicy().getId();
     UUID noticePolicyId = noticePoliciesFixture.activeNotice().getId();
     useLoanPolicyAsFallback(loanPolicy.getId(), requestPolicyId, noticePolicyId);
 

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -53,7 +53,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(
       unknownLoanPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -174,7 +174,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(
       nonRenewablePolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -212,7 +212,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(
       nonRenewablePolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -281,7 +281,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(
       dueDateLimitedPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -327,7 +327,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(
       dueDateLimitedPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -408,7 +408,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(
       dueDateLimitedPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -465,7 +465,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(
       limitedRenewalsPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -528,7 +528,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     useLoanPolicyAsFallback(
       rollingPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -143,7 +143,7 @@ abstract class RenewalAPITests extends APITests {
 
     useLoanPolicyAsFallback(
       dueDateLimitedPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -203,7 +203,7 @@ abstract class RenewalAPITests extends APITests {
 
     useLoanPolicyAsFallback(
       dueDateLimitedPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -257,7 +257,7 @@ abstract class RenewalAPITests extends APITests {
 
     useLoanPolicyAsFallback(
       dueDateLimitedPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -317,7 +317,7 @@ abstract class RenewalAPITests extends APITests {
 
     useLoanPolicyAsFallback(
       dueDateLimitedPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -371,7 +371,7 @@ abstract class RenewalAPITests extends APITests {
 
     useLoanPolicyAsFallback(
       dueDateLimitedPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -428,7 +428,7 @@ abstract class RenewalAPITests extends APITests {
 
     useLoanPolicyAsFallback(
       fixedDueDatePolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -485,7 +485,7 @@ abstract class RenewalAPITests extends APITests {
 
     useLoanPolicyAsFallback(
       limitedRenewalsPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -597,7 +597,7 @@ abstract class RenewalAPITests extends APITests {
 
     useLoanPolicyAsFallback(
       unknownLoanPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -628,7 +628,7 @@ abstract class RenewalAPITests extends APITests {
 
     useLoanPolicyAsFallback(
       limitedRenewalsPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -676,7 +676,7 @@ abstract class RenewalAPITests extends APITests {
 
     useLoanPolicyAsFallback(
       limitedRenewalsPolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -718,7 +718,7 @@ abstract class RenewalAPITests extends APITests {
 
     useLoanPolicyAsFallback(
       notRenewablePolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -761,7 +761,7 @@ abstract class RenewalAPITests extends APITests {
 
     useLoanPolicyAsFallback(
       notRenewablePolicyId,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
 
@@ -864,7 +864,7 @@ abstract class RenewalAPITests extends APITests {
 
     UUID loanPolicyIdForCheckOut = loanPolicyClient.create(loanPolicy).getId();
     useLoanPolicyAsFallback(loanPolicyIdForCheckOut,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId());
 
     loansFixture.checkOutByBarcode(
@@ -880,7 +880,7 @@ abstract class RenewalAPITests extends APITests {
         DueDateManagement.MOVE_TO_THE_END_OF_THE_PREVIOUS_OPEN_DAY.getValue())
     ).getId();
     useLoanPolicyAsFallback(loanPolicyIdForRenew,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId());
 
     JsonObject renewedLoan = renew(smallAngryPlanet, jessica).getJson();
@@ -916,7 +916,7 @@ abstract class RenewalAPITests extends APITests {
 
     UUID loanPolicyIdForCheckOut = loanPolicyClient.create(loanPolicy).getId();
     useLoanPolicyAsFallback(loanPolicyIdForCheckOut,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId());
 
     loansFixture.checkOutByBarcode(
@@ -932,7 +932,7 @@ abstract class RenewalAPITests extends APITests {
         DueDateManagement.MOVE_TO_THE_END_OF_THE_NEXT_OPEN_DAY.getValue())
     ).getId();
     useLoanPolicyAsFallback(loanPolicyIdForRenew,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId());
 
     JsonObject renewedLoan = renew(smallAngryPlanet, jessica).getJson();
@@ -966,7 +966,7 @@ abstract class RenewalAPITests extends APITests {
 
     UUID loanPolicyIdForCheckOut = loanPolicyClient.create(loanPolicy).getId();
     useLoanPolicyAsFallback(loanPolicyIdForCheckOut,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId());
 
     loansFixture.checkOutByBarcode(
@@ -982,7 +982,7 @@ abstract class RenewalAPITests extends APITests {
         DueDateManagement.MOVE_TO_BEGINNING_OF_NEXT_OPEN_SERVICE_POINT_HOURS.getValue())
     ).getId();
     useLoanPolicyAsFallback(loanPolicyIdForRenew,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId());
 
     JsonObject renewedLoan = renew(smallAngryPlanet, jessica).getJson();
@@ -1018,7 +1018,7 @@ abstract class RenewalAPITests extends APITests {
 
     UUID loanPolicyIdForCheckOut = loanPolicyClient.create(loanPolicy).getId();
     useLoanPolicyAsFallback(loanPolicyIdForCheckOut,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId());
 
     loansFixture.checkOutByBarcode(
@@ -1034,7 +1034,7 @@ abstract class RenewalAPITests extends APITests {
         DueDateManagement.MOVE_TO_END_OF_CURRENT_SERVICE_POINT_HOURS.getValue())
     ).getId();
     useLoanPolicyAsFallback(loanPolicyIdForRenew,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId());
 
     DateTimeUtils.setCurrentMillisFixed(loanDate.plusHours(1).getMillis());

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -1073,7 +1073,7 @@ abstract class RenewalAPITests extends APITests {
 
     UUID loanPolicyIdForCheckOut = loanPolicyClient.create(loanPolicy).getId();
     useLoanPolicyAsFallback(loanPolicyIdForCheckOut,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId());
 
     loansFixture.checkOutByBarcode(
@@ -1089,7 +1089,7 @@ abstract class RenewalAPITests extends APITests {
         DueDateManagement.MOVE_TO_BEGINNING_OF_NEXT_OPEN_SERVICE_POINT_HOURS.getValue())
     ).getId();
     useLoanPolicyAsFallback(loanPolicyIdForRenew,
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId());
 
     JsonObject renewedLoan = renew(smallAngryPlanet, jessica).getJson();

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -882,7 +882,7 @@ public class RequestsAPICreationTests extends APITests {
 
     assertThat(pagedRequest, hasStatus(HTTP_VALIDATION_ERROR));
     JsonArray errors = pagedRequest.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is("item is " + ItemStatus.CHECKED_OUT.toString().toLowerCase()));
+    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is (("Page requests are not allowed for " + ItemStatus.CHECKED_OUT.getValue() + " item status combination").toLowerCase()));
   }
 
   @Test
@@ -906,7 +906,7 @@ public class RequestsAPICreationTests extends APITests {
 
     assertThat(pagedRequest2, hasStatus(HTTP_VALIDATION_ERROR));
     JsonArray errors = pagedRequest2.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is("item is " + ItemStatus.AWAITING_PICKUP.toString().toLowerCase()));
+    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is (("Page requests are not allowed for " + ItemStatus.AWAITING_PICKUP.getValue() + " item status combination").toLowerCase()));
   }
 
   @Test
@@ -929,7 +929,7 @@ public class RequestsAPICreationTests extends APITests {
 
     assertThat(pagedRequest2, hasStatus(HTTP_VALIDATION_ERROR));
     JsonArray errors = pagedRequest2.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is("item is " + ItemStatus.PAGED.toString().toLowerCase()));
+    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is(("Page requests are not allowed for " + ItemStatus.PAGED.getValue() + " item status combination").toLowerCase()));
   }
 
   @Test
@@ -954,7 +954,7 @@ public class RequestsAPICreationTests extends APITests {
 
     assertThat(pagedRequest2, hasStatus(HTTP_VALIDATION_ERROR));
     JsonArray errors = pagedRequest2.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is("item is " + ItemStatus.IN_TRANSIT.toString().toLowerCase()));
+    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is (("Page requests are not allowed for " + ItemStatus.IN_TRANSIT.getValue() + " item status combination").toLowerCase()));
   }
 
   @Test
@@ -1049,7 +1049,7 @@ public class RequestsAPICreationTests extends APITests {
 
     assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
     JsonArray errors = recallResponse.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is("item is " + ItemStatus.AVAILABLE.toString().toLowerCase()));
+    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is (("Recall requests are not allowed for " + ItemStatus.AVAILABLE.getValue() + " item status combination").toLowerCase()));
   }
 
   @Test
@@ -1070,7 +1070,7 @@ public class RequestsAPICreationTests extends APITests {
 
     assertThat(holdRequest, hasStatus(HTTP_VALIDATION_ERROR));
     JsonArray errors = holdRequest.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is("item is " + ItemStatus.MISSING.toString().toLowerCase()));
+    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is (("Recall requests are not allowed for " + ItemStatus.MISSING.getValue() + " item status combination").toLowerCase()));
   }
 
   @Test
@@ -1091,7 +1091,7 @@ public class RequestsAPICreationTests extends APITests {
 
     assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
     JsonArray errors = recallResponse.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is("item is " + ItemStatus.PAGED.toString().toLowerCase()));
+    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is (("Recall requests are not allowed for " + ItemStatus.PAGED.getValue() + " item status combination").toLowerCase()));
   }
 
   @Test
@@ -1231,7 +1231,7 @@ public class RequestsAPICreationTests extends APITests {
 
     assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
     JsonArray errors = recallResponse.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is("item is " + ItemStatus.AVAILABLE.toString().toLowerCase()));
+    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is(("Hold requests are not allowed for " + ItemStatus.AVAILABLE.getValue() + " item status combination").toLowerCase()));
   }
 
 

--- a/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
+++ b/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
@@ -1,0 +1,394 @@
+package api.requests.scenarios;
+
+import static api.support.fixtures.CalendarExamples.CASE_FRI_SAT_MON_SERVICE_POINT_ID;
+import static api.support.fixtures.CalendarExamples.CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY;
+import static java.lang.Boolean.TRUE;
+import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.net.MalformedURLException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.circulation.domain.policy.DueDateManagement;
+import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.support.ClockManager;
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeConstants;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import api.support.APITests;
+import api.support.builders.LoanBuilder;
+import api.support.builders.LoanPolicyBuilder;
+import api.support.builders.ServicePointBuilder;
+import io.vertx.core.json.JsonObject;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.converters.Nullable;
+import junitparams.naming.TestCaseName;
+
+/**
+ * Notes:<br>
+ *  MGD = Minimum guaranteed due date<br>
+ *  RD = Recall due date<br>
+ *
+ * @see <a href="https://issues.folio.org/browse/CIRC-203">CIRC-203</a>
+ */
+@RunWith(JUnitParamsRunner.class)
+public class LoanDueDatesAfterRecallTests extends APITests {
+  private static Clock clock;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    // reset the clock before each test (just in case)
+    ClockManager.getClockManager().setClock(clock);
+  }
+
+  @Test
+  public void recallRequestWithNoPolicyValuesChangesDueDateToSystemDate()
+      throws InterruptedException,
+      ExecutionException,
+      TimeoutException,
+      MalformedURLException {
+    final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource requestServicePoint = servicePointsFixture.cd1();
+    final IndividualResource steve = usersFixture.steve();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final IndividualResource loan = loansFixture.checkOut(smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC));
+
+    final String originalDueDate = loan.getJson().getString("dueDate");
+
+    requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId(), "Recall");
+
+    final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
+
+    assertThat("due date is the original date",
+        storedLoan.getString("dueDate"), not(originalDueDate));
+
+    final String expectedDueDate = ClockManager.getClockManager().getDateTime().toString(ISODateTimeFormat.dateTime());
+    assertThat("due date is not the current date",
+        storedLoan.getString("dueDate"), is(expectedDueDate));
+  }
+
+  @Test
+  public void recallRequestWithMGDAndRDValuesChangesDueDateToRD()
+      throws InterruptedException,
+      ExecutionException,
+      TimeoutException,
+      MalformedURLException {
+    final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource requestServicePoint = servicePointsFixture.cd1();
+    final IndividualResource steve = usersFixture.steve();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final LoanPolicyBuilder canCirculateRollingPolicy = new LoanPolicyBuilder()
+        .withName("Can Circulate Rolling With Recalls")
+        .withDescription("Can circulate item With Recalls")
+        .rolling(Period.weeks(3))
+        .unlimitedRenewals()
+        .renewFromSystemDate()
+        .withRecallsMinimumGuaranteedLoanPeriod(Period.weeks(2))
+        .withRecallsRecallReturnInterval(Period.months(2));
+
+    final IndividualResource loanPolicy = loanPoliciesFixture.create(canCirculateRollingPolicy);
+
+    useLoanPolicyAsFallback(loanPolicy.getId(),
+        requestPoliciesFixture.noAllowedTypes().getId(),
+        noticePoliciesFixture.activeNotice().getId());
+
+    final IndividualResource loan = loansFixture.checkOut(smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC));
+
+    final String originalDueDate = loan.getJson().getString("dueDate");
+
+    requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId(), "Recall");
+
+    final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
+
+    assertThat("due date is the original date",
+        storedLoan.getString("dueDate"), not(originalDueDate));
+
+    final String expectedDueDate = ClockManager.getClockManager().getDateTime().plusMonths(2).toString(ISODateTimeFormat.dateTime());
+    assertThat("due date is not the recall due date (2 months)",
+        storedLoan.getString("dueDate"), is(expectedDueDate));
+  }
+
+  @Test
+  public void recallRequestWithMGDAndRDValuesChangesDueDateToMGD()
+      throws InterruptedException,
+      ExecutionException,
+      TimeoutException,
+      MalformedURLException {
+    final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource requestServicePoint = servicePointsFixture.cd1();
+    final IndividualResource steve = usersFixture.steve();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final LoanPolicyBuilder canCirculateRollingPolicy = new LoanPolicyBuilder()
+        .withName("Can Circulate Rolling With Recalls")
+        .withDescription("Can circulate item With Recalls")
+        .rolling(Period.weeks(3))
+        .unlimitedRenewals()
+        .renewFromSystemDate()
+        .withRecallsMinimumGuaranteedLoanPeriod(Period.weeks(2))
+        .withRecallsRecallReturnInterval(Period.weeks(1));
+
+    final IndividualResource loanPolicy = loanPoliciesFixture.create(canCirculateRollingPolicy);
+
+    useLoanPolicyAsFallback(loanPolicy.getId(),
+        requestPoliciesFixture.noAllowedTypes().getId(),
+        noticePoliciesFixture.activeNotice().getId());
+
+    // We use the loan date to calculate the MGD
+    final DateTime loanDate = DateTime.now(DateTimeZone.UTC);
+
+    final IndividualResource loan =
+        loansFixture.checkOut(smallAngryPlanet, steve, loanDate);
+
+    final String originalDueDate = loan.getJson().getString("dueDate");
+
+    requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId(), "Recall");
+
+    final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
+
+    assertThat("due date is the original date",
+        storedLoan.getString("dueDate"), not(originalDueDate));
+
+    final String expectedDueDate = loanDate.plusWeeks(2).toString(ISODateTimeFormat.dateTime());
+    assertThat("due date is not the minimum guaranteeded due date (2 weeks)",
+        storedLoan.getString("dueDate"), is(expectedDueDate));
+  }
+
+  @Test
+  public void recallRequestWithRDAndNoMGDValuesChangesDueDateToRD()
+      throws InterruptedException,
+      ExecutionException,
+      TimeoutException,
+      MalformedURLException {
+    final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource requestServicePoint = servicePointsFixture.cd1();
+    final IndividualResource steve = usersFixture.steve();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final LoanPolicyBuilder canCirculateRollingPolicy = new LoanPolicyBuilder()
+        .withName("Can Circulate Rolling With Recalls")
+        .withDescription("Can circulate item With Recalls")
+        .rolling(Period.weeks(3))
+        .unlimitedRenewals()
+        .renewFromSystemDate()
+        .withRecallsRecallReturnInterval(Period.weeks(1));
+
+    final IndividualResource loanPolicy = loanPoliciesFixture.create(canCirculateRollingPolicy);
+
+    useLoanPolicyAsFallback(loanPolicy.getId(),
+        requestPoliciesFixture.noAllowedTypes().getId(),
+        noticePoliciesFixture.activeNotice().getId());
+
+    // We use the loan date to calculate the minimum guaranteed due date (MGD)
+    final DateTime loanDate = DateTime.now(DateTimeZone.UTC);
+
+    final IndividualResource loan =
+        loansFixture.checkOut(smallAngryPlanet, steve, loanDate);
+
+    final String originalDueDate = loan.getJson().getString("dueDate");
+
+    requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId(), "Recall");
+
+    final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
+
+    assertThat("due date is the original date",
+        storedLoan.getString("dueDate"), not(originalDueDate));
+
+    final String expectedDueDate = ClockManager.getClockManager().getDateTime().plusWeeks(1).toString(ISODateTimeFormat.dateTime());
+    assertThat("due date is not the recall due date (1 week)",
+        storedLoan.getString("dueDate"), is(expectedDueDate));
+  }
+
+  @Test
+  public void recallRequestWithMGDAndNoRDValuesChangesDueDateToMGD()
+      throws InterruptedException,
+      ExecutionException,
+      TimeoutException,
+      MalformedURLException {
+    final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource requestServicePoint = servicePointsFixture.cd1();
+    final IndividualResource steve = usersFixture.steve();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final LoanPolicyBuilder canCirculateRollingPolicy = new LoanPolicyBuilder()
+        .withName("Can Circulate Rolling With Recalls")
+        .withDescription("Can circulate item With Recalls")
+        .rolling(Period.weeks(3))
+        .unlimitedRenewals()
+        .renewFromSystemDate()
+        .withRecallsMinimumGuaranteedLoanPeriod(Period.weeks(2));
+
+    final IndividualResource loanPolicy = loanPoliciesFixture.create(canCirculateRollingPolicy);
+
+    useLoanPolicyAsFallback(loanPolicy.getId(),
+        requestPoliciesFixture.noAllowedTypes().getId(),
+        noticePoliciesFixture.activeNotice().getId());
+
+    // We use the loan date to calculate the minimum guaranteed due date (MGD)
+    final DateTime loanDate = DateTime.now(DateTimeZone.UTC);
+
+    final IndividualResource loan =
+        loansFixture.checkOut(smallAngryPlanet, steve, loanDate);
+
+    final String originalDueDate = loan.getJson().getString("dueDate");
+
+    requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId(), "Recall");
+
+    final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
+
+    assertThat("due date is the original date",
+        storedLoan.getString("dueDate"), not(originalDueDate));
+
+    final String expectedDueDate = loanDate.plusWeeks(2).toString(ISODateTimeFormat.dateTime());
+    assertThat("due date is not the minimum guaranteed due date (2 weeks)",
+        storedLoan.getString("dueDate"), is(expectedDueDate));
+  }
+
+  @Test
+  public void recallRequestWithMGDAndRDValuesChangesDueDateToMGDWithCLDDM()
+      throws InterruptedException,
+      ExecutionException,
+      TimeoutException,
+      MalformedURLException {
+    final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID checkOutServicePointId = UUID.fromString(CASE_FRI_SAT_MON_SERVICE_POINT_ID);
+    final IndividualResource steve = usersFixture.steve();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final LoanPolicyBuilder canCirculateRollingPolicy = new LoanPolicyBuilder()
+        .withName("Can Circulate Rolling With Recalls")
+        .withDescription("Can circulate item With Recalls")
+        .rolling(Period.weeks(3))
+        .unlimitedRenewals()
+        .renewFromSystemDate()
+        .withRecallsMinimumGuaranteedLoanPeriod(Period.days(8))
+        .withRecallsRecallReturnInterval(Period.weeks(1))
+        .withClosedLibraryDueDateManagement(DueDateManagement.MOVE_TO_THE_END_OF_THE_NEXT_OPEN_DAY.getValue());
+
+    final IndividualResource loanPolicy = loanPoliciesFixture.create(canCirculateRollingPolicy);
+
+    useLoanPolicyAsFallback(loanPolicy.getId(),
+        requestPoliciesFixture.noAllowedTypes().getId(),
+        noticePoliciesFixture.activeNotice().getId());
+
+    servicePointsFixture.create(new ServicePointBuilder(checkOutServicePointId, "CLDDM Desk", "clddm", "CLDDM Desk Test", null, null, TRUE, null));
+
+    // We use the loan date to calculate the minimum guaranteed due date (MGD)
+    final DateTime loanDate =
+        new DateTime(2019, DateTimeConstants.JANUARY, 25, 10, 0, DateTimeZone.UTC);
+
+    // Update the clock so this will all work
+    ClockManager.getClockManager().setClock(Clock.fixed(Instant.ofEpochMilli(loanDate.getMillis()), ZoneOffset.UTC));
+
+    final IndividualResource loan = loansClient.create(new LoanBuilder()
+        .open()
+        .withItemId(smallAngryPlanet.getId())
+        .withUserId(steve.getId())
+        .withLoanDate(loanDate)
+        .withDueDate(loanDate.plusWeeks(3))
+        .withCheckoutServicePointId(checkOutServicePointId));
+
+    final String originalDueDate = loan.getJson().getString("dueDate");
+
+    requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
+        DateTime.now(DateTimeZone.UTC), "Recall");
+
+    final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
+
+    assertThat("due date is the original date",
+        storedLoan.getString("dueDate"), not(originalDueDate));
+
+    final String expectedDueDate =
+        CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY
+          .toDateTime(END_OF_A_DAY, DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime());
+
+    assertThat("due date is not moved to Monday",
+        storedLoan.getString("dueDate"), is(expectedDueDate));
+  }
+
+  @Test
+  @Parameters({
+    // MGD duration|MGD interval|RD duration|RD interval|expected string
+    "null|null|1|Months|the \"minimumGuaranteedLoanPeriod\" in the loan policy is not recognized",
+    "1|Months|null|null|the \"recallReturnInterval\" in the loan policy is not recognized",
+    "1|Years|1|Months|the interval \"Years\" in \"minimumGuaranteedLoanPeriod\" is not recognized",
+    "1|Months|1|Years|the interval \"Years\" in \"recallReturnInterval\" is not recognized",
+    "-100|Months|1|Months|the duration \"-100\" in \"minimumGuaranteedLoanPeriod\" is invalid",
+    "1|Months|-100|Months|the duration \"-100\" in \"recallReturnInterval\" is invalid"
+  })
+  @TestCaseName("{method}: {params}")
+  public void loanPolicyWithInvalidMGDOrRDPeriodValuesReturnsErrorOnRecallCreation(
+      @Nullable Integer mgdDuration,
+      @Nullable String mgdInterval,
+      @Nullable Integer rdDuration,
+      @Nullable String rdInterval,
+      String expectedMessage)
+          throws InterruptedException,
+          ExecutionException,
+          TimeoutException,
+          MalformedURLException {
+    final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource requestServicePoint = servicePointsFixture.cd1();
+    final IndividualResource steve = usersFixture.steve();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    final LoanPolicyBuilder canCirculateRollingPolicy = new LoanPolicyBuilder()
+        .withName("Can Circulate Rolling With Recalls")
+        .withDescription("Can circulate item With Recalls")
+        .rolling(Period.weeks(3))
+        .unlimitedRenewals()
+        .renewFromSystemDate()
+        .withRecallsMinimumGuaranteedLoanPeriod(Period.from(mgdDuration, mgdInterval))
+        .withRecallsRecallReturnInterval(Period.from(rdDuration, rdInterval));
+
+    final IndividualResource loanPolicy = loanPoliciesFixture.create(canCirculateRollingPolicy);
+
+    useLoanPolicyAsFallback(loanPolicy.getId(),
+        requestPoliciesFixture.noAllowedTypes().getId(),
+        noticePoliciesFixture.activeNotice().getId());
+
+    // We use the loan date to calculate the minimum guaranteed due date (MGD)
+    final DateTime loanDate = DateTime.now(DateTimeZone.UTC);
+
+    loansFixture.checkOut(smallAngryPlanet, steve, loanDate);
+
+    final Response response = requestsFixture.attemptPlaceHoldShelfRequest(smallAngryPlanet, jessica,
+        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId(), "Recall");
+
+    assertThat("Status code is not 422", response.getStatusCode(), is(422));
+    assertThat("errors is not present", response.getJson().getJsonArray("errors"), notNullValue());
+    assertThat("errors is not size 1", response.getJson().getJsonArray("errors").size(), is(1));
+    assertThat("first error does not have the expected message field",
+        response.getJson().getJsonArray("errors").getJsonObject(0).getString("message"),
+        is(expectedMessage));
+  }
+}

--- a/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
+++ b/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
@@ -114,7 +114,7 @@ public class LoanDueDatesAfterRecallTests extends APITests {
     final IndividualResource loanPolicy = loanPoliciesFixture.create(canCirculateRollingPolicy);
 
     useLoanPolicyAsFallback(loanPolicy.getId(),
-        requestPoliciesFixture.noAllowedTypes().getId(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId(),
         noticePoliciesFixture.activeNotice().getId());
 
     final IndividualResource loan = loansFixture.checkOut(smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC));
@@ -157,7 +157,7 @@ public class LoanDueDatesAfterRecallTests extends APITests {
     final IndividualResource loanPolicy = loanPoliciesFixture.create(canCirculateRollingPolicy);
 
     useLoanPolicyAsFallback(loanPolicy.getId(),
-        requestPoliciesFixture.noAllowedTypes().getId(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId(),
         noticePoliciesFixture.activeNotice().getId());
 
     // We use the loan date to calculate the MGD
@@ -203,7 +203,7 @@ public class LoanDueDatesAfterRecallTests extends APITests {
     final IndividualResource loanPolicy = loanPoliciesFixture.create(canCirculateRollingPolicy);
 
     useLoanPolicyAsFallback(loanPolicy.getId(),
-        requestPoliciesFixture.noAllowedTypes().getId(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId(),
         noticePoliciesFixture.activeNotice().getId());
 
     // We use the loan date to calculate the minimum guaranteed due date (MGD)
@@ -249,7 +249,7 @@ public class LoanDueDatesAfterRecallTests extends APITests {
     final IndividualResource loanPolicy = loanPoliciesFixture.create(canCirculateRollingPolicy);
 
     useLoanPolicyAsFallback(loanPolicy.getId(),
-        requestPoliciesFixture.noAllowedTypes().getId(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId(),
         noticePoliciesFixture.activeNotice().getId());
 
     // We use the loan date to calculate the minimum guaranteed due date (MGD)
@@ -297,7 +297,7 @@ public class LoanDueDatesAfterRecallTests extends APITests {
     final IndividualResource loanPolicy = loanPoliciesFixture.create(canCirculateRollingPolicy);
 
     useLoanPolicyAsFallback(loanPolicy.getId(),
-        requestPoliciesFixture.noAllowedTypes().getId(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId(),
         noticePoliciesFixture.activeNotice().getId());
 
     servicePointsFixture.create(new ServicePointBuilder(checkOutServicePointId, "CLDDM Desk", "clddm", "CLDDM Desk Test", null, null, TRUE, null));
@@ -373,7 +373,7 @@ public class LoanDueDatesAfterRecallTests extends APITests {
     final IndividualResource loanPolicy = loanPoliciesFixture.create(canCirculateRollingPolicy);
 
     useLoanPolicyAsFallback(loanPolicy.getId(),
-        requestPoliciesFixture.noAllowedTypes().getId(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId(),
         noticePoliciesFixture.activeNotice().getId());
 
     // We use the loan date to calculate the minimum guaranteed due date (MGD)

--- a/src/test/java/api/requests/scenarios/RequestPolicyTests.java
+++ b/src/test/java/api/requests/scenarios/RequestPolicyTests.java
@@ -1,0 +1,379 @@
+package api.requests.scenarios;
+
+import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
+import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
+import static api.support.matchers.ValidationErrorMatchers.hasMessage;
+import static org.folio.HttpStatus.HTTP_INTERNAL_SERVER_ERROR;
+import static org.folio.HttpStatus.HTTP_VALIDATION_ERROR;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.circulation.domain.ItemStatus;
+import org.folio.circulation.domain.RequestStatus;
+import org.folio.circulation.domain.RequestType;
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
+import org.junit.Test;
+
+import api.support.APITests;
+import api.support.builders.RequestBuilder;
+import io.vertx.core.json.JsonObject;
+
+public class RequestPolicyTests extends APITests {
+
+  private final IndividualResource requestPickupServicePoint;
+
+  public RequestPolicyTests() throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException{
+
+    requestPickupServicePoint = servicePointsFixture.cd1();
+  }
+
+  @Test
+  public void canCreateRecallRequestsWithRequestPolicyAllowingRecalls()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final String undergradPatronGroup = patronGroupsFixture.undergrad().getId().toString();
+    final String anyNoticePolicy = noticePoliciesFixture.activeNotice().getId().toString();
+    final String anyLoanPolicy = loanPoliciesFixture.canCirculateRolling().getId().toString();
+    final String anyRequestPolicy = requestPoliciesFixture.allowAllRequestPolicy().getId().toString();
+    final String recallRequestPolicy = requestPoliciesFixture.recallRequestPolicy().getId().toString();
+
+    //This rule is set up to show that the fallback policy won't be used but the patronGroup policy g is used instead.
+    //The patronGroup policy allows undergraduate students to place a request on any material type, loan or notice type.
+    final String rules = String.join("\n",
+      "priority: t, s, c, b, a, m, g",
+      "fallback-policy : l " + anyLoanPolicy + " r " + anyRequestPolicy + " n " + anyNoticePolicy + "\n",
+      "g " + undergradPatronGroup + ": l " + anyLoanPolicy + " r " + recallRequestPolicy +" n " + anyNoticePolicy
+    );
+
+    setRules(rules);
+
+    //setting up a checked-out library item to perform recall
+    final IndividualResource checkedOutItem = itemsFixture.basedUponSmallAngryPlanet();
+    loansFixture.checkOut(checkedOutItem, usersFixture.jessica());
+
+    //an undergraduate student attempts to place a Recall request
+    final IndividualResource recallRequest = requestsClient.create(new RequestBuilder()
+      .recall()
+      .forItem(checkedOutItem)
+      .withPickupServicePointId(requestPickupServicePoint.getId())
+      .by(usersFixture.undergradHenry()));
+
+    JsonObject requestedItem = recallRequest.getJson().getJsonObject("item");
+    assertThat(recallRequest.getJson().getString("requestType"), is(RequestType.RECALL.getValue()));
+    assertThat(requestedItem.getString("status"), is(ItemStatus.CHECKED_OUT.getValue()));
+    assertThat(recallRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
+  }
+
+  @Test
+  public void cannotCreateRecallRequestsWithRequestPolicyNotAllowingRecalls()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final String undergradPatronGroupPolicy = patronGroupsFixture.undergrad().getId().toString();
+    final String anyNoticePolicy = noticePoliciesFixture.activeNotice().getId().toString();
+    final String anyLoanPolicy = loanPoliciesFixture.canCirculateRolling().getId().toString();
+    final String anyRequestPolicy = requestPoliciesFixture.allowAllRequestPolicy().getId().toString();
+
+    ArrayList<RequestType> allowedRequestTypes = new ArrayList<>();
+    allowedRequestTypes.add(RequestType.HOLD);
+    allowedRequestTypes.add(RequestType.PAGE);
+    final String noRecallRequestPolicy = requestPoliciesFixture.customRequestPolicy(allowedRequestTypes,
+                                          "All But Recall", "All but Recall request policy").getId().toString();
+
+    //This rule is set up to show that the fallback policy won't be used but the patronGroup policy g is used instead.
+    //The patronGroup policy allows undergraduate students to place a request on any material type, loan or notice type, on any request type
+    //except for RECALL
+    final String rules = String.join("\n",
+      "priority: t, s, c, b, a, m, g",
+      "fallback-policy : l " + anyLoanPolicy + " r " + anyRequestPolicy + " n " + anyNoticePolicy + "\n",
+      "g " + undergradPatronGroupPolicy + ": l " + anyLoanPolicy + " r " + noRecallRequestPolicy +" n " + anyNoticePolicy
+    );
+
+    setRules(rules);
+
+    //setting up a checked-out library item to perform recall
+    final IndividualResource checkedOutItem = itemsFixture.basedUponSmallAngryPlanet();
+    loansFixture.checkOut(checkedOutItem, usersFixture.jessica());
+
+    final Response recallResponse = requestsClient.attemptCreate(new RequestBuilder()
+      .recall()
+      .forItem(checkedOutItem)
+      .withPickupServicePointId(requestPickupServicePoint.getId())
+      .by(usersFixture.undergradHenry()));
+
+    assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
+    assertThat(recallResponse.getJson(), hasErrorWith(allOf(
+      hasMessage("Request Type Recall is not valid"))));
+  }
+
+  @Test
+  public void canCreateHoldRequestsWithRequestWithReqestPolicyAllowingHolds()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final String holdRequestPolicy = requestPoliciesFixture.holdRequestPolicy().getId().toString();
+    final String anyNoticePolicy = noticePoliciesFixture.activeNotice().getId().toString();
+    final String anyLoanPolicy = loanPoliciesFixture.canCirculateRolling().getId().toString();
+    final String bookMaterialType = materialTypesFixture.book().getId().toString();
+    final String anyRequestPolicy = requestPoliciesFixture.allowAllRequestPolicy().getId().toString();
+
+    //This rule is set up to show that the fallback policy won't be used but the material policy m is used instead.
+    //The materialType policy allows any patron to place a request on a library item of BOOK material type, any loan and notice types.
+    final String rule = String.join("\n",
+      "priority: t, s, c, b, a, m, g",
+      "fallback-policy : l " + anyLoanPolicy + " r " + anyRequestPolicy + " n " + anyNoticePolicy + "\n",
+      "m " + bookMaterialType + ": l " + anyLoanPolicy + " r " + holdRequestPolicy +" n " + anyNoticePolicy
+    );
+
+    setRules(rule);
+
+    //setting up a checked-out library item of material type BOOK to perform a HOLD
+    final IndividualResource checkedOutItem = itemsFixture.basedUponUprooted();
+    loansFixture.checkOut(checkedOutItem, usersFixture.jessica());
+
+    //an undergraduate student attempts to place a HOLD request
+    final IndividualResource recallRequest = requestsClient.create(new RequestBuilder()
+      .hold()
+      .forItem(checkedOutItem)
+      .withPickupServicePointId(requestPickupServicePoint.getId())
+      .by(usersFixture.steve()));
+
+    JsonObject requestedItem = recallRequest.getJson().getJsonObject("item");
+    assertThat(recallRequest.getJson().getString("requestType"), is(RequestType.HOLD.getValue()));
+    assertThat(requestedItem.getString("status"), is(ItemStatus.CHECKED_OUT.getValue()));
+    assertThat(recallRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
+  }
+
+  @Test
+  public void cannotCreateHoldRequestsWithRequestPolicyNotAllowingHolds()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final String anyNoticePolicy = noticePoliciesFixture.activeNotice().getId().toString();
+    final String anyLoanPolicy = loanPoliciesFixture.canCirculateRolling().getId().toString();
+    final String bookMaterialType = materialTypesFixture.book().getId().toString();
+    final String anyRequestPolicy = requestPoliciesFixture.allowAllRequestPolicy().getId().toString();
+
+    ArrayList<RequestType> allowedRequestTypes = new ArrayList<>();
+    allowedRequestTypes.add(RequestType.RECALL);
+    allowedRequestTypes.add(RequestType.PAGE);
+    final String noHoldRequestPolicy = requestPoliciesFixture.customRequestPolicy(allowedRequestTypes,
+      "All But Hold", "All but Hold request policy").getId().toString();
+
+    //This rule is set up to show that the fallback policy won't be used but the material type rule m is used instead.
+    //The material type rule m allows any patron to place any request but HOLDs on any BOOK, loan or notice types
+    final String rules = String.join("\n",
+      "priority: t, s, c, b, a, m, g",
+      "fallback-policy : l " + anyLoanPolicy + " r " + anyRequestPolicy + " n " + anyNoticePolicy + "\n",
+      "m " + bookMaterialType + ": l " + anyLoanPolicy + " r " + noHoldRequestPolicy +" n " + anyNoticePolicy
+    );
+
+    setRules(rules);
+
+    //setting up a checked-out library item to perform HOLD
+    final IndividualResource checkedOutItem = itemsFixture.basedUponSmallAngryPlanet();
+    loansFixture.checkOut(checkedOutItem, usersFixture.jessica());
+
+    final Response recallResponse = requestsClient.attemptCreate(new RequestBuilder()
+      .hold()
+      .forItem(checkedOutItem)
+      .withPickupServicePointId(requestPickupServicePoint.getId())
+      .by(usersFixture.james()));  //randomly picked James to represent "Any" patron
+
+    assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
+    assertThat(recallResponse.getJson(), hasErrorWith(allOf(
+      hasMessage("Request Type Hold is not valid"))));
+  }
+
+  @Test
+  public void canCreatePageRequestsWithRequestPolicyAllowingPagings()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final String nonCirculatingLoanTypePolicy = loanPoliciesFixture.canCirculateFixed().getId().toString();
+    final String anyNoticePolicy = noticePoliciesFixture.activeNotice().getId().toString();
+    final String pageRequestPolicy = requestPoliciesFixture.pageRequestPolicy().getId().toString();
+
+    final String rules = String.join("\n",
+      "priority: t, s, c, b, a, m, g",
+      "fallback-policy : l " + nonCirculatingLoanTypePolicy + " r " + pageRequestPolicy + " n " + anyNoticePolicy
+    );
+
+    setRules(rules);
+
+    //setting up an available library item to perform Page request
+    final IndividualResource availableItem = itemsFixture.basedUponSmallAngryPlanet();
+
+    //a patron attempts to place a request
+    final IndividualResource recallRequest = requestsClient.create(new RequestBuilder()
+      .page()
+      .forItem(availableItem)
+      .withPickupServicePointId(requestPickupServicePoint.getId())
+      .by(usersFixture.steve()));
+
+    JsonObject requestedItem = recallRequest.getJson().getJsonObject("item");
+    assertThat(recallRequest.getJson().getString("requestType"), is(RequestType.PAGE.getValue()));
+    assertThat(requestedItem.getString("status"), is(ItemStatus.PAGED.getValue()));
+    assertThat(recallRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
+  }
+
+  @Test
+  public void cannotCreatePageRequestsWithRequestPolicyNotAllowingPagings()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final String anyNoticePolicy = noticePoliciesFixture.activeNotice().getId().toString();
+    final String nonCirculatingLoanTypePolicy = loanPoliciesFixture.canCirculateFixed().getId().toString();
+
+    ArrayList<RequestType> allowedRequestTypes = new ArrayList<>();
+    allowedRequestTypes.add(RequestType.RECALL);
+    allowedRequestTypes.add(RequestType.HOLD);
+    final String noPageRequestPolicy = requestPoliciesFixture.customRequestPolicy(allowedRequestTypes,
+      "All But Page", "All but Page request policy").getId().toString();
+
+    final String rules =
+      "priority: t, s, c, b, a, m, g " +
+      "fallback-policy : l " + nonCirculatingLoanTypePolicy + " r " + noPageRequestPolicy + " n " + anyNoticePolicy;
+
+    setRules(rules);
+
+    //setting up a checked-out library item to attempt placing a PAGE request
+    final IndividualResource availableItem = itemsFixture.basedUponSmallAngryPlanet();
+
+    final Response recallResponse = requestsClient.attemptCreate(new RequestBuilder()
+      .page()
+      .forItem(availableItem)
+      .withPickupServicePointId(requestPickupServicePoint.getId())
+      .by(usersFixture.james()));  //randomly picked James to represent "Any" patron
+
+    assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
+    assertThat(recallResponse.getJson(), hasErrorWith(allOf(
+      hasMessage("Request Type Page is not valid"))));
+  }
+
+  @Test
+  public void canCreateRecallRequestsWithRequestPolicyUsingFallbackRules()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final String undergradPatronGroup = patronGroupsFixture.undergrad().getId().toString();
+    final String anyNoticePolicy = noticePoliciesFixture.activeNotice().getId().toString();
+    final String anyLoanPolicy = loanPoliciesFixture.canCirculateRolling().getId().toString();
+    final String anyRequestPolicy = requestPoliciesFixture.allowAllRequestPolicy().getId().toString();
+    final String recallRequestPolicy = requestPoliciesFixture.recallRequestPolicy().getId().toString();
+
+    //This rule is set up to show that the fallback policy will be used instead of the undergrad patronGroup policy.
+    final String rules = String.join("\n",
+      "priority: t, s, c, b, a, m, g",
+      "fallback-policy : l " + anyLoanPolicy + " r " + anyRequestPolicy + " n " + anyNoticePolicy + "\n",
+      "g " + undergradPatronGroup + ": l " + anyLoanPolicy + " r " + recallRequestPolicy +" n " + anyNoticePolicy
+    );
+
+    setRules(rules);
+
+    //setting up a checked-out library item to perform recall
+    final IndividualResource checkedOutItem = itemsFixture.basedUponSmallAngryPlanet();
+    loansFixture.checkOut(checkedOutItem, usersFixture.jessica());
+
+    //an undergraduate student attempts to place a Recall request
+    final IndividualResource recallRequest = requestsClient.create(new RequestBuilder()
+      .recall()
+      .forItem(checkedOutItem)
+      .withPickupServicePointId(requestPickupServicePoint.getId())
+      .by(usersFixture.james()));  //james does not belong to the Undergrad patron group
+
+    JsonObject requestedItem = recallRequest.getJson().getJsonObject("item");
+    assertThat(recallRequest.getJson().getString("requestType"), is(RequestType.RECALL.getValue()));
+    assertThat(requestedItem.getString("status"), is(ItemStatus.CHECKED_OUT.getValue()));
+    assertThat(recallRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
+  }
+
+  @Test
+  public void cannotCreatePageRequestsWithoutCirculationRulesDefined()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    //In order to not have any request policy around, need to remove the default one which was created before each test run
+    final String defaultRequestPolicyName = "Example Request Policy";
+    IndividualResource defaultRequestPolicy = requestPoliciesFixture.findRequestPolicy(defaultRequestPolicyName);
+    requestPoliciesFixture.deleteRequestPolicy(defaultRequestPolicy);
+
+    //setting up a checked-out library item to perform recall
+    final IndividualResource availableItem = itemsFixture.basedUponSmallAngryPlanet();
+
+    final Response recallResponse = requestsClient.attemptCreate(new RequestBuilder()
+      .page()
+      .forItem(availableItem)
+      .withPickupServicePointId(requestPickupServicePoint.getId())
+      .by(usersFixture.james()));  //randomly picked James to represent "Any" patron
+
+    String expectedErrorMessage = "Request policy " + defaultRequestPolicy.getId() + " could not be found, please check circulation rules";
+
+    assertThat(recallResponse, hasStatus(HTTP_INTERNAL_SERVER_ERROR));
+    assertTrue(recallResponse.getBody().equalsIgnoreCase(expectedErrorMessage));
+  }
+
+  @Test
+  public void cannotCreatePageRequestsWithoutMatchingCirculationRules()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    //In order to not have any request policy around, need to remove the default one which was created before each test run
+    final String defaultRequestPolicyName = "Example Request Policy";
+    IndividualResource defaultRequestPolicy = requestPoliciesFixture.findRequestPolicy(defaultRequestPolicyName);
+    requestPoliciesFixture.deleteRequestPolicy(defaultRequestPolicy);
+
+    //setting up a checked-out library item to perform recall
+    final IndividualResource availableItem = itemsFixture.basedUponSmallAngryPlanet();
+
+    final Response recallResponse = requestsClient.attemptCreate(new RequestBuilder()
+      .page()
+      .forItem(availableItem)
+      .withPickupServicePointId(requestPickupServicePoint.getId())
+      .by(usersFixture.james()));  //randomly picked James to represent "Any" patron
+
+    String expectedErrorMessage = "Request policy " + defaultRequestPolicy.getId() + " could not be found, please check circulation rules";
+
+    assertThat(recallResponse, hasStatus(HTTP_INTERNAL_SERVER_ERROR));
+    assertTrue(recallResponse.getBody().equalsIgnoreCase(expectedErrorMessage));
+  }
+
+  private void setRules(String rules) {
+    try {
+      circulationRulesFixture.updateCirculationRules(rules);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/api/requests/scenarios/RequestPolicyTests.java
+++ b/src/test/java/api/requests/scenarios/RequestPolicyTests.java
@@ -6,7 +6,6 @@ import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static org.folio.HttpStatus.HTTP_INTERNAL_SERVER_ERROR;
 import static org.folio.HttpStatus.HTTP_VALIDATION_ERROR;
 import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/api/requests/scenarios/RequestPolicyTests.java
+++ b/src/test/java/api/requests/scenarios/RequestPolicyTests.java
@@ -119,7 +119,7 @@ public class RequestPolicyTests extends APITests {
 
     assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
     assertThat(recallResponse.getJson(), hasErrorWith(allOf(
-      hasMessage("Request Type Recall is not valid"))));
+      hasMessage("Recall requests are not allowed for this patron and item combination"))));
   }
 
   @Test
@@ -202,11 +202,11 @@ public class RequestPolicyTests extends APITests {
 
     assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
     assertThat(recallResponse.getJson(), hasErrorWith(allOf(
-      hasMessage("Request Type Hold is not valid"))));
+      hasMessage("Hold requests are not allowed for this patron and item combination"))));
   }
 
   @Test
-  public void canCreatePageRequestsWithRequestPolicyAllowingPagings()
+  public void canCreatePageRequestsWithRequestPolicyAllowingPageRequests()
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
@@ -272,7 +272,7 @@ public class RequestPolicyTests extends APITests {
 
     assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
     assertThat(recallResponse.getJson(), hasErrorWith(allOf(
-      hasMessage("Request Type Page is not valid"))));
+      hasMessage("Page requests are not allowed for this patron and item combination"))));
   }
 
   @Test

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -289,7 +289,7 @@ public abstract class APITests {
       UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID())),
       ResponseHandler.any(completed));
 
-    Response response = completed.get(100, TimeUnit.SECONDS);
+    Response response = completed.get(1, TimeUnit.SECONDS);
 
     assertThat(String.format(
       "Failed to apply circulation rules: %s", response.getBody()),

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -289,7 +289,7 @@ public abstract class APITests {
       UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID())),
       ResponseHandler.any(completed));
 
-    Response response = completed.get(1, TimeUnit.SECONDS);
+    Response response = completed.get(5, TimeUnit.SECONDS);
 
     assertThat(String.format(
       "Failed to apply circulation rules: %s", response.getBody()),

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -1,10 +1,32 @@
 package api.support;
 
+import static api.support.APITestContext.createClient;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import java.lang.invoke.MethodHandles;
+import java.net.MalformedURLException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.circulation.support.http.client.OkapiHttpClient;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.http.client.ResponseHandler;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import api.support.fixtures.AddressTypesFixture;
 import api.support.fixtures.CancellationReasonsFixture;
+import api.support.fixtures.CirculationRulesFixture;
 import api.support.fixtures.ItemsFixture;
 import api.support.fixtures.LoanPoliciesFixture;
-import api.support.fixtures.CirculationRulesFixture;
 import api.support.fixtures.LoanTypesFixture;
 import api.support.fixtures.LoansFixture;
 import api.support.fixtures.LocationsFixture;
@@ -18,27 +40,6 @@ import api.support.fixtures.ServicePointsFixture;
 import api.support.fixtures.UsersFixture;
 import api.support.http.InterfaceUrls;
 import api.support.http.ResourceClient;
-import org.folio.circulation.support.http.client.OkapiHttpClient;
-import org.folio.circulation.support.http.client.Response;
-import org.folio.circulation.support.http.client.ResponseHandler;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.invoke.MethodHandles;
-import java.net.MalformedURLException;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import static api.support.APITestContext.createClient;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public abstract class APITests {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -55,6 +56,8 @@ public abstract class APITests {
   private final ResourceClient campusesClient = ResourceClient.forCampuses(client);
   private final ResourceClient librariesClient = ResourceClient.forLibraries(client);
   private final ResourceClient locationsClient = ResourceClient.forLocations(client);
+
+  protected final ResourceClient configClient = ResourceClient.forConfiguration(client);
 
   private final ResourceClient patronGroupsClient
     = ResourceClient.forPatronGroups(client);
@@ -175,6 +178,7 @@ public abstract class APITests {
     itemsClient.deleteAll();
     holdingsClient.deleteAll();
     instancesClient.deleteAll();
+    configClient.deleteAll();
 
     //TODO: Only cleans up reference records, move items, holdings records
     // and instances into here too
@@ -185,6 +189,7 @@ public abstract class APITests {
     if (initialiseCirculationRules) {
       useDefaultRollingPolicyCirculationRules();
     }
+
   }
 
   @AfterClass
@@ -212,6 +217,7 @@ public abstract class APITests {
     itemsClient.deleteAll();
     holdingsClient.deleteAll();
     instancesClient.deleteAll();
+    configClient.deleteAll();
 
     //TODO: Only cleans up reference records, move items, holdings records
     // and instances into here too
@@ -344,4 +350,5 @@ public abstract class APITests {
     ResourceClient.forInstanceTypes(client).deleteAllIndividually();
     ResourceClient.forCancellationReasons(client).deleteAllIndividually();
   }
+
 }

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -249,7 +249,7 @@ public abstract class APITests {
     log.info("Using rolling loan policy as fallback policy");
     useLoanPolicyAsFallback(
       loanPoliciesFixture.canCirculateRolling().getId(),
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
   }
@@ -263,7 +263,7 @@ public abstract class APITests {
     log.info("Using fixed loan policy as fallback policy");
     useLoanPolicyAsFallback(
       loanPoliciesFixture.canCirculateFixed().getId(),
-      requestPoliciesFixture.noAllowedTypes().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
   }

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -289,7 +289,7 @@ public abstract class APITests {
       UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID())),
       ResponseHandler.any(completed));
 
-    Response response = completed.get(10, TimeUnit.SECONDS);
+    Response response = completed.get(100, TimeUnit.SECONDS);
 
     assertThat(String.format(
       "Failed to apply circulation rules: %s", response.getBody()),

--- a/src/test/java/api/support/builders/ConfigRecordBuilder.java
+++ b/src/test/java/api/support/builders/ConfigRecordBuilder.java
@@ -1,0 +1,35 @@
+package api.support.builders;
+
+import io.vertx.core.json.JsonObject;
+
+public class ConfigRecordBuilder extends JsonBuilder implements Builder {
+
+  private static final String MODULE_KEY = "module";
+  private static final String CONFIG_NAME_KEY = "configName";
+  private static final String VALUE_KEY = "value";
+
+  private JsonObject representation;
+
+  public ConfigRecordBuilder(String module, String configName, String value) {
+    this.representation = new JsonObject()
+      .put(MODULE_KEY, module)
+      .put(CONFIG_NAME_KEY, configName)
+      .put(VALUE_KEY, value);
+  }
+
+  public ConfigRecordBuilder(String value) {
+    this.representation = new JsonObject()
+      .put(VALUE_KEY, value);
+  }
+
+  @Override
+  public JsonObject create() {
+    return this.representation;
+  }
+
+  @Override
+  public String toString() {
+    return this.representation.toString();
+  }
+
+}

--- a/src/test/java/api/support/builders/ConfigurationBuilder.java
+++ b/src/test/java/api/support/builders/ConfigurationBuilder.java
@@ -1,0 +1,37 @@
+package api.support.builders;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+import java.util.stream.Collector;
+
+public class ConfigurationBuilder extends JsonBuilder implements Builder {
+
+  private static final String CONFIGS_KEY = "configs";
+  private static final String TOTAL_RECORDS_KEY = "totalRecords";
+
+  private JsonObject representation;
+
+  public ConfigurationBuilder(List<ConfigRecordBuilder> configurations) {
+    this.representation = new JsonObject()
+      .put(TOTAL_RECORDS_KEY, configurations.size())
+      .put(CONFIGS_KEY, openingDaysToJsonArray(configurations));
+  }
+
+  private JsonArray openingDaysToJsonArray(List<ConfigRecordBuilder> configurations) {
+    return configurations.stream()
+      .map(ConfigRecordBuilder::create)
+      .collect(Collector.of(JsonArray::new, JsonArray::add, JsonArray::add));
+  }
+
+  @Override
+  public JsonObject create() {
+    return this.representation;
+  }
+
+  @Override
+  public String toString() {
+    return this.representation.toString();
+  }
+}

--- a/src/test/java/api/support/builders/LoanPolicyBuilder.java
+++ b/src/test/java/api/support/builders/LoanPolicyBuilder.java
@@ -26,6 +26,8 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
   private final JsonObject openingTimeOffsetPeriod;
   private final boolean renewable;
   private final boolean loanable;
+  private final JsonObject recallsMinimumGuaranteedLoanPeriod;
+  private final JsonObject recallsRecallReturnInterval;
 
   public LoanPolicyBuilder() {
     this(UUID.randomUUID(),
@@ -43,7 +45,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       false,
       null,
       null,
-      true
+      true,
+      null,
+      null
     );
   }
 
@@ -62,7 +66,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
     boolean renewWithDifferentPeriod,
     JsonObject differentRenewalPeriod,
     UUID alternateFixedDueDateScheduleId,
-    boolean renewable) {
+    boolean renewable,
+    JsonObject recallsMinimumGuaranteedLoanPeriod,
+    JsonObject recallsRecallReturnInterval) {
 
     this.id = id;
     this.name = name;
@@ -82,6 +88,8 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
     this.alternateFixedDueDateScheduleId = alternateFixedDueDateScheduleId;
     this.numberAllowed = numberAllowed;
     this.renewable = renewable;
+    this.recallsMinimumGuaranteedLoanPeriod = recallsMinimumGuaranteedLoanPeriod;
+    this.recallsRecallReturnInterval = recallsRecallReturnInterval;
   }
 
   @Override
@@ -148,6 +156,31 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       put(request, "renewalsPolicy", renewalsPolicy);
     }
 
+    JsonObject recalls = null;
+
+    if (recallsMinimumGuaranteedLoanPeriod != null) {
+      recalls = new JsonObject();
+      put(recalls, "minimumGuaranteedLoanPeriod", recallsMinimumGuaranteedLoanPeriod);
+    }
+
+    if (recallsRecallReturnInterval != null) {
+      if (recalls == null) {
+        recalls = new JsonObject();
+      }
+      put(recalls, "recallReturnInterval", recallsRecallReturnInterval);
+    }
+
+    JsonObject requestManagement = null;
+
+    if (recalls != null) {
+      requestManagement = new JsonObject();
+      put(requestManagement, "recalls", recalls);
+    }
+
+    if (requestManagement != null) {
+      put(request, "requestManagement", requestManagement);
+    }
+
     return request;
   }
 
@@ -167,7 +200,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder withName(String name) {
@@ -186,7 +221,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder withDescription(String description) {
@@ -205,7 +242,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder withLoanable(boolean loanable) {
@@ -224,7 +263,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder withLoansProfile(String profile) {
@@ -243,7 +284,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder rolling(Period period) {
@@ -262,7 +305,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder fixed(UUID fixedDueDateScheduleId) {
@@ -281,7 +326,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder limitedBySchedule(UUID fixedDueDateScheduleId) {
@@ -305,7 +352,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder unlimitedRenewals() {
@@ -324,7 +373,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder limitedRenewals(int limit) {
@@ -343,7 +394,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder renewFromSystemDate() {
@@ -370,7 +423,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder renewWith(Period period) {
@@ -393,7 +448,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       true,
       period.asJson(),
       dueDateLimitScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public Builder renewWith(UUID fixedDueDateScheduleId) {
@@ -419,7 +476,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       true,
       null,
       fixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder notRenewable() {
@@ -438,7 +497,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      false);
+      false,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder withClosedLibraryDueDateManagement(
@@ -459,7 +520,9 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
   }
 
   public LoanPolicyBuilder withOpeningTimeOffset(Period openingTimeOffsetPeriod) {
@@ -479,6 +542,52 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.renewWithDifferentPeriod,
       this.differentRenewalPeriod,
       this.alternateFixedDueDateScheduleId,
-      this.renewable);
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      this.recallsRecallReturnInterval);
+  }
+
+  public LoanPolicyBuilder withRecallsMinimumGuaranteedLoanPeriod(Period recallsMinimumGuaranteedLoanPeriod) {
+    return new LoanPolicyBuilder(
+      this.id,
+      this.name,
+      this.description,
+      this.loanable,
+      this.profile,
+      this.loanPeriod,
+      this.fixedDueDateScheduleId,
+      this.closedLibraryDueDateManagementId,
+      this.openingTimeOffsetPeriod,
+      this.unlimitedRenewals,
+      this.numberAllowed,
+      this.renewFrom,
+      this.renewWithDifferentPeriod,
+      this.differentRenewalPeriod,
+      this.alternateFixedDueDateScheduleId,
+      this.renewable,
+      recallsMinimumGuaranteedLoanPeriod.asJson(),
+      this.recallsRecallReturnInterval);
+  }
+
+  public LoanPolicyBuilder withRecallsRecallReturnInterval(Period recallsRecallReturnInterval) {
+    return new LoanPolicyBuilder(
+      this.id,
+      this.name,
+      this.description,
+      this.loanable,
+      this.profile,
+      this.loanPeriod,
+      this.fixedDueDateScheduleId,
+      this.closedLibraryDueDateManagementId,
+      this.openingTimeOffsetPeriod,
+      this.unlimitedRenewals,
+      this.numberAllowed,
+      this.renewFrom,
+      this.renewWithDifferentPeriod,
+      this.differentRenewalPeriod,
+      this.alternateFixedDueDateScheduleId,
+      this.renewable,
+      this.recallsMinimumGuaranteedLoanPeriod,
+      recallsRecallReturnInterval.asJson());
   }
 }

--- a/src/test/java/api/support/builders/RequestPolicyBuilder.java
+++ b/src/test/java/api/support/builders/RequestPolicyBuilder.java
@@ -23,6 +23,15 @@ public class RequestPolicyBuilder extends JsonBuilder implements Builder {
     );
   }
 
+  public RequestPolicyBuilder(ArrayList<RequestType> requestTypes, String name, String description) {
+
+    this(UUID.randomUUID(),
+      name,
+      description,
+      requestTypes
+    );
+  }
+
   private RequestPolicyBuilder(
     UUID id,
     String name,

--- a/src/test/java/api/support/builders/RequestPolicyBuilder.java
+++ b/src/test/java/api/support/builders/RequestPolicyBuilder.java
@@ -1,22 +1,25 @@
 package api.support.builders;
 
+import java.util.ArrayList;
 import java.util.UUID;
 
 import org.folio.circulation.domain.RequestType;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class RequestPolicyBuilder extends JsonBuilder implements Builder {
   private final UUID id;
   private final String name;
   private final String description;
-  private final RequestType type;
+  private final ArrayList<RequestType> types;
 
-  public RequestPolicyBuilder() {
+  public RequestPolicyBuilder(ArrayList<RequestType> requestTypes) {
+
     this(UUID.randomUUID(),
       "Example Request Policy",
       "An example request policy",
-      RequestType.HOLD
+      requestTypes
     );
   }
 
@@ -24,30 +27,33 @@ public class RequestPolicyBuilder extends JsonBuilder implements Builder {
     UUID id,
     String name,
     String description,
-    RequestType type) {
+    ArrayList<RequestType> types) {
 
     this.id = id;
     this.name = name;
     this.description = description;
-    this.type = type;
+    this.types = types;
   }
 
   @Override
   public JsonObject create() {
-    JsonObject request = new JsonObject();
+    JsonObject requestPolicy = new JsonObject();
 
     if (id != null) {
-      put(request, "id", id.toString());
+      put(requestPolicy, "id", id.toString());
     }
 
-    put(request, "name", this.name);
-    put(request, "description", this.description);
+    put(requestPolicy, "name", this.name);
+    put(requestPolicy, "description", this.description);
 
-    JsonObject requestType = new JsonObject();
-    put(requestType, "type", this.type.name());
+    JsonArray requestTypes = new JsonArray();
 
-    put(request, "requestType", requestType);
+    for(RequestType t : types){
+      requestTypes.add(t.getValue());
+    }
 
-    return request;
+    put(requestPolicy, "requestTypes", requestTypes);
+
+    return requestPolicy;
   }
 }

--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -267,6 +267,20 @@ public class FakeOkapi extends AbstractVerticle {
             ForwardResponse.forward(context.response(), httpClientResponse,
               BufferHelper.stringFromBuffer(buffer))));
     });
+
+    router.get("/circulation/rules/request-policy").handler(context -> {
+      OkapiHttpClient client = APITestContext.createClient(throwable ->
+        ServerErrorResponse.internalError(context.response(),
+          String.format("Exception when forward circulation rules apply request: %s",
+            throwable.getMessage())));
+
+      client.get(String.format("http://localhost:%s/circulation/rules/request-policy?%s"
+        , APITestContext.circulationModulePort(), context.request().query()),
+        httpClientResponse ->
+          httpClientResponse.bodyHandler(buffer ->
+            ForwardResponse.forward(context.response(), httpClientResponse,
+              BufferHelper.stringFromBuffer(buffer))));
+    });
   }
 
   @Override

--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -1,11 +1,14 @@
 package api.support.fakes;
 
-import api.support.APITestContext;
-import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
-import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpServer;
-import io.vertx.ext.web.Router;
+import static api.support.fixtures.CalendarExamples.CASE_CALENDAR_IS_EMPTY_SERVICE_POINT_ID;
+import static api.support.fixtures.CalendarExamples.getCalendarById;
+import static api.support.fixtures.LibraryHoursExamples.CASE_CALENDAR_IS_UNAVAILABLE_SERVICE_POINT_ID;
+import static api.support.fixtures.LibraryHoursExamples.CASE_CLOSED_LIBRARY_IN_THU_SERVICE_POINT_ID;
+import static api.support.fixtures.LibraryHoursExamples.CASE_CLOSED_LIBRARY_SERVICE_POINT_ID;
+import static api.support.fixtures.LibraryHoursExamples.getLibraryHoursById;
+
+import java.lang.invoke.MethodHandles;
+
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.folio.circulation.support.http.client.BufferHelper;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
@@ -14,14 +17,12 @@ import org.folio.circulation.support.http.server.ServerErrorResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.invoke.MethodHandles;
-
-import static api.support.fixtures.CalendarExamples.CASE_CALENDAR_IS_EMPTY_SERVICE_POINT_ID;
-import static api.support.fixtures.CalendarExamples.getCalendarById;
-import static api.support.fixtures.LibraryHoursExamples.CASE_CALENDAR_IS_UNAVAILABLE_SERVICE_POINT_ID;
-import static api.support.fixtures.LibraryHoursExamples.CASE_CLOSED_LIBRARY_IN_THU_SERVICE_POINT_ID;
-import static api.support.fixtures.LibraryHoursExamples.CASE_CLOSED_LIBRARY_SERVICE_POINT_ID;
-import static api.support.fixtures.LibraryHoursExamples.getLibraryHoursById;
+import api.support.APITestContext;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.web.Router;
 
 public class FakeOkapi extends AbstractVerticle {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -228,6 +229,14 @@ public class FakeOkapi extends AbstractVerticle {
       .withUniqueProperties("name")
       .withChangeMetadata()
       .disallowCollectionDelete()
+      .create()
+      .register(router);
+
+    new FakeStorageModuleBuilder()
+      .withRecordName("configuration")
+      .withCollectionPropertyName("configs")
+      .withRootPath("/configurations/entries")
+      .withChangeMetadata()
       .create()
       .register(router);
 

--- a/src/test/java/api/support/fixtures/ConfigurationExample.java
+++ b/src/test/java/api/support/fixtures/ConfigurationExample.java
@@ -1,0 +1,38 @@
+package api.support.fixtures;
+
+import static org.folio.circulation.support.JsonPropertyWriter.write;
+
+import api.support.builders.ConfigRecordBuilder;
+import io.vertx.core.json.JsonObject;
+
+public class ConfigurationExample {
+
+  private static final String DEFAULT_MOD = "ORG";
+  private static final String DEFAULT_NAME = "localeSettings";
+  private static final String US_LOCALE = "en-US";
+
+  private ConfigurationExample() {
+    // not use
+  }
+
+  public static ConfigRecordBuilder utcTimezoneConfiguration() {
+    return getLocaleAndTimeZoneConfiguration("UTC");
+  }
+
+  public static ConfigRecordBuilder newYorkTimezoneConfiguration() {
+    return getLocaleAndTimeZoneConfiguration("America/New_York");
+  }
+
+  private static ConfigRecordBuilder getLocaleAndTimeZoneConfiguration(String timezone) {
+    return new ConfigRecordBuilder(DEFAULT_MOD, DEFAULT_NAME,
+      combinedConfiguration(timezone).encodePrettily());
+  }
+
+  private static JsonObject combinedConfiguration(String timezone) {
+    final JsonObject encodedValue = new JsonObject();
+    write(encodedValue, "locale", US_LOCALE);
+    write(encodedValue, "timezone", timezone);
+    return encodedValue;
+  }
+
+}

--- a/src/test/java/api/support/fixtures/MaterialTypesFixture.java
+++ b/src/test/java/api/support/fixtures/MaterialTypesFixture.java
@@ -42,6 +42,17 @@ public class MaterialTypesFixture {
     return materialTypeRecordCreator.createIfAbsent(book);
   }
 
+  public IndividualResource any()
+    throws MalformedURLException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    final JsonObject book = materialType("Book");
+
+    return materialTypeRecordCreator.createIfAbsent(book);
+  }
+
   private JsonObject materialType(String name) {
     final JsonObject materialType = new JsonObject();
 

--- a/src/test/java/api/support/fixtures/MaterialTypesFixture.java
+++ b/src/test/java/api/support/fixtures/MaterialTypesFixture.java
@@ -42,17 +42,6 @@ public class MaterialTypesFixture {
     return materialTypeRecordCreator.createIfAbsent(book);
   }
 
-  public IndividualResource any()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
-    final JsonObject book = materialType("Book");
-
-    return materialTypeRecordCreator.createIfAbsent(book);
-  }
-
   private JsonObject materialType(String name) {
     final JsonObject materialType = new JsonObject();
 

--- a/src/test/java/api/support/fixtures/PatronGroupExamples.java
+++ b/src/test/java/api/support/fixtures/PatronGroupExamples.java
@@ -10,12 +10,16 @@ class PatronGroupExamples {
   static PatronGroupBuilder alternative() {
     return new PatronGroupBuilder("Alternative Group", "Alternative group");
   }
-  
+
   static PatronGroupBuilder staff() {
     return new PatronGroupBuilder("staff", "Staff users");
   }
-  
+
   static PatronGroupBuilder faculty() {
     return new PatronGroupBuilder("faculty", "Faculty users");
-  }  
+  }
+
+  static PatronGroupBuilder undergrad(){
+    return new PatronGroupBuilder("undergrad", "Undergraduate users");
+  }
 }

--- a/src/test/java/api/support/fixtures/PatronGroupsFixture.java
+++ b/src/test/java/api/support/fixtures/PatronGroupsFixture.java
@@ -61,4 +61,13 @@ public class PatronGroupsFixture {
 
     return patronGroupRecordCreator.createIfAbsent(PatronGroupExamples.faculty());
   }
+
+  public IndividualResource undergrad()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    return patronGroupRecordCreator.createIfAbsent(PatronGroupExamples.undergrad());
+  }
 }

--- a/src/test/java/api/support/fixtures/RecordCreator.java
+++ b/src/test/java/api/support/fixtures/RecordCreator.java
@@ -110,6 +110,10 @@ class RecordCreator {
     removeFromIdentityMap(record);
   }
 
+  public IndividualResource getExistingRecord(String name){
+     return identityMap.get(name);
+  }
+
   private void removeFromIdentityMap(IndividualResource record) {
 
     //TODO: Find a better way of removing from the identity map

--- a/src/test/java/api/support/fixtures/RequestPoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/RequestPoliciesFixture.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.circulation.domain.RequestType;
+import org.folio.circulation.domain.policy.RequestPolicy;
 import org.folio.circulation.support.http.client.IndividualResource;
 
 import api.support.builders.RequestPolicyBuilder;
@@ -21,7 +22,7 @@ public class RequestPoliciesFixture {
       reason -> getProperty(reason, "name"));
   }
 
-  public IndividualResource noAllowedTypes()
+  public IndividualResource allowAllRequestPolicy()
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
@@ -31,10 +32,77 @@ public class RequestPoliciesFixture {
     types.add(RequestType.HOLD);
     types.add(RequestType.PAGE);
     types.add(RequestType.RECALL);
-    types.add(RequestType.NONE);
 
-    final RequestPolicyBuilder noAllowedTypesPolicy = new RequestPolicyBuilder(types);
+    final RequestPolicyBuilder allowAllPolicy = new RequestPolicyBuilder(types);
 
-    return requestPolicyRecordCreator.createIfAbsent(noAllowedTypesPolicy);
+    return requestPolicyRecordCreator.createIfAbsent(allowAllPolicy);
+  }
+
+  public IndividualResource customRequestPolicy(ArrayList<RequestType> types)
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final RequestPolicyBuilder customPolicy = new RequestPolicyBuilder(types);
+    return requestPolicyRecordCreator.createIfAbsent(customPolicy);
+  }
+
+  public IndividualResource customRequestPolicy(ArrayList<RequestType> types, String name, String description)
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final RequestPolicyBuilder customPolicy = new RequestPolicyBuilder(types, name, description);
+    return requestPolicyRecordCreator.createIfAbsent(customPolicy);
+  }
+
+  public IndividualResource recallRequestPolicy()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    ArrayList<RequestType> requestTypesList = new ArrayList<>();
+    requestTypesList.add(RequestType.RECALL);
+
+    return customRequestPolicy(requestTypesList, "Recall request policy", "sample recall policy");
+  }
+
+  public IndividualResource holdRequestPolicy()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    ArrayList<RequestType> requestTypesList = new ArrayList<>();
+    requestTypesList.add(RequestType.HOLD);
+
+    return customRequestPolicy(requestTypesList);
+  }
+
+  public IndividualResource pageRequestPolicy()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    ArrayList<RequestType> requestTypesList = new ArrayList<>();
+    requestTypesList.add(RequestType.PAGE);
+
+    return customRequestPolicy(requestTypesList);
+  }
+
+  public void deleteRequestPolicy(IndividualResource policyToDelete)
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+      requestPolicyRecordCreator.delete(policyToDelete);
+  }
+
+  public IndividualResource findRequestPolicy(String requestPolicyName) {
+    return requestPolicyRecordCreator.getExistingRecord(requestPolicyName);
   }
 }

--- a/src/test/java/api/support/fixtures/RequestPoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/RequestPoliciesFixture.java
@@ -8,7 +8,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.circulation.domain.RequestType;
-import org.folio.circulation.domain.policy.RequestPolicy;
 import org.folio.circulation.support.http.client.IndividualResource;
 
 import api.support.builders.RequestPolicyBuilder;

--- a/src/test/java/api/support/fixtures/RequestPoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/RequestPoliciesFixture.java
@@ -3,9 +3,11 @@ package api.support.fixtures;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 
 import java.net.MalformedURLException;
+import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import org.folio.circulation.domain.RequestType;
 import org.folio.circulation.support.http.client.IndividualResource;
 
 import api.support.builders.RequestPolicyBuilder;
@@ -25,7 +27,13 @@ public class RequestPoliciesFixture {
     TimeoutException,
     ExecutionException {
 
-    final RequestPolicyBuilder noAllowedTypesPolicy = new RequestPolicyBuilder();
+    ArrayList<RequestType> types = new ArrayList<>();
+    types.add(RequestType.HOLD);
+    types.add(RequestType.PAGE);
+    types.add(RequestType.RECALL);
+    types.add(RequestType.NONE);
+
+    final RequestPolicyBuilder noAllowedTypesPolicy = new RequestPolicyBuilder(types);
 
     return requestPolicyRecordCreator.createIfAbsent(noAllowedTypesPolicy);
   }

--- a/src/test/java/api/support/fixtures/RequestsFixture.java
+++ b/src/test/java/api/support/fixtures/RequestsFixture.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
 
 import api.support.RestAssuredClient;
@@ -38,6 +39,15 @@ public class RequestsFixture {
     ExecutionException {
 
     return requestsClient.create(requestToBuild);
+  }
+
+  public Response attemptPlace(RequestBuilder requestToBuild)
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    return requestsClient.attemptCreate(requestToBuild);
   }
 
   public IndividualResource placeHoldShelfRequest(
@@ -132,6 +142,27 @@ public class RequestsFixture {
       .withRequestDate(on)
       .withItemId(item.getId())
       .withRequesterId(by.getId()));
+  }
+
+  public Response attemptPlaceHoldShelfRequest(
+      IndividualResource item,
+      IndividualResource by,
+      DateTime on,
+      UUID pickupServicePointId,
+      String type)
+          throws InterruptedException,
+          MalformedURLException,
+          TimeoutException,
+          ExecutionException {
+
+    return attemptPlace(new RequestBuilder()
+        .hold()
+        .withRequestType(type)
+        .fulfilToHoldShelf()
+        .withItemId(item.getId())
+        .withRequestDate(on)
+        .withRequesterId(by.getId())
+        .withPickupServicePointId(pickupServicePointId));
   }
 
   public void cancelRequest(IndividualResource request)

--- a/src/test/java/api/support/fixtures/ServicePointsFixture.java
+++ b/src/test/java/api/support/fixtures/ServicePointsFixture.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.folio.circulation.support.http.client.IndividualResource;
 
+import api.support.builders.ServicePointBuilder;
 import api.support.http.ResourceClient;
 
 public class ServicePointsFixture {
@@ -39,7 +40,7 @@ public class ServicePointsFixture {
       TimeoutException,
       ExecutionException {
 
-    return servicePointRecordCreator.createIfAbsent(basedUponCircDesk1());
+    return create(basedUponCircDesk1());
   }
   
   public IndividualResource cd2()
@@ -48,7 +49,7 @@ public class ServicePointsFixture {
       TimeoutException,
       ExecutionException {
 
-    return servicePointRecordCreator.createIfAbsent(basedUponCircDesk2());
+    return create(basedUponCircDesk2());
   } 
   
   public IndividualResource cd3()
@@ -57,7 +58,7 @@ public class ServicePointsFixture {
       TimeoutException,
       ExecutionException {
 
-    return servicePointRecordCreator.createIfAbsent(basedUponCircDesk3());
+    return create(basedUponCircDesk3());
   }
 
   public IndividualResource cd4()
@@ -66,7 +67,7 @@ public class ServicePointsFixture {
       TimeoutException,
       ExecutionException {
 
-    return servicePointRecordCreator.createIfAbsent(basedUponCircDesk4());
+    return create(basedUponCircDesk4());
   }
 
   public IndividualResource cd5()
@@ -75,7 +76,7 @@ public class ServicePointsFixture {
       TimeoutException,
       ExecutionException {
 
-    return servicePointRecordCreator.createIfAbsent(basedUponCircDesk5());
+    return create(basedUponCircDesk5());
   }
 
   public IndividualResource cd6()
@@ -84,6 +85,15 @@ public class ServicePointsFixture {
       TimeoutException,
       ExecutionException {
 
-    return servicePointRecordCreator.createIfAbsent(basedUponCircDesk6());
+    return create(basedUponCircDesk6());
+  }
+
+  public IndividualResource create(ServicePointBuilder builder)
+      throws InterruptedException,
+      MalformedURLException,
+      TimeoutException,
+      ExecutionException {
+
+    return servicePointRecordCreator.createIfAbsent(builder);
   }
 }

--- a/src/test/java/api/support/fixtures/UserExamples.java
+++ b/src/test/java/api/support/fixtures/UserExamples.java
@@ -33,4 +33,16 @@ public class UserExamples {
       .withName("Broadwell", "Charlotte")
       .withBarcode("6430705932");
   }
+
+  static UserBuilder basedUponBobbyBibbin() {
+    return new UserBuilder()
+      .withName("Bibbin", "Bobby")
+      .withBarcode("6630705935");
+  }
+
+  static UserBuilder basedUponHenryHanks() {
+    return new UserBuilder()
+      .withName("Hanks", "Henry")
+      .withBarcode("6430777932");
+  }
 }

--- a/src/test/java/api/support/fixtures/UsersFixture.java
+++ b/src/test/java/api/support/fixtures/UsersFixture.java
@@ -1,6 +1,8 @@
 package api.support.fixtures;
 
+import static api.support.fixtures.UserExamples.basedUponBobbyBibbin;
 import static api.support.fixtures.UserExamples.basedUponCharlotteBroadwell;
+import static api.support.fixtures.UserExamples.basedUponHenryHanks;
 import static api.support.fixtures.UserExamples.basedUponJamesRodwell;
 import static api.support.fixtures.UserExamples.basedUponJessicaPontefract;
 import static api.support.fixtures.UserExamples.basedUponRebeccaStuart;
@@ -69,7 +71,7 @@ public class UsersFixture {
 
     return rebecca(identity());
   }
-  
+
   public IndividualResource rebecca(
     Function<UserBuilder, UserBuilder> additionalProperties)
     throws InterruptedException,
@@ -122,6 +124,47 @@ public class UsersFixture {
     return userRecordCreator.createIfAbsent(
       additionalConfiguration.apply(basedUponCharlotteBroadwell()
         .inGroupFor(patronGroupsFixture.regular())));
+  }
+
+  public IndividualResource undergradHenry()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    return undergradHenry(identity());
+  }
+
+  public IndividualResource undergradHenry(
+    Function<UserBuilder, UserBuilder> additionalUserProperties)
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    return userRecordCreator.createIfAbsent(
+      additionalUserProperties.apply(basedUponHenryHanks()
+        .inGroupFor(patronGroupsFixture.undergrad())));
+  }
+
+  public IndividualResource noUserGroupBob()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    return noUserGroupBob(identity());
+  }
+
+  public IndividualResource noUserGroupBob(
+    Function<UserBuilder, UserBuilder> additionalUserProperties)
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    return userRecordCreator.createIfAbsent(
+      additionalUserProperties.apply(basedUponBobbyBibbin()));
   }
 
   public void remove(IndividualResource user)

--- a/src/test/java/api/support/http/InterfaceUrls.java
+++ b/src/test/java/api/support/http/InterfaceUrls.java
@@ -152,4 +152,8 @@ public class InterfaceUrls {
   static URL servicePointsStorageUrl(String subPath) {
     return APITestContext.viaOkapiModuleUrl("/service-points" + subPath);
   }
+
+  static URL configurationUrl(String subPath) {
+    return APITestContext.viaOkapiModuleUrl("/configurations/entries" + subPath);
+  }
 }

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -164,6 +164,11 @@ public class ResourceClient {
       "service points", "servicepoints");
   }
 
+  public static ResourceClient forConfiguration(OkapiHttpClient client) {
+    return new ResourceClient(client, InterfaceUrls::configurationUrl,
+      "configuration entries", "configs");
+  }
+
   private ResourceClient(
     OkapiHttpClient client,
     UrlMaker urlMaker,

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -229,7 +229,7 @@ public class ResourceClient {
     client.post(urlMaker.combine(""), request,
       ResponseHandler.json(createCompleted));
 
-    Response response = createCompleted.get(5, TimeUnit.SECONDS);
+    Response response = createCompleted.get(500, TimeUnit.SECONDS);
 
     assertThat(
       String.format("Failed to create %s: %s", resourceName,
@@ -275,7 +275,7 @@ public class ResourceClient {
 
     client.put(location, representation, ResponseHandler.any(createCompleted));
 
-    Response createResponse = createCompleted.get(5, TimeUnit.SECONDS);
+    Response createResponse = createCompleted.get(500, TimeUnit.SECONDS);
 
     assertThat(
       String.format("Failed to create %s %s: %s", resourceName, id, createResponse.getBody()),
@@ -448,7 +448,7 @@ public class ResourceClient {
     client.delete(urlMaker.combine(""),
       ResponseHandler.any(deleteAllFinished));
 
-    Response response = deleteAllFinished.get(5, TimeUnit.SECONDS);
+    Response response = deleteAllFinished.get(500, TimeUnit.SECONDS);
 
     assertThat(String.format(
       "Failed to delete %s: %s", resourceName, response.getBody()),

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -257,7 +257,7 @@ public class ResourceClient {
 
     client.put(location, representation, ResponseHandler.any(createCompleted));
 
-    return createCompleted.get(5, TimeUnit.SECONDS);
+    return createCompleted.get(500, TimeUnit.SECONDS);
   }
 
   public IndividualResource createAtSpecificLocation(Builder builder)

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -229,7 +229,7 @@ public class ResourceClient {
     client.post(urlMaker.combine(""), request,
       ResponseHandler.json(createCompleted));
 
-    Response response = createCompleted.get(500, TimeUnit.SECONDS);
+    Response response = createCompleted.get(5, TimeUnit.SECONDS);
 
     assertThat(
       String.format("Failed to create %s: %s", resourceName,
@@ -257,7 +257,7 @@ public class ResourceClient {
 
     client.put(location, representation, ResponseHandler.any(createCompleted));
 
-    return createCompleted.get(500, TimeUnit.SECONDS);
+    return createCompleted.get(5, TimeUnit.SECONDS);
   }
 
   public IndividualResource createAtSpecificLocation(Builder builder)
@@ -275,7 +275,7 @@ public class ResourceClient {
 
     client.put(location, representation, ResponseHandler.any(createCompleted));
 
-    Response createResponse = createCompleted.get(500, TimeUnit.SECONDS);
+    Response createResponse = createCompleted.get(5, TimeUnit.SECONDS);
 
     assertThat(
       String.format("Failed to create %s %s: %s", resourceName, id, createResponse.getBody()),
@@ -448,7 +448,7 @@ public class ResourceClient {
     client.delete(urlMaker.combine(""),
       ResponseHandler.any(deleteAllFinished));
 
-    Response response = deleteAllFinished.get(500, TimeUnit.SECONDS);
+    Response response = deleteAllFinished.get(5, TimeUnit.SECONDS);
 
     assertThat(String.format(
       "Failed to delete %s: %s", resourceName, response.getBody()),

--- a/src/test/java/org/folio/circulation/domain/ConfigurationServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/ConfigurationServiceTest.java
@@ -1,0 +1,76 @@
+package org.folio.circulation.domain;
+
+import static org.folio.circulation.support.JsonPropertyWriter.write;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+
+import api.support.builders.ConfigRecordBuilder;
+import api.support.builders.ConfigurationBuilder;
+import io.vertx.core.json.JsonObject;
+import org.joda.time.DateTimeZone;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ConfigurationServiceTest {
+
+  private static final String US_LOCALE = "en-US";
+
+  private static ConfigurationService service;
+
+  @BeforeClass
+  public static void before() {
+    service = new ConfigurationService();
+  }
+
+  @Test
+  public void testUtcTimeZone() {
+    String timeZoneValue = getTimezoneValue("UTC");
+    JsonObject jsonObject = getJsonObject(timeZoneValue);
+
+    assertEquals(DateTimeZone.UTC, service.findDateTimeZone(jsonObject));
+  }
+
+  @Test
+  public void testEuropeTimeZone() {
+    String zone = "Europe/Kiev";
+    String timeZoneValue = getTimezoneValue(zone);
+    JsonObject jsonObject = getJsonObject(timeZoneValue);
+
+    assertEquals(DateTimeZone.forID(zone), service.findDateTimeZone(jsonObject));
+  }
+
+  @Test
+  public void testEmptyTimeZoneValue() {
+    String timeZoneValue = getTimezoneValue("");
+    JsonObject jsonObject = getJsonObject(timeZoneValue);
+
+    assertEquals(DateTimeZone.UTC, service.findDateTimeZone(jsonObject));
+  }
+
+  @Test
+  public void testEmptyJsonValue() {
+    JsonObject jsonObject = getJsonObject("");
+
+    assertEquals(DateTimeZone.UTC, service.findDateTimeZone(jsonObject));
+  }
+
+  @Test
+  public void testEmptyJson() {
+    JsonObject jsonObject = new JsonObject();
+
+    assertEquals(DateTimeZone.UTC, service.findDateTimeZone(jsonObject));
+  }
+
+  private JsonObject getJsonObject(String timeZoneValue) {
+    ConfigRecordBuilder config = new ConfigRecordBuilder(timeZoneValue);
+    return new ConfigurationBuilder(Collections.singletonList(config)).create();
+  }
+
+  private String getTimezoneValue(String timezone) {
+    final JsonObject encodedValue = new JsonObject();
+    write(encodedValue, "locale", US_LOCALE);
+    write(encodedValue, "timezone", timezone);
+    return encodedValue.toString();
+  }
+}


### PR DESCRIPTION
- Added RequestPolicyRepository, RequestPolicy, and modified CreatRequestService to handle the logic of looking up the request policy ID and the request policy.  
- Added validation logic for requester not being NULL and requester's patron group not being NULL.
- Added tests for this implementation in scenario/RequestPolicyTests.java. Had to modify the following classes in order to create tests for the scenarios enumerated in[UIREQ-211]( https://issues.folio.org/browse/UIREQ-211):
  - MaterialTypesFixture.java
  - PatronGroupExamples.java
  - PatronGroupsFixture.java
  - RecordCreator.java
  - UserExamples.java
  - UsersFixture.java

Because I had to rename requestPolicyFixture.noAllowedTypes() to allowAllRequestPolicy() for it to make sense after these changes, this created changes in a lot of files. This PR's file count may look daunting, but it's partly because of this change.  Files affected:
- CheckOutByBarcodeFixedDueDateScenariosTest.java
- CheckOutByBarcodeTests.java
- CheckOutCalculateDueDateShortTermTests.java
- CheckOutCalculateDueDateTests.java
- CheckOutCalculateOffsetTimeTests.java
- OverrideRenewByBarcodeTests.java

