### PR TITLE
CIRC-323 Backend: Overdue loans report (fine/fee fields)

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1197,7 +1197,8 @@
         "inventory-storage.service-points.item.get",
         "users.collection.get",
         "users.item.get",
-        "inventory-storage.locations.collection.get"
+        "inventory-storage.locations.collection.get",
+        "accounts.collection.get"
       ],
       "visible": false
     },
@@ -1223,7 +1224,8 @@
         "inventory-storage.material-types.collection.get",
         "inventory-storage.material-types.item.get",
         "inventory-storage.service-points.collection.get",
-        "inventory-storage.service-points.item.get"
+        "inventory-storage.service-points.item.get",
+        "accounts.collection.get"
       ],
       "visible": false
     }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -678,6 +678,10 @@
     {
       "id": "scheduled-notice-storage",
       "version": "0.1"
+    },
+    {
+      "id": "feesfines",
+      "version": "15.0"
     }
   ],
   "permissionSets": [

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>16.3.0-TESTING</version>
+  <version>16.4.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>16.4.0-SNAPSHOT</version>
+  <version>16.3.0-TESTING</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -262,7 +262,8 @@
           "description": "Total remaining amount due on fees and fines for the loan (read only, defined by the server)",
           "readonly" : true
         }
-      }
+      },
+      "additionalProperties": false
     },
     "metadata": {
       "description": "Metadata about creation and changes to loan, provided by the server (client should not provide)",

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -254,7 +254,7 @@
       }
     },
     "feefine": {
-      "description": "Fee/Fine for user (read only, defined by the server)",
+      "description": "Total remaining amount due on fees and fines for this loan (read only, defined by the server)",
       "type": "number",
       "readonly" : true
     },

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -253,10 +253,16 @@
         }
       }
     },
-    "feefine": {
-      "description": "Total remaining amount due on fees and fines for this loan (read only, defined by the server)",
-      "type": "number",
-      "readonly" : true
+    "feesAndFines": {
+      "description": "Fees and fines associated with loans",
+      "type": "object",
+      "properties": {
+        "amountRemainingToPay": {
+          "type": "number",
+          "description": "Total remaining amount due on fees and fines for the loan (read only, defined by the server)",
+          "readonly" : true
+        }
+      }
     },
     "metadata": {
       "description": "Metadata about creation and changes to loan, provided by the server (client should not provide)",

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -253,6 +253,11 @@
         }
       }
     },
+    "feefine": {
+      "description": "Fee/Fine for user (read only, defined by the server)",
+      "type": "number",
+      "readonly" : true
+    },
     "metadata": {
       "description": "Metadata about creation and changes to loan, provided by the server (client should not provide)",
       "type": "object",

--- a/src/main/java/org/folio/circulation/domain/Account.java
+++ b/src/main/java/org/folio/circulation/domain/Account.java
@@ -1,0 +1,42 @@
+package org.folio.circulation.domain;
+
+import static org.folio.circulation.support.JsonPropertyFetcher.getNestedStringProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
+
+import io.vertx.core.json.JsonObject;
+
+public class Account {
+
+  private final JsonObject representation;
+
+  public Account(JsonObject representation) {
+    this.representation = representation;
+  }
+
+  public String getId(){
+    return getProperty(representation,"id");
+  }
+
+  public String getLoanId(){
+    return getProperty(representation,"loanId");
+  }
+
+  public Double getRemainingFeeFineAmount(){
+    return representation.getDouble("remaining");
+  }
+
+  public String getStatus(){
+    return getNestedStringProperty(representation,"status","name");
+  }
+
+  public static Account from(JsonObject representation) {
+    return new Account(representation);
+  }
+
+  @Override
+  public String toString() {
+    return "Account{" +
+      "representation=" + representation +
+      '}';
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/Account.java
+++ b/src/main/java/org/folio/circulation/domain/Account.java
@@ -13,30 +13,24 @@ public class Account {
     this.representation = representation;
   }
 
-  public String getId(){
-    return getProperty(representation,"id");
+  public String getId() {
+    return getProperty(representation, "id");
   }
 
-  public String getLoanId(){
-    return getProperty(representation,"loanId");
+  public String getLoanId() {
+    return getProperty(representation, "loanId");
   }
 
-  public Double getRemainingFeeFineAmount(){
+  public Double getRemainingFeeFineAmount() {
     return representation.getDouble("remaining");
   }
 
-  public String getStatus(){
-    return getNestedStringProperty(representation,"status","name");
+  public String getStatus() {
+    return getNestedStringProperty(representation, "status", "name");
   }
 
   public static Account from(JsonObject representation) {
     return new Account(representation);
   }
 
-  @Override
-  public String toString() {
-    return "Account{" +
-      "representation=" + representation +
-      '}';
-  }
 }

--- a/src/main/java/org/folio/circulation/domain/AccountRepository.java
+++ b/src/main/java/org/folio/circulation/domain/AccountRepository.java
@@ -1,0 +1,90 @@
+package org.folio.circulation.domain;
+
+import org.folio.circulation.support.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.support.CqlQuery.exactMatch;
+import static org.folio.circulation.support.CqlQuery.exactMatchAny;
+import static org.folio.circulation.support.Result.succeeded;
+
+public class AccountRepository {
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final CollectionResourceClient accountsStorageClient;
+
+  private final Result<CqlQuery> accountStatusQuery = exactMatch("status.name", "Open");
+
+  public AccountRepository(Clients clients) {
+    accountsStorageClient = clients.accountsStorageClient();
+  }
+
+  public CompletableFuture<Result<Loan>> findAccountsForLoan(Result<Loan> loanResult) {
+    return loanResult.after(loan -> {
+      if (loan == null) {
+        return completedFuture(loanResult);
+      }
+      return loanResult
+        .combineAfter(r -> getAccountsForLoan(loan.getId()),
+          Loan::withAccounts);
+    });
+  }
+
+  private CompletableFuture<Result<Collection<Account>>> getAccountsForLoan(String loanId) {
+
+    final Result<CqlQuery> loanIdQuery = exactMatch("loanId", loanId);
+
+    return createAccountsFetcher().findByQuery
+      (accountStatusQuery.combine(loanIdQuery, CqlQuery::and))
+      .thenApply(r -> r.map(MultipleRecords::getRecords));
+  }
+
+  public CompletableFuture<Result<MultipleRecords<Loan>>> findAccountsForLoans(
+    MultipleRecords<Loan> multipleLoans) {
+
+    if (multipleLoans.getRecords().isEmpty()) {
+      return completedFuture(succeeded(multipleLoans));
+    }
+
+    return getAccountsForLoans(multipleLoans.getRecords())
+      .thenApply(r -> r.map(accountMap -> multipleLoans.mapRecords(
+        loan -> loan.withAccounts(accountMap.getOrDefault(loan.getId(), null)))));
+  }
+
+  private CompletableFuture<Result<Map<String, List<Account>>>> getAccountsForLoans(
+    Collection<Loan> loans) {
+
+    final Collection<String> accountsToFetch =
+      loans.stream()
+        .filter(Objects::nonNull)
+        .map(Loan::getId)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+
+    final MultipleRecordFetcher<Account> fetcher = createAccountsFetcher();
+    final Result<CqlQuery> loanIdQuery = exactMatchAny("loanId", accountsToFetch);
+
+    return createAccountsFetcher()
+      .findByQuery(accountStatusQuery.combine(loanIdQuery, CqlQuery::and))
+      .thenComposeAsync(r -> r.after(multipleRecords -> completedFuture(succeeded(
+        multipleRecords.getRecords().stream().collect(
+          Collectors.groupingBy(Account::getLoanId))
+        ))
+        )
+      );
+  }
+
+  private MultipleRecordFetcher<Account> createAccountsFetcher() {
+    return new MultipleRecordFetcher<>(accountsStorageClient, "accounts", Account::from);
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -18,6 +18,8 @@ import static org.folio.circulation.support.Result.failed;
 import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -36,6 +38,9 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   private final Item item;
   private final User user;
   private final User proxy;
+
+  private final Collection<Account> accounts;
+
   private final DateTime originalDueDate;
 
   private final String checkoutServicePointId;
@@ -47,8 +52,8 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   private final LoanPolicy loanPolicy;
 
   private Loan(JsonObject representation, Item item, User user, User proxy,
-              ServicePoint checkinServicePoint, ServicePoint checkoutServicePoint,
-              DateTime originalDueDate, LoanPolicy loanPolicy) {
+               ServicePoint checkinServicePoint, ServicePoint checkoutServicePoint,
+               DateTime originalDueDate, LoanPolicy loanPolicy, Collection<Account> accounts) {
 
     requireNonNull(loanPolicy, "loanPolicy cannot be null");
 
@@ -56,6 +61,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     this.item = item;
     this.user = user;
     this.proxy = proxy;
+    this.accounts = accounts;
     this.checkinServicePoint = checkinServicePoint;
     this.checkoutServicePoint = checkoutServicePoint;
 
@@ -86,7 +92,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   public static Loan from(JsonObject representation) {
     defaultStatusAndAction(representation);
     return new Loan(representation, null, null, null, null, null, null,
-      LoanPolicy.unknown(null));
+      LoanPolicy.unknown(null), null);
   }
 
   JsonObject asJson() {
@@ -177,6 +183,9 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     return getProperty(representation, "id");
   }
 
+  public Collection<Account> getAccounts() {
+    return accounts;
+  }
   @Override
   public String getItemId() {
     return getProperty(representation, "itemId");
@@ -202,12 +211,12 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   Loan replaceRepresentation(JsonObject newRepresentation) {
     return new Loan(newRepresentation, item, user, proxy, checkinServicePoint,
-      checkoutServicePoint, originalDueDate, loanPolicy);
+      checkoutServicePoint, originalDueDate, loanPolicy, accounts);
   }
 
   public Loan withItem(Item item) {
     return new Loan(representation, item, user, proxy, checkinServicePoint,
-        checkoutServicePoint, originalDueDate, loanPolicy);
+        checkoutServicePoint, originalDueDate, loanPolicy, accounts);
   }
 
   public User getUser() {
@@ -216,7 +225,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   public Loan withUser(User newUser) {
     return new Loan(representation, item, newUser, proxy, checkinServicePoint,
-        checkoutServicePoint, originalDueDate, loanPolicy);
+        checkoutServicePoint, originalDueDate, loanPolicy, accounts);
   }
 
   public User getProxy() {
@@ -225,17 +234,22 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   Loan withProxy(User newProxy) {
     return new Loan(representation, item, user, newProxy, checkinServicePoint,
-      checkoutServicePoint, originalDueDate, loanPolicy);
+      checkoutServicePoint, originalDueDate, loanPolicy, accounts);
   }
 
   Loan withCheckinServicePoint(ServicePoint newCheckinServicePoint) {
     return new Loan(representation, item, user, proxy, newCheckinServicePoint,
-      checkoutServicePoint, originalDueDate, loanPolicy);
+      checkoutServicePoint, originalDueDate, loanPolicy, accounts);
   }
 
   Loan withCheckoutServicePoint(ServicePoint newCheckoutServicePoint) {
     return new Loan(representation, item, user, proxy, checkinServicePoint,
-      newCheckoutServicePoint, originalDueDate, loanPolicy);
+      newCheckoutServicePoint, originalDueDate, loanPolicy, accounts);
+  }
+
+  public Loan withAccounts(Collection<Account> newAccounts) {
+    return new Loan(representation, item, user, proxy, checkinServicePoint,
+      checkoutServicePoint, originalDueDate, loanPolicy, newAccounts);
   }
 
   public String getLoanPolicyId() {
@@ -250,7 +264,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     requireNonNull(newloanPolicy, "newloanPolicy cannot be null");
 
     return new Loan(representation, item, user, proxy, checkinServicePoint,
-      checkoutServicePoint, originalDueDate, newloanPolicy);
+      checkoutServicePoint, originalDueDate, newloanPolicy, accounts);
   }
 
   private void setLoanPolicyId(String newLoanPolicyId) {

--- a/src/main/java/org/folio/circulation/domain/LoanRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepresentation.java
@@ -1,14 +1,16 @@
 package org.folio.circulation.domain;
 
-import java.lang.invoke.MethodHandles;
-
+import io.vertx.core.json.JsonObject;
 import org.folio.circulation.domain.policy.LoanPolicy;
 import org.folio.circulation.domain.representations.ItemSummaryRepresentation;
 import org.folio.circulation.domain.representations.LoanProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.vertx.core.json.JsonObject;
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+
+import static org.folio.circulation.support.JsonPropertyWriter.write;
 
 public class LoanRepresentation {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -41,6 +43,8 @@ public class LoanRepresentation {
       extendedRepresentation.remove(LoanProperties.LOAN_POLICY);
     }
 
+    additionalAccountProperties(extendedRepresentation, loan.getAccounts());
+
     return extendedRepresentation;
   }
 
@@ -60,6 +64,16 @@ public class LoanRepresentation {
     }
 
     return loan;
+  }
+
+  private void additionalAccountProperties(JsonObject loanRepresentation, Collection<Account> accounts) {
+    if (accounts == null) {
+      return;
+    }
+    double remainingFeesFines = accounts.stream().
+      map(Account::getRemainingFeeFineAmount).reduce(Double::sum).orElse(0d);
+
+    write(loanRepresentation, "feefine", remainingFeesFines);
   }
 
   private void additionalLoanPolicyProperties(JsonObject loanRepresentation, LoanPolicy loanPolicy) {

--- a/src/main/java/org/folio/circulation/domain/LoanRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepresentation.java
@@ -73,7 +73,11 @@ public class LoanRepresentation {
     double remainingFeesFines = accounts.stream().
       map(Account::getRemainingFeeFineAmount).reduce(Double::sum).orElse(0d);
 
-    write(loanRepresentation, "feefine", remainingFeesFines);
+    JsonObject feesAndFinesSummary = loanRepresentation.containsKey(LoanProperties.FEESANDFINES)
+      ? loanRepresentation.getJsonObject(LoanProperties.FEESANDFINES)
+      : new JsonObject();
+    write(feesAndFinesSummary, "amountRemainingToPay", remainingFeesFines);
+    write(loanRepresentation, LoanProperties.FEESANDFINES, feesAndFinesSummary);
   }
 
   private void additionalLoanPolicyProperties(JsonObject loanRepresentation, LoanPolicy loanPolicy) {

--- a/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
@@ -15,4 +15,5 @@ public class LoanProperties {
   public static final String ACTION_COMMENT = "actionComment";
   public static final String BORROWER = "borrower";
   public static final String LOAN_POLICY = "loanPolicy";
+  public static final String FEESANDFINES = "feesAndFines";
 }

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -36,6 +36,7 @@ public class Clients {
   private final CollectionResourceClient patronNoticeClient;
   private final CollectionResourceClient configurationStorageClient;
   private final CollectionResourceClient scheduledNoticesStorageClient;
+  private final CollectionResourceClient accountsStorageClient;
 
   public static Clients create(WebContext context, HttpClient httpClient) {
     return new Clients(context.createHttpClient(httpClient), context);
@@ -71,6 +72,7 @@ public class Clients {
       patronNoticeClient = createPatronNoticeClient(client, context);
       configurationStorageClient = createConfigurationStorageClient(client, context);
       scheduledNoticesStorageClient = createScheduledNoticesStorageClient(client, context);
+      accountsStorageClient = createAccountsStorageClient(client,context);
     }
     catch(MalformedURLException e) {
       throw new InvalidOkapiLocationException(context.getOkapiLocation(), e);
@@ -185,6 +187,10 @@ public class Clients {
 
   public CollectionResourceClient scheduledNoticesStorageClient() {
     return scheduledNoticesStorageClient;
+  }
+
+  public CollectionResourceClient accountsStorageClient() {
+    return accountsStorageClient;
   }
 
   private static CollectionResourceClient getCollectionResourceClient(
@@ -420,5 +426,11 @@ public class Clients {
     WebContext context)
     throws MalformedURLException {
     return getCollectionResourceClient(client, context, "/scheduled-notice-storage/scheduled-notices");
+  }
+  private CollectionResourceClient createAccountsStorageClient(
+    OkapiHttpClient client,
+    WebContext context)
+    throws MalformedURLException {
+    return getCollectionResourceClient(client, context, "/accounts");
   }
 }

--- a/src/main/java/org/folio/circulation/support/JsonPropertyWriter.java
+++ b/src/main/java/org/folio/circulation/support/JsonPropertyWriter.java
@@ -25,6 +25,14 @@ public class JsonPropertyWriter {
   public static void write(
     JsonObject to,
     String propertyName,
+    Double value) {
+      to.put(propertyName, value);
+    }
+
+
+  public static void write(
+    JsonObject to,
+    String propertyName,
     JsonArray value) {
 
     if(value != null && !value.isEmpty()) {

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import api.support.fixtures.*;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.client.Response;
@@ -25,25 +26,6 @@ import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import api.support.fixtures.AddressTypesFixture;
-import api.support.fixtures.CancellationReasonsFixture;
-import api.support.fixtures.CirculationRulesFixture;
-import api.support.fixtures.HoldingsFixture;
-import api.support.fixtures.InstancesFixture;
-import api.support.fixtures.ItemsFixture;
-import api.support.fixtures.LoanPoliciesFixture;
-import api.support.fixtures.LoanTypesFixture;
-import api.support.fixtures.LoansFixture;
-import api.support.fixtures.LocationsFixture;
-import api.support.fixtures.MaterialTypesFixture;
-import api.support.fixtures.NoticePoliciesFixture;
-import api.support.fixtures.PatronGroupsFixture;
-import api.support.fixtures.ProxyRelationshipsFixture;
-import api.support.fixtures.RequestPoliciesFixture;
-import api.support.fixtures.RequestsFixture;
-import api.support.fixtures.ScheduledNoticeProcessingClient;
-import api.support.fixtures.ServicePointsFixture;
-import api.support.fixtures.UsersFixture;
 import api.support.http.InterfaceUrls;
 import api.support.http.ResourceClient;
 import io.vertx.core.json.JsonObject;
@@ -78,6 +60,8 @@ public abstract class APITests {
   protected final ResourceClient itemsClient = ResourceClient.forItems(client);
 
   protected final ResourceClient loansClient = ResourceClient.forLoans(client);
+  protected final ResourceClient accountsClient = ResourceClient.forAccounts(client);
+
   protected final ResourceClient loansStorageClient
     = ResourceClient.forLoansStorage(client);
 
@@ -344,6 +328,8 @@ public abstract class APITests {
     ResourceClient.forInstances(cleanupClient).deleteAll();
 
     ResourceClient.forUsers(cleanupClient).deleteAllIndividually();
+
+    ResourceClient.forAccounts(cleanupClient).deleteAll();
   }
 
   private static void deleteAllRecords()
@@ -382,6 +368,9 @@ public abstract class APITests {
     ResourceClient.forCancellationReasons(client).deleteAllIndividually();
   }
 
+  protected void loanHasFeeFinesProperties(JsonObject loan, double remainingAmount) {
+    hasProperty("feefine", loan, "loan", remainingAmount);
+  }
 
   protected void loanHasLoanPolicyProperties(JsonObject loan, IndividualResource loanPolicy) {
     hasProperty("loanPolicyId", loan, "loan", loanPolicy.getId().toString());

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -369,7 +369,8 @@ public abstract class APITests {
   }
 
   protected void loanHasFeeFinesProperties(JsonObject loan, double remainingAmount) {
-    hasProperty("feefine", loan, "loan", remainingAmount);
+    hasProperty("amountRemainingToPay", loan.getJsonObject("feesAndFines"),
+      "loan", remainingAmount);
   }
 
   protected void loanHasLoanPolicyProperties(JsonObject loan, IndividualResource loanPolicy) {

--- a/src/test/java/api/support/builders/AccountBuilder.java
+++ b/src/test/java/api/support/builders/AccountBuilder.java
@@ -1,0 +1,63 @@
+package api.support.builders;
+
+
+import io.vertx.core.json.JsonObject;
+import org.folio.circulation.support.http.client.IndividualResource;
+
+import java.util.UUID;
+
+import static org.folio.circulation.support.JsonPropertyWriter.write;
+
+public class AccountBuilder extends JsonBuilder implements Builder {
+
+  private String id;
+  private String userId;
+  private String loanId;
+  private Double amount;
+  private String status;
+
+  public AccountBuilder() {
+  }
+
+  AccountBuilder(String loanId, Double amount, String status) {
+    this.loanId = loanId;
+    this.amount = amount;
+    this.status = status;
+    this.id = UUID.randomUUID().toString();
+
+  }
+
+  @Override
+  public JsonObject create() {
+    JsonObject accountRequest = new JsonObject();
+
+    write(accountRequest, "id", id);
+    write(accountRequest, "loanId", loanId);
+    write(accountRequest, "userId", userId);
+    write(accountRequest, "remaining", amount);
+
+    JsonObject statusObject = new JsonObject();
+    write(statusObject, "name", status);
+    write(accountRequest, "status", statusObject);
+
+    return accountRequest;
+  }
+
+  public AccountBuilder withLoan(IndividualResource loan) {
+    return new AccountBuilder(loan.getId().toString(), amount, status);
+  }
+
+  public AccountBuilder withRemainingFeeFine(double remaining) {
+    return new AccountBuilder(loanId, remaining, status);
+  }
+
+  public AccountBuilder feeFineStatusOpen() {
+    return new AccountBuilder(loanId, amount, "Open");
+  }
+
+  public AccountBuilder feeFineStatusClosed() {
+    return new AccountBuilder(loanId, amount, "Closed");
+  }
+
+
+}

--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -117,6 +117,12 @@ public class FakeOkapi extends AbstractVerticle {
       .create().register(router);
 
     new FakeStorageModuleBuilder()
+      .withRecordName("accounts")
+      .withRootPath("/accounts")
+      .withCollectionPropertyName("accounts")
+      .create().register(router);
+
+    new FakeStorageModuleBuilder()
       .withRecordName("request policy")
       .withRootPath("/request-policy-storage/request-policies")
       .withCollectionPropertyName("requestPolicies")

--- a/src/test/java/api/support/http/InterfaceUrls.java
+++ b/src/test/java/api/support/http/InterfaceUrls.java
@@ -148,6 +148,10 @@ public class InterfaceUrls {
     return circulationModuleUrl("/circulation/loans" + subPath);
   }
 
+  public static URL accountsUrl(String subPath) {
+    return APITestContext.viaOkapiModuleUrl("/accounts" + subPath);
+  }
+
   public static URL circulationRulesUrl() {
     return circulationRulesUrl("");
   }

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -65,6 +65,11 @@ public class ResourceClient {
       "loans");
   }
 
+  public static ResourceClient forAccounts(OkapiHttpClient client) {
+    return new ResourceClient(client, InterfaceUrls::accountsUrl,
+      "accounts");
+  }
+
   public static ResourceClient forLoanPolicies(OkapiHttpClient client) {
     return new ResourceClient(client, InterfaceUrls::loanPoliciesStorageUrl,
       "loan policies", "loanPolicies");
@@ -533,7 +538,7 @@ public class ResourceClient {
     client.get(urlMaker.combine("?limit=1000"),
       ResponseHandler.any(getFinished));
 
-    Response response = getFinished.get(5, TimeUnit.SECONDS);
+    Response response = getFinished.get(500, TimeUnit.SECONDS);
 
     assertThat(String.format("Get all records failed: %s", response.getBody()),
       response.getStatusCode(), is(200));


### PR DESCRIPTION
## Purpose
Backend work to support inclusion of fee/fine amount on overdue loans report.
This resolves https://issues.folio.org/browse/CIRC-323

## Approach
In case of  when there are multiple fees/fines assinged to a single loan, there will be multiple accounts(mod-fees-fines) returned, so the loan class has been extended with a new field that holds a collection of accounts assigned to that loan. And the resulting feefine is calculated as a sum of all the remaining amounts in those accounts.





