### PR TITLE
Upgrade dependencies and maven plugins CIRC-307

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <dependency>
       <groupId>org.jacoco</groupId>
       <artifactId>jacoco-maven-plugin</artifactId>
-      <version>0.8.0</version>
+      <version>0.8.3</version>
     </dependency>
   </dependencies>
 
@@ -336,7 +336,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.3</version>
         <configuration>
           <excludes>**org.drools**</excludes>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
       <plugin>
         <groupId>com.coderplus.maven.plugins</groupId>
         <artifactId>copy-rename-maven-plugin</artifactId>
-        <version>1.0</version>
+        <version>1.0.1</version>
         <executions>
           <execution>
             <id>rename-descriptor-outputs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </repositories>
 
   <properties>
-    <antlr4.version>4.7.1</antlr4.version>
+    <antlr4.version>4.7.2</antlr4.version>
     <drools.version>7.0.0.Final</drools.version>
     <rmb.version>24.0.0</rmb.version>
     <vertx.version>3.7.0</vertx.version>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.0.7</version>
+      <version>3.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
-      <version>4.5.2</version>
+      <version>4.5.8</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-cache</artifactId>
-      <version>4.5.2</version>
+      <version>4.5.8</version>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.25</version>
+      <version>1.7.26</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.9.7</version>
+      <version>2.10.1</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>filter-descriptor-inputs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.5</version>
+      <version>3.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <antlr4.version>4.7.1</antlr4.version>
     <drools.version>7.0.0.Final</drools.version>
     <rmb.version>23.1.0</rmb.version>
-    <vertx.version>3.5.4</vertx.version>
+    <vertx.version>3.7.0</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,26 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.3.9</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.20</version>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <antlr4.version>4.7.2</antlr4.version>
-    <drools.version>7.0.0.Final</drools.version>
+    <drools.version>7.21.0.Final</drools.version>
     <rmb.version>24.0.0</rmb.version>
     <vertx.version>3.7.0</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
         <version>2.20</version>
-        
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -340,6 +339,14 @@
         <version>0.8.0</version>
         <configuration>
           <excludes>**org.drools**</excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <generateBackupPoms>false</generateBackupPoms>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <antlr4.version>4.7.1</antlr4.version>
     <drools.version>7.0.0.Final</drools.version>
-    <rmb.version>23.1.0</rmb.version>
+    <rmb.version>24.0.0</rmb.version>
     <vertx.version>3.7.0</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.20</version>
+        <version>2.22.0</version>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -313,7 +313,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
+        <version>2.22.1</version>
         <configuration>
           <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
                https://issues.folio.org/browse/FOLIO-1609
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.20</version>
+        <version>2.22.0</version>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
## Purpose

In order to ease the challenges with upgrading libraries it is valuable to periodically upgrade them. This is also useful for addressing security issues and gain feedback about deprecation of features.

The back end java modules are intending to become compatible with Java 11 soon. This requires upgrades to some dependencies and maven plugins.

[CIRC-307](https://issues.folio.org/browse/CIRC-307)

## Approach
* Enforce a minimum version of maven
* Include the maven versions plugin to determine which dependencies and plugins have upgrades 
* Upgrade to the latest release of each dependency and plugin separately

## TODO
* The deprecated methods in the Vert.x HTTP client will be addressed by migrating to the web client (and changing the collection resource client to return results instead of responses)

## Learning
* I didn't realise that there were plugins for enforcing a version of maven or for checking out of date dependencies.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [x] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [x] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.