### PR TITLE
Cannot fetch single record with null CIRC-359 

### DIFF
--- a/src/main/java/org/folio/circulation/domain/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepository.java
@@ -22,8 +22,10 @@ import org.folio.circulation.domain.representations.LoanProperties;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.CqlQuery;
+import org.folio.circulation.support.FetchSingleRecord;
 import org.folio.circulation.support.ForwardOnFailure;
 import org.folio.circulation.support.ItemRepository;
+import org.folio.circulation.support.RecordNotFoundFailure;
 import org.folio.circulation.support.Result;
 import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.SingleRecordFetcher;
@@ -156,8 +158,10 @@ public class LoanRepository {
   }
 
   private CompletableFuture<Result<Loan>> fetchLoan(String id) {
-    return new SingleRecordFetcher<>(
-      loansStorageClient, "loan", Loan::from)
+    return FetchSingleRecord.<Loan>forRecord("loan")
+      .using(loansStorageClient)
+      .mapTo(Loan::from)
+      .whenNotFound(failed(new RecordNotFoundFailure("loan", id)))
       .fetch(id);
   }
 

--- a/src/main/java/org/folio/circulation/domain/LocationRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LocationRepository.java
@@ -1,5 +1,7 @@
 package org.folio.circulation.domain;
 
+import static java.util.Objects.isNull;
+import static org.folio.circulation.support.Result.ofAsync;
 import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.ResultBinding.mapResult;
 
@@ -23,10 +25,11 @@ public class LocationRepository {
   private CollectionResourceClient campusesStorageClient;
   private CollectionResourceClient librariesStorageClient;
 
-  public LocationRepository(CollectionResourceClient locationsStorageClient,
-                            CollectionResourceClient institutionsStorageClient,
-                            CollectionResourceClient campusesStorageClient,
-                            CollectionResourceClient librariesStorageClient) {
+  private LocationRepository(CollectionResourceClient locationsStorageClient,
+                             CollectionResourceClient institutionsStorageClient,
+                             CollectionResourceClient campusesStorageClient,
+                             CollectionResourceClient librariesStorageClient) {
+
     this.locationsStorageClient = locationsStorageClient;
     this.institutionsStorageClient = institutionsStorageClient;
     this.campusesStorageClient = campusesStorageClient;
@@ -43,7 +46,11 @@ public class LocationRepository {
   }
 
   public CompletableFuture<Result<Location>> getLocation(Item item) {
-    return SingleRecordFetcher.json(locationsStorageClient, "locations",
+    if(isNull(item) || isNull(item.getLocationId())) {
+      return ofAsync(() -> null);
+    }
+
+    return SingleRecordFetcher.json(locationsStorageClient, "location",
       response -> succeeded(null))
       .fetch(item.getLocationId())
       .thenApply(r -> r.map(Location::from))
@@ -68,18 +75,30 @@ public class LocationRepository {
   }
 
   private CompletableFuture<Result<Location>> loadLibrary(Location location) {
+    if(isNull(location) || isNull(location.getLibraryId())) {
+      return ofAsync(() -> null);
+    }
+
     return SingleRecordFetcher.json(librariesStorageClient, "library", response -> succeeded(null))
       .fetch(location.getLibraryId())
       .thenApply(r -> r.map(location::withLibraryRepresentation));
   }
 
   private CompletableFuture<Result<Location>> loadCampus(Location location) {
+    if(isNull(location) || isNull(location.getCampusId())) {
+      return ofAsync(() -> null);
+    }
+
     return SingleRecordFetcher.json(campusesStorageClient, "campus", response -> succeeded(null))
       .fetch(location.getCampusId())
       .thenApply(r -> r.map(location::withCampusRepresentation));
   }
 
   private CompletableFuture<Result<Location>> loadInstitution(Location location) {
+    if(isNull(location) || isNull(location.getInstitutionId())) {
+      return ofAsync(() -> null);
+    }
+
     return SingleRecordFetcher.json(institutionsStorageClient, "institution", response -> succeeded(null))
       .fetch(location.getInstitutionId())
       .thenApply(r -> r.map(location::withInstitutionRepresentation));

--- a/src/main/java/org/folio/circulation/domain/MaterialTypeRepository.java
+++ b/src/main/java/org/folio/circulation/domain/MaterialTypeRepository.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain;
 
+import static java.util.Objects.isNull;
 import static java.util.function.Function.identity;
 import static org.folio.circulation.support.JsonKeys.byId;
 import static org.folio.circulation.support.Result.succeeded;
@@ -28,9 +29,15 @@ public class MaterialTypeRepository {
   }
 
   public CompletableFuture<Result<JsonObject>> getFor(Item item) {
+    final String materialTypeId = item.getMaterialTypeId();
+
+    if(isNull(materialTypeId)) {
+      return Result.ofAsync(() -> null);
+    }
+
     return SingleRecordFetcher.json(materialTypesStorageClient, "material types",
       response -> succeeded(null))
-      .fetch(item.getMaterialTypeId());
+      .fetch(materialTypeId);
   }
 
   public CompletableFuture<Result<Map<String, JsonObject>>> getMaterialTypes(

--- a/src/main/java/org/folio/circulation/domain/RequestRepository.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepository.java
@@ -1,6 +1,8 @@
 package org.folio.circulation.domain;
 
+import static java.util.Objects.isNull;
 import static org.folio.circulation.support.Result.failed;
+import static org.folio.circulation.support.Result.ofAsync;
 import static org.folio.circulation.support.Result.succeeded;
 
 import java.lang.invoke.MethodHandles;
@@ -192,8 +194,11 @@ public class RequestRepository {
   }
 
   public CompletableFuture<Result<Request>> loadCancellationReason(Request request) {
+    if(isNull(request) || isNull(request.getCancellationReasonId())) {
+      return ofAsync(() -> null);
+    }
 
-    return FetchSingleRecord.<Request>forRecord("cancellationreason")
+    return FetchSingleRecord.<Request>forRecord("cancellation reason")
       .using(cancellationReasonStorageClient)
       .mapTo(request::withCancellationReasonJsonRepresentation)
       .whenNotFound(succeeded(request))

--- a/src/main/java/org/folio/circulation/domain/RequestRepository.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepository.java
@@ -17,10 +17,10 @@ import org.folio.circulation.support.Result;
 import org.folio.circulation.support.SingleRecordFetcher;
 import org.folio.circulation.support.SingleRecordMapper;
 import org.folio.circulation.support.http.client.Response;
-
-import io.vertx.core.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.vertx.core.json.JsonObject;
 
 public class RequestRepository {
   private final CollectionResourceClient requestsStorageClient;
@@ -225,12 +225,11 @@ public class RequestRepository {
     return patronGroupRepository.findPatronGroupsForSingleRequestUsers(result);
   }
 
-  private CompletableFuture<Result<User>> getUser(String proxyUserId) {
-    return userRepository.getUser(proxyUserId);
+  private CompletableFuture<Result<User>> getUser(String userId) {
+    return userRepository.getUser(userId);
   }
 
   private CompletableFuture<Result<ServicePoint>> getServicePoint(String servicePointId) {
     return servicePointRepository.getServicePointById(servicePointId);
   }
-
 }

--- a/src/main/java/org/folio/circulation/domain/RequestRepository.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepository.java
@@ -12,6 +12,7 @@ import org.folio.circulation.support.CqlQuery;
 import org.folio.circulation.support.FetchSingleRecord;
 import org.folio.circulation.support.ForwardOnFailure;
 import org.folio.circulation.support.ItemRepository;
+import org.folio.circulation.support.RecordNotFoundFailure;
 import org.folio.circulation.support.Result;
 import org.folio.circulation.support.SingleRecordFetcher;
 import org.folio.circulation.support.SingleRecordMapper;
@@ -123,7 +124,10 @@ public class RequestRepository {
   }
 
   private CompletableFuture<Result<Request>> fetchRequest(String id) {
-    return new SingleRecordFetcher<>(requestsStorageClient, "request", Request::from)
+    return FetchSingleRecord.<Request>forRecord("request")
+      .using(requestsStorageClient)
+      .mapTo(Request::from)
+      .whenNotFound(failed(new RecordNotFoundFailure("request", id)))
       .fetch(id);
   }
 

--- a/src/main/java/org/folio/circulation/domain/UserRepository.java
+++ b/src/main/java/org/folio/circulation/domain/UserRepository.java
@@ -110,6 +110,10 @@ public class UserRepository {
 
   //TODO: Replace this with validator
   public CompletableFuture<Result<User>> getUserFailOnNotFound(String userId) {
+    if(isNull(userId)) {
+      return completedFuture(failedValidation("user is not found", "userId", userId));
+    }
+
     return FetchSingleRecord.<User>forRecord("user")
       .using(usersStorageClient)
       .mapTo(User::new)

--- a/src/main/java/org/folio/circulation/domain/UserRepository.java
+++ b/src/main/java/org/folio/circulation/domain/UserRepository.java
@@ -1,7 +1,9 @@
 package org.folio.circulation.domain;
 
+import static java.util.Objects.isNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.support.Result.of;
+import static org.folio.circulation.support.Result.ofAsync;
 import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.ResultBinding.mapResult;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
@@ -42,13 +44,18 @@ public class UserRepository {
   }
 
   public CompletableFuture<Result<User>> getProxyUser(UserRelatedRecord userRelatedRecord) {
-    if (userRelatedRecord.getProxyUserId() == null){
+    if (userRelatedRecord.getProxyUserId() == null) {
       return CompletableFuture.completedFuture(succeeded(null));
     }
+
     return getUser(userRelatedRecord.getProxyUserId());
   }
 
   public CompletableFuture<Result<User>> getUser(String userId) {
+    if(isNull(userId)) {
+      return ofAsync(() -> null);
+    }
+
     return FetchSingleRecord.<User>forRecord("user")
       .using(usersStorageClient)
       .mapTo(User::new)
@@ -57,25 +64,18 @@ public class UserRepository {
   }
 
   public CompletableFuture<Result<Loan>> findUserForLoan(Result<Loan> loanResult) {
-    return loanResult.after(loan -> {
-      String userId = loan.getUserId();
-      if (userId == null) {
-        return completedFuture(loanResult);
-      }
-      return getUser(userId)
-        .thenApply(userResult ->
-          userResult.map(user -> {
-            if (user == null) {
-              log.info("No user found for loan {}", loan.getId());
-            } else {
-              log.info("User with username {} found for loan {}",
-                loan.getUser().getUsername(), loan.getId());
-            }
-            return loan.withUser(user);
-          }));
-    });
+    return loanResult.after(loan -> getUser(loan.getUserId())
+      .thenApply(userResult ->
+        userResult.map(user -> {
+          if (isNull(user)) {
+            log.info("No user found for loan {}", loan.getId());
+          } else {
+            log.info("User with username {} found for loan {}",
+              loan.getUser().getUsername(), loan.getId());
+          }
+          return loan.withUser(user);
+        })));
   }
-
 
   public CompletableFuture<Result<MultipleRecords<Loan>>> findUsersForLoans(
     MultipleRecords<Loan> multipleLoans) {

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicyRepository.java
@@ -1,5 +1,7 @@
 package org.folio.circulation.domain.policy;
 
+import static java.util.Objects.isNull;
+import static org.folio.circulation.support.Result.ofAsync;
 import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.ResultBinding.mapResult;
 
@@ -45,11 +47,15 @@ public class LoanPolicyRepository extends CirculationPolicyRepository<LoanPolicy
   }
 
   private CompletableFuture<Result<LoanPolicy>> getLoanPolicyById(String loanPolicyId) {
+    if(isNull(loanPolicyId)) {
+      return ofAsync(() -> null);
+    }
+
     return FetchSingleRecord.<LoanPolicy>forRecord("loan policy")
-            .using(policyStorageClient)
-            .mapTo(LoanPolicy::from)
-            .whenNotFound(succeeded(null))
-            .fetch(loanPolicyId);
+      .using(policyStorageClient)
+      .mapTo(LoanPolicy::from)
+      .whenNotFound(succeeded(null))
+      .fetch(loanPolicyId);
   }
 
   public CompletableFuture<Result<MultipleRecords<Loan>>> findLoanPoliciesForLoans(MultipleRecords<Loan> multipleLoans) {

--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -2,6 +2,7 @@ package org.folio.circulation.resources;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.support.Result.failed;
+import static org.folio.circulation.support.Result.ofAsync;
 import static org.folio.circulation.support.Result.succeeded;
 
 import java.util.concurrent.CompletableFuture;
@@ -73,9 +74,11 @@ class RequestFromRepresentationService {
 
   private CompletableFuture<Result<User>> getUserForExistingLoan(Request request) {
     Loan loan = request.getLoan();
+
     if (loan == null) {
-      return CompletableFuture.completedFuture(succeeded(null));
+      return ofAsync(() -> null);
     }
+
     return userRepository.getUser(loan.getUserId());
   }
 

--- a/src/main/java/org/folio/circulation/support/RecordNotFoundFailure.java
+++ b/src/main/java/org/folio/circulation/support/RecordNotFoundFailure.java
@@ -1,0 +1,26 @@
+package org.folio.circulation.support;
+
+import org.folio.circulation.support.http.server.ClientErrorResponse;
+
+import io.vertx.core.http.HttpServerResponse;
+
+public class RecordNotFoundFailure implements HttpFailure {
+  private final String recordType;
+  private final String id;
+
+  public RecordNotFoundFailure(String recordType, String id) {
+    this.recordType = recordType;
+    this.id = id;
+  }
+
+  @Override
+  public void writeTo(HttpServerResponse response) {
+    ClientErrorResponse.notFound(response, toString());
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s record with ID \"%s\" cannot be found",
+      recordType, id);
+  }
+}

--- a/src/main/java/org/folio/circulation/support/Result.java
+++ b/src/main/java/org/folio/circulation/support/Result.java
@@ -333,6 +333,28 @@ public interface Result<T> {
     return next(value -> succeeded(map.apply(value)));
   }
 
+  /**
+   * Map the cause of a failed result to a new result (of the same type)
+   *
+   * Responds with a new result with the outcome of applying the map to the current
+   * failure cause unless current result has succeeded (or the mapping throws an exception)
+   *
+   * @param map function to apply to value of result
+   * @return success when result succeeded and map is applied successfully, failure otherwise
+   */
+  default Result<T> mapFailure(Function<HttpFailure, Result<T>> map) {
+    if(succeeded()) {
+      return Result.of(this::value);
+    }
+
+    try {
+      return map.apply(cause());
+    }
+    catch(Exception e) {
+      return failed(e);
+    }
+  }
+
   default T orElse(T other) {
     return succeeded()
       ? value()

--- a/src/main/java/org/folio/circulation/support/SingleRecordFetcher.java
+++ b/src/main/java/org/folio/circulation/support/SingleRecordFetcher.java
@@ -1,5 +1,7 @@
 package org.folio.circulation.support;
 
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 import static org.folio.circulation.support.Result.failed;
 import static org.folio.circulation.support.Result.succeeded;
@@ -57,6 +59,8 @@ public class SingleRecordFetcher<T> {
 
   public CompletableFuture<Result<T>> fetch(String id) {
     log.info("Fetching {} with ID: {}", recordType, id);
+
+    requireNonNull(id, format("Cannot fetch single %s with null ID", recordType));
 
     return client.get(id)
       .thenApply(mapper::mapFrom)

--- a/src/main/java/org/folio/circulation/support/SingleRecordMapper.java
+++ b/src/main/java/org/folio/circulation/support/SingleRecordMapper.java
@@ -66,8 +66,8 @@ public class SingleRecordMapper<T> {
 
     //TODO: Include the request URL here
     final String diagnosticError = String.format(
-      "HTTP request failed, status code: %s, response: \"%s\"",
-      response.getStatusCode(), response.getBody());
+      "HTTP request to \"%s\" failed, status code: %s, response: \"%s\"",
+      response.getFromUrl(), response.getStatusCode(), response.getBody());
 
     return failed(new ServerErrorFailure(diagnosticError));
   }

--- a/src/main/java/org/folio/circulation/support/SingleRecordMapper.java
+++ b/src/main/java/org/folio/circulation/support/SingleRecordMapper.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.support;
 
+import static java.util.Objects.isNull;
 import static org.folio.circulation.support.Result.failed;
 import static org.folio.circulation.support.Result.succeeded;
 
@@ -18,19 +19,21 @@ public class SingleRecordMapper<T> {
   private final Function<JsonObject, T> mapper;
   private final Function<Response, Result<T>> resultOnFailure;
 
-  public static <T> SingleRecordMapper<T> notFound(Function<JsonObject, T> mapper, Result<T> notFoundResult) {
+  static <T> SingleRecordMapper<T> notFound(
+    Function<JsonObject, T> mapper, Result<T> notFoundResult) {
+
     return new SingleRecordMapper<>(mapper, notFoundMapper(notFoundResult));
   }
 
   SingleRecordMapper(Function<JsonObject, T> mapper) {
-    this(mapper, (response -> failed(new ForwardOnFailure(response))));
+    this(mapper, (SingleRecordMapper::mapResponseToFailure));
   }
 
   public SingleRecordMapper(
     Function<JsonObject, T> mapper,
-    Function<Response, Result<T>> responseHttpResultFunction) {
+    Function<Response, Result<T>> onFailure) {
     this.mapper = mapper;
-    resultOnFailure = responseHttpResultFunction;
+    resultOnFailure = onFailure;
   }
 
   Result<T> mapFrom(Response response) {
@@ -41,7 +44,7 @@ public class SingleRecordMapper<T> {
       if (response.getStatusCode() == 200) {
         return succeeded(mapper.apply(response.getJson()));
       } else {
-        return this.resultOnFailure.apply(response);
+        return resultOnFailure.apply(response);
       }
     }
     else {
@@ -53,6 +56,19 @@ public class SingleRecordMapper<T> {
   private static <T> Function<Response, Result<T>> notFoundMapper(Result<T> result) {
     return response -> response.getStatusCode() == 404
       ? result
-      : failed(new ForwardOnFailure(response));
+      : mapResponseToFailure(response);
+  }
+
+  private static <T> ResponseWritableResult<T> mapResponseToFailure(Response response) {
+    if(isNull(response)) {
+      return failed(new ServerErrorFailure("Null response received"));
+    }
+
+    //TODO: Include the request URL here
+    final String diagnosticError = String.format(
+      "HTTP request failed, status code: %s, response: \"%s\"",
+      response.getStatusCode(), response.getBody());
+
+    return failed(new ServerErrorFailure(diagnosticError));
   }
 }

--- a/src/main/java/org/folio/circulation/support/http/client/OkapiHttpClient.java
+++ b/src/main/java/org/folio/circulation/support/http/client/OkapiHttpClient.java
@@ -1,20 +1,25 @@
 package org.folio.circulation.support.http.client;
 
-import io.vertx.core.Handler;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.json.Json;
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.folio.circulation.support.http.OkapiHeader.OKAPI_URL;
+import static org.folio.circulation.support.http.OkapiHeader.REQUEST_ID;
+import static org.folio.circulation.support.http.OkapiHeader.TENANT;
+import static org.folio.circulation.support.http.OkapiHeader.TOKEN;
+import static org.folio.circulation.support.http.OkapiHeader.USER_ID;
 
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.function.Consumer;
 
-import static org.folio.circulation.support.http.OkapiHeader.*;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.json.Json;
 
 public class OkapiHttpClient {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -125,7 +130,7 @@ public class OkapiHttpClient {
 
     addStandardHeaders(request);
 
-    request.exceptionHandler(this.exceptionHandler::accept);
+    request.exceptionHandler(exceptionHandler::accept);
 
     request.end();
   }

--- a/src/main/java/org/folio/circulation/support/http/client/Response.java
+++ b/src/main/java/org/folio/circulation/support/http/client/Response.java
@@ -14,24 +14,33 @@ public class Response {
   private final int statusCode;
   private final String contentType;
   private final CaseInsensitiveHeaders headers;
+  private final String fromUrl;
 
   public Response(int statusCode, String body, String contentType) {
-    this(statusCode, body, contentType, new CaseInsensitiveHeaders());
+    this(statusCode, body, contentType, new CaseInsensitiveHeaders(), null);
   }
 
   public Response(
     int statusCode,
     String body,
     String contentType,
-    CaseInsensitiveHeaders headers) {
+    CaseInsensitiveHeaders headers,
+    String fromUrl) {
 
     this.statusCode = statusCode;
     this.body = body;
     this.contentType = contentType;
     this.headers = headers;
+    this.fromUrl = fromUrl;
   }
 
   public static Response from(HttpClientResponse response, Buffer body) {
+    return from(response, body, null);
+  }
+
+  public static Response from(HttpClientResponse response, Buffer body,
+                              String fromUrl) {
+
     final CaseInsensitiveHeaders headers = new CaseInsensitiveHeaders();
 
     headers.addAll(response.headers());
@@ -39,7 +48,7 @@ public class Response {
     return new Response(response.statusCode(),
       BufferHelper.stringFromBuffer(body),
       convertNullToEmpty(response.getHeader(CONTENT_TYPE)),
-      headers);
+      headers, fromUrl);
   }
 
   public boolean hasBody() {
@@ -73,5 +82,9 @@ public class Response {
 
   String getHeader(String name) {
     return headers.get(name);
+  }
+
+  public String getFromUrl() {
+    return fromUrl;
   }
 }

--- a/src/main/java/org/folio/circulation/support/http/server/ClientErrorResponse.java
+++ b/src/main/java/org/folio/circulation/support/http/server/ClientErrorResponse.java
@@ -1,14 +1,19 @@
 package org.folio.circulation.support.http.server;
 
-import io.vertx.core.http.HttpServerResponse;
 import org.apache.http.entity.ContentType;
+
+import io.vertx.core.http.HttpServerResponse;
 
 public class ClientErrorResponse {
   private ClientErrorResponse() { }
 
-  public static void notFound(HttpServerResponse response) {
+  public static void notFound(HttpServerResponse response, String text) {
     response.setStatusCode(404);
-    response.end("Not Found");
+    response.end(text);
+  }
+
+  public static void notFound(HttpServerResponse response) {
+    notFound(response, "Not Found");
   }
 
   public static void badRequest(HttpServerResponse response, String reason) {

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -3,6 +3,7 @@ package api.loans;
 import static api.requests.RequestsAPICreationTests.setupMissingItem;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
 import static api.support.http.InterfaceUrls.loansUrl;
+import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static api.support.matchers.UUIDMatcher.is;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
@@ -10,8 +11,12 @@ import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasMessageContaining;
 import static api.support.matchers.ValidationErrorMatchers.hasNullParameter;
 import static api.support.matchers.ValidationErrorMatchers.hasUUIDParameter;
+import static org.folio.HttpStatus.HTTP_VALIDATION_ERROR;
 import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -26,7 +31,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import api.support.fixtures.ConfigurationExample;
 import org.folio.circulation.domain.representations.LoanProperties;
 import org.folio.circulation.support.JsonArrayHelper;
 import org.folio.circulation.support.http.client.IndividualResource;
@@ -41,6 +45,7 @@ import org.junit.Test;
 import api.support.APITests;
 import api.support.builders.ItemBuilder;
 import api.support.builders.LoanBuilder;
+import api.support.fixtures.ConfigurationExample;
 import api.support.http.InterfaceUrls;
 import api.support.http.InventoryItemResource;
 import io.vertx.core.json.JsonArray;
@@ -298,7 +303,7 @@ public class LoanAPITests extends APITests {
         .withLoanDate(loanDate)
         .withDueDate(dueDate)
         .create(),
-      ResponseHandler.json(createCompleted));
+      ResponseHandler.any(createCompleted));
 
     Response response = createCompleted.get(5, TimeUnit.SECONDS);
 
@@ -1130,6 +1135,8 @@ public class LoanAPITests extends APITests {
       ResponseHandler.any(putCompleted));
 
     Response putResponse = putCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(putResponse, hasStatus(HTTP_VALIDATION_ERROR));
 
     assertThat(putResponse.getJson(), hasErrorWith(allOf(
       hasMessage("Open loan must have a user ID"),

--- a/src/test/java/api/loans/scenarios/ServicePointCheckInTests.java
+++ b/src/test/java/api/loans/scenarios/ServicePointCheckInTests.java
@@ -1,6 +1,8 @@
 package api.loans.scenarios;
 
+import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static api.support.matchers.UUIDMatcher.is;
+import static org.folio.HttpStatus.HTTP_OK;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -10,6 +12,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
@@ -81,7 +84,11 @@ public class ServicePointCheckInTests extends APITests {
     assertThat("Checkin Service Point Id should be stored",
       storedLoan.getString("checkinServicePointId"), is(checkInServicePoint.getId()));
 
-    final JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+    final Response getByIdResponse = requestsClient.getById(request.getId());
+
+    assertThat(getByIdResponse, hasStatus(HTTP_OK));
+
+    final JsonObject storedRequest = getByIdResponse.getJson();
 
     assertThat("request status snapshot in storage is open - awaiting pickup",
         storedRequest.getString("status"), is("Open - Awaiting pickup"));
@@ -174,9 +181,11 @@ public class ServicePointCheckInTests extends APITests {
     assertThat("Checkin Service Point Id should be stored",
       storedLoan.getString("checkinServicePointId"), is(checkInServicePoint.getId()));
 
-    final JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+    final Response getByIdResponse = requestsClient.getById(request.getId());
+
+    assertThat(getByIdResponse, hasStatus(HTTP_OK));
 
     assertThat("request status snapshot in storage is open - in transit",
-        storedRequest.getString("status"), is("Open - In transit"));
+        getByIdResponse.getJson().getString("status"), is("Open - In transit"));
   }
 }

--- a/src/test/java/api/loans/scenarios/ServicePointCheckOutTests.java
+++ b/src/test/java/api/loans/scenarios/ServicePointCheckOutTests.java
@@ -1,6 +1,8 @@
 package api.loans.scenarios;
 
+import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static api.support.matchers.UUIDMatcher.is;
+import static org.folio.HttpStatus.HTTP_OK;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -10,6 +12,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
+import org.hamcrest.junit.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
@@ -113,7 +117,11 @@ public class ServicePointCheckOutTests extends APITests {
     assertThat("item status snapshot in storage is checked out",
       storedLoan.getString("itemStatus"), is("Checked out"));
 
-    final JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+    final Response getByIdResponse = requestsClient.getById(request.getId());
+
+    MatcherAssert.assertThat(getByIdResponse, hasStatus(HTTP_OK));
+
+    final JsonObject storedRequest = getByIdResponse.getJson();
 
     assertThat("request status snapshot in storage is closed - filled",
         storedRequest.getString("status"), is("Closed - Filled"));

--- a/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
+++ b/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
@@ -1,5 +1,7 @@
 package api.requests;
 
+import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
+import static org.folio.HttpStatus.HTTP_CREATED;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -7,8 +9,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -99,13 +99,15 @@ public class InstanceRequestsAPICreationTests extends APITests {
 
     Response postResponse = postCompleted.get(10, TimeUnit.SECONDS);
 
+    assertThat(postResponse, hasStatus(HTTP_CREATED));
+
     JsonObject representation = postResponse.getJson();
+
     validateInstanceRequestResponse(representation,
       pickupServicePointId,
       instance.getId(),
       item.getId(),
       RequestType.PAGE);
-
   }
 
   @Test
@@ -133,6 +135,8 @@ public class InstanceRequestsAPICreationTests extends APITests {
       ResponseHandler.any(postCompleted));
 
     Response postResponse = postCompleted.get(10, TimeUnit.SECONDS);
+
+    assertThat(postResponse, hasStatus(HTTP_CREATED));
 
     JsonObject representation = postResponse.getJson();
     validateInstanceRequestResponse(representation,
@@ -173,7 +177,10 @@ public class InstanceRequestsAPICreationTests extends APITests {
 
     Response postResponse = postCompleted.get(10, TimeUnit.SECONDS);
 
+    assertThat(postResponse, hasStatus(HTTP_CREATED));
+
     JsonObject representation = postResponse.getJson();
+
     validateInstanceRequestResponse(representation,
       pickupServicePointId,
       instance.getId(),

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -1789,6 +1789,28 @@ public class RequestsAPICreationTests extends APITests {
     assertThat(finalStatus, is(ItemStatus.PAGED.getValue()));
   }
 
+  @Test
+  public void requestCreationDoesNotFailWhenCirculationRulesReferenceInvalidNoticePolicyId()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    setInvalidNoticePolicyReferenceInRules("some-invalid-policy");
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource steve = usersFixture.steve();
+
+    requestsFixture.place(new RequestBuilder()
+      .open()
+      .page()
+      .forItem(smallAngryPlanet)
+      .by(steve)
+      .withRequestDate(DateTime.now())
+      .fulfilToHoldShelf()
+      .withPickupServicePointId(servicePointsFixture.cd1().getId()));
+  }
+
   private void mockClockManagerToReturnFixedTime(DateTime dateTime) {
     ClockManager.getClockManager().setClock(
       Clock.fixed(

--- a/src/test/java/api/requests/RequestsAPIProxyTests.java
+++ b/src/test/java/api/requests/RequestsAPIProxyTests.java
@@ -2,11 +2,11 @@ package api.requests;
 
 import static api.support.http.InterfaceUrls.requestsUrl;
 import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
+import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static org.folio.HttpStatus.HTTP_CREATED;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -146,7 +146,7 @@ public class RequestsAPIProxyTests extends APITests {
     CompletableFuture<Response> postCompleted = new CompletableFuture<>();
 
     client.post(requestsUrl(), requestRequest,
-      ResponseHandler.json(postCompleted));
+      ResponseHandler.any(postCompleted));
 
     Response postResponse = postCompleted.get(5, TimeUnit.SECONDS);
 
@@ -180,7 +180,7 @@ public class RequestsAPIProxyTests extends APITests {
     CompletableFuture<Response> postCompleted = new CompletableFuture<>();
 
     client.post(requestsUrl(), requestRequest,
-      ResponseHandler.json(postCompleted));
+      ResponseHandler.any(postCompleted));
 
     Response postResponse = postCompleted.get(5, TimeUnit.SECONDS);
 
@@ -213,7 +213,7 @@ public class RequestsAPIProxyTests extends APITests {
     CompletableFuture<Response> postCompleted = new CompletableFuture<>();
 
     client.post(requestsUrl(), requestRequest,
-      ResponseHandler.json(postCompleted));
+      ResponseHandler.any(postCompleted));
 
     Response postResponse = postCompleted.get(5, TimeUnit.SECONDS);
 
@@ -255,9 +255,11 @@ public class RequestsAPIProxyTests extends APITests {
 
     Response putResponse = putCompleted.get(5, TimeUnit.SECONDS);
 
-    assertThat(putResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+    assertThat(putResponse.getStatusCode(), is(HTTP_NO_CONTENT));
 
-    final JsonObject representation = requestsClient.get(createdRequest).getJson();
+    final IndividualResource fetchedRequest = requestsClient.get(createdRequest);
+
+    final JsonObject representation = fetchedRequest.getJson();
 
     assertThat("has information taken from proxying user",
       representation.containsKey("proxy"), is(true));

--- a/src/test/java/api/requests/scenarios/PageRequestWorkflowTests.java
+++ b/src/test/java/api/requests/scenarios/PageRequestWorkflowTests.java
@@ -5,9 +5,11 @@ import static api.support.builders.ItemBuilder.PAGED;
 import static api.support.builders.RequestBuilder.CLOSED_FILLED;
 import static api.support.builders.RequestBuilder.OPEN_NOT_YET_FILLED;
 import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
+import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
+import static org.folio.HttpStatus.HTTP_OK;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
@@ -46,9 +48,11 @@ public class PageRequestWorkflowTests extends APITests {
 
     loansFixture.checkOutByBarcode(smallAngryPlanet, jessica);
 
-    Response request = requestsClient.getById(requestByJessica.getId());
+    Response getByIdResponse = requestsClient.getById(requestByJessica.getId());
 
-    assertThat(request.getJson().getString("status"), is(CLOSED_FILLED));
+    assertThat(getByIdResponse, hasStatus(HTTP_OK));
+
+    assertThat(getByIdResponse.getJson().getString("status"), is(CLOSED_FILLED));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 
@@ -82,9 +86,11 @@ public class PageRequestWorkflowTests extends APITests {
         "because it has been requested by another patron"),
       hasParameter("userBarcode", rebecca.getJson().getString("barcode")))));
 
-    Response request = requestsClient.getById(requestByJessica.getId());
+    Response getByIdResponse = requestsClient.getById(requestByJessica.getId());
 
-    assertThat(request.getJson().getString("status"), is(OPEN_NOT_YET_FILLED));
+    assertThat(getByIdResponse, hasStatus(HTTP_OK));
+
+    assertThat(getByIdResponse.getJson().getString("status"), is(OPEN_NOT_YET_FILLED));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 

--- a/src/test/java/api/requests/scenarios/SingleClosedRequestTests.java
+++ b/src/test/java/api/requests/scenarios/SingleClosedRequestTests.java
@@ -3,6 +3,8 @@ package api.requests.scenarios;
 import static api.support.builders.ItemBuilder.CHECKED_OUT;
 import static api.support.builders.RequestBuilder.CLOSED_FILLED;
 import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
+import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
+import static org.folio.HttpStatus.HTTP_OK;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -51,6 +53,8 @@ public class SingleClosedRequestTests extends APITests {
 
     Response request = requestsClient.getById(requestByJessica.getId());
 
+    assertThat(request, hasStatus(HTTP_OK));
+
     assertThat(request.getJson().getString("status"), is(CLOSED_FILLED));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
@@ -87,9 +91,11 @@ public class SingleClosedRequestTests extends APITests {
 
     loansFixture.checkOutByBarcode(smallAngryPlanet, steve);
 
-    Response request = requestsClient.getById(requestByJessica.getId());
+    Response getByIdResponse = requestsClient.getById(requestByJessica.getId());
 
-    assertThat(request.getJson().getString("status"), is(CLOSED_FILLED));
+    assertThat(getByIdResponse, hasStatus(HTTP_OK));
+
+    assertThat(getByIdResponse.getJson().getString("status"), is(CLOSED_FILLED));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 

--- a/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
+++ b/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
@@ -7,9 +7,11 @@ import static api.support.builders.RequestBuilder.CLOSED_FILLED;
 import static api.support.builders.RequestBuilder.OPEN_AWAITING_PICKUP;
 import static api.support.http.ResourceClient.forRequestsStorage;
 import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
+import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
+import static org.folio.HttpStatus.HTTP_OK;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
@@ -52,6 +54,8 @@ public class SingleOpenHoldShelfRequestTests extends APITests {
 
     Response request = requestsClient.getById(requestByJessica.getId());
 
+    assertThat(request, hasStatus(HTTP_OK));
+
     assertThat(request.getJson().getString("status"), is(OPEN_AWAITING_PICKUP));
     assertThat(request.getJson().getInteger("position"), is(1));
 
@@ -81,6 +85,8 @@ public class SingleOpenHoldShelfRequestTests extends APITests {
     loansFixture.checkOutByBarcode(smallAngryPlanet, jessica);
 
     Response request = requestsClient.getById(requestByJessica.getId());
+
+    assertThat(request, hasStatus(HTTP_OK));
 
     assertThat(request.getJson().getString("status"), is(CLOSED_FILLED));
 
@@ -117,6 +123,8 @@ public class SingleOpenHoldShelfRequestTests extends APITests {
       hasParameter("userBarcode", rebecca.getBarcode()))));
 
     Response request = requestsClient.getById(requestByJessica.getId());
+
+    assertThat(request, hasStatus(HTTP_OK));
 
     assertThat(request.getJson().getString("status"), is(OPEN_AWAITING_PICKUP));
 
@@ -174,6 +182,8 @@ public class SingleOpenHoldShelfRequestTests extends APITests {
     loansFixture.checkOutByBarcode(smallAngryPlanet, jessica);
 
     Response request = requestsClient.getById(requestByJessica.getId());
+
+    assertThat(request, hasStatus(HTTP_OK));
 
     assertThat(request.getJson().getString("status"), is(CLOSED_FILLED));
 

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import io.vertx.core.json.JsonObject;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.client.Response;
@@ -47,6 +46,7 @@ import api.support.fixtures.ServicePointsFixture;
 import api.support.fixtures.UsersFixture;
 import api.support.http.InterfaceUrls;
 import api.support.http.ResourceClient;
+import io.vertx.core.json.JsonObject;
 
 public abstract class APITests {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -296,12 +296,15 @@ public abstract class APITests {
     );
   }
 
-  protected void useLoanPolicyAsFallback(UUID loanPolicyId, UUID requestPolicyId, UUID noticePolicyId)
+  protected void useLoanPolicyAsFallback(UUID loanPolicyId, UUID requestPolicyId,
+                                         UUID noticePolicyId)
     throws InterruptedException,
     ExecutionException,
     TimeoutException {
 
-    circulationRulesFixture.updateCirculationRules(loanPolicyId, requestPolicyId, noticePolicyId);
+    circulationRulesFixture.updateCirculationRules(loanPolicyId, requestPolicyId,
+      noticePolicyId);
+
     warmUpApplyEndpoint();
   }
 
@@ -405,5 +408,30 @@ public abstract class APITests {
     assertThat(String.format("%s should NOT have an %s: %s",
             type, property, resource),
             resource.getValue(property), is(nullValue()));
+  }
+
+  protected void setInvalidLoanPolicyReferenceInRules(String invalidLoanPolicyReference)
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException,
+    MalformedURLException {
+
+    circulationRulesFixture.updateCirculationRules(
+      circulationRulesFixture.soleFallbackPolicyRule(invalidLoanPolicyReference,
+        requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
+        noticePoliciesFixture.inactiveNotice().getId().toString()));
+  }
+
+  protected void setInvalidNoticePolicyReferenceInRules(String invalidNoticePolicyReference)
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException,
+    MalformedURLException {
+
+    circulationRulesFixture.updateCirculationRules(
+      circulationRulesFixture.soleFallbackPolicyRule(
+        loanPoliciesFixture.canCirculateRolling().getId().toString(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
+        invalidNoticePolicyReference));
   }
 }

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -53,8 +53,7 @@ public class RestAssuredClient {
     });
 
     return new Response(response.statusCode(), response.body().print(),
-      response.contentType(),
-      mappedHeaders);
+      response.contentType(), mappedHeaders, null);
   }
 
   public static io.restassured.response.Response manuallyStartTimedTask(

--- a/src/test/java/api/support/fakes/FakeStorageModule.java
+++ b/src/test/java/api/support/fakes/FakeStorageModule.java
@@ -108,7 +108,7 @@ public class FakeStorageModule extends AbstractVerticle {
     router.put(rootPath + "/:id").handler(this::checkDisallowedProperties);
     router.put(rootPath + "/:id").handler(this::replace);
 
-    router.get(rootPath + "/:id").handler(this::get);
+    router.get(rootPath + "/:id").handler(this::getById);
     router.delete(rootPath + "/:id").handler(this::delete);
   }
 
@@ -192,7 +192,7 @@ public class FakeStorageModule extends AbstractVerticle {
     }
   }
 
-  private void get(RoutingContext routingContext) {
+  private void getById(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
 
     String id = routingContext.request().getParam("id");

--- a/src/test/java/api/support/fixtures/CirculationRulesFixture.java
+++ b/src/test/java/api/support/fixtures/CirculationRulesFixture.java
@@ -23,7 +23,8 @@ public class CirculationRulesFixture {
     this.client = client;
   }
 
-  public void updateCirculationRules(UUID loanPolicyId, UUID requestPolicyId, UUID noticePolicyId)
+  public void updateCirculationRules(UUID loanPolicyId, UUID requestPolicyId,
+                                     UUID noticePolicyId)
     throws InterruptedException,
     ExecutionException,
     TimeoutException {
@@ -53,7 +54,16 @@ public class CirculationRulesFixture {
       response.getStatusCode(), is(204));
   }
 
-  private String soleFallbackPolicyRule(UUID loanPolicyId, UUID requestPolicyId, UUID noticePolicyId) {
+  private String soleFallbackPolicyRule(UUID loanPolicyId, UUID requestPolicyId,
+                                        UUID noticePolicyId) {
+
+    return soleFallbackPolicyRule(loanPolicyId.toString(), requestPolicyId.toString(),
+      noticePolicyId.toString());
+  }
+
+  public String soleFallbackPolicyRule(String loanPolicyId, String requestPolicyId,
+                                        String noticePolicyId) {
+
     return String.format("priority: t, s, c, b, a, m, g%nfallback-policy: l %s r %s n %s%n",
       loanPolicyId, requestPolicyId, noticePolicyId);
   }

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -1,5 +1,6 @@
 package api.support.http;
 
+import static java.net.HttpURLConnection.HTTP_CREATED;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -260,21 +261,20 @@ public class ResourceClient {
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
-    log.debug("Attempting to create %s record: %s", resourceName,
+    log.debug("Attempting to create {} record: {}", resourceName,
       request.encodePrettily());
 
     client.post(urlMaker.combine(""), request,
-      ResponseHandler.json(createCompleted));
+      ResponseHandler.any(createCompleted));
 
     Response response = createCompleted.get(5, TimeUnit.SECONDS);
 
     assertThat(
       String.format("Failed to create %s: %s", resourceName,
-        response.getBody()), response.getStatusCode(),
-      is(HttpURLConnection.HTTP_CREATED));
+        response.getBody()), response.getStatusCode(), is(HTTP_CREATED));
 
-    log.debug(String.format("Created resource %s: %s", resourceName,
-      response.getJson().encodePrettily()));
+    log.debug("Created resource {}: {}", resourceName,
+      response.getJson().encodePrettily());
 
     return new IndividualResource(response);
   }


### PR DESCRIPTION
## Purpose

Some modules using RAML Module Builder 24 and the PgUtil respond with a 500 when getting a record by ID and the ID provided is not a UUID.

The error reported is similar to
`ErrorMessage(fields=Map(Line -> 137, File -> uuid.c, SQLSTATE -> 22P02, Routine -> string_to_uuid, V -> ERROR, Message -> invalid input syntax for type uuid: "null", Severity -> ERROR))`

This change in behaviour, from a 404, exposes a sloppy flaw in mod-circulation that allows `null` values to be used to fetch single records, resulting in errors during request creation (and likely other processes).

## Approach
* Improve the diagnostic output of some of the API tests when an unexpected status code is received
* Make the single record fetcher respond with a diagnostic error rather than forwarding on the failure response
* Stop the single record fetcher from allowing null parameters
* Guard and short-circuit `null` IDs in methods using the `SingleRecordFetcher`
* Explicitly respond with a `404` when a record is not found (previously this was done implicitly by forwarding)
* Make fake modules respond with 500 when getting a record other than with a UUID

#### TODOS and Open Questions
This UUID related error could still be reported if a non-null but invalid ID is used. The improved diagnostic responses should help identify this more easily. 

It could be prevented by checking that the ID is a UUID before fetching. However, this requires more work, as some code takes advantage of the weak typing of a ID to fetch records using a path instead of an ID (see learning below).

## Learning
The calendar repository tries to fetch a single record using a path fragment, this (hopefully temporarily) prevents changing the `id` parameter to be a UUID instead of a String
```  
String path = String.format(PATH_PARAM_WITH_QUERY, servicePointId, requestedDate);

return FetchSingleRecord.<AdjacentOpeningDays>forRecord(RECORD_NAME)
      .using(calendarClient)
      .mapTo(this::createOpeningDays)
      .whenNotFound(failedValidation(
        new ValidationError("Calendar open periods are not found", Collections.emptyMap())))
      .fetch(path);
```

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
