### PR TITLE
Remove service point summary CIRC-237

### DIFF
--- a/src/main/java/org/folio/circulation/domain/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepository.java
@@ -171,14 +171,25 @@ public class LoanRepository {
   private static JsonObject mapToStorageRepresentation(Loan loan, Item item) {
     JsonObject storageLoan = loan.asJson();
 
-    storageLoan.remove("metadata");
-    storageLoan.remove("item");
-    storageLoan.remove("itemStatus");
-
-    //TODO: Check for null item status
-    storageLoan.put("itemStatus", item.getStatus().getValue());
+    removeChangeMetadata(storageLoan);
+    removeSummaryProperties(storageLoan);
+    keepLatestItemStatus(item, storageLoan);
 
     return storageLoan;
+  }
+
+  private static void keepLatestItemStatus(Item item, JsonObject storageLoan) {
+    //TODO: Check for null item status
+    storageLoan.remove("itemStatus");
+    storageLoan.put("itemStatus", item.getStatus().getValue());
+  }
+
+  private static void removeChangeMetadata(JsonObject storageLoan) {
+    storageLoan.remove("metadata");
+  }
+
+  private static void removeSummaryProperties(JsonObject storageLoan) {
+    storageLoan.remove("item");
   }
 
   public CompletableFuture<HttpResult<Boolean>> hasOpenLoan(String itemId) {

--- a/src/main/java/org/folio/circulation/domain/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepository.java
@@ -165,9 +165,7 @@ public class LoanRepository {
   private HttpResult<MultipleRecords<Loan>> mapResponseToLoans(Response response) {
     return MultipleRecords.from(response, Loan::from, "loans");
   }
-
-
-
+  
   private static JsonObject mapToStorageRepresentation(Loan loan, Item item) {
     JsonObject storageLoan = loan.asJson();
 
@@ -190,6 +188,8 @@ public class LoanRepository {
 
   private static void removeSummaryProperties(JsonObject storageLoan) {
     storageLoan.remove("item");
+    storageLoan.remove("checkinServicePoint");
+    storageLoan.remove("checkoutServicePoint");
   }
 
   public CompletableFuture<HttpResult<Boolean>> hasOpenLoan(String itemId) {

--- a/src/test/java/api/loans/scenarios/ChangeDueDateTests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateTests.java
@@ -1,0 +1,86 @@
+package api.loans.scenarios;
+
+import static api.support.http.InterfaceUrls.loansUrl;
+import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
+import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+import static org.folio.circulation.support.JsonPropertyWriter.write;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import java.net.MalformedURLException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.http.client.ResponseHandler;
+import org.joda.time.DateTime;
+import org.joda.time.Period;
+import org.junit.Test;
+
+import api.support.APITests;
+import api.support.http.InventoryItemResource;
+import io.vertx.core.json.JsonObject;
+
+public class ChangeDueDateTests extends APITests {
+
+  @Test
+  public void canRenewALoanByExtendingTheDueDate()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final InventoryItemResource item = itemsFixture.basedUponNod();
+
+    IndividualResource loan = loansFixture.checkOutByBarcode(item);
+
+    JsonObject loanToChange = loan.copyJson();
+
+    DateTime dueDate = DateTime.parse(loanToChange.getString("dueDate"));
+    DateTime newDueDate = dueDate.plus(Period.days(14));
+
+    write(loanToChange, "action", "dueDateChange");
+    write(loanToChange, "dueDate", newDueDate);
+
+    CompletableFuture<Response> putCompleted = new CompletableFuture<>();
+
+    client.put(loansUrl(String.format("/%s", loan.getId())), loanToChange,
+      ResponseHandler.any(putCompleted));
+
+    Response putResponse = putCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(String.format("Failed to update loan: %s",
+      putResponse.getBody()), putResponse.getStatusCode(), is(HTTP_NO_CONTENT));
+
+    Response updatedLoanResponse = loansClient.getById(loan.getId());
+
+    JsonObject updatedLoan = updatedLoanResponse.getJson();
+
+    assertThat("status is not open",
+      updatedLoan.getJsonObject("status").getString("name"), is("Open"));
+
+    assertThat("action is not change due date",
+      updatedLoan.getString("action"), is("dueDateChange"));
+
+    assertThat("should not contain a return date",
+      updatedLoan.containsKey("returnDate"), is(false));
+
+    assertThat("due date does not match",
+      updatedLoan.getString("dueDate"), isEquivalentTo(newDueDate));
+
+    assertThat("renewal count should not have changed",
+      updatedLoan.containsKey("renewalCount"), is(false));
+
+    JsonObject fetchedItem = itemsClient.getById(item.getId()).getJson();
+
+    assertThat("item status is not checked out",
+      fetchedItem.getJsonObject("status").getString("name"), is("Checked out"));
+
+    assertThat("item status snapshot in storage is not checked out",
+      loansStorageClient.getById(loan.getId()).getJson().getString("itemStatus"),
+      is("Checked out"));
+  }
+}

--- a/src/test/java/api/loans/scenarios/ChangeDueDateTests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateTests.java
@@ -18,7 +18,6 @@ import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.client.ResponseHandler;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import api.support.APITests;
@@ -28,7 +27,6 @@ import io.vertx.core.json.JsonObject;
 public class ChangeDueDateTests extends APITests {
 
   @Test
-  @Ignore("Fails due to summary properties being incorrectly stored")
   public void canRenewALoanByExtendingTheDueDate()
     throws InterruptedException,
     MalformedURLException,

--- a/src/test/java/api/support/builders/CheckOutByBarcodeRequestBuilder.java
+++ b/src/test/java/api/support/builders/CheckOutByBarcodeRequestBuilder.java
@@ -90,6 +90,10 @@ public class CheckOutByBarcodeRequestBuilder extends JsonBuilder implements Buil
       checkoutServicePointId);
   }
 
+  public CheckOutByBarcodeRequestBuilder at(IndividualResource checkoutServicePoint) {
+    return at(checkoutServicePoint.getId());
+  }
+
   public CheckOutByBarcodeRequestBuilder at(UUID checkoutServicePointId) {
     return new CheckOutByBarcodeRequestBuilder(
       this.itemBarcode,

--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -98,6 +98,7 @@ public class FakeOkapi extends AbstractVerticle {
       .withRecordName("loan")
       .withRootPath("/loan-storage/loans")
       .withRequiredProperties("itemId", "loanDate", "action")
+      .withDisallowedProperties("checkinServicePoint", "checkoutServicePoint")
       .withChangeMetadata()
       .create().register(router);
 

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -141,24 +141,32 @@ public class LoansFixture {
 
   public IndividualResource checkOutByBarcode(
     IndividualResource item,
-    IndividualResource to) {
+    IndividualResource to)
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
 
     return checkOutByBarcode(new CheckOutByBarcodeRequestBuilder()
       .forItem(item)
       .to(to)
-      .at(UUID.randomUUID()));
+      .at(defaultServicePoint()));
   }
 
   public IndividualResource checkOutByBarcode(
     IndividualResource item,
     IndividualResource to,
-    DateTime loanDate) {
+    DateTime loanDate)
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
 
     return checkOutByBarcode(new CheckOutByBarcodeRequestBuilder()
       .forItem(item)
       .to(to)
       .on(loanDate)
-      .at(UUID.randomUUID()));
+      .at(defaultServicePoint()));
   }
 
   public IndividualResource checkOutByBarcode(
@@ -337,7 +345,7 @@ public class LoansFixture {
     return checkInByBarcode(new CheckInByBarcodeRequestBuilder()
       .forItem(item)
       .on(DateTime.now(DateTimeZone.UTC))
-      .at(servicePointsFixture.cd1()));
+      .at(defaultServicePoint()));
   }
 
   public CheckInByBarcodeResponse checkInByBarcode(
@@ -349,5 +357,14 @@ public class LoansFixture {
       .forItem(item)
       .on(checkInDate)
       .at(servicePointId));
+  }
+
+  private IndividualResource defaultServicePoint()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    return servicePointsFixture.cd1();
   }
 }


### PR DESCRIPTION
*Context*

Investigation into [UIU-795](https://issues.folio.org/browse/UIU-795) revealed that this issue is caused by the check in and check out service point summary properties (provided to help the UI) are not removed before the loan is sent to storage.

*Approach*
* Demonstrate change due date behaviour in an API test
* Extend test to demonstrate this issue
* Extract methods for removing properties that should not be stored (to improve readability)
* Remove summary properties before storage
* Block summary properties in fake storage module

*Scope*
* Also includes using a known service point when checking out (it appears we don’t validate this at the moment)

*References*
[CIRC-237](https://issues.folio.org/browse/CIRC-237)
[UIU-795](https://issues.folio.org/browse/UIU-795)