### PR TITLE
CIRC-250: remove unnecessary heavy count(*) query on whole item/holding/instance tables

### DIFF
--- a/src/main/java/org/folio/circulation/domain/PatronGroupRepository.java
+++ b/src/main/java/org/folio/circulation/domain/PatronGroupRepository.java
@@ -1,5 +1,8 @@
 package org.folio.circulation.domain;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.support.HttpResult.succeeded;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -48,7 +51,7 @@ class PatronGroupRepository {
       .collect(Collectors.toList());
 
     if (groupsToFetch.isEmpty()) {
-      return CompletableFuture.completedFuture(HttpResult.succeeded(multipleRequests));
+      return completedFuture(succeeded(multipleRequests));
     }
 
     final String query = CqlHelper.multipleRecordsCqlQuery(groupsToFetch);

--- a/src/main/java/org/folio/circulation/domain/PatronGroupRepository.java
+++ b/src/main/java/org/folio/circulation/domain/PatronGroupRepository.java
@@ -47,6 +47,10 @@ class PatronGroupRepository {
       .distinct()
       .collect(Collectors.toList());
 
+    if (groupsToFetch.isEmpty()) {
+      return CompletableFuture.completedFuture(HttpResult.succeeded(multipleRequests));
+    }
+
     final String query = CqlHelper.multipleRecordsCqlQuery(groupsToFetch);
 
     return patronGroupsStorageClient.getMany(query, groupsToFetch.size(), 0)
@@ -54,7 +58,7 @@ class PatronGroupRepository {
       .thenApply(multiplePatronGroupsResult -> multiplePatronGroupsResult.next(
         patronGroups -> matchGroupsToUsers(multipleRequests, patronGroups)));
   }
-    
+
   private HttpResult<MultipleRecords<PatronGroup>> mapResponseToPatronGroups(Response response) {
     return MultipleRecords.from(response, PatronGroup::from, "usergroups");
   }

--- a/src/main/java/org/folio/circulation/domain/UserRepository.java
+++ b/src/main/java/org/folio/circulation/domain/UserRepository.java
@@ -79,7 +79,7 @@ public class UserRepository {
         .next(user -> user.map(HttpResult::succeeded).orElseGet(() -> failed(failure(
           "Could not find user with matching barcode", propertyName, barcode)))));
   }
-  
+
   CompletableFuture<HttpResult<MultipleRecords<Request>>> findUsersForRequests(
     MultipleRecords<Request> multipleRequests) {
 
@@ -90,6 +90,10 @@ public class UserRepository {
       .flatMap(Collection::stream)
       .distinct()
       .collect(Collectors.toList());
+
+    if (usersToFetch.isEmpty()) {
+      return CompletableFuture.completedFuture(HttpResult.succeeded(multipleRequests));
+    }
 
     final String query = CqlHelper.multipleRecordsCqlQuery(usersToFetch);
 

--- a/src/main/java/org/folio/circulation/domain/UserRepository.java
+++ b/src/main/java/org/folio/circulation/domain/UserRepository.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.failure;
@@ -57,7 +58,7 @@ public class UserRepository {
   public CompletableFuture<HttpResult<User>> getProxyUserByBarcode(String barcode) {
     //Not proxying, so no need to get proxy user
     if(StringUtils.isBlank(barcode)) {
-      return CompletableFuture.completedFuture(succeeded(null));
+      return completedFuture(succeeded(null));
     }
     else {
       return getUserByBarcode(barcode, "proxyUserBarcode");
@@ -92,7 +93,7 @@ public class UserRepository {
       .collect(Collectors.toList());
 
     if (usersToFetch.isEmpty()) {
-      return CompletableFuture.completedFuture(HttpResult.succeeded(multipleRequests));
+      return completedFuture(succeeded(multipleRequests));
     }
 
     final String query = CqlHelper.multipleRecordsCqlQuery(usersToFetch);

--- a/src/main/java/org/folio/circulation/support/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/support/ItemRepository.java
@@ -245,7 +245,7 @@ public class ItemRepository {
     HttpResult<MultipleRecords<T>> result,
     BiFunction<T, Item, T> includeItemMap) {
 
-    if (result.value().getRecords().isEmpty()) {
+    if (result.failed() || result.value().getRecords().isEmpty()) {
       return CompletableFuture.completedFuture(result);
     }
 

--- a/src/main/java/org/folio/circulation/support/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/support/ItemRepository.java
@@ -245,6 +245,10 @@ public class ItemRepository {
     HttpResult<MultipleRecords<T>> result,
     BiFunction<T, Item, T> includeItemMap) {
 
+    if (result.value().getRecords().isEmpty()) {
+      return CompletableFuture.completedFuture(result);
+    }
+
     return result.combineAfter(r -> fetchFor(getItemIds(r)),
       (records, items) -> new MultipleRecords<>(
         matchItemToRecord(records, items, includeItemMap),


### PR DESCRIPTION
When there are no "Request" records for an Item, currently the code triggered a count(*) query with limit=0&offset=0 on whole item, holding-records, and instance table. Since those tables are quite large in performance testing environment, those unnecessary queries deteriorates the checkin/out related response time a lot. With this fix, the response time can be reduced about 2-3 times. While working on this, I also made similar fixes to eliminate the unnecessary count(*) query on whole users and groups table.