### PR TITLE
CIRC-324: Show time of scan when checking any item in

### DIFF
--- a/ramls/check-in-by-barcode-response.json
+++ b/ramls/check-in-by-barcode-response.json
@@ -96,6 +96,11 @@
               "type": "string"
             }
           }
+        },
+        "returnDate": {
+          "description": "Date and time when the item was returned",
+          "type": "string",
+          "format": "date-time"
         }
       },
       "additionalProperties": false

--- a/src/main/java/org/folio/circulation/domain/representations/CheckInByBarcodeResponse.java
+++ b/src/main/java/org/folio/circulation/domain/representations/CheckInByBarcodeResponse.java
@@ -38,8 +38,10 @@ public class CheckInByBarcodeResponse {
     write(checkInResponseBody, "loan",
       loanRepresentation.extendedLoan(records.getLoan()));
 
-    write(checkInResponseBody, "item",
-      itemRepresentation.createItemSummary(records.getItem()));
+    JsonObject itemSummary = itemRepresentation.createItemSummary(records.getItem());
+
+    write(itemSummary, "returnDate", records.getCheckInRequest().getCheckInDate());
+    write(checkInResponseBody, "item", itemSummary);
 
     return new OkJsonResponseResult(checkInResponseBody);
   }

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -69,10 +69,11 @@ public class CheckInByBarcodeTests extends APITests {
 
     DateTime expectedSystemReturnDate = DateTime.now(DateTimeZone.UTC);
 
+    DateTime checkInDate = new DateTime(2018, 3, 5, 14, 23, 41, DateTimeZone.UTC);
     final CheckInByBarcodeResponse checkInResponse = loansFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
         .forItem(nod)
-        .on(new DateTime(2018, 3, 5, 14 ,23, 41, DateTimeZone.UTC))
+        .on(checkInDate)
         .at(checkInServicePointId));
 
     JsonObject loanRepresentation = checkInResponse.getLoan();
@@ -81,6 +82,9 @@ public class CheckInByBarcodeTests extends APITests {
       loanRepresentation, notNullValue());
 
     assertThat(loanRepresentation.getString("userId"), is(james.getId().toString()));
+
+    hasProperty("returnDate",
+      checkInResponse.getItem(), "item", checkInDate.toString());
 
     assertThat("Should have return date",
       loanRepresentation.getString("returnDate"), is("2018-03-05T14:23:41.000Z"));
@@ -247,8 +251,9 @@ public class CheckInByBarcodeTests extends APITests {
     final IndividualResource nod = itemsFixture.basedUponNod(
       builder -> builder.withTemporaryLocation(homeLocation.getId()));
 
+    DateTime checkInDate = new DateTime(2018, 3, 5, 14, 23, 41, DateTimeZone.UTC);
     final CheckInByBarcodeResponse checkInResponse = loansFixture.checkInByBarcode(
-      nod, new DateTime(2018, 3, 5, 14, 23, 41, DateTimeZone.UTC),
+      nod, checkInDate,
       checkInServicePointId);
 
     assertThat("Response should not include a loan",
@@ -258,6 +263,9 @@ public class CheckInByBarcodeTests extends APITests {
       checkInResponse.getJson().containsKey("item"), is(true));
 
     final JsonObject itemFromResponse = checkInResponse.getItem();
+
+    hasProperty("returnDate",
+      itemFromResponse, "item", checkInDate.toString());
 
     assertThat("ID should be included for item",
       itemFromResponse.getString("id"), is(nod.getId()));


### PR DESCRIPTION
## Purpose
To see the time of scan for items I have checked in (even if the item wasn't checked out), so that I have full feedback on what I scan and can keep track of my work. 
This resolves CIRC-324

## Approach
When checking an item in, the server responds with two ojbects: loan and item and the `returnDate`, which was read in the fron-end, was located in the loan object. Now, the `returnDate` has also been included in the item object to cover various scenarious when there is no loan present.
