### PR TITLE
[CIRC-357] Fix absence of request reason for cancellation token on request cancellation notice

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -9,10 +9,11 @@ import static org.folio.circulation.domain.RequestStatus.OPEN_AWAITING_PICKUP;
 import static org.folio.circulation.domain.RequestStatus.OPEN_IN_TRANSIT;
 import static org.folio.circulation.domain.RequestStatus.OPEN_NOT_YET_FILLED;
 import static org.folio.circulation.domain.representations.RequestProperties.CANCELLATION_ADDITIONAL_INFORMATION;
+import static org.folio.circulation.domain.representations.RequestProperties.CANCELLATION_REASON_PUBLIC_DESCRIPTION;
 import static org.folio.circulation.domain.representations.RequestProperties.CANCELLATION_REASON_ID;
+import static org.folio.circulation.domain.representations.RequestProperties.CANCELLATION_REASON_NAME;
 import static org.folio.circulation.domain.representations.RequestProperties.HOLD_SHELF_EXPIRATION_DATE;
 import static org.folio.circulation.domain.representations.RequestProperties.ITEM_ID;
-import static org.folio.circulation.domain.representations.RequestProperties.NAME;
 import static org.folio.circulation.domain.representations.RequestProperties.POSITION;
 import static org.folio.circulation.domain.representations.RequestProperties.REQUEST_EXPIRATION_DATE;
 import static org.folio.circulation.domain.representations.RequestProperties.REQUEST_TYPE;
@@ -307,6 +308,10 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   public String getCancellationReasonName() {
-    return getProperty(cancellationReasonRepresentation, NAME);
+    return getProperty(cancellationReasonRepresentation, CANCELLATION_REASON_NAME);
+  }
+
+  public String getCancellationReasonPublicDescription() {
+    return getProperty(cancellationReasonRepresentation, CANCELLATION_REASON_PUBLIC_DESCRIPTION);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/NoticeContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/NoticeContextUtil.java
@@ -135,7 +135,7 @@ public class NoticeContextUtil {
       .ifPresent(value -> requestContext.put("additionalInfo", value));
     optionalRequest
       .map(Request::getCancellationReasonName)
-      .ifPresent(value -> requestContext.put("cancellationReason", value));
+      .ifPresent(value -> requestContext.put("reasonForCancellation", value));
 
     return requestContext;
   }

--- a/src/main/java/org/folio/circulation/domain/notice/NoticeContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/NoticeContextUtil.java
@@ -134,7 +134,9 @@ public class NoticeContextUtil {
       .map(Request::getCancellationAdditionalInformation)
       .ifPresent(value -> requestContext.put("additionalInfo", value));
     optionalRequest
-      .map(Request::getCancellationReasonName)
+      .map(Request::getCancellationReasonPublicDescription)
+      .map(Optional::of)
+      .orElse(optionalRequest.map(Request::getCancellationReasonName))
       .ifPresent(value -> requestContext.put("reasonForCancellation", value));
 
     return requestContext;

--- a/src/main/java/org/folio/circulation/domain/representations/RequestProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/RequestProperties.java
@@ -4,7 +4,6 @@ public class RequestProperties {
   private RequestProperties() { }
 
   public static final String STATUS = "status";
-  public static final String NAME = "name";
   public static final String ITEM_ID = "itemId";
   public static final String REQUEST_TYPE = "requestType";
   public static final String PROXY_USER_ID = "proxyUserId";
@@ -13,5 +12,7 @@ public class RequestProperties {
   public static final String REQUEST_EXPIRATION_DATE = "requestExpirationDate";
   public static final String CANCELLATION_ADDITIONAL_INFORMATION = "cancellationAdditionalInformation";
   public static final String CANCELLATION_REASON_ID = "cancellationReasonId";
+  public static final String CANCELLATION_REASON_NAME = "name";
+  public static final String CANCELLATION_REASON_PUBLIC_DESCRIPTION = "publicDescription";
   public static final String REQUESTER_ID = "requesterId";
 }

--- a/src/test/java/api/requests/RequestsAPIUpdatingTests.java
+++ b/src/test/java/api/requests/RequestsAPIUpdatingTests.java
@@ -33,7 +33,6 @@ import org.awaitility.Awaitility;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.hamcrest.Matcher;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -549,7 +548,7 @@ public class RequestsAPIUpdatingTests extends APITests {
     noticeContextMatchers.putAll(NoticeMatchers.getCancelledRequestContextMatchers(updatedRequest));
     noticeContextMatchers.put("request.reasonForCancellation",
       is(itemNotAvailable.getJson().getString(CANCELLATION_REASON_PUBLIC_DESCRIPTION)));
-    MatcherAssert.assertThat(sentNotices,
+    assertThat(sentNotices,
       hasItems(
         hasEmailNoticeProperties(requester.getId(), requestCancellationTemplateId, noticeContextMatchers)));
   }
@@ -609,7 +608,7 @@ public class RequestsAPIUpdatingTests extends APITests {
     noticeContextMatchers.putAll(NoticeMatchers.getCancelledRequestContextMatchers(updatedRequest));
     noticeContextMatchers.put("request.reasonForCancellation",
       is(courseReserves.getJson().getString(CANCELLATION_REASON_NAME)));
-    MatcherAssert.assertThat(sentNotices,
+    assertThat(sentNotices,
       hasItems(
         hasEmailNoticeProperties(requester.getId(), requestCancellationTemplateId, noticeContextMatchers)));
   }

--- a/src/test/java/api/support/fixtures/CancellationReasonsFixture.java
+++ b/src/test/java/api/support/fixtures/CancellationReasonsFixture.java
@@ -38,7 +38,25 @@ public class CancellationReasonsFixture {
     return createReason("Course Reserves", "Item needed for course reserves");
   }
 
+  public IndividualResource itemNotAvailable()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    return createReason("Item Not Available", "Item is no longer available", "Item is no longer available");
+  }
+
   private IndividualResource createReason(String name, String description)
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException {
+
+    return createReason(name, description, null);
+  }
+
+  private IndividualResource createReason(String name, String description, String publicDescription)
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
@@ -48,6 +66,7 @@ public class CancellationReasonsFixture {
 
     write(reason, "name", name);
     write(reason, "description", description);
+    write(reason, "publicDescription", publicDescription);
 
     return cancellationReasonsRecordCreator.createIfAbsent(reason);
   }

--- a/src/test/java/api/support/fixtures/NoticeMatchers.java
+++ b/src/test/java/api/support/fixtures/NoticeMatchers.java
@@ -154,7 +154,7 @@ public class NoticeMatchers {
     Map<String, Matcher<String>> tokenMatchers = new HashMap<>();
     tokenMatchers.put("request.additionalInfo",
       is(request.getString("cancellationAdditionalInformation")));
-    tokenMatchers.put("request.cancellationReason", notNullValue(String.class));
+    tokenMatchers.put("request.reasonForCancellation", notNullValue(String.class));
     return tokenMatchers;
   }
 


### PR DESCRIPTION
## Purpose
Resolves: [CIRC-357](https://issues.folio.org/browse/CIRC-357)
Request reason for cancellation token value not showing on request cancellation notice
## Approach

- change the token name from `cancellationReason` to `reasonForCancellation` (to be consistent with the [UICIRC-249](https://issues.folio.org/browse/UICIRC-249))
- use cancellation reason `publicDescription` instead of `name`
- use cancellation reason `name` if `publicDescription` is not present

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
 
