### PR TITLE
[CIRC-251, CIRC-249] Remove action comment on renewal and check-in & Adding new renewal override case when item is not loanable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>15.1.0-SNAPSHOT</version>
+  <version>16.0.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -1,18 +1,7 @@
 package org.folio.circulation.domain;
 
-import io.vertx.core.json.JsonObject;
-import org.apache.commons.lang3.StringUtils;
-import org.folio.circulation.domain.representations.LoanProperties;
-import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ServerErrorFailure;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-
-import java.util.Objects;
-import java.util.UUID;
-
-import static org.folio.circulation.domain.representations.LoanProperties.CHECKIN_SERVICE_POINT_ID;
 import static org.folio.circulation.domain.representations.LoanProperties.ACTION_COMMENT;
+import static org.folio.circulation.domain.representations.LoanProperties.CHECKIN_SERVICE_POINT_ID;
 import static org.folio.circulation.domain.representations.LoanProperties.DUE_DATE;
 import static org.folio.circulation.domain.representations.LoanProperties.RETURN_DATE;
 import static org.folio.circulation.domain.representations.LoanProperties.STATUS;
@@ -25,6 +14,18 @@ import static org.folio.circulation.support.JsonPropertyFetcher.getNestedStringP
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.JsonPropertyWriter.write;
 import static org.folio.circulation.support.ValidationErrorFailure.failure;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+import org.folio.circulation.domain.representations.LoanProperties;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import io.vertx.core.json.JsonObject;
 
 public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   private final JsonObject representation;
@@ -234,6 +235,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   public Loan renew(DateTime dueDate, String basedUponLoanPolicyId) {
     changeAction("renewed");
+    changeActionComment(null);
     changeLoanPolicy(basedUponLoanPolicyId);
     changeDueDate(dueDate);
     incrementRenewalCount();
@@ -255,6 +257,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   Loan checkIn(DateTime returnDate, UUID servicePointId) {
     changeAction("checkedin");
+    changeActionComment(null);
     changeStatus("Closed");
     changeReturnDate(returnDate);
     changeSystemReturnDate(DateTime.now(DateTimeZone.UTC));

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -119,6 +119,11 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   private void changeActionComment(String comment) {
     representation.put(ACTION_COMMENT, comment);
   }
+
+  private void removeActionComment() {
+    representation.remove(ACTION_COMMENT);
+  }
+
   public HttpResult<Void> isValidStatus() {
     if (!representation.containsKey(STATUS)) {
       return failed(new ServerErrorFailure("Loan does not have a status"));
@@ -235,7 +240,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   public Loan renew(DateTime dueDate, String basedUponLoanPolicyId) {
     changeAction("renewed");
-    changeActionComment(null);
+    removeActionComment();
     changeLoanPolicy(basedUponLoanPolicyId);
     changeDueDate(dueDate);
     incrementRenewalCount();
@@ -257,7 +262,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   Loan checkIn(DateTime returnDate, UUID servicePointId) {
     changeAction("checkedin");
-    changeActionComment(null);
+    removeActionComment();
     changeStatus("Closed");
     changeReturnDate(returnDate);
     changeSystemReturnDate(DateTime.now(DateTimeZone.UTC));

--- a/src/main/java/org/folio/circulation/domain/validation/ItemIsNotLoanableValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ItemIsNotLoanableValidator.java
@@ -1,12 +1,12 @@
 package org.folio.circulation.domain.validation;
 
-import org.folio.circulation.domain.LoanAndRelatedRecords;
-import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
+import static org.folio.circulation.support.HttpResult.succeeded;
 
 import java.util.function.Supplier;
 
-import static org.folio.circulation.support.HttpResult.succeeded;
+import org.folio.circulation.domain.LoanAndRelatedRecords;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.ValidationErrorFailure;
 
 public class ItemIsNotLoanableValidator {
 
@@ -21,7 +21,7 @@ public class ItemIsNotLoanableValidator {
     HttpResult<LoanAndRelatedRecords> result) {
 
     return result.failWhen(
-      records -> succeeded(!records.getLoanPolicy().isLoanable()),
+      records -> succeeded(records.getLoanPolicy().isNotLoanable()),
       r -> itemIsNotLoanableFunction.get());
   }
 }

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -37,6 +37,7 @@ import io.vertx.core.json.JsonObject;
 public class OverrideRenewByBarcodeTests extends APITests {
   private static final String OVERRIDE_COMMENT = "Comment to override";
   private static final String ITEM_IS_NOT_LOANABLE_MESSAGE = "item is not loanable";
+  private static final String ACTION_COMMENT_KEY = "actionComment";
 
   @Test
   public void cannotOverrideRenewalWhenLoanPolicyDoesNotExist()
@@ -239,7 +240,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
       renewedLoan.getString("action"), is("Renewed through override"));
 
     assertThat("'actionComment' field should contain comment specified for override",
-      renewedLoan.getString("actionComment"), is(OVERRIDE_COMMENT));
+      renewedLoan.getString(ACTION_COMMENT_KEY), is(OVERRIDE_COMMENT));
 
     assertThat("renewal count should be incremented",
       renewedLoan.getInteger("renewalCount"), is(1));
@@ -355,7 +356,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
       renewedLoan.getString("action"), is("Renewed through override"));
 
     assertThat("'actionComment' field should contain comment specified for override",
-      renewedLoan.getString("actionComment"), is(OVERRIDE_COMMENT));
+      renewedLoan.getString(ACTION_COMMENT_KEY), is(OVERRIDE_COMMENT));
 
     assertThat("renewal count should be incremented",
       renewedLoan.getInteger("renewalCount"), is(1));
@@ -436,7 +437,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
       renewedLoan.getString("action"), is("Renewed through override"));
 
     assertThat("'actionComment' field should contain comment specified for override",
-      renewedLoan.getString("actionComment"), is(OVERRIDE_COMMENT));
+      renewedLoan.getString(ACTION_COMMENT_KEY), is(OVERRIDE_COMMENT));
 
     assertThat("renewal count should be incremented",
       renewedLoan.getInteger("renewalCount"), is(1));
@@ -496,7 +497,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
       renewedLoan.getString("action"), is("Renewed through override"));
 
     assertThat("'actionComment' field should contain comment specified for override",
-      renewedLoan.getString("actionComment"), is(OVERRIDE_COMMENT));
+      renewedLoan.getString(ACTION_COMMENT_KEY), is(OVERRIDE_COMMENT));
 
     assertThat("renewal count should be incremented",
       renewedLoan.getInteger("renewalCount"), is(2));
@@ -684,7 +685,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
     assertThat("action should be renewed",
       renewedLoan.getString("action"), is("Renewed through override"));
     assertThat("'actionComment' field should contain comment specified for override",
-      renewedLoan.getString("actionComment"), is(OVERRIDE_COMMENT));
+      renewedLoan.getString(ACTION_COMMENT_KEY), is(OVERRIDE_COMMENT));
     assertThat("due date should be 2 weeks from now",
       renewedLoan.getString("dueDate"),
       isEquivalentTo(newDueDate));
@@ -718,10 +719,10 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
   private void assertLoanHasActionComment(JsonObject loan, String actionComment) {
     assertThat("loan should have 'actionComment' property",
-      loan.getString("actionComment"), is(actionComment));
+      loan.getString(ACTION_COMMENT_KEY), is(actionComment));
   }
   private void assertActionCommentIsAbsentInLoan(JsonObject loan) {
     assertThat("'actionComment' property should be absent in loan",
-      loan.getString("actionComment"), nullValue());
+      loan.getString(ACTION_COMMENT_KEY), nullValue());
   }
 }


### PR DESCRIPTION
## Purpose
Resolves: CIRC-251, CIRC-249
Fix bug for cases when action comment in loan record stays unchanged after renew or check-in
Block renewal for items that are not loanable
Add new renewal override case for items that are not loanable
## Links
https://issues.folio.org/browse/CIRC-251
https://issues.folio.org/browse/CIRC-249