### PR TITLE
[CIRC-350] Add missing statuses to the request schema

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "requests-reports",
-      "version": "0.1",
+      "version": "0.2",
       "handlers": [
         {
           "methods": [
@@ -22,7 +22,7 @@
     },
     {
       "id": "request-move",
-      "version": "0.1",
+      "version": "0.2",
       "handlers": [
         {
           "methods": [
@@ -40,7 +40,7 @@
     },
     {
       "id": "circulation",
-      "version": "7.8",
+      "version": "7.9",
       "handlers": [
         {
           "methods": [

--- a/ramls/circulation.raml
+++ b/ramls/circulation.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Circulation
-version: v7.8
+version: v7.9
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/request-move.raml
+++ b/ramls/request-move.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Circulation
-version: v0.1
+version: v0.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/request.json
+++ b/ramls/request.json
@@ -42,7 +42,9 @@
         "Open - Awaiting pickup",
         "Open - In transit",
         "Closed - Filled",
-        "Closed - Cancelled"
+        "Closed - Cancelled",
+        "Closed - Unfilled",
+        "Closed - Pickup expired"
       ]
     },
     "cancellationReasonId": {

--- a/ramls/requests-reports.raml
+++ b/ramls/requests-reports.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Circulation
-version: v0.1
+version: v0.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 


### PR DESCRIPTION
## Purpose
Resolves: [CIRC-350](https://issues.folio.org/browse/CIRC-350)
Request schema (request.json) does not include all possible statuses in "status"
## Approach

Add `Closed - Unfilled` and `Closed - Pickup expired` statuses to the `request.json` schema

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
 
