### PR TITLE
Do not attempt to check in open loan CIRC-351

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -173,6 +173,10 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     return StringUtils.equals(getStatus(), "Closed");
   }
 
+  public boolean isOpen() {
+    return StringUtils.equals(getStatus(), "Open");
+  }
+
   private String getStatus() {
     return getNestedStringProperty(representation, STATUS, "name");
   }

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -1,6 +1,7 @@
 package org.folio.circulation.domain;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.support.Result.ofAsync;
 import static org.folio.circulation.support.Result.succeeded;
 
 import java.lang.invoke.MethodHandles;
@@ -41,6 +42,11 @@ public class UpdateRequestQueue {
 
   public CompletableFuture<Result<LoanAndRelatedRecords>> onCheckIn(
     LoanAndRelatedRecords relatedRecords) {
+
+    //Do not attempt check in for open loan
+    if(relatedRecords.getLoan().isOpen()) {
+      return ofAsync(() -> relatedRecords);
+    }
 
     final RequestQueue requestQueue = relatedRecords.getRequestQueue();
 

--- a/src/test/java/api/loans/scenarios/ChangeDueDateTests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateTests.java
@@ -21,13 +21,13 @@ import org.joda.time.Period;
 import org.junit.Test;
 
 import api.support.APITests;
+import api.support.builders.RequestBuilder;
 import api.support.http.InventoryItemResource;
 import io.vertx.core.json.JsonObject;
 
 public class ChangeDueDateTests extends APITests {
-
   @Test
-  public void canRenewALoanByExtendingTheDueDate()
+  public void canManuallyChangeTheDueDateOfLoan()
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
@@ -36,6 +36,79 @@ public class ChangeDueDateTests extends APITests {
     final InventoryItemResource item = itemsFixture.basedUponNod();
 
     IndividualResource loan = loansFixture.checkOutByBarcode(item);
+
+    Response fetchedLoan = loansClient.getById(loan.getId());
+
+    JsonObject loanToChange = fetchedLoan.getJson().copy();
+
+    DateTime dueDate = DateTime.parse(loanToChange.getString("dueDate"));
+    DateTime newDueDate = dueDate.plus(Period.days(14));
+
+    write(loanToChange, "action", "dueDateChange");
+    write(loanToChange, "dueDate", newDueDate);
+
+    CompletableFuture<Response> putCompleted = new CompletableFuture<>();
+
+    client.put(loansUrl(String.format("/%s", loan.getId())), loanToChange,
+      ResponseHandler.any(putCompleted));
+
+    Response putResponse = putCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(String.format("Failed to update loan: %s",
+      putResponse.getBody()), putResponse.getStatusCode(), is(HTTP_NO_CONTENT));
+
+    Response updatedLoanResponse = loansClient.getById(loan.getId());
+
+    JsonObject updatedLoan = updatedLoanResponse.getJson();
+
+    assertThat("status is not open",
+      updatedLoan.getJsonObject("status").getString("name"), is("Open"));
+
+    assertThat("action is not change due date",
+      updatedLoan.getString("action"), is("dueDateChange"));
+
+    assertThat("should not contain a return date",
+      updatedLoan.containsKey("returnDate"), is(false));
+
+    assertThat("due date does not match",
+      updatedLoan.getString("dueDate"), isEquivalentTo(newDueDate));
+
+    assertThat("renewal count should not have changed",
+      updatedLoan.containsKey("renewalCount"), is(false));
+
+    JsonObject fetchedItem = itemsClient.getById(item.getId()).getJson();
+
+    assertThat("item status is not checked out",
+      fetchedItem.getJsonObject("status").getString("name"), is("Checked out"));
+
+    final JsonObject loanInStorage = loansStorageClient.getById(loan.getId()).getJson();
+
+    assertThat("item status snapshot in storage is not checked out",
+      loanInStorage.getString("itemStatus"), is("Checked out"));
+
+    assertThat("Should not contain check in service point summary",
+      loanInStorage.containsKey("checkinServicePoint"), is(false));
+
+    assertThat("Should not contain check out service point summary",
+      loanInStorage.containsKey("checkoutServicePoint"), is(false));
+  }
+
+  @Test
+  public void canChangeDueDateOfLoanWithOpenRequest()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    final InventoryItemResource item = itemsFixture.basedUponNod();
+
+    IndividualResource loan = loansFixture.checkOutByBarcode(item);
+
+    requestsFixture.place(new RequestBuilder()
+      .hold()
+      .forItem(item)
+      .by(usersFixture.steve())
+      .fulfilToHoldShelf(servicePointsFixture.cd1()));
 
     Response fetchedLoan = loansClient.getById(loan.getId());
 

--- a/src/test/java/api/support/builders/RequestBuilder.java
+++ b/src/test/java/api/support/builders/RequestBuilder.java
@@ -343,6 +343,11 @@ public class RequestBuilder extends JsonBuilder implements Builder {
     return withFulfilmentPreference("Hold Shelf");
   }
 
+  public RequestBuilder fulfilToHoldShelf(IndividualResource newPickupServicePoint) {
+    return withFulfilmentPreference("Hold Shelf")
+      .withPickupServicePointId(newPickupServicePoint.getId());
+  }
+
   public RequestBuilder fulfilToHoldShelf(UUID newPickupServicePointId) {
     return withFulfilmentPreference("Hold Shelf")
       .withPickupServicePointId(newPickupServicePointId);


### PR DESCRIPTION
## Purpose
See https://issues.folio.org/browse/CIRC-351 for more details

## Approach
* Demonstrate the behaviour with a failing test
* Add the required check to short circuit

#### TODOS and Open Questions
* The PUT `/circulation/loans/[id]` endpoint currently attempts to mimic a check out. This was convenient during the transition to the check out / check in APIs, however now it is a source of confusion and issues as it is only behaves partially similar

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
