### PR TITLE
CIRC-286 Multiple renewal failures only displaying one reason

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -69,9 +69,10 @@ public class LoanPolicy {
     try {
       if (isNotLoanable()) {
         errors.add(errorForPolicy("item is not loanable"));
-      }
-      if(isNotRenewable()) {
+      } else if (isNotRenewable()) {
         errors.add(errorForPolicy("loan is not renewable"));
+      } else {
+        errorWhenReachedRenewalLimit(loan, errors);
       }
 
       final Result<DateTime> proposedDueDateResult =
@@ -89,8 +90,6 @@ public class LoanPolicy {
       else {
         errorWhenEarlierOrSameDueDate(loan, proposedDueDateResult.value(), errors);
       }
-
-      errorWhenReachedRenewalLimit(loan, errors);
 
       if(errors.isEmpty()) {
         return proposedDueDateResult.map(dueDate -> loan.renew(dueDate, getId()));

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -65,18 +65,17 @@ public class LoanPolicy {
 
   public Result<Loan> renew(Loan loan, DateTime systemDate) {
     //TODO: Create HttpResult wrapper that traps exceptions
+    List<ValidationError> errors = new ArrayList<>();
     try {
       if (isNotLoanable()) {
-        return failedValidation(errorForPolicy("item is not loanable"));
+        errors.add(errorForPolicy("item is not loanable"));
       }
       if(isNotRenewable()) {
-        return failedValidation(errorForPolicy("loan is not renewable"));
+        errors.add(errorForPolicy("loan is not renewable"));
       }
 
       final Result<DateTime> proposedDueDateResult =
         determineStrategy(true, systemDate).calculateDueDate(loan);
-
-      List<ValidationError> errors = new ArrayList<>();
 
       //TODO: Need a more elegent way of combining validation errors
       if(proposedDueDateResult.failed()) {

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -68,7 +68,7 @@ public class LoanPolicy {
     List<ValidationError> errors = new ArrayList<>();
     try {
       if (isNotLoanable()) {
-        errors.add(errorForPolicy("item is not loanable"));
+        return failedValidation(errorForPolicy("item is not loanable"));
       } else if (isNotRenewable()) {
         errors.add(errorForPolicy("loan is not renewable"));
       } else {

--- a/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
@@ -54,7 +54,9 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
   @Override
   Result<DateTime> calculateDueDate(Loan loan) {
     if(StringUtils.isBlank(renewFrom)) {
-      return failedValidation(errorForPolicy(RENEW_FROM_UNRECOGNISED_MESSAGE));
+      return isDueDateAfterLoanDate(loan)
+        ? failedValidation(errorForPolicy(NO_APPLICABLE_DUE_DATE_LIMIT_SCHEDULE_MESSAGE))
+        : failedValidation(errorForPolicy(RENEW_FROM_UNRECOGNISED_MESSAGE));
     }
 
     switch (renewFrom) {
@@ -65,6 +67,10 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
       default:
         return failedValidation(errorForPolicy(RENEW_FROM_UNRECOGNISED_MESSAGE));
     }
+  }
+
+  private boolean isDueDateAfterLoanDate(Loan loan) {
+    return loan.getDueDate().isAfter(loan.getLoanDate());
   }
 
   protected Result<DateTime> calculateDueDate(DateTime from, DateTime loanDate) {

--- a/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RollingRenewalDueDateStrategy.java
@@ -3,6 +3,7 @@ package org.folio.circulation.domain.policy;
 import static java.lang.String.format;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 import org.apache.commons.lang3.StringUtils;
@@ -54,7 +55,8 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
   @Override
   Result<DateTime> calculateDueDate(Loan loan) {
     if(StringUtils.isBlank(renewFrom)) {
-      return isDueDateAfterLoanDate(loan)
+      DateTime dueDate = Optional.ofNullable(loan.getDueDate()).orElse(systemDate);
+      return calculateDueDate(dueDate, loan.getLoanDate()).failed()
         ? failedValidation(errorForPolicy(NO_APPLICABLE_DUE_DATE_LIMIT_SCHEDULE_MESSAGE))
         : failedValidation(errorForPolicy(RENEW_FROM_UNRECOGNISED_MESSAGE));
     }
@@ -67,10 +69,6 @@ class RollingRenewalDueDateStrategy extends DueDateStrategy {
       default:
         return failedValidation(errorForPolicy(RENEW_FROM_UNRECOGNISED_MESSAGE));
     }
-  }
-
-  private boolean isDueDateAfterLoanDate(Loan loan) {
-    return loan.getDueDate().isAfter(loan.getLoanDate());
   }
 
   protected Result<DateTime> calculateDueDate(DateTime from, DateTime loanDate) {


### PR DESCRIPTION
## Purpose

Multiple renewal failures should be displaying a few reasons

Actual Impl: 

- One failure reason displays: item is not renewable

Expected: 

- Two failure reasons display: item is not renewable, renewal date falls outside of date ranges in rolling loan policy


## Approach
Collected all errors in ValidationError list

## Link
[CIRC-286](https://issues.folio.org/browse/CIRC-286)
