### PR TITLE
Rename static validation error failure methods CIRC-263

### DIFF
--- a/src/main/java/org/folio/circulation/domain/CalendarRepository.java
+++ b/src/main/java/org/folio/circulation/domain/CalendarRepository.java
@@ -1,21 +1,21 @@
 package org.folio.circulation.domain;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
+import static org.folio.circulation.domain.OpeningDay.createClosedDay;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
 import org.folio.circulation.AdjacentOpeningDays;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FetchSingleRecord;
 import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.LocalDate;
 
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
-
-import static org.folio.circulation.domain.OpeningDay.createClosedDay;
-import static org.folio.circulation.support.HttpResult.failed;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 public class CalendarRepository {
 
@@ -34,11 +34,12 @@ public class CalendarRepository {
   public CompletableFuture<HttpResult<AdjacentOpeningDays>> lookupOpeningDays(LocalDate requestedDate, String servicePointId) {
     String path = String.format(PATH_PARAM_WITH_QUERY, servicePointId, requestedDate);
 
+    //TODO: Validation error should have parameters
     return FetchSingleRecord.<AdjacentOpeningDays>forRecord(RECORD_NAME)
       .using(calendarClient)
       .mapTo(this::createOpeningDays)
-      .whenNotFound(failed(new ValidationErrorFailure(
-        new ValidationError("Calendar open periods are not found", Collections.emptyMap()))))
+      .whenNotFound(failedValidation(
+        new ValidationError("Calendar open periods are not found", Collections.emptyMap())))
       .fetch(path);
   }
 

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -8,12 +8,13 @@ import static org.folio.circulation.domain.representations.LoanProperties.STATUS
 import static org.folio.circulation.domain.representations.LoanProperties.SYSTEM_RETURN_DATE;
 import static org.folio.circulation.domain.representations.LoanProperties.USER_ID;
 import static org.folio.circulation.support.HttpResult.failed;
+import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimeProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getIntegerProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.JsonPropertyWriter.write;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -132,27 +133,29 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     switch (getStatus()) {
     case "Open":
     case "Closed":
-      return HttpResult.succeeded(null);
+      return succeeded(null);
 
     default:
-      return failed(failure("Loan status must be \"Open\" or \"Closed\"", STATUS, getStatus()));
+      return failedValidation("Loan status must be \"Open\" or \"Closed\"",
+        STATUS, getStatus());
     }
   }
 
   public HttpResult<Void> openLoanHasUserId() {
     if (Objects.equals(getStatus(), "Open") && getUserId() == null) {
-      return failed(failure("Open loan must have a user ID", USER_ID, getUserId()));
+      return failedValidation("Open loan must have a user ID",
+        USER_ID, getUserId());
     } else {
-      return HttpResult.succeeded(null);
+      return succeeded(null);
     }
   }
 
   public HttpResult<Void> closedLoanHasCheckInServicePointId() {
     if (isClosed() && getCheckInServicePointId() == null) {
-      return failed(failure("A Closed loan must have a Checkin Service Point",
-          CHECKIN_SERVICE_POINT_ID, getCheckInServicePointId()));
+      return failedValidation("A Closed loan must have a Checkin Service Point",
+          CHECKIN_SERVICE_POINT_ID, getCheckInServicePointId());
     } else {
-      return HttpResult.succeeded(null);
+      return succeeded(null);
     }
   }
 

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -5,7 +5,7 @@ import static org.folio.circulation.domain.ItemStatus.CHECKED_OUT;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.of;
 import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -49,8 +49,8 @@ public class UpdateItem {
 
       String pickupServicePointIdString = request.getPickupServicePointId();
       if (pickupServicePointIdString == null) {
-          return failedResult(
-              "Failed to check in item due to the highest priority " +
+          return failedValidation(
+            "Failed to check in item due to the highest priority " +
               "request missing a pickup service point",
               "pickupServicePointId", null);
       }

--- a/src/main/java/org/folio/circulation/domain/UserRepository.java
+++ b/src/main/java/org/folio/circulation/domain/UserRepository.java
@@ -1,7 +1,6 @@
 package org.folio.circulation.domain;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
@@ -18,9 +17,7 @@ import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.CqlHelper;
 import org.folio.circulation.support.FetchSingleRecord;
 import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.client.Response;
-import org.folio.circulation.support.http.server.ValidationError;
 
 public class UserRepository {
   private final CollectionResourceClient usersStorageClient;
@@ -50,8 +47,7 @@ public class UserRepository {
     return FetchSingleRecord.<User>forRecord("user")
       .using(usersStorageClient)
       .mapTo(User::new)
-      .whenNotFound(failed(new ValidationErrorFailure(
-        new ValidationError("user is not found", "userId", userId))))
+      .whenNotFound(failedValidation("user is not found", "userId", userId))
       .fetch(userId);
   }
 

--- a/src/main/java/org/folio/circulation/domain/UserRepository.java
+++ b/src/main/java/org/folio/circulation/domain/UserRepository.java
@@ -3,7 +3,7 @@ package org.folio.circulation.domain;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -77,8 +77,9 @@ public class UserRepository {
       .thenApply(response -> MultipleRecords.from(response, User::new, "users")
         .map(MultipleRecords::getRecords)
         .map(users -> users.stream().findFirst())
-        .next(user -> user.map(HttpResult::succeeded).orElseGet(() -> failed(failure(
-          "Could not find user with matching barcode", propertyName, barcode)))));
+        .next(user -> user.map(HttpResult::succeeded).orElseGet(() ->
+          failedValidation("Could not find user with matching barcode",
+            propertyName, barcode))));
   }
 
   CompletableFuture<HttpResult<MultipleRecords<Request>>> findUsersForRequests(

--- a/src/main/java/org/folio/circulation/domain/policy/DueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/DueDateStrategy.java
@@ -1,15 +1,14 @@
 package org.folio.circulation.domain.policy;
 
+import java.lang.invoke.MethodHandles;
+import java.util.function.Function;
+
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.lang.invoke.MethodHandles;
-import java.util.function.Function;
 
 abstract class DueDateStrategy {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -30,8 +29,8 @@ abstract class DueDateStrategy {
 
   abstract HttpResult<DateTime> calculateDueDate(Loan loan);
 
-  ValidationErrorFailure validationError(String reason) {
-    return ValidationErrorFailure.failure(errorForPolicy.apply(reason));
+  ValidationError validationError(String reason) {
+    return errorForPolicy.apply(reason);
   }
 
   //TODO: Replace with logging in loan policy, that use toString of strategy

--- a/src/main/java/org/folio/circulation/domain/policy/DueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/DueDateStrategy.java
@@ -29,7 +29,7 @@ abstract class DueDateStrategy {
 
   abstract HttpResult<DateTime> calculateDueDate(Loan loan);
 
-  ValidationError validationError(String reason) {
+  ValidationError errorForPolicy(String reason) {
     return errorForPolicy.apply(reason);
   }
 

--- a/src/main/java/org/folio/circulation/domain/policy/FixedDueDateSchedules.java
+++ b/src/main/java/org/folio/circulation/domain/policy/FixedDueDateSchedules.java
@@ -1,17 +1,18 @@
 package org.folio.circulation.domain.policy;
 
-import io.vertx.core.json.JsonObject;
-import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.JsonArrayHelper;
-import org.folio.circulation.support.ValidationErrorFailure;
-import org.joda.time.DateTime;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import static org.folio.circulation.support.HttpResult.failed;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.JsonArrayHelper;
+import org.folio.circulation.support.http.server.ValidationError;
+import org.joda.time.DateTime;
+
+import io.vertx.core.json.JsonObject;
 
 public class FixedDueDateSchedules {
   private final List<JsonObject> schedules;
@@ -61,12 +62,12 @@ public class FixedDueDateSchedules {
   HttpResult<DateTime> truncateDueDate(
     DateTime dueDate,
     DateTime loanDate,
-    Supplier<ValidationErrorFailure> noApplicableScheduleError) {
+    Supplier<ValidationError> noApplicableScheduleError) {
 
     return findDueDateFor(loanDate)
       .map(limit -> earliest(dueDate, limit))
       .map(HttpResult::succeeded)
-      .orElseGet(() -> failed(noApplicableScheduleError.get()));
+      .orElseGet(() -> failedValidation(noApplicableScheduleError.get()));
   }
 
   private DateTime earliest(DateTime rollingDueDate, DateTime limit) {

--- a/src/main/java/org/folio/circulation/domain/policy/FixedScheduleCheckOutDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/FixedScheduleCheckOutDueDateStrategy.java
@@ -44,7 +44,7 @@ class FixedScheduleCheckOutDueDateStrategy extends DueDateStrategy {
       return fixedDueDateSchedules.findDueDateFor(loanDate)
         .map(HttpResult::succeeded)
         .orElseGet(() -> failedValidation(
-          validationError(NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE)));
+          errorForPolicy(NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE)));
     }
     catch(Exception e) {
       logException(e, "Error occurred during fixed schedule check out due date calculation");

--- a/src/main/java/org/folio/circulation/domain/policy/FixedScheduleCheckOutDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/FixedScheduleCheckOutDueDateStrategy.java
@@ -1,14 +1,15 @@
 package org.folio.circulation.domain.policy;
 
+import static org.folio.circulation.support.HttpResult.failed;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+
+import java.util.function.Function;
+
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
-
-import java.util.function.Function;
-
-import static org.folio.circulation.support.HttpResult.failed;
 
 class FixedScheduleCheckOutDueDateStrategy extends DueDateStrategy {
   private static final String NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE =
@@ -42,7 +43,7 @@ class FixedScheduleCheckOutDueDateStrategy extends DueDateStrategy {
     try {
       return fixedDueDateSchedules.findDueDateFor(loanDate)
         .map(HttpResult::succeeded)
-        .orElseGet(() -> failed(
+        .orElseGet(() -> failedValidation(
           validationError(NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE)));
     }
     catch(Exception e) {

--- a/src/main/java/org/folio/circulation/domain/policy/FixedScheduleRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/FixedScheduleRenewalDueDateStrategy.java
@@ -45,7 +45,7 @@ class FixedScheduleRenewalDueDateStrategy extends DueDateStrategy {
       return fixedDueDateSchedules.findDueDateFor(systemDate)
         .map(HttpResult::succeeded)
         .orElseGet(() -> failedValidation(
-          validationError(NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE)));
+          errorForPolicy(NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE)));
     } catch (Exception e) {
       logException(e, "Error occurred during fixed schedule renewal due date calculation");
       return failed(new ServerErrorFailure(e));

--- a/src/main/java/org/folio/circulation/domain/policy/FixedScheduleRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/FixedScheduleRenewalDueDateStrategy.java
@@ -1,14 +1,15 @@
 package org.folio.circulation.domain.policy;
 
+import static org.folio.circulation.support.HttpResult.failed;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+
+import java.util.function.Function;
+
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
-
-import java.util.function.Function;
-
-import static org.folio.circulation.support.HttpResult.failed;
 
 class FixedScheduleRenewalDueDateStrategy extends DueDateStrategy {
   private static final String NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE =
@@ -43,7 +44,7 @@ class FixedScheduleRenewalDueDateStrategy extends DueDateStrategy {
     try {
       return fixedDueDateSchedules.findDueDateFor(systemDate)
         .map(HttpResult::succeeded)
-        .orElseGet(() -> failed(
+        .orElseGet(() -> failedValidation(
           validationError(NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE)));
     } catch (Exception e) {
       logException(e, "Error occurred during fixed schedule renewal due date calculation");

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain.policy;
 
+import static java.lang.String.format;
 import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.JsonPropertyFetcher.getBooleanProperty;
@@ -8,7 +9,6 @@ import static org.folio.circulation.support.JsonPropertyFetcher.getNestedInteger
 import static org.folio.circulation.support.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -499,9 +499,9 @@ public class LoanPolicy {
 
     if (representation.containsKey(key)) {
       result = getPeriod(representation, key).addTo(initialDateTime,
-          () -> failure(errorForPolicy(String.format("the \"%s\" in the loan policy is not recognized", key))), 
-          interval -> failure(errorForPolicy(String.format("the interval \"%s\" in \"%s\" is not recognized", interval, key))),
-          duration -> failure(errorForPolicy(String.format("the duration \"%s\" in \"%s\" is invalid", duration, key))));
+          () -> errorForPolicy(format("the \"%s\" in the loan policy is not recognized", key)),
+          interval -> errorForPolicy(format("the interval \"%s\" in \"%s\" is not recognized", interval, key)),
+          duration -> errorForPolicy(format("the duration \"%s\" in \"%s\" is invalid", duration, key)));
     } else {
       result = succeeded(defaultDateTime);
     }

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -7,7 +7,7 @@ import static org.folio.circulation.support.JsonPropertyFetcher.getIntegerProper
 import static org.folio.circulation.support.JsonPropertyFetcher.getNestedIntegerProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
-import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
 import java.util.ArrayList;
@@ -66,10 +66,10 @@ public class LoanPolicy {
     //TODO: Create HttpResult wrapper that traps exceptions
     try {
       if (isNotLoanable()) {
-        return failedResult(errorForPolicy("item is not loanable"));
+        return failedValidation(errorForPolicy("item is not loanable"));
       }
       if(isNotRenewable()) {
-        return failedResult(errorForPolicy("loan is not renewable"));
+        return failedValidation(errorForPolicy("loan is not renewable"));
       }
 
       final HttpResult<DateTime> proposedDueDateResult =

--- a/src/main/java/org/folio/circulation/domain/policy/NoFixedDueDateSchedules.java
+++ b/src/main/java/org/folio/circulation/domain/policy/NoFixedDueDateSchedules.java
@@ -1,12 +1,12 @@
 package org.folio.circulation.domain.policy;
 
-import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
-import org.joda.time.DateTime;
-
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.function.Supplier;
+
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.http.server.ValidationError;
+import org.joda.time.DateTime;
 
 class NoFixedDueDateSchedules extends FixedDueDateSchedules {
   NoFixedDueDateSchedules() {
@@ -22,7 +22,7 @@ class NoFixedDueDateSchedules extends FixedDueDateSchedules {
   HttpResult<DateTime> truncateDueDate(
     DateTime dueDate,
     DateTime loanDate,
-    Supplier<ValidationErrorFailure> noApplicableScheduleError) {
+    Supplier<ValidationError> noApplicableScheduleError) {
 
     return HttpResult.succeeded(dueDate);
   }

--- a/src/main/java/org/folio/circulation/domain/policy/Period.java
+++ b/src/main/java/org/folio/circulation/domain/policy/Period.java
@@ -1,15 +1,17 @@
 package org.folio.circulation.domain.policy;
 
-import io.vertx.core.json.JsonObject;
-import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
-import org.joda.time.DateTime;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
-import static org.folio.circulation.support.HttpResult.failed;
+import org.folio.circulation.support.HttpResult;
+import org.folio.circulation.support.http.server.ValidationError;
+import org.joda.time.DateTime;
+
+import io.vertx.core.json.JsonObject;
 
 public class Period {
   private final Integer duration;
@@ -44,38 +46,37 @@ public class Period {
     return new Period(duration, interval);
   }
 
-  //TODO: Change this to use ValidationError instead of ValidationErrorFailure
   HttpResult<DateTime> addTo(
     DateTime from,
-    Supplier<ValidationErrorFailure> onUnrecognisedPeriod,
-    Function<String, ValidationErrorFailure> onUnrecognisedInterval,
-    IntFunction<ValidationErrorFailure> onUnrecognisedDuration) {
+    Supplier<ValidationError> onUnrecognisedPeriod,
+    Function<String, ValidationError> onUnrecognisedInterval,
+    IntFunction<ValidationError> onUnrecognisedDuration) {
 
     if(interval == null) {
-      return failed(onUnrecognisedPeriod.get());
+      return failedValidation(onUnrecognisedPeriod.get());
     }
 
     if(duration == null) {
-      return failed(onUnrecognisedPeriod.get());
+      return  failedValidation(onUnrecognisedPeriod.get());
     }
 
     if(duration <= 0) {
-      return failed(onUnrecognisedDuration.apply(duration));
+      return failedValidation(onUnrecognisedDuration.apply(duration));
     }
 
     switch (interval) {
       case "Months":
-        return HttpResult.succeeded(from.plusMonths(duration));
+        return succeeded(from.plusMonths(duration));
       case "Weeks":
-        return HttpResult.succeeded(from.plusWeeks(duration));
+        return succeeded(from.plusWeeks(duration));
       case "Days":
-        return HttpResult.succeeded(from.plusDays(duration));
+        return succeeded(from.plusDays(duration));
       case "Hours":
-        return HttpResult.succeeded(from.plusHours(duration));
+        return succeeded(from.plusHours(duration));
       case "Minutes":
-        return HttpResult.succeeded(from.plusMinutes(duration));
+        return succeeded(from.plusMinutes(duration));
       default:
-        return failed(onUnrecognisedInterval.apply(interval));
+        return failedValidation(onUnrecognisedInterval.apply(interval));
     }
   }
 

--- a/src/main/java/org/folio/circulation/domain/policy/RollingCheckOutDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingCheckOutDueDateStrategy.java
@@ -1,11 +1,13 @@
 package org.folio.circulation.domain.policy;
 
+import static java.lang.String.format;
+
+import java.util.function.Function;
+
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
-
-import java.util.function.Function;
 
 class RollingCheckOutDueDateStrategy extends DueDateStrategy {
   private static final String NO_APPLICABLE_DUE_DATE_LIMIT_SCHEDULE_MESSAGE =
@@ -46,8 +48,8 @@ class RollingCheckOutDueDateStrategy extends DueDateStrategy {
   private HttpResult<DateTime> initialDueDate(DateTime loanDate) {
     return period.addTo(loanDate,
       () -> validationError(CHECK_OUT_UNRECOGNISED_PERIOD_MESSAGE),
-      interval -> validationError(String.format(CHECK_OUT_UNRECOGNISED_INTERVAL_MESSAGE, interval)),
-      duration -> validationError(String.format(CHECKOUT_INVALID_DURATION_MESSAGE, duration)));
+      interval -> validationError(format(CHECK_OUT_UNRECOGNISED_INTERVAL_MESSAGE, interval)),
+      duration -> validationError(format(CHECKOUT_INVALID_DURATION_MESSAGE, duration)));
   }
 
   private HttpResult<DateTime> truncateDueDateBySchedule(

--- a/src/main/java/org/folio/circulation/domain/policy/RollingCheckOutDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingCheckOutDueDateStrategy.java
@@ -47,9 +47,9 @@ class RollingCheckOutDueDateStrategy extends DueDateStrategy {
 
   private HttpResult<DateTime> initialDueDate(DateTime loanDate) {
     return period.addTo(loanDate,
-      () -> validationError(CHECK_OUT_UNRECOGNISED_PERIOD_MESSAGE),
-      interval -> validationError(format(CHECK_OUT_UNRECOGNISED_INTERVAL_MESSAGE, interval)),
-      duration -> validationError(format(CHECKOUT_INVALID_DURATION_MESSAGE, duration)));
+      () -> errorForPolicy(CHECK_OUT_UNRECOGNISED_PERIOD_MESSAGE),
+      interval -> errorForPolicy(format(CHECK_OUT_UNRECOGNISED_INTERVAL_MESSAGE, interval)),
+      duration -> errorForPolicy(format(CHECKOUT_INVALID_DURATION_MESSAGE, duration)));
   }
 
   private HttpResult<DateTime> truncateDueDateBySchedule(
@@ -57,6 +57,6 @@ class RollingCheckOutDueDateStrategy extends DueDateStrategy {
     DateTime dueDate) {
 
     return dueDateLimitSchedules.truncateDueDate(dueDate, loanDate,
-      () -> validationError(NO_APPLICABLE_DUE_DATE_LIMIT_SCHEDULE_MESSAGE));
+      () -> errorForPolicy(NO_APPLICABLE_DUE_DATE_LIMIT_SCHEDULE_MESSAGE));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
@@ -54,7 +54,7 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
   @Override
   HttpResult<DateTime> calculateDueDate(Loan loan) {
     if(StringUtils.isBlank(renewFrom)) {
-      return failedValidation(validationError(RENEW_FROM_UNRECOGNISED_MESSAGE));
+      return failedValidation(errorForPolicy(RENEW_FROM_UNRECOGNISED_MESSAGE));
     }
 
     switch (renewFrom) {
@@ -63,7 +63,7 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
       case RENEW_FROM_SYSTEM_DATE:
         return calculateDueDate(systemDate, loan.getLoanDate());
       default:
-        return failedValidation(validationError(RENEW_FROM_UNRECOGNISED_MESSAGE));
+        return failedValidation(errorForPolicy(RENEW_FROM_UNRECOGNISED_MESSAGE));
     }
   }
 
@@ -74,9 +74,9 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
 
   HttpResult<DateTime> renewalDueDate(DateTime from) {
     return period.addTo(from,
-      () -> validationError(RENEWAL_UNRECOGNISED_PERIOD_MESSAGE),
-      interval -> validationError(format(RENEWAL_UNRECOGNISED_INTERVAL_MESSAGE, interval)),
-      duration -> validationError(format(RENEWAL_INVALID_DURATION_MESSAGE, duration)));
+      () -> errorForPolicy(RENEWAL_UNRECOGNISED_PERIOD_MESSAGE),
+      interval -> errorForPolicy(format(RENEWAL_UNRECOGNISED_INTERVAL_MESSAGE, interval)),
+      duration -> errorForPolicy(format(RENEWAL_INVALID_DURATION_MESSAGE, duration)));
   }
 
   private HttpResult<DateTime> truncateDueDateBySchedule(
@@ -84,6 +84,6 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
     DateTime dueDate) {
 
     return dueDateLimitSchedules.truncateDueDate(dueDate, loanDate,
-      () -> validationError(NO_APPLICABLE_DUE_DATE_LIMIT_SCHEDULE_MESSAGE));
+      () -> errorForPolicy(NO_APPLICABLE_DUE_DATE_LIMIT_SCHEDULE_MESSAGE));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
@@ -1,14 +1,15 @@
 package org.folio.circulation.domain.policy;
 
+import static java.lang.String.format;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+
+import java.util.function.Function;
+
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
-
-import java.util.function.Function;
-
-import static org.folio.circulation.support.HttpResult.failed;
 
 class RollingRenewalDueDateStrategy extends DueDateStrategy {
   private static final String RENEW_FROM_SYSTEM_DATE = "SYSTEM_DATE";
@@ -53,7 +54,7 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
   @Override
   HttpResult<DateTime> calculateDueDate(Loan loan) {
     if(StringUtils.isBlank(renewFrom)) {
-      return failed(validationError(RENEW_FROM_UNRECOGNISED_MESSAGE));
+      return failedValidation(validationError(RENEW_FROM_UNRECOGNISED_MESSAGE));
     }
 
     switch (renewFrom) {
@@ -62,7 +63,7 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
       case RENEW_FROM_SYSTEM_DATE:
         return calculateDueDate(systemDate, loan.getLoanDate());
       default:
-        return failed(validationError(RENEW_FROM_UNRECOGNISED_MESSAGE));
+        return failedValidation(validationError(RENEW_FROM_UNRECOGNISED_MESSAGE));
     }
   }
 
@@ -74,8 +75,8 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
   HttpResult<DateTime> renewalDueDate(DateTime from) {
     return period.addTo(from,
       () -> validationError(RENEWAL_UNRECOGNISED_PERIOD_MESSAGE),
-      interval -> validationError(String.format(RENEWAL_UNRECOGNISED_INTERVAL_MESSAGE, interval)),
-      duration -> validationError(String.format(RENEWAL_INVALID_DURATION_MESSAGE, duration)));
+      interval -> validationError(format(RENEWAL_UNRECOGNISED_INTERVAL_MESSAGE, interval)),
+      duration -> validationError(format(RENEWAL_INVALID_DURATION_MESSAGE, duration)));
   }
 
   private HttpResult<DateTime> truncateDueDateBySchedule(

--- a/src/main/java/org/folio/circulation/domain/policy/UnknownDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/UnknownDueDateStrategy.java
@@ -34,11 +34,11 @@ class UnknownDueDateStrategy extends DueDateStrategy {
   @Override
   HttpResult<DateTime> calculateDueDate(Loan loan) {
     if(isRenewal) {
-      return failedValidation(validationError(
+      return failedValidation(errorForPolicy(
           format(RENEWAL_UNRECOGNISED_PROFILE_MESSAGE, profileId)));
     }
     else {
-      return failedValidation(validationError(
+      return failedValidation(errorForPolicy(
         format(CHECK_OUT_UNRECOGNISED_PROFILE_MESSAGE, profileId)));
     }
   }

--- a/src/main/java/org/folio/circulation/domain/policy/UnknownDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/UnknownDueDateStrategy.java
@@ -1,13 +1,14 @@
 package org.folio.circulation.domain.policy;
 
+import static java.lang.String.format;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+
+import java.util.function.Function;
+
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
-
-import java.util.function.Function;
-
-import static org.folio.circulation.support.HttpResult.failed;
 
 class UnknownDueDateStrategy extends DueDateStrategy {
   private static final String CHECK_OUT_UNRECOGNISED_PROFILE_MESSAGE =
@@ -33,12 +34,12 @@ class UnknownDueDateStrategy extends DueDateStrategy {
   @Override
   HttpResult<DateTime> calculateDueDate(Loan loan) {
     if(isRenewal) {
-      return failed(validationError(
-          String.format(RENEWAL_UNRECOGNISED_PROFILE_MESSAGE, profileId)));
+      return failedValidation(validationError(
+          format(RENEWAL_UNRECOGNISED_PROFILE_MESSAGE, profileId)));
     }
     else {
-      return failed(validationError(
-        String.format(CHECK_OUT_UNRECOGNISED_PROFILE_MESSAGE, profileId)));
+      return failedValidation(validationError(
+        format(CHECK_OUT_UNRECOGNISED_PROFILE_MESSAGE, profileId)));
     }
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyUtils.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyUtils.java
@@ -1,5 +1,11 @@
 package org.folio.circulation.domain.policy.library;
 
+import static java.util.Collections.emptyMap;
+import static org.folio.circulation.domain.policy.LoanPolicyPeriod.isShortTermLoans;
+import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
+
+import java.util.concurrent.CompletableFuture;
+
 import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.LoanPolicy;
@@ -10,11 +16,6 @@ import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalTime;
-
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
-
-import static org.folio.circulation.domain.policy.LoanPolicyPeriod.isShortTermLoans;
 
 public final class ClosedLibraryStrategyUtils {
 
@@ -56,10 +57,10 @@ public final class ClosedLibraryStrategyUtils {
       : new EndOfPreviousDayStrategy(zone);
   }
 
-  public static ValidationErrorFailure failureForAbsentTimetable() {
+  //TODO: Should have parameters for validation error
+  static ValidationErrorFailure failureForAbsentTimetable() {
     String message = "Calendar timetable is absent for requested date";
-    return new ValidationErrorFailure(
-      new ValidationError(message, Collections.emptyMap()));
+    return singleValidationError(new ValidationError(message, emptyMap()));
   }
 
   public static CompletableFuture<HttpResult<LoanAndRelatedRecords>> applyCLDDMForLoanAndRelatedRecords(

--- a/src/main/java/org/folio/circulation/domain/representations/CheckInByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/domain/representations/CheckInByBarcodeRequest.java
@@ -4,7 +4,7 @@ import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimeProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getUUIDProperty;
-import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
 import java.util.UUID;
 
@@ -37,21 +37,21 @@ public class CheckInByBarcodeRequest {
     final String itemBarcode = getProperty(json, ITEM_BARCODE);
 
     if (StringUtils.isBlank(itemBarcode)) {
-      return failedResult("Checkin request must have an item barcode",
+      return failedValidation("Checkin request must have an item barcode",
         ITEM_BARCODE, null);
     }
 
     final UUID servicePointId = getUUIDProperty(json, SERVICE_POINT_ID);
 
     if (servicePointId == null) {
-      return failedResult("Checkin request must have a service point id",
+      return failedValidation("Checkin request must have a service point id",
         SERVICE_POINT_ID, null);
     }
 
     final DateTime checkInDate = getDateTimeProperty(json, CHECK_IN_DATE);
 
     if(checkInDate == null) {
-      return failedResult("Checkin request must have an check in date",
+      return failedValidation("Checkin request must have an check in date",
         CHECK_IN_DATE, null);
     }
 

--- a/src/main/java/org/folio/circulation/domain/validation/BlockRenewalValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/BlockRenewalValidator.java
@@ -2,10 +2,9 @@ package org.folio.circulation.domain.validation;
 
 import static org.folio.circulation.domain.RequestStatus.OPEN_NOT_YET_FILLED;
 import static org.folio.circulation.domain.RequestType.RECALL;
-import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.of;
 import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
 import java.util.Comparator;
 import java.util.Optional;
@@ -16,7 +15,6 @@ import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestQueue;
 import org.folio.circulation.domain.RequestQueueRepository;
 import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
 
 public class BlockRenewalValidator {
   private final RequestQueueRepository requestQueueRepository;
@@ -37,8 +35,8 @@ public class BlockRenewalValidator {
 
     if (request.isPresent() && isRecallRequest(request.get())) {
       String reason = "Items cannot be renewed when there is an active recall request";
-      ValidationErrorFailure error = failure(reason, "request id", request.get().getId());
-      return failed(error);
+
+      return failedValidation(reason, "request id", request.get().getId());
     } else {
       return succeeded(item);
     }

--- a/src/main/java/org/folio/circulation/domain/validation/ClosedRequestValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ClosedRequestValidator.java
@@ -1,14 +1,14 @@
 package org.folio.circulation.domain.validation;
 
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
+
+import java.util.concurrent.CompletableFuture;
+
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestAndRelatedRecords;
 import org.folio.circulation.domain.RequestRepository;
 import org.folio.circulation.support.HttpResult;
-
-import java.util.concurrent.CompletableFuture;
-
-import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
 public class ClosedRequestValidator {
   private final RequestRepository requestRepository;
@@ -29,7 +29,7 @@ public class ClosedRequestValidator {
 
     return requestRepository.getById(requestId)
       .thenApply(r -> r.failWhen(existing -> succeeded(existing.isClosed()),
-        v -> failure("Cannot edit a closed request", "id", requestId)));
+        v -> singleValidationError("Cannot edit a closed request", "id", requestId)));
   }
 
 }

--- a/src/main/java/org/folio/circulation/domain/validation/CommonFailures.java
+++ b/src/main/java/org/folio/circulation/domain/validation/CommonFailures.java
@@ -1,6 +1,7 @@
 package org.folio.circulation.domain.validation;
 
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
+import static java.lang.String.format;
+import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 
 import java.util.function.Supplier;
 
@@ -12,18 +13,17 @@ public class CommonFailures {
 
   public static Supplier<HttpFailure> moreThanOneOpenLoanFailure(String itemBarcode) {
     return () -> new ServerErrorFailure(
-      String.format("More than one open loan for item %s", itemBarcode));
+      format("More than one open loan for item %s", itemBarcode));
   }
 
   public static Supplier<HttpFailure> noItemFoundForBarcodeFailure(String itemBarcode) {
-    return () -> failure(
-      String.format("No item with barcode %s exists", itemBarcode),
+    return () -> singleValidationError(
+      format("No item with barcode %s exists", itemBarcode),
       "itemBarcode", itemBarcode);
   }
 
   public static Supplier<HttpFailure> noItemFoundForIdFailure(String itemId) {
-    return () -> failure(
-      String.format("No item with ID %s exists", itemId),
+    return () -> singleValidationError(format("No item with ID %s exists", itemId),
       "itemId", itemId);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/validation/InactiveUserValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/InactiveUserValidator.java
@@ -1,18 +1,18 @@
 package org.folio.circulation.domain.validation;
 
+import static org.folio.circulation.domain.representations.CheckOutByBarcodeRequest.PROXY_USER_BARCODE;
+import static org.folio.circulation.domain.representations.CheckOutByBarcodeRequest.USER_BARCODE;
+import static org.folio.circulation.support.HttpResult.failed;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
+
+import java.util.function.Function;
+
 import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.ValidationErrorFailure;
-
-import java.util.function.Function;
-
-import static org.folio.circulation.domain.representations.CheckOutByBarcodeRequest.PROXY_USER_BARCODE;
-import static org.folio.circulation.domain.representations.CheckOutByBarcodeRequest.USER_BARCODE;
-import static org.folio.circulation.support.HttpResult.failed;
-import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
 public class InactiveUserValidator {
   private final Function<String, ValidationErrorFailure> inactiveUserErrorFunction;
@@ -37,7 +37,7 @@ public class InactiveUserValidator {
       LoanAndRelatedRecords::getProxy,
       "Cannot check out via inactive proxying user",
       "Cannot determine if proxying user is active or not",
-      message -> failure(message, PROXY_USER_BARCODE, proxyUserBarcode));
+      message -> singleValidationError(message, PROXY_USER_BARCODE, proxyUserBarcode));
   }
 
   public static InactiveUserValidator forUser(String userBarcode) {
@@ -45,7 +45,7 @@ public class InactiveUserValidator {
       records -> records.getLoan().getUser(),
       "Cannot check out to inactive user",
       "Cannot determine if user is active or not",
-      message -> failure(message, USER_BARCODE, userBarcode));
+      message -> singleValidationError(message, USER_BARCODE, userBarcode));
   }
 
   public HttpResult<LoanAndRelatedRecords> refuseWhenUserIsInactive(

--- a/src/main/java/org/folio/circulation/domain/validation/ServicePointLoanLocationValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ServicePointLoanLocationValidator.java
@@ -1,11 +1,11 @@
 package org.folio.circulation.domain.validation;
 
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.support.HttpResult;
-import static org.folio.circulation.support.HttpResult.failed;
-import static org.folio.circulation.support.HttpResult.succeeded;
-import org.folio.circulation.support.ValidationErrorFailure;
 
 public class ServicePointLoanLocationValidator {
   public HttpResult<LoanAndRelatedRecords> checkServicePointLoanLocation(
@@ -27,13 +27,13 @@ public class ServicePointLoanLocationValidator {
     }
     
     if(loan.getCheckInServicePointId() != null && loan.getCheckinServicePoint() == null) {
-      return failed(ValidationErrorFailure.failure("Check In Service Point does not exist",
-          "checkinServicePointId", loan.getCheckInServicePointId()));
+      return failedValidation("Check In Service Point does not exist",
+          "checkinServicePointId", loan.getCheckInServicePointId());
     }
     
     if(loan.getCheckoutServicePointId() != null && loan.getCheckoutServicePoint() == null) {
-      return failed(ValidationErrorFailure.failure("Check Out Service Point does not exist",
-          "checkoutServicePointId", loan.getCheckoutServicePointId()));
+      return failedValidation("Check Out Service Point does not exist",
+          "checkoutServicePointId", loan.getCheckoutServicePointId());
     }
     
     return succeeded(larr);

--- a/src/main/java/org/folio/circulation/domain/validation/ServicePointPickupLocationValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ServicePointPickupLocationValidator.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.domain.validation;
 
-import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
 import java.lang.invoke.MethodHandles;
 
@@ -9,7 +9,6 @@ import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestAndRelatedRecords;
 import org.folio.circulation.domain.RequestFulfilmentPreference;
 import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,9 +39,9 @@ public class ServicePointPickupLocationValidator {
     if(request.getPickupServicePointId() == null) {
       if(request.getFulfilmentPreference() == RequestFulfilmentPreference.HOLD_SHELF) {
         log.info("Hold Shelf Fulfillment Requests require a Pickup Service Point");
-        return failed(ValidationErrorFailure.failure(
-              "Hold Shelf Fulfillment Requests require a Pickup Service Point", "id",
-              request.getId()));
+        return failedValidation(
+          "Hold Shelf Fulfillment Requests require a Pickup Service Point",
+          "id", request.getId());
       } else {
         log.info("No pickup service point specified for request");
         return succeeded(requestAndRelatedRecords);
@@ -50,9 +49,8 @@ public class ServicePointPickupLocationValidator {
     }
 
     if(request.getPickupServicePointId() != null && request.getPickupServicePoint() == null) {
-      return failed(ValidationErrorFailure.failure(
-        "Pickup service point does not exist", "pickupServicePointId",
-        request.getPickupServicePointId()));
+      return failedValidation("Pickup service point does not exist",
+        "pickupServicePointId", request.getPickupServicePointId());
     }
 
     if(request.getPickupServicePoint() != null) {
@@ -64,9 +62,9 @@ public class ServicePointPickupLocationValidator {
         log.info("Request {} has {} as a pickup location which is an invalid service point",
             request.getId(), request.getPickupServicePointId());
 
-        return failed(ValidationErrorFailure.failure(
-            "Service point is not a pickup location", "pickupServicePointId",
-            request.getPickupServicePointId()));
+        return failedValidation(
+            "Service point is not a pickup location",
+          "pickupServicePointId", request.getPickupServicePointId());
       }
     }
     else {

--- a/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
@@ -3,7 +3,7 @@ package org.folio.circulation.resources;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.domain.representations.LoanProperties.ITEM_ID;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
+import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -64,16 +64,17 @@ public class LoanCollectionResource extends CollectionResource {
 
     final ProxyRelationshipValidator proxyRelationshipValidator =
       new ProxyRelationshipValidator(clients,
-        () -> failure("proxyUserId is not valid", "proxyUserId", loan.getProxyUserId()));
+        () -> singleValidationError("proxyUserId is not valid", "proxyUserId",
+          loan.getProxyUserId()));
 
     final AwaitingPickupValidator awaitingPickupValidator = new AwaitingPickupValidator(
-      message -> failure(message, "userId", loan.getUserId()));
+      message -> singleValidationError(message, "userId", loan.getUserId()));
 
     final AlreadyCheckedOutValidator alreadyCheckedOutValidator = new AlreadyCheckedOutValidator(
-      message -> failure(message, "itemId", loan.getItemId()));
+      message -> singleValidationError(message, "itemId", loan.getItemId()));
 
     final ItemMissingValidator itemMissingValidator = new ItemMissingValidator(
-      message -> failure(message, "itemId", loan.getItemId()));
+      message -> singleValidationError(message, "itemId", loan.getItemId()));
 
     final ItemNotFoundValidator itemNotFoundValidator = createItemNotFoundValidator(loan);
 
@@ -126,7 +127,7 @@ public class LoanCollectionResource extends CollectionResource {
     final LoanRepository loanRepository = new LoanRepository(clients);
 
     final ProxyRelationshipValidator proxyRelationshipValidator = new ProxyRelationshipValidator(
-      clients, () -> failure("proxyUserId is not valid", "proxyUserId",
+      clients, () -> singleValidationError("proxyUserId is not valid", "proxyUserId",
         loan.getProxyUserId()));
 
     final ItemNotFoundValidator itemNotFoundValidator = createItemNotFoundValidator(loan);
@@ -292,7 +293,8 @@ public class LoanCollectionResource extends CollectionResource {
 
   private ItemNotFoundValidator createItemNotFoundValidator(Loan loan) {
     return new ItemNotFoundValidator(
-      () -> failure(String.format("No item with ID %s could be found", loan.getItemId()),
+      () -> singleValidationError(
+        String.format("No item with ID %s could be found", loan.getItemId()),
         ITEM_ID, loan.getItemId()));
   }
 }

--- a/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
@@ -2,6 +2,7 @@ package org.folio.circulation.resources;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.domain.representations.LoanProperties.ITEM_ID;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
 import java.util.concurrent.CompletableFuture;
@@ -237,8 +238,8 @@ public class LoanCollectionResource extends CollectionResource {
 
     return result.next(loan -> {
       if(loan.getLoan().getItem().doesNotHaveHolding()) {
-        return HttpResult.failed(failure(
-          "Holding does not exist", ITEM_ID, loan.getLoan().getItemId()));
+        return failedValidation("Holding does not exist",
+          ITEM_ID, loan.getLoan().getItemId());
       }
       else {
         return result;

--- a/src/main/java/org/folio/circulation/resources/OverrideByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/resources/OverrideByBarcodeRequest.java
@@ -1,14 +1,15 @@
 package org.folio.circulation.resources;
 
-import io.vertx.core.json.JsonObject;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimeProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.support.HttpResult;
 import org.joda.time.DateTime;
 
-import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimeProperty;
-import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
-import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
+import io.vertx.core.json.JsonObject;
 
 public class OverrideByBarcodeRequest {
 
@@ -48,21 +49,25 @@ public class OverrideByBarcodeRequest {
   public static HttpResult<OverrideByBarcodeRequest> from(JsonObject json) {
     final String itemBarcode = getProperty(json, ITEM_BARCODE);
     if(StringUtils.isBlank(itemBarcode)) {
-      return failedResult("Override renewal request must have an item barcode", ITEM_BARCODE, null);
+      return failedValidation("Override renewal request must have an item barcode",
+        ITEM_BARCODE, null);
     }
 
     final String userBarcode = getProperty(json, USER_BARCODE);
     if(StringUtils.isBlank(userBarcode)) {
-      return failedResult("Override renewal request must have a user barcode", USER_BARCODE, null);
+      return failedValidation("Override renewal request must have a user barcode",
+        USER_BARCODE, null);
     }
 
     final String comment = getProperty(json, COMMENT_PROPERTY);
     if(StringUtils.isBlank(comment)) {
-      return failedResult("Override renewal request must have a comment", COMMENT_PROPERTY, null);
+      return failedValidation("Override renewal request must have a comment",
+        COMMENT_PROPERTY, null);
     }
     final DateTime dueDate = getDateTimeProperty(json, DUE_DATE);
 
-    return succeeded(new OverrideByBarcodeRequest(itemBarcode, userBarcode, comment, dueDate));
+    return succeeded(new OverrideByBarcodeRequest(itemBarcode, userBarcode,
+      comment, dueDate));
   }
 
 }

--- a/src/main/java/org/folio/circulation/resources/RenewByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByBarcodeRequest.java
@@ -1,12 +1,13 @@
 package org.folio.circulation.resources;
 
-import io.vertx.core.json.JsonObject;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.support.HttpResult;
 
-import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
-import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
+import io.vertx.core.json.JsonObject;
 
 public class RenewByBarcodeRequest {
   public static final String USER_BARCODE = "userBarcode";
@@ -24,13 +25,15 @@ public class RenewByBarcodeRequest {
     final String itemBarcode = getProperty(json, ITEM_BARCODE);
 
     if(StringUtils.isBlank(itemBarcode)) {
-      return failedResult("Renewal request must have an item barcode", ITEM_BARCODE, null);
+      return failedValidation("Renewal request must have an item barcode",
+        ITEM_BARCODE, null);
     }
 
     final String userBarcode = getProperty(json, USER_BARCODE);
 
     if(StringUtils.isBlank(userBarcode)) {
-      return failedResult("Renewal request must have a user barcode", USER_BARCODE, null);
+      return failedValidation("Renewal request must have a user barcode",
+        USER_BARCODE, null);
     }
 
     return succeeded(new RenewByBarcodeRequest(itemBarcode, userBarcode));

--- a/src/main/java/org/folio/circulation/resources/RenewByIdRequest.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByIdRequest.java
@@ -1,12 +1,13 @@
 package org.folio.circulation.resources;
 
-import io.vertx.core.json.JsonObject;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.support.HttpResult;
 
-import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
-import static org.folio.circulation.support.ValidationErrorFailure.failedResult;
+import io.vertx.core.json.JsonObject;
 
 public class RenewByIdRequest {
   static final String USER_ID = "userId";
@@ -24,13 +25,15 @@ public class RenewByIdRequest {
     final String itemBarcode = getProperty(json, ITEM_ID);
 
     if(StringUtils.isBlank(itemBarcode)) {
-      return failedResult("Renewal request must have an item ID", ITEM_ID, null);
+      return failedValidation("Renewal request must have an item ID",
+        ITEM_ID, null);
     }
 
     final String userBarcode = getProperty(json, USER_ID);
 
     if(StringUtils.isBlank(userBarcode)) {
-      return failedResult("Renewal request must have a user ID", USER_ID, null);
+      return failedValidation("Renewal request must have a user ID",
+        USER_ID, null);
     }
 
     return succeeded(new RenewByIdRequest(itemBarcode, userBarcode));

--- a/src/main/java/org/folio/circulation/resources/RenewByIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByIdResource.java
@@ -4,7 +4,7 @@ import static org.folio.circulation.domain.validation.CommonFailures.moreThanOne
 import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundForIdFailure;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
+import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -44,7 +44,7 @@ public class RenewByIdResource extends RenewalResource {
       .orElse("unknown item ID");
 
     final UserNotFoundValidator userNotFoundValidator = new UserNotFoundValidator(
-      userId -> failure("user is not found", "userId", userId));
+      userId -> singleValidationError("user is not found", "userId", userId));
 
     final SingleOpenLoanForItemInStorageFinder singleOpenLoanFinder
       = new SingleOpenLoanForItemInStorageFinder(loanRepository, userRepository,

--- a/src/main/java/org/folio/circulation/resources/RenewByIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RenewByIdResource.java
@@ -2,8 +2,8 @@ package org.folio.circulation.resources;
 
 import static org.folio.circulation.domain.validation.CommonFailures.moreThanOneOpenLoanFailure;
 import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundForIdFailure;
-import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
 import java.util.concurrent.CompletableFuture;
@@ -73,8 +73,8 @@ public class RenewByIdResource extends RenewalResource {
       return succeeded(loan);
     }
     else {
-      return failed(failure("Cannot renew item checked out to different user",
-        RenewByIdRequest.USER_ID, idRequest.getUserId()));
+      return failedValidation("Cannot renew item checked out to different user",
+        RenewByIdRequest.USER_ID, idRequest.getUserId());
     }
   }
 

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -1,7 +1,8 @@
 package org.folio.circulation.resources;
 
+import static org.folio.circulation.domain.representations.RequestProperties.PROXY_USER_ID;
 import static org.folio.circulation.support.JsonPropertyWriter.write;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
+import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 
 import org.folio.circulation.domain.CreateRequestService;
 import org.folio.circulation.domain.LoanRepository;
@@ -16,9 +17,8 @@ import org.folio.circulation.domain.UpdateLoanActionHistory;
 import org.folio.circulation.domain.UpdateRequestQueue;
 import org.folio.circulation.domain.UpdateRequestService;
 import org.folio.circulation.domain.UserRepository;
-import org.folio.circulation.domain.policy.RequestPolicyRepository;
 import org.folio.circulation.domain.policy.LoanPolicyRepository;
-import org.folio.circulation.domain.representations.RequestProperties;
+import org.folio.circulation.domain.policy.RequestPolicyRepository;
 import org.folio.circulation.domain.validation.ClosedRequestValidator;
 import org.folio.circulation.domain.validation.ProxyRelationshipValidator;
 import org.folio.circulation.domain.validation.ServicePointPickupLocationValidator;
@@ -190,8 +190,8 @@ public class RequestCollectionResource extends CollectionResource {
     JsonObject representation,
     Clients clients) {
 
-    return new ProxyRelationshipValidator(clients, () -> failure(
-      "proxyUserId is not valid", RequestProperties.PROXY_USER_ID,
-      representation.getString(RequestProperties.PROXY_USER_ID)));
+    return new ProxyRelationshipValidator(clients, () ->
+      singleValidationError("proxyUserId is not valid",
+        PROXY_USER_ID, representation.getString(PROXY_USER_ID)));
   }
 }

--- a/src/main/java/org/folio/circulation/storage/SingleOpenLoanByUserAndItemBarcodeFinder.java
+++ b/src/main/java/org/folio/circulation/storage/SingleOpenLoanByUserAndItemBarcodeFinder.java
@@ -4,7 +4,7 @@ import static org.folio.circulation.domain.validation.CommonFailures.moreThanOne
 import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundForBarcodeFailure;
 import static org.folio.circulation.support.HttpResult.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
+import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -46,7 +46,7 @@ public class SingleOpenLoanByUserAndItemBarcodeFinder {
       moreThanOneOpenLoanFailure(itemBarcode), false);
 
     final UserNotFoundValidator userNotFoundValidator = new UserNotFoundValidator(
-      userId -> failure("user is not found", "userId", userId));
+      userId -> singleValidationError("user is not found", "userId", userId));
 
     final BlockRenewalValidator blockRenewalValidator =
       new BlockRenewalValidator(requestQueueRepository);

--- a/src/main/java/org/folio/circulation/storage/SingleOpenLoanByUserAndItemBarcodeFinder.java
+++ b/src/main/java/org/folio/circulation/storage/SingleOpenLoanByUserAndItemBarcodeFinder.java
@@ -2,8 +2,8 @@ package org.folio.circulation.storage;
 
 import static org.folio.circulation.domain.validation.CommonFailures.moreThanOneOpenLoanFailure;
 import static org.folio.circulation.domain.validation.CommonFailures.noItemFoundForBarcodeFailure;
-import static org.folio.circulation.support.HttpResult.failed;
 import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.ValidationErrorFailure.failure;
 
 import java.util.concurrent.CompletableFuture;
@@ -66,8 +66,8 @@ public class SingleOpenLoanByUserAndItemBarcodeFinder {
     if (userMatches(loan, barcodeRequest.getUserBarcode())) {
       return succeeded(loan);
     } else {
-      return failed(failure("Cannot renew item checked out to different user",
-        RenewByBarcodeRequest.USER_BARCODE, barcodeRequest.getUserBarcode()));
+      return failedValidation("Cannot renew item checked out to different user",
+        RenewByBarcodeRequest.USER_BARCODE, barcodeRequest.getUserBarcode());
     }
   }
 

--- a/src/main/java/org/folio/circulation/support/ValidationErrorFailure.java
+++ b/src/main/java/org/folio/circulation/support/ValidationErrorFailure.java
@@ -19,7 +19,7 @@ public class ValidationErrorFailure implements HttpFailure {
 
   private final Collection<ValidationError> errors = new ArrayList<>();
 
-  public static <T> HttpResult<T> failedResult(
+  public static <T> HttpResult<T> failedValidation(
     String reason,
     String key,
     String value) {
@@ -28,7 +28,7 @@ public class ValidationErrorFailure implements HttpFailure {
       failure(new ValidationError(reason, key, value)));
   }
 
-  public static <T> HttpResult<T> failedResult(ValidationError error) {
+  public static <T> HttpResult<T> failedValidation(ValidationError error) {
     return HttpResult.failed(failure(error));
   }
 

--- a/src/main/java/org/folio/circulation/support/ValidationErrorFailure.java
+++ b/src/main/java/org/folio/circulation/support/ValidationErrorFailure.java
@@ -1,5 +1,7 @@
 package org.folio.circulation.support;
 
+import static org.folio.circulation.support.HttpResult.failed;
+
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -19,40 +21,42 @@ public class ValidationErrorFailure implements HttpFailure {
 
   private final Collection<ValidationError> errors = new ArrayList<>();
 
-  public static <T> HttpResult<T> failedValidation(
+  public static <T> WritableHttpResult<T> failedValidation(
     String reason,
     String key,
     String value) {
 
-    return HttpResult.failed(
-      failure(new ValidationError(reason, key, value)));
+    return failedValidation(new ValidationError(reason, key, value));
   }
 
-  public static <T> HttpResult<T> failedValidation(ValidationError error) {
-    return HttpResult.failed(failure(error));
+  public static <T> WritableHttpResult<T> failedValidation(ValidationError error) {
+    return failed(singleValidationError(error));
   }
 
-  public static ValidationErrorFailure failure(
+  public static <T> WritableHttpResult<T> failedValidation(
+    Collection<ValidationError> errors) {
+
+    return failed(new ValidationErrorFailure(errors));
+  }
+
+  public static ValidationErrorFailure singleValidationError(
     String reason,
     String propertyName,
     String propertyValue) {
 
-    return failure(new ValidationError(reason, propertyName, propertyValue));
+    return singleValidationError(
+      new ValidationError(reason, propertyName, propertyValue));
   }
 
-  public static ValidationErrorFailure failure(ValidationError error) {
+  public static ValidationErrorFailure singleValidationError(ValidationError error) {
     return new ValidationErrorFailure(error);
   }
 
-  public static ValidationErrorFailure failure(Collection<ValidationError> errors) {
-    return new ValidationErrorFailure(errors);
-  }
-
-  public ValidationErrorFailure(ValidationError error) {
+  private ValidationErrorFailure(ValidationError error) {
     this.errors.add(error);
   }
 
-  public ValidationErrorFailure(Collection<ValidationError> errors) {
+  private ValidationErrorFailure(Collection<ValidationError> errors) {
     this.errors.addAll(errors);
   }
 

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -6,6 +6,7 @@ import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static api.support.matchers.UUIDMatcher.is;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
+import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static api.support.matchers.ValidationErrorMatchers.hasUUIDParameter;
 import static java.util.Arrays.asList;
 import static org.folio.HttpStatus.HTTP_BAD_REQUEST;
@@ -46,7 +47,6 @@ import api.support.fixtures.RequestsFixture;
 import api.support.fixtures.UsersFixture;
 import api.support.http.InventoryItemResource;
 import api.support.http.ResourceClient;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -933,9 +933,9 @@ public class RequestsAPICreationTests extends APITests {
       .withPickupServicePointId(servicePoint.getId())
       .by(usersFixture.jessica()));
 
-    assertThat(pagedRequest, hasStatus(HTTP_VALIDATION_ERROR));
-    JsonArray errors = pagedRequest.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is (("Page requests are not allowed for " + ItemStatus.CHECKED_OUT.getValue() + " item status combination").toLowerCase()));
+    assertThat(pagedRequest.getJson(), hasErrorWith(allOf(
+      hasMessage("Page requests are not allowed for this patron and item combination"),
+      hasParameter("requestType", "Page"))));
   }
 
   @Test
@@ -957,9 +957,9 @@ public class RequestsAPICreationTests extends APITests {
       .withPickupServicePointId(servicePoint.getId())
       .by(usersFixture.jessica()));
 
-    assertThat(pagedRequest2, hasStatus(HTTP_VALIDATION_ERROR));
-    JsonArray errors = pagedRequest2.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is (("Page requests are not allowed for " + ItemStatus.AWAITING_PICKUP.getValue() + " item status combination").toLowerCase()));
+    assertThat(pagedRequest2.getJson(), hasErrorWith(allOf(
+      hasMessage("Page requests are not allowed for this patron and item combination"),
+      hasParameter("requestType", "Page"))));
   }
 
   @Test
@@ -980,9 +980,9 @@ public class RequestsAPICreationTests extends APITests {
       .withPickupServicePointId(servicePoint.getId())
       .by(usersFixture.jessica()));
 
-    assertThat(pagedRequest2, hasStatus(HTTP_VALIDATION_ERROR));
-    JsonArray errors = pagedRequest2.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is(("Page requests are not allowed for " + ItemStatus.PAGED.getValue() + " item status combination").toLowerCase()));
+    assertThat(pagedRequest2.getJson(), hasErrorWith(allOf(
+      hasMessage("Page requests are not allowed for this patron and item combination"),
+      hasParameter("requestType", "Page"))));
   }
 
   @Test
@@ -1005,9 +1005,9 @@ public class RequestsAPICreationTests extends APITests {
       .withPickupServicePointId(requestPickupServicePoint.getId())
       .by(usersFixture.jessica()));
 
-    assertThat(pagedRequest2, hasStatus(HTTP_VALIDATION_ERROR));
-    JsonArray errors = pagedRequest2.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is (("Page requests are not allowed for " + ItemStatus.IN_TRANSIT.getValue() + " item status combination").toLowerCase()));
+    assertThat(pagedRequest2.getJson(), hasErrorWith(allOf(
+      hasMessage("Page requests are not allowed for this patron and item combination"),
+      hasParameter("requestType", "Page"))));
   }
 
   @Test
@@ -1100,9 +1100,9 @@ public class RequestsAPICreationTests extends APITests {
       .withPickupServicePointId(requestPickupServicePoint.getId())
       .by(usersFixture.james()));
 
-    assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
-    JsonArray errors = recallResponse.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is (("Recall requests are not allowed for " + ItemStatus.AVAILABLE.getValue() + " item status combination").toLowerCase()));
+    assertThat(recallResponse.getJson(), hasErrorWith(allOf(
+      hasMessage("Recall requests are not allowed for this patron and item combination"),
+      hasParameter("requestType", "Recall"))));
   }
 
   @Test
@@ -1114,16 +1114,15 @@ public class RequestsAPICreationTests extends APITests {
 
     final IndividualResource missingItem = setupMissingItem(itemsFixture);
 
-    //create a Recall request
-    final Response holdRequest = requestsClient.attemptCreate(new RequestBuilder()
+    final Response recallRequest = requestsClient.attemptCreate(new RequestBuilder()
       .recall()
       .forItem(missingItem)
       .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.jessica()));
 
-    assertThat(holdRequest, hasStatus(HTTP_VALIDATION_ERROR));
-    JsonArray errors = holdRequest.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is (("Recall requests are not allowed for " + ItemStatus.MISSING.getValue() + " item status combination").toLowerCase()));
+    assertThat(recallRequest.getJson(), hasErrorWith(allOf(
+      hasMessage("Recall requests are not allowed for this patron and item combination"),
+      hasParameter("requestType", "Recall"))));
   }
 
   @Test
@@ -1142,9 +1141,9 @@ public class RequestsAPICreationTests extends APITests {
       .withPickupServicePointId(requestPickupServicePoint.getId())
       .by(usersFixture.jessica()));
 
-    assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
-    JsonArray errors = recallResponse.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is (("Recall requests are not allowed for " + ItemStatus.PAGED.getValue() + " item status combination").toLowerCase()));
+    assertThat(recallResponse.getJson(), hasErrorWith(allOf(
+      hasMessage("Recall requests are not allowed for this patron and item combination"),
+      hasParameter("requestType", "Recall"))));
   }
 
   @Test
@@ -1276,17 +1275,16 @@ public class RequestsAPICreationTests extends APITests {
     final IndividualResource availableItem = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource requestPickupServicePoint = servicePointsFixture.cd1();
 
-    final Response recallResponse = requestsClient.attemptCreate(new RequestBuilder()
+    final Response holdResponse = requestsClient.attemptCreate(new RequestBuilder()
       .hold()
       .forItem(availableItem)
       .withPickupServicePointId(requestPickupServicePoint.getId())
       .by(usersFixture.james()));
 
-    assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
-    JsonArray errors = recallResponse.getJson().getJsonArray("errors");
-    assertThat(errors.getJsonObject(0).getString("message").toLowerCase(), is(("Hold requests are not allowed for " + ItemStatus.AVAILABLE.getValue() + " item status combination").toLowerCase()));
+    assertThat(holdResponse.getJson(), hasErrorWith(allOf(
+      hasMessage("Hold requests are not allowed for this patron and item combination"),
+      hasParameter("requestType", "Hold"))));
   }
-
 
   public static IndividualResource setupPagedItem(IndividualResource requestPickupServicePoint, ItemsFixture itemsFixture,
                                                   ResourceClient requestClient, UsersFixture usersFixture)

--- a/src/test/java/api/requests/scenarios/RequestPolicyTests.java
+++ b/src/test/java/api/requests/scenarios/RequestPolicyTests.java
@@ -3,8 +3,8 @@ package api.requests.scenarios;
 import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
+import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static org.folio.HttpStatus.HTTP_INTERNAL_SERVER_ERROR;
-import static org.folio.HttpStatus.HTTP_VALIDATION_ERROR;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
@@ -117,9 +117,9 @@ public class RequestPolicyTests extends APITests {
       .withPickupServicePointId(requestPickupServicePoint.getId())
       .by(usersFixture.undergradHenry()));
 
-    assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
     assertThat(recallResponse.getJson(), hasErrorWith(allOf(
-      hasMessage("Recall requests are not allowed for this patron and item combination"))));
+      hasMessage("Recall requests are not allowed for this patron and item combination"),
+      hasParameter("requestType", "Recall"))));
   }
 
   @Test
@@ -194,15 +194,15 @@ public class RequestPolicyTests extends APITests {
     final IndividualResource checkedOutItem = itemsFixture.basedUponSmallAngryPlanet();
     loansFixture.checkOut(checkedOutItem, usersFixture.jessica());
 
-    final Response recallResponse = requestsClient.attemptCreate(new RequestBuilder()
+    final Response holdResponse = requestsClient.attemptCreate(new RequestBuilder()
       .hold()
       .forItem(checkedOutItem)
       .withPickupServicePointId(requestPickupServicePoint.getId())
       .by(usersFixture.james()));  //randomly picked James to represent "Any" patron
 
-    assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
-    assertThat(recallResponse.getJson(), hasErrorWith(allOf(
-      hasMessage("Hold requests are not allowed for this patron and item combination"))));
+    assertThat(holdResponse.getJson(), hasErrorWith(allOf(
+      hasMessage("Hold requests are not allowed for this patron and item combination"),
+      hasParameter("requestType", "Hold"))));
   }
 
   @Test
@@ -264,15 +264,15 @@ public class RequestPolicyTests extends APITests {
     //setting up a checked-out library item to attempt placing a PAGE request
     final IndividualResource availableItem = itemsFixture.basedUponSmallAngryPlanet();
 
-    final Response recallResponse = requestsClient.attemptCreate(new RequestBuilder()
+    final Response pageResponse = requestsClient.attemptCreate(new RequestBuilder()
       .page()
       .forItem(availableItem)
       .withPickupServicePointId(requestPickupServicePoint.getId())
       .by(usersFixture.james()));  //randomly picked James to represent "Any" patron
 
-    assertThat(recallResponse, hasStatus(HTTP_VALIDATION_ERROR));
-    assertThat(recallResponse.getJson(), hasErrorWith(allOf(
-      hasMessage("Page requests are not allowed for this patron and item combination"))));
+    assertThat(pageResponse.getJson(), hasErrorWith(allOf(
+      hasMessage("Page requests are not allowed for this patron and item combination"),
+      hasParameter("requestType", "Page"))));
   }
 
   @Test

--- a/src/test/java/api/support/fakes/FakeStorageModule.java
+++ b/src/test/java/api/support/fakes/FakeStorageModule.java
@@ -1,5 +1,7 @@
 package api.support.fakes;
 
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -15,8 +17,6 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.support.CreatedJsonHttpResult;
-import org.folio.circulation.support.HttpResult;
-import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.server.ClientErrorResponse;
 import org.folio.circulation.support.http.server.SuccessResponse;
 import org.folio.circulation.support.http.server.ValidationError;
@@ -360,8 +360,7 @@ public class FakeStorageModule extends AbstractVerticle {
       routingContext.next();
     }
     else {
-      HttpResult.failed(ValidationErrorFailure.failure(errors))
-        .writeTo(routingContext.response());
+      failedValidation(errors).writeTo(routingContext.response());
     }
   }
 
@@ -388,8 +387,7 @@ public class FakeStorageModule extends AbstractVerticle {
           String.format("%s with this %s already exists", recordTypeName, uniqueProperty),
           uniqueProperty, proposedValue));
 
-        HttpResult.failed(ValidationErrorFailure.failure(errors))
-          .writeTo(routingContext.response());
+        failedValidation(errors).writeTo(routingContext.response());
       }
     });
 
@@ -414,8 +412,7 @@ public class FakeStorageModule extends AbstractVerticle {
           String.format("Unrecognised field \"%s\"", disallowedProperty),
           disallowedProperty, null));
 
-        HttpResult.failed(ValidationErrorFailure.failure(errors))
-          .writeTo(routingContext.response());
+        failedValidation(errors).writeTo(routingContext.response());
       }
     });
 

--- a/src/test/java/org/folio/circulation/domain/validation/InactiveUserValidatorTests.java
+++ b/src/test/java/org/folio/circulation/domain/validation/InactiveUserValidatorTests.java
@@ -1,20 +1,21 @@
 package org.folio.circulation.domain.validation;
 
-import io.vertx.core.json.JsonObject;
+import static api.support.fixtures.UserExamples.basedUponStevenJones;
+import static org.folio.circulation.domain.validation.InactiveUserValidator.forUser;
+import static org.folio.circulation.support.HttpResult.succeeded;
+import static org.folio.circulation.support.ValidationErrorFailure.failure;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.support.HttpResult;
 import org.folio.circulation.support.ServerErrorFailure;
-import org.folio.circulation.support.ValidationErrorFailure;
 import org.junit.Test;
 
-import static api.support.fixtures.UserExamples.basedUponStevenJones;
-import static org.folio.circulation.domain.validation.InactiveUserValidator.forUser;
-import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import io.vertx.core.json.JsonObject;
 
 public class InactiveUserValidatorTests {
   @Test
@@ -75,8 +76,7 @@ public class InactiveUserValidatorTests {
 
     final InactiveUserValidator validator = new InactiveUserValidator(
       records -> { throw new RuntimeException("Something went wrong"); },
-      "", "", s -> ValidationErrorFailure.failure("failed", "", "")
-    );
+      "", "", s -> failure("failed", "", ""));
 
     final HttpResult<LoanAndRelatedRecords> result =
       validator.refuseWhenUserIsInactive(succeeded(new LoanAndRelatedRecords(

--- a/src/test/java/org/folio/circulation/domain/validation/InactiveUserValidatorTests.java
+++ b/src/test/java/org/folio/circulation/domain/validation/InactiveUserValidatorTests.java
@@ -3,7 +3,7 @@ package org.folio.circulation.domain.validation;
 import static api.support.fixtures.UserExamples.basedUponStevenJones;
 import static org.folio.circulation.domain.validation.InactiveUserValidator.forUser;
 import static org.folio.circulation.support.HttpResult.succeeded;
-import static org.folio.circulation.support.ValidationErrorFailure.failure;
+import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -76,7 +76,7 @@ public class InactiveUserValidatorTests {
 
     final InactiveUserValidator validator = new InactiveUserValidator(
       records -> { throw new RuntimeException("Something went wrong"); },
-      "", "", s -> failure("failed", "", ""));
+      "", "", s -> singleValidationError("failed", "", ""));
 
     final HttpResult<LoanAndRelatedRecords> result =
       validator.refuseWhenUserIsInactive(succeeded(new LoanAndRelatedRecords(


### PR DESCRIPTION
*Purpose*

In order to improve the readability of providing validation errors as feedback to a client, rename the static methods used for creation of both failures and failed results.

*Approach*
* Rename the static methods
* Increase the use of the static methods over the constructor for ValidationErrorFailure
* Where easily possible return a failed result rather than a failure

*Limitations*
* Many functions still return a failure, rather than a result, it is likely that the readability can be improved further by consolidating this further.

*Learning*
* Some validation responses do not include any parameter information, this is likely incorrect. These areas have not been changed as part of this pull request.

I think it may be worth stopping this in the ValidationError class in future.