### PR TITLE
CIRC-254 Adding async asserts for check-in/check-out patron notices tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,12 @@
       <version>3.0.7</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>3.1.6</version>
+      <scope>test</scope>
+    </dependency>
     <!-- Reinstate if we figure out a way to refer to schema that are compatible
     with other tools, see FOLIO-1213 -->
     <!--<dependency>-->

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -418,7 +418,7 @@ public class CheckInByBarcodeTests extends APITests {
       .pollDelay(1, TimeUnit.SECONDS)
       .untilAsserted(() -> {
         List<JsonObject> sentNotices = patronNoticesClient.getAll();
-        MatcherAssert.assertThat("Check-in notice shouldn't sent if item isn't checked-out",
+        MatcherAssert.assertThat("Check-in notice shouldn't be sent if item isn't checked-out",
           sentNotices, Matchers.empty());
       });
   }

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -414,7 +414,7 @@ public class CheckInByBarcodeTests extends APITests {
     assertThat("Response should not include a loan",
       checkInResponse.getJson().containsKey("loan"), is(false));
 
-    Thread.sleep(5000);
+    TimeUnit.SECONDS.sleep(1);
     List<JsonObject> sentNotices = patronNoticesClient.getAll();
     assertThat("Check-in notice shouldn't be sent if item isn't checked-out",
       sentNotices, Matchers.empty());

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -407,9 +407,6 @@ public class CheckInByBarcodeTests extends APITests {
     final IndividualResource nod = itemsFixture.basedUponNod(
       builder -> builder.withTemporaryLocation(homeLocation.getId()));
 
-    loansFixture.checkInByBarcode(
-      nod, new DateTime(2018, 3, 5, 14, 23, 41, DateTimeZone.UTC),
-      checkInServicePointId);
     final CheckInByBarcodeResponse checkInResponse = loansFixture.checkInByBarcode(
       nod, new DateTime(2018, 3, 5, 14, 23, 41, DateTimeZone.UTC),
       checkInServicePointId);
@@ -418,11 +415,11 @@ public class CheckInByBarcodeTests extends APITests {
       checkInResponse.getJson().containsKey("loan"), is(false));
 
     Awaitility.await()
-      .timeout(1, TimeUnit.SECONDS)
+      .pollDelay(1, TimeUnit.SECONDS)
       .untilAsserted(() -> {
         List<JsonObject> sentNotices = patronNoticesClient.getAll();
-        MatcherAssert.assertThat("Notice shouldn't be sent second time",
-          sentNotices.size(), Matchers.lessThan(2));
+        MatcherAssert.assertThat("Check-in notice shouldn't sent if item isn't checked-out",
+          sentNotices, Matchers.empty());
       });
   }
 }

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -414,12 +414,9 @@ public class CheckInByBarcodeTests extends APITests {
     assertThat("Response should not include a loan",
       checkInResponse.getJson().containsKey("loan"), is(false));
 
-    Awaitility.await()
-      .pollDelay(1, TimeUnit.SECONDS)
-      .untilAsserted(() -> {
-        List<JsonObject> sentNotices = patronNoticesClient.getAll();
-        MatcherAssert.assertThat("Check-in notice shouldn't be sent if item isn't checked-out",
-          sentNotices, Matchers.empty());
-      });
+    Thread.sleep(5000);
+    List<JsonObject> sentNotices = patronNoticesClient.getAll();
+    assertThat("Check-in notice shouldn't be sent if item isn't checked-out",
+      sentNotices, Matchers.empty());
   }
 }

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -358,7 +358,7 @@ public class CheckInByBarcodeTests extends APITests {
       loanRepresentation, notNullValue());
 
     Awaitility.await()
-      .atMost(5, TimeUnit.SECONDS)
+      .atMost(1, TimeUnit.SECONDS)
       .until(patronNoticesClient::getAll, Matchers.hasSize(1));
 
     List<JsonObject> sentNotices = patronNoticesClient.getAll();

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.awaitility.Awaitility;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
@@ -654,9 +655,11 @@ public class CheckOutByBarcodeTests extends APITests {
       loan.getString("dueDate"),
       isEquivalentTo(loanDate.plusWeeks(3)));
 
-    List<JsonObject> sentNotices = patronNoticesClient.getAll();
-    assertThat("one notice should have been sent", sentNotices, Matchers.hasSize(1));
+    Awaitility.await()
+      .atMost(5, TimeUnit.SECONDS)
+      .until(patronNoticesClient::getAll, Matchers.hasSize(1));
 
+    List<JsonObject> sentNotices = patronNoticesClient.getAll();
     JsonObject notice = sentNotices.get(0);
     assertThat("sent notice should have template id form notice policy",
       notice.getString("templateId"), is(checkOutTemplateId));

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -656,7 +656,7 @@ public class CheckOutByBarcodeTests extends APITests {
       isEquivalentTo(loanDate.plusWeeks(3)));
 
     Awaitility.await()
-      .atMost(5, TimeUnit.SECONDS)
+      .atMost(1, TimeUnit.SECONDS)
       .until(patronNoticesClient::getAll, Matchers.hasSize(1));
 
     List<JsonObject> sentNotices = patronNoticesClient.getAll();

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -221,6 +221,7 @@ public abstract class APITests {
     holdingsClient.deleteAll();
     instancesClient.deleteAll();
     configClient.deleteAll();
+    patronNoticesClient.deleteAll();
 
     //TODO: Only cleans up reference records, move items, holdings records
     // and instances into here too

--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -237,7 +237,6 @@ public class FakeOkapi extends AbstractVerticle {
       .withRecordName("patron notice")
       .withCollectionPropertyName("patronnotices")
       .withRootPath("/patron-notice")
-      .disallowCollectionDelete()
       .create()
       .register(router);
 


### PR DESCRIPTION
## Purpose
Resolves: CIRC-254
Fix patron notices tests that can fail due to the fact they are sent asynchronously 
## Approach
Use [Awaitility](https://github.com/awaitility/awaitility) library in tests to wait for async action to complete
## Links
https://issues.folio.org/browse/CIRC-254
https://github.com/awaitility/awaitility