### PR TITLE
CIRC-243 Require pickup service point for hold shelf requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>15.1.0-SNAPSHOT</version>
+  <version>16.0.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -147,7 +147,7 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
     return representation.getString("fulfilmentPreference");
   }
 
-  private RequestFulfilmentPreference getFulfilmentPreference() {
+  public RequestFulfilmentPreference getFulfilmentPreference() {
     return RequestFulfilmentPreference.from(getFulfilmentPreferenceName());
   }
 

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -5,6 +5,7 @@ import static org.folio.circulation.domain.ItemStatus.CHECKED_OUT;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.of;
 import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -47,6 +48,13 @@ public class UpdateItem {
       Request request = requestQueue.getHighestPriorityFulfillableRequest();
 
       String pickupServicePointIdString = request.getPickupServicePointId();
+      if (pickupServicePointIdString == null) {
+          return failedResult(
+              "Failed to check in item due to the highest priority " +
+              "request missing a pickup service point",
+              "pickupServicePointId", null);
+      }
+
       UUID pickUpServicePointId = UUID.fromString(pickupServicePointIdString);
       if (checkInServicePointId.equals(pickUpServicePointId)) {
         return succeeded(item.changeStatus(requestQueue.getHighestPriorityFulfillableRequest()

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -5,7 +5,6 @@ import static org.folio.circulation.domain.ItemStatus.CHECKED_OUT;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.of;
 import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -48,13 +47,6 @@ public class UpdateItem {
       Request request = requestQueue.getHighestPriorityFulfillableRequest();
 
       String pickupServicePointIdString = request.getPickupServicePointId();
-      if (pickupServicePointIdString == null) {
-        return failedResult(
-            "Failed to check in item due to the highest priority " +
-            "request missing a pickup service point",
-            "pickupServicePointId", null);
-      }
-
       UUID pickUpServicePointId = UUID.fromString(pickupServicePointIdString);
       if (checkInServicePointId.equals(pickUpServicePointId)) {
         return succeeded(item.changeStatus(requestQueue.getHighestPriorityFulfillableRequest()

--- a/src/main/java/org/folio/circulation/domain/validation/ServicePointPickupLocationValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ServicePointPickupLocationValidator.java
@@ -7,6 +7,7 @@ import java.lang.invoke.MethodHandles;
 
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestAndRelatedRecords;
+import org.folio.circulation.domain.RequestFulfilmentPreference;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.slf4j.Logger;
@@ -14,7 +15,7 @@ import org.slf4j.LoggerFactory;
 
 public class ServicePointPickupLocationValidator {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  
+
   public HttpResult<RequestAndRelatedRecords> checkServicePointPickupLocation(
       HttpResult<RequestAndRelatedRecords> requestAndRelatedRecordsResult) {
 
@@ -37,8 +38,15 @@ public class ServicePointPickupLocationValidator {
     }
 
     if(request.getPickupServicePointId() == null) {
-      log.info("No pickup service point specified for request");
-      return succeeded(requestAndRelatedRecords);
+      if(request.getFulfilmentPreference() == RequestFulfilmentPreference.HOLD_SHELF) {
+        log.info("Hold Shelf Fulfilment Requests require a Pickup Service Point");
+        return failed(ValidationErrorFailure.failure(
+              "Hold Shelf Fulfilment Requests require a Pickup Service Point", "id",
+              request.getId()));
+      } else {
+        log.info("No pickup service point specified for request");
+        return succeeded(requestAndRelatedRecords);
+      }
     }
 
     if(request.getPickupServicePointId() != null && request.getPickupServicePoint() == null) {

--- a/src/main/java/org/folio/circulation/domain/validation/ServicePointPickupLocationValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ServicePointPickupLocationValidator.java
@@ -39,9 +39,9 @@ public class ServicePointPickupLocationValidator {
 
     if(request.getPickupServicePointId() == null) {
       if(request.getFulfilmentPreference() == RequestFulfilmentPreference.HOLD_SHELF) {
-        log.info("Hold Shelf Fulfilment Requests require a Pickup Service Point");
+        log.info("Hold Shelf Fulfillment Requests require a Pickup Service Point");
         return failed(ValidationErrorFailure.failure(
-              "Hold Shelf Fulfilment Requests require a Pickup Service Point", "id",
+              "Hold Shelf Fulfillment Requests require a Pickup Service Point", "id",
               request.getId()));
       } else {
         log.info("No pickup service point specified for request");

--- a/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
+++ b/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -26,10 +27,12 @@ public class CheckoutWithRequestScenarioTests extends APITests {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource charlotte = usersFixture.charlotte();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     requestsClient.create(new RequestBuilder()
       .page()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(charlotte));
 
     loansFixture.checkOutByBarcode(smallAngryPlanet, charlotte);

--- a/src/test/java/api/requests/RequestsAPICreateMultipleRequestsTests.java
+++ b/src/test/java/api/requests/RequestsAPICreateMultipleRequestsTests.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -25,22 +26,26 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
     MalformedURLException {
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOut(smallAngryPlanet, usersFixture.steve());
 
     final IndividualResource firstRequest = requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.jessica()));
 
     final IndividualResource secondRequest = requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.rebecca()));
 
     final IndividualResource thirdRequest = requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.charlotte()));
 
     assertThat(firstRequest.getJson().getInteger("position"), is(1));
@@ -56,22 +61,26 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
     MalformedURLException {
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOut(smallAngryPlanet, usersFixture.rebecca());
 
     final IndividualResource firstRequest = requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.james()));
 
     final IndividualResource secondRequest = requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.charlotte()));
 
     final IndividualResource thirdRequest = requestsClient.create(new RequestBuilder()
       .recall()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.steve()));
 
     assertThat(firstRequest.getJson().getInteger("position"), is(1));
@@ -87,17 +96,20 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
     MalformedURLException {
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOut(smallAngryPlanet, usersFixture.rebecca());
 
     final IndividualResource firstRequest = requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.james()));
 
     final IndividualResource secondRequest = requestsClient.create(new RequestBuilder()
       .recall()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.steve()));
 
     assertThat(firstRequest.getJson().getInteger("position"), is(1));
@@ -122,6 +134,7 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
     MalformedURLException {
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOut(smallAngryPlanet, usersFixture.steve());
 
@@ -130,6 +143,7 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
         .open()
         .hold()
         .forItem(smallAngryPlanet)
+        .withPickupServicePointId(pickupServicePointId)
         .by(usersFixture.jessica()));
 
     final IndividualResource secondRequest = requestsClient.createAtSpecificLocation(
@@ -137,6 +151,7 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
         .open()
         .hold()
         .forItem(smallAngryPlanet)
+        .withPickupServicePointId(pickupServicePointId)
         .by(usersFixture.rebecca()));
 
     final IndividualResource thirdRequest = requestsClient.createAtSpecificLocation(
@@ -144,6 +159,7 @@ public class RequestsAPICreateMultipleRequestsTests extends APITests {
         .open()
         .hold()
         .forItem(smallAngryPlanet)
+        .withPickupServicePointId(pickupServicePointId)
         .by(usersFixture.charlotte()));
 
     assertThat("First request should have position",

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -787,6 +787,37 @@ public class RequestsAPICreationTests extends APITests {
   }
 
   @Test
+  public void cannotCreateARequestWithoutAPickupLocationServicePoint()
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException,
+    MalformedURLException {
+
+    IndividualResource item = itemsFixture.basedUponSmallAngryPlanet();
+
+    loansFixture.checkOut(item, usersFixture.jessica());
+
+    IndividualResource requester = usersFixture.steve();
+
+    DateTime requestDate = new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC);
+
+    Response postResponse = requestsClient.attemptCreate(new RequestBuilder()
+      .open()
+      .recall()
+      .forItem(item)
+      .by(requester)
+      .withRequestDate(requestDate)
+      .fulfilToHoldShelf()
+      .withRequestExpiration(new LocalDate(2017, 7, 30))
+      .withHoldShelfExpiration(new LocalDate(2017, 8, 31)));
+
+    assertThat(postResponse, hasStatus(HTTP_VALIDATION_ERROR));
+
+    assertThat(postResponse.getJson(), hasErrorWith(allOf(
+      hasMessage("Hold Shelf Fulfilment Requests require a Pickup Service Point"))));
+  }
+
+  @Test
   public void cannotCreateARequestWithANonPickupLocationServicePoint()
     throws InterruptedException,
     ExecutionException,

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -166,6 +166,8 @@ public class RequestsAPICreationTests extends APITests {
 
     DateTime requestDate = new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC);
 
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+
     Response response = requestsClient.attemptCreateAtSpecificLocation(new RequestBuilder()
       .withId(id)
       .open()
@@ -176,6 +178,7 @@ public class RequestsAPICreationTests extends APITests {
       .fulfilToHoldShelf()
       .withRequestExpiration(new LocalDate(2017, 7, 30))
       .withHoldShelfExpiration(new LocalDate(2017, 8, 31))
+      .withPickupServicePointId(pickupServicePointId)
       .withTags(new RequestBuilder.Tags(asList("new", "important"))));
 
     assertThat(response.getStatusCode(), is(204));
@@ -313,6 +316,7 @@ public class RequestsAPICreationTests extends APITests {
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
     final IndividualResource rebecca = usersFixture.rebecca();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     UUID itemId = smallAngryPlanet.getId();
 
@@ -331,6 +335,7 @@ public class RequestsAPICreationTests extends APITests {
       .withRequestDate(requestDate)
       .forItem(smallAngryPlanet)
       .by(steve)
+      .withPickupServicePointId(pickupServicePointId)
       .fulfilToHoldShelf()
       .withRequestExpiration(new LocalDate(2017, 7, 30))
       .withHoldShelfExpiration(new LocalDate(2017, 8, 31)));
@@ -352,6 +357,7 @@ public class RequestsAPICreationTests extends APITests {
     final InventoryItemResource smallAngryPlanet =
       itemsFixture.basedUponSmallAngryPlanet(itemBuilder -> itemBuilder
         .withBarcode("036000291452"));
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     UUID itemId = smallAngryPlanet.getId();
 
@@ -363,6 +369,7 @@ public class RequestsAPICreationTests extends APITests {
       .recall().fulfilToHoldShelf()
       .withItemId(itemId)
       .withRequesterId(requesterId)
+      .withPickupServicePointId(pickupServicePointId)
       .withStatus(status));
 
     JsonObject representation = request.getJson();
@@ -503,12 +510,14 @@ public class RequestsAPICreationTests extends APITests {
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource rebecca = usersFixture.rebecca();
     final IndividualResource steve = usersFixture.steve();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOut(smallAngryPlanet, rebecca);
 
     IndividualResource createdRequest = requestsFixture.place(new RequestBuilder()
       .recall().fulfilToHoldShelf()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(steve)
       .withNoStatus());
 
@@ -526,6 +535,7 @@ public class RequestsAPICreationTests extends APITests {
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource jessica = usersFixture.jessica();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOut(smallAngryPlanet, jessica);
 
@@ -537,6 +547,7 @@ public class RequestsAPICreationTests extends APITests {
       .recall()
       .withRequestDate(requestDate)
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(nonExistentRequester));
 
     JsonObject representation = createdRequest.getJson();
@@ -554,6 +565,7 @@ public class RequestsAPICreationTests extends APITests {
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOut(smallAngryPlanet, steve);
 
@@ -565,6 +577,7 @@ public class RequestsAPICreationTests extends APITests {
       .recall()
       .withRequestDate(requestDate)
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(nonExistentRequesterId));
 
     JsonObject representation = createdRequest.getJson();
@@ -593,6 +606,7 @@ public class RequestsAPICreationTests extends APITests {
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource jessica = usersFixture.jessica();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     final IndividualResource steve = usersFixture.steve(
       b -> b.withName("Jones", "Steven", "Anthony"));
@@ -604,6 +618,7 @@ public class RequestsAPICreationTests extends APITests {
     IndividualResource createdRequest = requestsFixture.place(new RequestBuilder()
       .recall()
       .withRequestDate(requestDate)
+      .withPickupServicePointId(pickupServicePointId)
       .forItem(smallAngryPlanet)
       .by(steve));
 
@@ -638,6 +653,7 @@ public class RequestsAPICreationTests extends APITests {
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource james = usersFixture.james();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     final IndividualResource steveWithNoBarcode = usersFixture.steve(
       UserBuilder::withNoBarcode);
@@ -650,6 +666,7 @@ public class RequestsAPICreationTests extends APITests {
       .recall()
       .withRequestDate(requestDate)
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(steveWithNoBarcode));
 
     JsonObject representation = createdRequest.getJson();
@@ -682,12 +699,14 @@ public class RequestsAPICreationTests extends APITests {
 
     final IndividualResource rebecca = usersFixture.rebecca();
     final IndividualResource charlotte = usersFixture.charlotte();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOut(smallAngryPlanet, rebecca);
 
     IndividualResource createdRequest = requestsFixture.place(new RequestBuilder()
       .recall()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(charlotte));
 
     JsonObject representation = createdRequest.getJson();
@@ -716,6 +735,7 @@ public class RequestsAPICreationTests extends APITests {
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource rebecca = usersFixture.rebecca();
     final IndividualResource steve = usersFixture.steve();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     UUID itemId = smallAngryPlanet.getId();
 
@@ -727,6 +747,7 @@ public class RequestsAPICreationTests extends APITests {
       .recall()
       .withRequestDate(requestDate)
       .withItemId(itemId)
+      .withPickupServicePointId(pickupServicePointId)
       .by(steve)
       .create();
 

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -814,7 +814,7 @@ public class RequestsAPICreationTests extends APITests {
     assertThat(postResponse, hasStatus(HTTP_VALIDATION_ERROR));
 
     assertThat(postResponse.getJson(), hasErrorWith(allOf(
-      hasMessage("Hold Shelf Fulfilment Requests require a Pickup Service Point"))));
+      hasMessage("Hold Shelf Fulfillment Requests require a Pickup Service Point"))));
   }
 
   @Test

--- a/src/test/java/api/requests/RequestsAPIDeletionTests.java
+++ b/src/test/java/api/requests/RequestsAPIDeletionTests.java
@@ -39,6 +39,7 @@ public class RequestsAPIDeletionTests extends APITests {
     final InventoryItemResource nod = itemsFixture.basedUponNod();
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final InventoryItemResource temeraire = itemsFixture.basedUponTemeraire();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(nod);
     loansFixture.checkOutByBarcode(smallAngryPlanet);
@@ -46,16 +47,19 @@ public class RequestsAPIDeletionTests extends APITests {
 
     requestsClient.create(new RequestBuilder()
       .withItemId(nod.getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId))
       .getId();
 
     requestsClient.create(new RequestBuilder()
       .withItemId(smallAngryPlanet.getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId))
       .getId();
 
     requestsClient.create(new RequestBuilder()
       .withItemId(temeraire.getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId))
       .getId();
 
@@ -96,6 +100,7 @@ public class RequestsAPIDeletionTests extends APITests {
     final InventoryItemResource nod = itemsFixture.basedUponNod();
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final InventoryItemResource temeraire = itemsFixture.basedUponTemeraire();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(nod);
     loansFixture.checkOutByBarcode(smallAngryPlanet);
@@ -103,16 +108,19 @@ public class RequestsAPIDeletionTests extends APITests {
 
     final UUID firstRequestId = requestsClient.create(new RequestBuilder()
       .withItemId(nod.getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId))
       .getId();
 
     final UUID secondRequestId = requestsClient.create(new RequestBuilder()
       .withItemId(smallAngryPlanet.getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId))
       .getId();
 
     final UUID thirdRequestId = requestsClient.create(new RequestBuilder()
       .withItemId(temeraire.getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId))
       .getId();
 

--- a/src/test/java/api/requests/RequestsAPILoanHistoryTests.java
+++ b/src/test/java/api/requests/RequestsAPILoanHistoryTests.java
@@ -25,12 +25,14 @@ public class RequestsAPILoanHistoryTests extends APITests {
     MalformedURLException {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     UUID loanId = loansFixture.checkOutByBarcode(smallAngryPlanet).getId();
 
     requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(usersFixture.charlotte().getId()));
 
     JsonObject loanFromStorage = loansStorageClient.getById(loanId).getJson();
@@ -50,12 +52,14 @@ public class RequestsAPILoanHistoryTests extends APITests {
     MalformedURLException {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     UUID loanId = loansFixture.checkOutByBarcode(smallAngryPlanet).getId();
 
     requestsClient.create(new RequestBuilder()
       .recall()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(usersFixture.charlotte().getId()));
 
     JsonObject loanFromStorage = loansStorageClient.getById(loanId).getJson();
@@ -72,6 +76,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     MalformedURLException {
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     UUID closedLoanId = loansFixture.checkOutByBarcode(smallAngryPlanet).getId();
 
@@ -82,6 +87,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.charlotte()));
 
     JsonObject closedLoanFromStorage = loansStorageClient.getById(closedLoanId)
@@ -102,6 +108,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     MalformedURLException {
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     UUID closedLoanId = loansFixture.checkOutByBarcode(smallAngryPlanet).getId();
 
@@ -112,6 +119,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     requestsClient.create(new RequestBuilder()
       .recall()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.charlotte()));
 
     JsonObject closedLoanFromStorage = loansStorageClient.getById(closedLoanId)
@@ -133,6 +141,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final InventoryItemResource nod = itemsFixture.basedUponNod();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet);
 
@@ -141,6 +150,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.james()));
 
     JsonObject storageLoanForOtherItem = loansStorageClient
@@ -163,6 +173,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final InventoryItemResource nod = itemsFixture.basedUponNod();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet);
 
@@ -171,6 +182,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     requestsClient.create(new RequestBuilder()
       .recall()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.james()));
 
     JsonObject storageLoanForOtherItem = loansStorageClient
@@ -192,6 +204,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     MalformedURLException {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     UUID loanId = loansFixture.checkOutByBarcode(smallAngryPlanet).getId();
 
@@ -200,6 +213,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     requestsClient.create(new RequestBuilder()
       .hold()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.charlotte()));
   }
 
@@ -211,6 +225,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     MalformedURLException {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     UUID loanId = loansFixture.checkOutByBarcode(smallAngryPlanet).getId();
 
@@ -219,6 +234,7 @@ public class RequestsAPILoanHistoryTests extends APITests {
     requestsClient.create(new RequestBuilder()
       .recall()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.charlotte()));
   }
 }

--- a/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
+++ b/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -25,12 +26,14 @@ public class RequestsAPILoanRenewalTests extends APITests {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource rebecca = usersFixture.rebecca();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet, rebecca);
 
     requestsClient.create(new RequestBuilder()
       .recall()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.charlotte()));
 
     loansFixture.renewLoan(smallAngryPlanet, rebecca);
@@ -50,12 +53,14 @@ public class RequestsAPILoanRenewalTests extends APITests {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource rebecca = usersFixture.rebecca();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet, rebecca);
 
     requestsClient.create(new RequestBuilder()
       .recall()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.charlotte()));
 
     loansFixture.renewLoan(smallAngryPlanet, rebecca);

--- a/src/test/java/api/requests/RequestsAPILocationTests.java
+++ b/src/test/java/api/requests/RequestsAPILocationTests.java
@@ -6,6 +6,7 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -29,6 +30,7 @@ public class RequestsAPILocationTests extends APITests {
     final IndividualResource thirdFloor = locationsFixture.thirdFloor();
     final IndividualResource secondFloorEconomics = locationsFixture.secondFloorEconomics();
     final IndividualResource mezzanineDisplayCase = locationsFixture.mezzanineDisplayCase();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet(
       holdingBuilder -> holdingBuilder
@@ -46,6 +48,7 @@ public class RequestsAPILocationTests extends APITests {
     IndividualResource request = requestsFixture.place(new RequestBuilder()
       .open()
       .hold()
+      .withPickupServicePointId(pickupServicePointId)
       .forItem(smallAngryPlanet)
       .by(requester));
 
@@ -82,6 +85,7 @@ public class RequestsAPILocationTests extends APITests {
     final IndividualResource thirdFloor = locationsFixture.thirdFloor();
     final IndividualResource secondFloorEconomics = locationsFixture.secondFloorEconomics();
     final IndividualResource mezzanineDisplayCase = locationsFixture.mezzanineDisplayCase();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet(
       holdingBuilder -> holdingBuilder
@@ -94,6 +98,7 @@ public class RequestsAPILocationTests extends APITests {
     IndividualResource firstRequest = requestsFixture.place(new RequestBuilder()
       .open()
       .hold()
+      .withPickupServicePointId(pickupServicePointId)
       .forItem(smallAngryPlanet)
       .by(usersFixture.rebecca()));
 
@@ -110,6 +115,7 @@ public class RequestsAPILocationTests extends APITests {
     IndividualResource secondRequest = requestsFixture.place(new RequestBuilder()
       .open()
       .hold()
+      .withPickupServicePointId(pickupServicePointId)
       .forItem(temeraire)
       .by(usersFixture.steve()));
 

--- a/src/test/java/api/requests/RequestsAPIProxyTests.java
+++ b/src/test/java/api/requests/RequestsAPIProxyTests.java
@@ -8,6 +8,7 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +35,8 @@ public class RequestsAPIProxyTests extends APITests {
 
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
 
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+
     loansFixture.checkOutByBarcode(smallAngryPlanet, usersFixture.steve());
 
     IndividualResource sponsor = usersFixture.jessica();
@@ -43,6 +46,7 @@ public class RequestsAPIProxyTests extends APITests {
 
     JsonObject requestRequest = new RequestBuilder()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(sponsor)
       .proxiedBy(proxy)
       .create();
@@ -89,6 +93,8 @@ public class RequestsAPIProxyTests extends APITests {
 
     IndividualResource item = itemsFixture.basedUponSmallAngryPlanet();
 
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+
     loansFixture.checkOut(item, usersFixture.steve());
 
     IndividualResource sponsor = usersFixture.jessica();
@@ -98,6 +104,7 @@ public class RequestsAPIProxyTests extends APITests {
 
     JsonObject requestRequest = new RequestBuilder()
       .forItem(item)
+      .withPickupServicePointId(pickupServicePointId)
       .by(sponsor)
       .proxiedBy(proxy)
       .create();
@@ -156,7 +163,7 @@ public class RequestsAPIProxyTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
 
     final IndividualResource steve = usersFixture.steve();
-    
+
     loansFixture.checkOutByBarcode(smallAngryPlanet, steve);
 
     IndividualResource jessica = usersFixture.jessica();
@@ -221,6 +228,7 @@ public class RequestsAPIProxyTests extends APITests {
     MalformedURLException {
 
     final InventoryItemResource temeraire = itemsFixture.basedUponTemeraire();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(temeraire, usersFixture.steve());
 
@@ -230,6 +238,7 @@ public class RequestsAPIProxyTests extends APITests {
     IndividualResource createdRequest = requestsClient.create(
       new RequestBuilder()
         .recall()
+        .withPickupServicePointId(pickupServicePointId)
         .forItem(temeraire)
         .by(sponsor));
 
@@ -280,6 +289,7 @@ public class RequestsAPIProxyTests extends APITests {
     MalformedURLException {
 
     final InventoryItemResource temeraire = itemsFixture.basedUponTemeraire();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(temeraire, usersFixture.rebecca());
 
@@ -289,6 +299,7 @@ public class RequestsAPIProxyTests extends APITests {
     IndividualResource createdRequest = requestsClient.create(
       new RequestBuilder()
         .recall()
+        .withPickupServicePointId(pickupServicePointId)
         .forItem(temeraire)
         .by(sponsor));
 
@@ -316,6 +327,7 @@ public class RequestsAPIProxyTests extends APITests {
     MalformedURLException {
 
     final InventoryItemResource temeraire = itemsFixture.basedUponTemeraire();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(temeraire);
 
@@ -326,6 +338,7 @@ public class RequestsAPIProxyTests extends APITests {
     IndividualResource createdRequest = requestsClient.create(
       new RequestBuilder()
         .recall()
+        .withPickupServicePointId(pickupServicePointId)
         .forItem(temeraire)
         .by(otherUser));
 

--- a/src/test/java/api/requests/RequestsAPIRelatedRecordsTests.java
+++ b/src/test/java/api/requests/RequestsAPIRelatedRecordsTests.java
@@ -34,11 +34,13 @@ public class RequestsAPIRelatedRecordsTests extends APITests {
     MalformedURLException {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet);
 
     IndividualResource response = requestsClient.create(new RequestBuilder()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.charlotte()));
 
     JsonObject createdRequest = response.getJson();
@@ -90,6 +92,7 @@ public class RequestsAPIRelatedRecordsTests extends APITests {
     );
 
     final InventoryItemResource temeraire = itemsFixture.basedUponTemeraire();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet);
     loansFixture.checkOutByBarcode(temeraire);
@@ -98,11 +101,13 @@ public class RequestsAPIRelatedRecordsTests extends APITests {
 
     UUID firstRequestId = requestsClient.create(new RequestBuilder()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(charlotte))
       .getId();
 
     UUID secondRequestId = requestsClient.create(new RequestBuilder()
       .forItem(temeraire)
+      .withPickupServicePointId(pickupServicePointId)
       .by(charlotte))
       .getId();
 

--- a/src/test/java/api/requests/RequestsAPIRetrievalTests.java
+++ b/src/test/java/api/requests/RequestsAPIRetrievalTests.java
@@ -486,33 +486,41 @@ public class RequestsAPIRetrievalTests extends APITests {
     TimeoutException {
 
     UUID requesterId = usersFixture.charlotte().getId();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponSmallAngryPlanet(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponInterestingTimes(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponUprooted(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     CompletableFuture<Response> getFirstPageCompleted = new CompletableFuture<>();
@@ -559,33 +567,41 @@ public class RequestsAPIRetrievalTests extends APITests {
 
     UUID firstRequester = usersFixture.steve().getId();
     UUID secondRequester = usersFixture.jessica().getId();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponSmallAngryPlanet(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(firstRequester));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(firstRequester));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponInterestingTimes(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(secondRequester));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(firstRequester));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(firstRequester));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponUprooted(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(secondRequester));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(secondRequester));
 
     CompletableFuture<Response> getRequestsCompleted = new CompletableFuture<>();
@@ -619,32 +635,38 @@ public class RequestsAPIRetrievalTests extends APITests {
 
     final IndividualResource firstProxy = usersFixture.charlotte();
     final IndividualResource secondProxy = usersFixture.james();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     proxyRelationshipsFixture.currentProxyFor(sponsor, firstProxy);
     proxyRelationshipsFixture.currentProxyFor(sponsor, secondProxy);
 
     requestsClient.create(new RequestBuilder()
       .forItem(itemsFixture.basedUponSmallAngryPlanet(ItemBuilder::checkOut))
+      .withPickupServicePointId(pickupServicePointId)
       .by(sponsor)
       .proxiedBy(firstProxy));
 
     requestsClient.create(new RequestBuilder()
       .forItem(itemsFixture.basedUponNod(ItemBuilder::checkOut))
+      .withPickupServicePointId(pickupServicePointId)
       .by(sponsor)
       .proxiedBy(secondProxy));
 
     requestsClient.create(new RequestBuilder()
       .forItem(itemsFixture.basedUponNod(ItemBuilder::checkOut))
+      .withPickupServicePointId(pickupServicePointId)
       .by(sponsor)
       .proxiedBy(secondProxy));
 
     requestsClient.create(new RequestBuilder()
       .forItem(itemsFixture.basedUponUprooted(ItemBuilder::checkOut))
+      .withPickupServicePointId(pickupServicePointId)
       .by(sponsor)
       .proxiedBy(firstProxy));
 
     requestsClient.create(new RequestBuilder()
       .forItem(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut))
+      .withPickupServicePointId(pickupServicePointId)
       .by(sponsor)
       .proxiedBy(secondProxy));
 
@@ -676,33 +698,41 @@ public class RequestsAPIRetrievalTests extends APITests {
     TimeoutException {
 
     UUID requesterId = usersFixture.charlotte().getId();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponSmallAngryPlanet(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponInterestingTimes(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponNod(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponUprooted(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     requestsClient.create(new RequestBuilder()
       .withItemId(itemsFixture.basedUponTemeraire(ItemBuilder::checkOut).getId())
+      .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId));
 
     CompletableFuture<Response> getRequestsCompleted = new CompletableFuture<>();

--- a/src/test/java/api/requests/RequestsAPITitleTests.java
+++ b/src/test/java/api/requests/RequestsAPITitleTests.java
@@ -29,11 +29,13 @@ public class RequestsAPITitleTests extends APITests {
     MalformedURLException {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet);
 
     IndividualResource response = requestsClient.create(new RequestBuilder()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.james()));
 
     JsonObject createdRequest = response.getJson();
@@ -67,11 +69,13 @@ public class RequestsAPITitleTests extends APITests {
     MalformedURLException {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet);
 
     IndividualResource response = requestsClient.create(new RequestBuilder()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.steve()));
 
     JsonObject createdRequest = response.getJson();
@@ -106,11 +110,13 @@ public class RequestsAPITitleTests extends APITests {
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final InventoryItemResource temeraire = itemsFixture.basedUponTemeraire();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet);
 
     UUID firstRequestId = requestsClient.create(new RequestBuilder()
       .forItem(smallAngryPlanet)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.james()))
       .getId();
 
@@ -118,6 +124,7 @@ public class RequestsAPITitleTests extends APITests {
 
     UUID secondRequestId = requestsClient.create(new RequestBuilder()
       .forItem(temeraire)
+      .withPickupServicePointId(pickupServicePointId)
       .by(usersFixture.james()))
       .getId();
 

--- a/src/test/java/api/requests/RequestsAPIUpdatingTests.java
+++ b/src/test/java/api/requests/RequestsAPIUpdatingTests.java
@@ -197,12 +197,14 @@ public class RequestsAPIUpdatingTests extends APITests {
     ExecutionException {
 
     final InventoryItemResource nod = itemsFixture.basedUponNod();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(nod);
 
     IndividualResource createdRequest = requestsClient.create(
       new RequestBuilder()
         .recall()
+        .withPickupServicePointId(pickupServicePointId)
         .forItem(nod)
         .by(usersFixture.steve()));
 
@@ -233,6 +235,7 @@ public class RequestsAPIUpdatingTests extends APITests {
     ExecutionException {
 
     final InventoryItemResource nod = itemsFixture.basedUponNod();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(nod);
 
@@ -241,6 +244,7 @@ public class RequestsAPIUpdatingTests extends APITests {
     IndividualResource createdRequest = requestsClient.create(
       new RequestBuilder()
         .recall()
+        .withPickupServicePointId(pickupServicePointId)
         .forItem(nod)
         .by(requester));
 
@@ -266,6 +270,7 @@ public class RequestsAPIUpdatingTests extends APITests {
     ExecutionException {
 
     final InventoryItemResource nod = itemsFixture.basedUponNod();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(nod);
 
@@ -274,6 +279,7 @@ public class RequestsAPIUpdatingTests extends APITests {
     IndividualResource createdRequest = requestsClient.create(
       new RequestBuilder()
         .recall()
+        .withPickupServicePointId(pickupServicePointId)
         .forItem(nod)
         .by(steve));
 
@@ -319,10 +325,12 @@ public class RequestsAPIUpdatingTests extends APITests {
     loansFixture.checkOutByBarcode(nod);
 
     final IndividualResource steve = usersFixture.steve();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     IndividualResource createdRequest = requestsClient.create(
       new RequestBuilder()
         .recall()
+        .withPickupServicePointId(pickupServicePointId)
         .forItem(nod)
         .by(steve));
 
@@ -366,11 +374,13 @@ public class RequestsAPIUpdatingTests extends APITests {
     ExecutionException {
 
     final InventoryItemResource temeraire = itemsFixture.basedUponTemeraire();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     loansFixture.checkOutByBarcode(temeraire);
 
     IndividualResource createdRequest = requestsClient.create(new RequestBuilder()
       .recall()
+      .withPickupServicePointId(pickupServicePointId)
       .forItem(temeraire)
       .by(usersFixture.steve()));
 

--- a/src/test/java/api/requests/scenarios/RequestsForDifferentItemsTests.java
+++ b/src/test/java/api/requests/scenarios/RequestsForDifferentItemsTests.java
@@ -6,6 +6,7 @@ import org.folio.circulation.support.http.client.IndividualResource;
 import org.junit.Test;
 
 import java.net.MalformedURLException;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -22,6 +23,7 @@ public class RequestsForDifferentItemsTests extends APITests {
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource nod = itemsFixture.basedUponNod();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     final IndividualResource steve = usersFixture.steve();
 
@@ -31,6 +33,7 @@ public class RequestsForDifferentItemsTests extends APITests {
     final IndividualResource firstRequestForSmallAngryPlanet = requestsClient.create(
       new RequestBuilder()
       .hold()
+      .withPickupServicePointId(pickupServicePointId)
       .forItem(smallAngryPlanet)
       .by(usersFixture.jessica())
       .create());
@@ -38,6 +41,7 @@ public class RequestsForDifferentItemsTests extends APITests {
     final IndividualResource firstRequestForNod = requestsClient.create(
       new RequestBuilder()
       .hold()
+      .withPickupServicePointId(pickupServicePointId)
       .forItem(nod)
       .by(usersFixture.rebecca())
       .create());
@@ -45,6 +49,7 @@ public class RequestsForDifferentItemsTests extends APITests {
     final IndividualResource secondRequestForNod = requestsClient.create(
       new RequestBuilder()
         .hold()
+        .withPickupServicePointId(pickupServicePointId)
         .forItem(nod)
         .by(usersFixture.james())
         .create());
@@ -52,6 +57,7 @@ public class RequestsForDifferentItemsTests extends APITests {
     final IndividualResource secondRequestForSmallAngryPlannet = requestsClient.create(
       new RequestBuilder()
       .hold()
+      .withPickupServicePointId(pickupServicePointId)
       .forItem(smallAngryPlanet)
       .by(usersFixture.charlotte())
       .create());

--- a/src/test/java/api/requests/scenarios/SingleClosedRequestTests.java
+++ b/src/test/java/api/requests/scenarios/SingleClosedRequestTests.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -31,10 +32,13 @@ public class SingleClosedRequestTests extends APITests {
     IndividualResource james = usersFixture.james();
     IndividualResource jessica = usersFixture.jessica();
 
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+
     IndividualResource loanToJames = loansFixture.checkOut(smallAngryPlanet, james);
 
     IndividualResource requestByJessica = requestsClient.create(new RequestBuilder()
       .hold()
+      .withPickupServicePointId(pickupServicePointId)
       .fulfilToHoldShelf()
       .withRequestDate(new DateTime(2018, 1, 10, 15, 34, 21, DateTimeZone.UTC))
       .fulfilled() //TODO: Replace with closed cancelled when introduced
@@ -66,10 +70,13 @@ public class SingleClosedRequestTests extends APITests {
     IndividualResource jessica = usersFixture.jessica();
     IndividualResource steve = usersFixture.steve();
 
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+
     IndividualResource loanToJames = loansFixture.checkOut(smallAngryPlanet, james);
 
     IndividualResource requestByJessica = requestsClient.create(new RequestBuilder()
       .hold()
+      .withPickupServicePointId(pickupServicePointId)
       .fulfilToHoldShelf()
       .withRequestDate(new DateTime(2018, 1, 10, 15, 34, 21, DateTimeZone.UTC))
       .fulfilled() //TODO: Replace with closed cancelled when introduced

--- a/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
+++ b/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
@@ -200,7 +200,9 @@ public class SingleOpenHoldShelfRequestTests extends APITests {
         .forItem(smallAngryPlanet)
         .by(jessica)
         .withRequestDate(new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC))
-        .hold());
+        .hold()
+        .withFulfilmentPreference("Delivery")
+        .withPickupServicePointId(null));
 
     Response response = loansFixture.attemptCheckInByBarcode(new CheckInByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)

--- a/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
+++ b/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
@@ -24,8 +24,6 @@ import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import api.support.APITests;
-import api.support.builders.CheckInByBarcodeRequestBuilder;
-import api.support.builders.RequestBuilder;
 
 public class SingleOpenHoldShelfRequestTests extends APITests {
   @Test
@@ -182,32 +180,4 @@ public class SingleOpenHoldShelfRequestTests extends APITests {
     assertThat(smallAngryPlanet, hasItemStatus(CHECKED_OUT));
   }
 
-  @Test
-  public void itemCannotBeCheckedInWhenRequestIsMissingPickupServicePoint()
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
-
-    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
-    IndividualResource james = usersFixture.james();
-    IndividualResource jessica = usersFixture.jessica();
-    IndividualResource checkInServicePoint = servicePointsFixture.cd1();
-
-    loansFixture.checkOut(smallAngryPlanet, james);
-
-    requestsFixture.place(new RequestBuilder()
-        .forItem(smallAngryPlanet)
-        .by(jessica)
-        .withRequestDate(new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC))
-        .hold()
-        .withFulfilmentPreference("Delivery")
-        .withPickupServicePointId(null));
-
-    Response response = loansFixture.attemptCheckInByBarcode(new CheckInByBarcodeRequestBuilder()
-        .forItem(smallAngryPlanet)
-        .at(checkInServicePoint.getId()));
-
-    assertThat(response.getJson(), hasErrorWith(hasMessage("Failed to check in item due to the highest priority request missing a pickup service point")));
-  }
 }

--- a/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
+++ b/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
@@ -5,6 +5,7 @@ import static api.support.builders.ItemBuilder.AWAITING_PICKUP;
 import static api.support.builders.ItemBuilder.CHECKED_OUT;
 import static api.support.builders.RequestBuilder.CLOSED_FILLED;
 import static api.support.builders.RequestBuilder.OPEN_AWAITING_PICKUP;
+import static api.support.http.ResourceClient.forRequestsStorage;
 import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
@@ -14,6 +15,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -24,6 +26,10 @@ import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import api.support.APITests;
+import api.support.builders.CheckInByBarcodeRequestBuilder;
+import api.support.builders.RequestBuilder;
+import api.support.http.ResourceClient;
+import io.vertx.core.json.JsonObject;
 
 public class SingleOpenHoldShelfRequestTests extends APITests {
   @Test
@@ -180,4 +186,51 @@ public class SingleOpenHoldShelfRequestTests extends APITests {
     assertThat(smallAngryPlanet, hasItemStatus(CHECKED_OUT));
   }
 
+  @Test
+  public void itemCannotBeCheckedInWhenRequestIsMissingPickupServicePoint()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    IndividualResource james = usersFixture.james();
+    IndividualResource jessica = usersFixture.jessica();
+    IndividualResource checkInServicePoint = servicePointsFixture.cd1();
+
+    loansFixture.checkOut(smallAngryPlanet, james);
+
+    final IndividualResource holdRequest = requestsFixture.place(new RequestBuilder()
+      .hold()
+      .forItem(smallAngryPlanet)
+      .by(jessica)
+      .withRequestDate(new DateTime(2017, 7, 22, 10, 22, 54, DateTimeZone.UTC))
+      .withPickupServicePoint(servicePointsFixture.cd1()));
+
+    removeServicePoint(holdRequest.getId());
+
+    Response response = loansFixture.attemptCheckInByBarcode(new CheckInByBarcodeRequestBuilder()
+        .forItem(smallAngryPlanet)
+        .at(checkInServicePoint.getId()));
+
+    assertThat(response.getJson(), hasErrorWith(hasMessage(
+      "Failed to check in item due to the highest priority request missing a pickup service point")));
+  }
+
+  private void removeServicePoint(UUID requestId)
+    throws MalformedURLException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    final ResourceClient requestsStorage = forRequestsStorage(client);
+
+    final Response fetchedRequest = requestsStorage.getById(requestId);
+
+    final JsonObject holdRequestWithoutPickupServicePoint = fetchedRequest.getJson();
+
+    holdRequestWithoutPickupServicePoint.remove("pickupServicePointId");
+
+    requestsStorage.replace(requestId, holdRequestWithoutPickupServicePoint);
+  }
 }

--- a/src/test/java/api/support/builders/RequestBuilder.java
+++ b/src/test/java/api/support/builders/RequestBuilder.java
@@ -348,7 +348,7 @@ public class RequestBuilder extends JsonBuilder implements Builder {
       .withPickupServicePointId(newPickupServicePointId);
   }
 
-  private RequestBuilder withFulfilmentPreference(String fulfilmentPreference) {
+  public RequestBuilder withFulfilmentPreference(String fulfilmentPreference) {
     return new RequestBuilder(
       this.id,
       this.requestType,

--- a/src/test/java/api/support/builders/RequestBuilder.java
+++ b/src/test/java/api/support/builders/RequestBuilder.java
@@ -634,8 +634,11 @@ public class RequestBuilder extends JsonBuilder implements Builder {
       this.tags);
   }
 
-  public RequestBuilder withPickupServicePointId(UUID newPickupServicePointId) {
+  public RequestBuilder withPickupServicePoint(IndividualResource newPickupServicePoint) {
+    return withPickupServicePointId(newPickupServicePoint.getId());
+  }
 
+  public RequestBuilder withPickupServicePointId(UUID newPickupServicePointId) {
     return new RequestBuilder(
       this.id,
       this.requestType,

--- a/src/test/java/api/support/builders/RequestBuilder.java
+++ b/src/test/java/api/support/builders/RequestBuilder.java
@@ -348,7 +348,7 @@ public class RequestBuilder extends JsonBuilder implements Builder {
       .withPickupServicePointId(newPickupServicePointId);
   }
 
-  public RequestBuilder withFulfilmentPreference(String fulfilmentPreference) {
+  private RequestBuilder withFulfilmentPreference(String fulfilmentPreference) {
     return new RequestBuilder(
       this.id,
       this.requestType,

--- a/src/test/java/api/support/http/InterfaceUrls.java
+++ b/src/test/java/api/support/http/InterfaceUrls.java
@@ -56,6 +56,10 @@ public class InterfaceUrls {
     return APITestContext.viaOkapiModuleUrl("/loan-storage/loans" + subPath);
   }
 
+  static URL requestStorageUrl(String subPath) {
+    return APITestContext.viaOkapiModuleUrl("/request-storage/requests" + subPath);
+  }
+
   static URL loanPoliciesStorageUrl(String subPath) {
     return APITestContext.viaOkapiModuleUrl("/loan-policy-storage/loan-policies" + subPath);
   }
@@ -151,10 +155,6 @@ public class InterfaceUrls {
 
   static URL servicePointsStorageUrl(String subPath) {
     return APITestContext.viaOkapiModuleUrl("/service-points" + subPath);
-  }
-
-  static URL patronNoticesUrl() {
-    return proxyRelationshipsUrl("");
   }
 
   static URL patronNoticesUrl(String subPath) {

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -114,6 +114,11 @@ public class ResourceClient {
       "storage loans", "loans");
   }
 
+  public static ResourceClient forRequestsStorage(OkapiHttpClient client) {
+    return new ResourceClient(client, InterfaceUrls::requestStorageUrl,
+      "storage requests", "requests");
+  }
+
   public static ResourceClient forMaterialTypes(OkapiHttpClient client) {
     return new ResourceClient(client, InterfaceUrls::materialTypesStorageUrl,
       "material types", "mtypes");


### PR DESCRIPTION
This PR:

- Adds a validation requirement that requests to the hold shelf include a pickup service point.
- Updates tests to include a pickup service point where appropriate.
- Removes a check in UpdateItem that should no longer be possible and removed the corresponding test for the condition.
