### PR TITLE
CIRC-371: Refuse new request for patron who already placed a request on a copy of the same title

### DIFF
--- a/src/main/java/org/folio/circulation/domain/InstanceRequestItemsComparer.java
+++ b/src/main/java/org/folio/circulation/domain/InstanceRequestItemsComparer.java
@@ -2,10 +2,7 @@ package org.folio.circulation.domain;
 
 import org.joda.time.DateTime;
 
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class InstanceRequestItemsComparer {

--- a/src/main/java/org/folio/circulation/domain/InstanceRequestItemsComparer.java
+++ b/src/main/java/org/folio/circulation/domain/InstanceRequestItemsComparer.java
@@ -2,7 +2,10 @@ package org.folio.circulation.domain;
 
 import org.joda.time.DateTime;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class InstanceRequestItemsComparer {

--- a/src/main/java/org/folio/circulation/domain/InstanceRequestRelatedRecords.java
+++ b/src/main/java/org/folio/circulation/domain/InstanceRequestRelatedRecords.java
@@ -2,6 +2,7 @@ package org.folio.circulation.domain;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import org.folio.circulation.domain.representations.RequestByInstanceIdRequest;
 
@@ -14,6 +15,7 @@ public class InstanceRequestRelatedRecords {
   private List<Item> itemsWithoutLoans;
   private List<Item> itemsWithoutRequests;
   private RequestByInstanceIdRequest instanceLevelRequest;
+  private Map<Item, RequestQueue> itemRequestQueueMap;
 
   public List<Item> getUnsortedAvailableItems() {
     return unsortedAvailableItems;
@@ -76,5 +78,13 @@ public class InstanceRequestRelatedRecords {
 
   public void setItemsWithoutRequests(List<Item> itemsWithoutRequests) {
     this.itemsWithoutRequests = itemsWithoutRequests;
+  }
+
+  public Map<Item, RequestQueue> getItemRequestQueueMap() {
+    return itemRequestQueueMap;
+  }
+
+  public void setItemRequestQueueMap(Map<Item, RequestQueue> itemRequestQueueMap) {
+    this.itemRequestQueueMap = itemRequestQueueMap;
   }
 }

--- a/src/main/java/org/folio/circulation/domain/InstanceRequestRelatedRecords.java
+++ b/src/main/java/org/folio/circulation/domain/InstanceRequestRelatedRecords.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain;
 
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -14,6 +15,7 @@ public class InstanceRequestRelatedRecords {
   private List<Item> sortedUnavailableItems;
   private List<Item> itemsWithoutLoans;
   private List<Item> itemsWithoutRequests;
+  private Collection<Item> allUnsortedItems;
   private RequestByInstanceIdRequest instanceLevelRequest;
   private Map<Item, RequestQueue> itemRequestQueueMap;
 
@@ -86,5 +88,13 @@ public class InstanceRequestRelatedRecords {
 
   public void setItemRequestQueueMap(Map<Item, RequestQueue> itemRequestQueueMap) {
     this.itemRequestQueueMap = itemRequestQueueMap;
+  }
+
+  public Collection<Item> getAllUnsortedItems() {
+    return allUnsortedItems;
+  }
+
+  public void setAllUnsortedItems(Collection<Item> allUnsortedItems) {
+    this.allUnsortedItems = allUnsortedItems;
   }
 }

--- a/src/main/java/org/folio/circulation/domain/representations/RequestProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/RequestProperties.java
@@ -13,4 +13,5 @@ public class RequestProperties {
   public static final String REQUEST_EXPIRATION_DATE = "requestExpirationDate";
   public static final String CANCELLATION_ADDITIONAL_INFORMATION = "cancellationAdditionalInformation";
   public static final String CANCELLATION_REASON_ID = "cancellationReasonId";
+  public static final String REQUESTER_ID = "requesterId";
 }

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -1,7 +1,9 @@
 package org.folio.circulation.resources;
 
 import static org.folio.circulation.domain.InstanceRequestItemsComparer.sortRequestQueues;
-import static org.folio.circulation.domain.representations.RequestProperties.*;
+import static org.folio.circulation.domain.representations.RequestProperties.ITEM_ID;
+import static org.folio.circulation.domain.representations.RequestProperties.PROXY_USER_ID;
+import static org.folio.circulation.domain.representations.RequestProperties.REQUESTER_ID;
 import static org.folio.circulation.support.JsonPropertyWriter.write;
 import static org.folio.circulation.support.Result.failed;
 import static org.folio.circulation.support.Result.of;
@@ -22,7 +24,24 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import org.folio.circulation.domain.*;
+import org.folio.circulation.domain.CreateRequestService;
+import org.folio.circulation.domain.InstanceRequestRelatedRecords;
+import org.folio.circulation.domain.Item;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.LoanRepository;
+import org.folio.circulation.domain.Request;
+import org.folio.circulation.domain.RequestAndRelatedRecords;
+import org.folio.circulation.domain.RequestQueue;
+import org.folio.circulation.domain.RequestQueueRepository;
+import org.folio.circulation.domain.RequestRepository;
+import org.folio.circulation.domain.RequestRepresentation;
+import org.folio.circulation.domain.RequestType;
+import org.folio.circulation.domain.ServicePointRepository;
+import org.folio.circulation.domain.UpdateItem;
+import org.folio.circulation.domain.UpdateLoan;
+import org.folio.circulation.domain.UpdateLoanActionHistory;
+import org.folio.circulation.domain.UpdateUponRequest;
+import org.folio.circulation.domain.UserRepository;
 import org.folio.circulation.domain.policy.LoanPolicyRepository;
 import org.folio.circulation.domain.policy.RequestPolicyRepository;
 import org.folio.circulation.domain.representations.RequestByInstanceIdRequest;

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -10,11 +10,36 @@ import static org.folio.circulation.support.ValidationErrorFailure.failedValidat
 import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 
 import java.lang.invoke.MethodHandles;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import org.folio.circulation.domain.*;
+import org.folio.circulation.domain.CreateRequestService;
+import org.folio.circulation.domain.InstanceRequestRelatedRecords;
+import org.folio.circulation.domain.Item;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.LoanRepository;
+import org.folio.circulation.domain.Request;
+import org.folio.circulation.domain.RequestAndRelatedRecords;
+import org.folio.circulation.domain.RequestQueue;
+import org.folio.circulation.domain.RequestQueueRepository;
+import org.folio.circulation.domain.RequestRepository;
+import org.folio.circulation.domain.RequestRepresentation;
+import org.folio.circulation.domain.RequestType;
+import org.folio.circulation.domain.ServicePointRepository;
+import org.folio.circulation.domain.UpdateItem;
+import org.folio.circulation.domain.UpdateLoan;
+import org.folio.circulation.domain.UpdateLoanActionHistory;
+import org.folio.circulation.domain.UpdateUponRequest;
+import org.folio.circulation.domain.UserRepository;
 import org.folio.circulation.domain.policy.LoanPolicyRepository;
 import org.folio.circulation.domain.policy.RequestPolicyRepository;
 import org.folio.circulation.domain.representations.RequestByInstanceIdRequest;

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -202,7 +202,7 @@ public class RequestByInstanceIdResource extends Resource {
           && (instanceRequestPackage.getSortedAvailableItems() == null || instanceRequestPackage.getSortedAvailableItems().isEmpty())) {
           //fail the requests when there are no items to make requests from.
           log.error("Failed to find request queues for all items of instanceId {}",
-            instanceRequestPackage.getInstanceLevelRequest().getInstanceId().toString());
+            instanceRequestPackage.getInstanceLevelRequest().getInstanceId());
           return failed(new ServerErrorFailure("Unable to find an item to place a request"));
         }
         instanceRequestPackage.setItemsWithoutRequests(itemsWithoutRequestQueues);

--- a/src/main/java/org/folio/circulation/storage/ItemByInstanceIdFinder.java
+++ b/src/main/java/org/folio/circulation/storage/ItemByInstanceIdFinder.java
@@ -48,7 +48,7 @@ public class ItemByInstanceIdFinder {
     return holdingsRecordsResult.after(holdingsRecords -> {
       if (holdingsRecords == null || holdingsRecords.isEmpty()) {
         return completedFuture(failedValidation(
-          "holdingsRecords is null or empty", "holdingsRecords", "null"));
+          "There are no holdings for this instance", "holdingsRecords", "null"));
       }
 
       List<String> holdingsIds = holdingsRecords.toKeys(byId());

--- a/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
+++ b/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
@@ -427,7 +427,7 @@ public class InstanceRequestsAPICreationTests extends APITests {
     TimeoutException,
     MalformedURLException {
 
-    //The scenario we're checking is if a user has already checked out an iemm, but then
+    //The scenario we're checking is if a user has already checked out an item, but then
     //goes back to place an instance level request. The system will find this item and rejects the request for the user, so the user
     //could be given a successful request on an unavailable item instead, if there is any.
     UUID pickupServicePointId = servicePointsFixture.cd1().getId();
@@ -750,7 +750,7 @@ public class InstanceRequestsAPICreationTests extends APITests {
     Response postResponse = postCompleted.get(REQUEST_TIMEOUT, TimeUnit.SECONDS);
     assertEquals(422, postResponse.getStatusCode());
     assertThat(postResponse.getJson(), hasErrorWith(allOf(
-      hasMessage("This requester already has an open request for a copy of this title"),
+      hasMessage("This requester already has an open request for a copy of this title (instance)"),
       hasParameter("itemId", item1.getId().toString()))));
   }
 

--- a/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
+++ b/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
@@ -767,7 +767,6 @@ public class InstanceRequestsAPICreationTests extends APITests {
 
     IndividualResource instanceMultipleCopies = instancesFixture.basedUponDunkirk();
     holdingsFixture.defaultWithHoldings(instanceMultipleCopies.getId());
-    ;
 
     JsonObject requestBody = createInstanceRequestObject(instanceMultipleCopies.getId(),
       usersFixture.jessica().getId(),


### PR DESCRIPTION
## Purpose
It was clarified that a patron cannot place multiple requests on various copies of the same title.  In this implementation we are going to validate the requester against the requests in the items' request queues.

## Approach

- Added a validateRequester method to check the requesterId against the requesterIds in the requests of the request queues. If any existing request has matching requesterId, then fail the instance-level request with the message "This requester already has an open request for a copy of this title".
- Previously getting both request queues and loans were done in parallel because one wasn't depending on the other. Now there's a need to validate the requester against all instance's items' request queues, so this check has to be done first, If the validation passes then the step to get the loans would come after. Therefore once-again all the calls could be chained together and no need to break up the futures chain. 

#### TODOS and Open Questions
- Should this validation be done on loans as well? We don't want to allow the same requester to checkout a copy and subsequently place requests on other copies of the instance?

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
