### PR TITLE
Downgrade Drools to 7.0.0 CIRC-309

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <antlr4.version>4.7.2</antlr4.version>
-    <drools.version>7.21.0.Final</drools.version>
+    <drools.version>7.0.0.Final</drools.version>
     <rmb.version>24.0.0</rmb.version>
     <vertx.version>3.7.0</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Purpose
Something is causing drools initialisation to fail in the hosted
environments.

Experiment rolling back to the previous stable version to check if that
fixes the issue.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [x] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [x] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
