### PR TITLE
CIRC-291: include loan policy name

### DIFF
--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -53,6 +53,10 @@
       "description": "ID of last policy used in relation to this loan",
       "type": "string"
     },
+    "loanPolicyName": {
+      "description": "Name of last policy used in relation to this loan",
+      "type": "string"
+    },
     "item": {
       "description": "Additional information about the item",
       "type": "object",

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -241,7 +241,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   private void changeLoanPolicyName(String newLoanPolicyName) {
     if (Objects.nonNull(newLoanPolicyName) ) {
-      representation.put("loanPolicyName", newLoanPolicyName);
+      representation.put(LoanProperties.LOAN_POLICY_NAME, newLoanPolicyName);
     }
   }
 

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -240,7 +240,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   private void changeLoanPolicyName(String newLoanPolicyName) {
-    if (newLoanPolicyName != null) {
+    if (Objects.nonNull(newLoanPolicyName) ) {
       representation.put("loanPolicyName", newLoanPolicyName);
     }
   }

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -222,35 +222,43 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     return new Loan(representation, item, user, newProxy, checkinServicePoint,
       checkoutServicePoint, originalDueDate);
   }
-  
+
   public Loan withCheckinServicePoint(ServicePoint newCheckinServicePoint) {
     return new Loan(representation, item, user, proxy, newCheckinServicePoint,
       checkoutServicePoint, originalDueDate);
   }
-  
+
   public Loan withCheckoutServicePoint(ServicePoint newCheckoutServicePoint) {
     return new Loan(representation, item, user, proxy, checkinServicePoint,
       newCheckoutServicePoint, originalDueDate);
   }
 
-  private void changeLoanPolicy(String newLoanPolicyId) {
+  private void changeLoanPolicyId(String newLoanPolicyId) {
     if (newLoanPolicyId != null) {
       representation.put("loanPolicyId", newLoanPolicyId);
     }
   }
-  
+
+  private void changeLoanPolicyName(String newLoanPolicyName) {
+    if (newLoanPolicyName != null) {
+      representation.put("loanPolicyName", newLoanPolicyName);
+    }
+  }
+
   public ServicePoint getCheckinServicePoint() {
     return this.checkinServicePoint;
   }
-  
+
   public ServicePoint getCheckoutServicePoint() {
     return this.checkoutServicePoint;
   }
 
-  public Loan renew(DateTime dueDate, String basedUponLoanPolicyId) {
+  public Loan renew(DateTime dueDate, String basedUponLoanPolicyId,
+                    String basedUponLoanPolicyName) {
     changeAction("renewed");
     removeActionComment();
-    changeLoanPolicy(basedUponLoanPolicyId);
+    changeLoanPolicyId(basedUponLoanPolicyId);
+    changeLoanPolicyName(basedUponLoanPolicyName);
     changeDueDate(dueDate);
     incrementRenewalCount();
 
@@ -261,7 +269,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
                               String basedUponLoanPolicyId,
                               String actionComment) {
     changeAction("renewedThroughOverride");
-    changeLoanPolicy(basedUponLoanPolicyId);
+    changeLoanPolicyId(basedUponLoanPolicyId);
     changeDueDate(dueDate);
     incrementRenewalCount();
     changeActionComment(actionComment);

--- a/src/main/java/org/folio/circulation/domain/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepository.java
@@ -18,6 +18,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.folio.circulation.domain.policy.LoanPolicy;
+import org.folio.circulation.domain.representations.LoanProperties;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.CqlQuery;
@@ -73,6 +74,9 @@ public class LoanRepository {
 
     if(newLoanAndRelatedRecords.getLoanPolicy() != null) {
       storageLoan.put("loanPolicyId", newLoanAndRelatedRecords.getLoanPolicy().getId());
+      if (Objects.nonNull(newLoanAndRelatedRecords.getLoanPolicy())) {
+        storageLoan.put(LoanProperties.LOAN_POLICY_NAME, newLoanAndRelatedRecords.getLoanPolicy().getName());
+      }
     }
 
     User user = newLoanAndRelatedRecords.getLoan().getUser();

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -94,7 +94,7 @@ public class LoanPolicy {
       errorWhenReachedRenewalLimit(loan, errors);
 
       if(errors.isEmpty()) {
-        return proposedDueDateResult.map(dueDate -> loan.renew(dueDate, getId()));
+        return proposedDueDateResult.map(dueDate -> loan.renew(dueDate, getId(),getName()));
       }
       else {
         return failedValidation(errors);

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.representations.LoanProperties;
 import org.folio.circulation.support.ClockManager;
 import org.folio.circulation.support.Result;
 import org.folio.circulation.support.ServerErrorFailure;
@@ -185,7 +186,7 @@ public class LoanPolicy {
   private ValidationError errorForPolicy(String reason) {
     HashMap<String, String> parameters = new HashMap<>();
     parameters.put("loanPolicyId", getId());
-    parameters.put("loanPolicyName", getName());
+    parameters.put(LoanProperties.LOAN_POLICY_NAME, getName());
 
     return new ValidationError(reason, parameters);
   }
@@ -323,7 +324,7 @@ public class LoanPolicy {
     return loansPolicy.getString("profileId");
   }
 
-  private String getName() {
+  public String getName() {
     return representation.getString("name");
   }
 

--- a/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
@@ -14,4 +14,5 @@ public class LoanProperties {
   public static final String CHECKOUT_SERVICE_POINT_ID = "checkoutServicePointId";
   public static final String ACTION_COMMENT = "actionComment";
   public static final String BORROWER = "borrower";
+  public static final String LOAN_POLICY_NAME = "loanPolicyName";
 }

--- a/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
@@ -35,8 +35,6 @@ import org.folio.circulation.support.NoContentResult;
 import org.folio.circulation.support.OkJsonResponseResult;
 import org.folio.circulation.support.Result;
 import org.folio.circulation.support.http.server.WebContext;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonObject;
@@ -168,18 +166,12 @@ public class LoanCollectionResource extends CollectionResource {
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
     final UserRepository userRepository = new UserRepository(clients);
-    final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
 
     String id = routingContext.request().getParam("id");
 
     loanRepository.getById(id)
       .thenComposeAsync(servicePointRepository::findServicePointsForLoan)
       .thenComposeAsync(userRepository::findUserForLoan)
-      .thenComposeAsync(result -> loanPolicyRepository.lookupLoanPolicy(
-         new LoanAndRelatedRecords(result.value())).thenApply(loanAndRelatedRecords ->
-             loanAndRelatedRecords.value().getLoanPolicy()
-               .renew(loanAndRelatedRecords.value().getLoan(),
-                 DateTime.now(DateTimeZone.UTC))))
       .thenApply(loanResult -> loanResult.map(loanRepresentation::extendedLoan))
       .thenApply(OkJsonResponseResult::from)
       .thenAccept(result -> result.writeTo(routingContext.response()));

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -1690,27 +1690,9 @@ public class LoanAPITests extends APITests {
       loan.containsKey("itemStatus"), is(false));
   }
 
-  private void hasProperty(String property, JsonObject resource, String type, Object value) {
-    assertThat(String.format("%s should have an %s: %s",
-      type, property, resource),
-      resource.getMap().get(property), equalTo(value));
-  }
-
   private void hasNoBorrowerProperties(JsonObject loanJson) {
     doesNotHaveProperty("userId", loanJson, "loan");
     doesNotHaveProperty(LoanProperties.BORROWER, loanJson, "loan");
-  }
-
-  private void doesNotHaveProperty(String property, JsonObject resource, String type) {
-    assertThat(String.format("%s should NOT have an %s: %s",
-            type, property, resource),
-            resource.getValue(property), is(nullValue()));
-  }
-
-  private void hasProperty(String property, JsonObject resource, String type) {
-    assertThat(String.format("%s should have an %s: %s",
-      type, property, resource),
-      resource.containsKey(property), is(true));
   }
 
   private void loanHasCheckinServicePointProperties(JsonObject loanJson) {

--- a/src/test/java/api/requests/RequestsAPIRetrievalTests.java
+++ b/src/test/java/api/requests/RequestsAPIRetrievalTests.java
@@ -799,7 +799,7 @@ public class RequestsAPIRetrievalTests extends APITests {
 
   }
 
-  private void hasProperty(String property, JsonObject resource, String type) {
+  protected void hasProperty(String property, JsonObject resource, String type) {
     assertThat(format("%s should have %s: %s: is missing outer property",
       type, property, resource),
       resource, notNullValue());

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -1,6 +1,8 @@
 package api.support;
 
 import static api.support.APITestContext.createClient;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -12,9 +14,12 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import io.vertx.core.json.JsonObject;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.client.ResponseHandler;
+import org.hamcrest.CustomTypeSafeMatcher;
+import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -355,4 +360,34 @@ public abstract class APITests {
     ResourceClient.forCancellationReasons(client).deleteAllIndividually();
   }
 
+
+  protected Matcher<JsonObject> hasProperty(String key, String value) {
+
+    return new CustomTypeSafeMatcher<JsonObject>(key) {
+
+      @Override protected boolean matchesSafely(JsonObject item) {
+        return item.getValue(key).equals(value);
+      }
+    };
+  }
+
+  protected void hasProperty(String property, JsonObject resource, String type) {
+    assertThat(String.format("%s should have an %s: %s",
+      type, property, resource),
+      resource.containsKey(property), is(true));
+  }
+
+
+  protected void hasProperty(String property, JsonObject resource, String type, Object value) {
+    assertThat(String.format("%s should have an %s: %s",
+      type, property, resource),
+      resource.getMap().get(property), equalTo(value));
+  }
+
+
+  protected void doesNotHaveProperty(String property, JsonObject resource, String type) {
+    assertThat(String.format("%s should NOT have an %s: %s",
+            type, property, resource),
+            resource.getValue(property), is(nullValue()));
+  }
 }


### PR DESCRIPTION
## Purpose

In order to include the loan policy name in the overdue loans CSV export, and avoid the UI having to fetch this information itself, this information needs providing by the loan collection business logic API
This resolves https://issues.folio.org/browse/CIRC-291

## Approach
The main change is in the Loan class: the loan policy name is set along with the policyId - when the loan is created. Other changes are mostly refactoring: moving  the "loanPolicyName" to a single place; moving the common test methods to the parent class.
