### PR TITLE
Escape searching by barcode CQL CIRC-284

### DIFF
--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -5,7 +5,6 @@ import static api.support.RestAssuredClient.post;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
 import static api.support.http.InterfaceUrls.checkInByBarcodeUrl;
 import static api.support.http.InterfaceUrls.checkOutByBarcodeUrl;
-import static api.support.http.InterfaceUrls.loansUrl;
 import static api.support.http.InterfaceUrls.overrideCheckOutByBarcodeUrl;
 import static api.support.http.InterfaceUrls.overrideRenewalByBarcodeUrl;
 import static api.support.http.InterfaceUrls.renewByBarcodeUrl;
@@ -18,6 +17,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import org.folio.HttpStatus;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
@@ -150,6 +150,16 @@ public class LoansFixture {
     CheckOutByBarcodeRequestBuilder builder) {
 
     return attemptCheckOutByBarcode(422, builder);
+  }
+
+  public Response attemptCheckOutByBarcode(
+    HttpStatus expectedStatusCode,
+    CheckOutByBarcodeRequestBuilder builder) {
+
+    JsonObject request = builder.create();
+
+    return from(post(request, checkOutByBarcodeUrl(),
+      expectedStatusCode.toInt(), "check-out-by-barcode-request"));
   }
 
   public Response attemptCheckOutByBarcode(


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
CQL queries for finding either items or users by barcode are not URL encoded. This means that spaces cause the HTTP request to fail.

Reported in https://issues.folio.org/browse/CIRC-284

## Approach
Encode the CQL query for only these particular operations

#### TODOS and Open Questions
* Change how collection endpoint queries are performed so CQL queries have to be escaped

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [x] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [x] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
