### PR TITLE
Check for Item Not Found when creating a request

### DIFF
--- a/src/main/java/org/folio/circulation/domain/CreateRequestService.java
+++ b/src/main/java/org/folio/circulation/domain/CreateRequestService.java
@@ -35,9 +35,9 @@ public class CreateRequestService {
   public CompletableFuture<HttpResult<RequestAndRelatedRecords>> createRequest(
     RequestAndRelatedRecords requestAndRelatedRecords) {
 
-    return completedFuture(refuseWhenItemIsNotValid(requestAndRelatedRecords)
-      .next(CreateRequestService::refuseWhenItemDoesNotExist)
-      .next(CreateRequestService::refuseWhenInvalidUserAndPatronGroup))
+    return completedFuture(refuseWhenItemDoesNotExist(requestAndRelatedRecords)
+      .next(CreateRequestService::refuseWhenInvalidUserAndPatronGroup)
+      .next(CreateRequestService::refuseWhenItemIsNotValid))
       .thenComposeAsync( r-> r.after(requestPolicyRepository::lookupRequestPolicy))
       .thenApply( r -> r.next(CreateRequestService::refuseWhenRequestCannotBeFulfilled))
       .thenApply(r -> r.map(CreateRequestService::setRequestQueuePosition))

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -258,13 +258,37 @@ public class RequestsAPICreationTests extends APITests {
     MalformedURLException {
 
     UUID itemId = UUID.randomUUID();
+    UUID patronId = usersFixture.charlotte().getId();
 
+    //Check RECALL
     Response postResponse = requestsClient.attemptCreate(new RequestBuilder()
       .recall()
       .withItemId(itemId)
-      .withRequesterId(usersFixture.charlotte().getId()));
+      .withRequesterId(patronId));
 
     assertThat(postResponse, hasStatus(HTTP_VALIDATION_ERROR));
+    assertThat(postResponse.getJson(), hasErrorWith(allOf(
+      hasMessage("Item does not exist"))));
+
+    //check HOLD
+    postResponse = requestsClient.attemptCreate(new RequestBuilder()
+      .hold()
+      .withItemId(itemId)
+      .withRequesterId(patronId));
+
+    assertThat(postResponse, hasStatus(HTTP_VALIDATION_ERROR));
+    assertThat(postResponse.getJson(), hasErrorWith(allOf(
+      hasMessage("Item does not exist"))));
+
+    //check PAGE
+    postResponse = requestsClient.attemptCreate(new RequestBuilder()
+      .page()
+      .withItemId(itemId)
+      .withRequesterId(patronId));
+
+    assertThat(postResponse, hasStatus(HTTP_VALIDATION_ERROR));
+    assertThat(postResponse.getJson(), hasErrorWith(allOf(
+      hasMessage("Item does not exist"))));
   }
 
   @Test

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -260,29 +260,9 @@ public class RequestsAPICreationTests extends APITests {
     UUID itemId = UUID.randomUUID();
     UUID patronId = usersFixture.charlotte().getId();
 
-    //Check RECALL
+    //Check RECALL -- should give the same response when placing other types of request.
     Response postResponse = requestsClient.attemptCreate(new RequestBuilder()
       .recall()
-      .withItemId(itemId)
-      .withRequesterId(patronId));
-
-    assertThat(postResponse, hasStatus(HTTP_VALIDATION_ERROR));
-    assertThat(postResponse.getJson(), hasErrorWith(allOf(
-      hasMessage("Item does not exist"))));
-
-    //check HOLD
-    postResponse = requestsClient.attemptCreate(new RequestBuilder()
-      .hold()
-      .withItemId(itemId)
-      .withRequesterId(patronId));
-
-    assertThat(postResponse, hasStatus(HTTP_VALIDATION_ERROR));
-    assertThat(postResponse.getJson(), hasErrorWith(allOf(
-      hasMessage("Item does not exist"))));
-
-    //check PAGE
-    postResponse = requestsClient.attemptCreate(new RequestBuilder()
-      .page()
       .withItemId(itemId)
       .withRequesterId(patronId));
 


### PR DESCRIPTION
After recent changes when sending in an invalid itemID mod-circulation is not returning the message "Item is NONE" anymore, but it's still good to reorganize the validation steps to make them more logical and catch errors earlier.  Therefore, I reordered the validation steps as follows:
1. Check for item's existence
2. Check that the patron and patron group are valid
3. Check the item's status and request type against the white list