### PR TITLE
CIRC-395: Update request queue order when moving request

### DIFF
--- a/src/main/java/org/folio/circulation/domain/MoveRequestService.java
+++ b/src/main/java/org/folio/circulation/domain/MoveRequestService.java
@@ -39,9 +39,10 @@ public class MoveRequestService {
         .thenComposeAsync(r -> r.after(moveRequestProcessAdapter::getDestinationRequestQueue))
         .thenApply(r -> r.map(this::pagedRequestIfDestinationItemAvailable))
         .thenCompose(r -> r.after(this::updateRequest))
+        .thenCompose(r -> r.after(updateRequestQueue::onMovedTo))
         .thenComposeAsync(r -> r.after(moveRequestProcessAdapter::findSourceItem))
         .thenComposeAsync(r -> r.after(moveRequestProcessAdapter::getSourceRequestQueue))
-        .thenCompose(r -> r.after(updateRequestQueue::onMoved))
+        .thenCompose(r -> r.after(updateRequestQueue::onMovedFrom))
         .thenComposeAsync(r -> r.after(moveRequestProcessAdapter::findDestinationItem))
         .thenComposeAsync(r -> r.after(moveRequestProcessAdapter::getDestinationRequestQueue));
   }
@@ -65,7 +66,6 @@ public class MoveRequestService {
         .after(requestLoanValidator::refuseWhenUserHasAlreadyBeenLoanedItem)
         .thenComposeAsync(r -> r.after(requestPolicyRepository::lookupRequestPolicy))
         .thenApply(r -> r.next(RequestServiceUtility::refuseWhenRequestCannotBeFulfilled))
-        .thenApply(r -> r.map(RequestServiceUtility::setRequestQueuePosition))
         .thenComposeAsync(r -> r.after(updateUponRequest.updateItem::onRequestCreationOrMove))
         .thenComposeAsync(r -> r.after(updateUponRequest.updateLoanActionHistory::onRequestCreationOrMove))
         .thenComposeAsync(r -> r.after(updateUponRequest.updateLoan::onRequestCreationOrMove))

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -93,7 +93,11 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   public boolean isOpen() {
-    return isAwaitingPickup() || isNotYetFilled()|| isInTransit();
+    return isAwaitingPickup() || isNotYetFilled() || isInTransit();
+  }
+
+  public boolean isNotDisplaceable() {
+    return isAwaitingPickup() || isInTransit();
   }
 
   private boolean isInTransit(){

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -9,12 +9,13 @@ import static org.folio.circulation.domain.RequestStatus.OPEN_AWAITING_PICKUP;
 import static org.folio.circulation.domain.RequestStatus.OPEN_IN_TRANSIT;
 import static org.folio.circulation.domain.RequestStatus.OPEN_NOT_YET_FILLED;
 import static org.folio.circulation.domain.representations.RequestProperties.CANCELLATION_ADDITIONAL_INFORMATION;
-import static org.folio.circulation.domain.representations.RequestProperties.CANCELLATION_REASON_PUBLIC_DESCRIPTION;
 import static org.folio.circulation.domain.representations.RequestProperties.CANCELLATION_REASON_ID;
 import static org.folio.circulation.domain.representations.RequestProperties.CANCELLATION_REASON_NAME;
+import static org.folio.circulation.domain.representations.RequestProperties.CANCELLATION_REASON_PUBLIC_DESCRIPTION;
 import static org.folio.circulation.domain.representations.RequestProperties.HOLD_SHELF_EXPIRATION_DATE;
 import static org.folio.circulation.domain.representations.RequestProperties.ITEM_ID;
 import static org.folio.circulation.domain.representations.RequestProperties.POSITION;
+import static org.folio.circulation.domain.representations.RequestProperties.REQUEST_DATE;
 import static org.folio.circulation.domain.representations.RequestProperties.REQUEST_EXPIRATION_DATE;
 import static org.folio.circulation.domain.representations.RequestProperties.REQUEST_TYPE;
 import static org.folio.circulation.domain.representations.RequestProperties.STATUS;
@@ -250,13 +251,11 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
     return pickupServicePoint;
   }
 
-  Request changePosition(Integer newPosition) {
+  void changePosition(Integer newPosition) {
     if (!Objects.equals(getPosition(), newPosition)) {
       write(requestRepresentation, POSITION, newPosition);
       changedPosition = true;
     }
-
-    return this;
   }
 
   void removePosition() {
@@ -289,6 +288,10 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
 
   void removeHoldShelfExpirationDate() {
     requestRepresentation.remove(HOLD_SHELF_EXPIRATION_DATE);
+  }
+  
+  public DateTime getRequestDate() {
+    return getDateTimeProperty(requestRepresentation, REQUEST_DATE);
   }
 
   public DateTime getHoldShelfExpirationDate() {

--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -3,19 +3,11 @@ package org.folio.circulation.domain;
 import static org.folio.circulation.domain.ItemStatus.AVAILABLE;
 
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 public class RequestQueue {
-
-  private final static Comparator<Request> REQUEST_DATE_COMPARATOR = new Comparator<Request>() {
-    @Override
-    public int compare(Request req1, Request req2) {
-      return req1.getRequestDate().compareTo(req2.getRequestDate());
-    }
-  };
 
   private Collection<Request> requests;
 
@@ -73,7 +65,10 @@ public class RequestQueue {
 
   private void orderRequests() {
     requests = requests.stream()
-      .sorted(REQUEST_DATE_COMPARATOR)
+      // order by date descending
+      .sorted((req1, req2) -> req1.getRequestDate().compareTo(req2.getRequestDate()))
+      // order by (request status = "Open - In transit" or "Open - Awaiting pickup") first
+      .sorted((req1, req2) -> Boolean.compare(req2.isNotDisplaceable(), req1.isNotDisplaceable()))
       .collect(Collectors.toList());
     final AtomicInteger position = new AtomicInteger(1);
     requests.forEach(req -> req.changePosition(position.getAndIncrement()));

--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -1,13 +1,22 @@
 package org.folio.circulation.domain;
 
-import static java.util.Comparator.naturalOrder;
 import static org.folio.circulation.domain.ItemStatus.AVAILABLE;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 public class RequestQueue {
+
+  private final static Comparator<Request> REQUEST_DATE_COMPARATOR = new Comparator<Request>() {
+    @Override
+    public int compare(Request req1, Request req2) {
+      return req1.getRequestDate().compareTo(req2.getRequestDate());
+    }
+  };
+
   private Collection<Request> requests;
 
   RequestQueue(Collection<Request> requests) {
@@ -46,36 +55,28 @@ public class RequestQueue {
       .collect(Collectors.toList());
   }
 
-  Integer nextAvailablePosition() {
-    return highestPosition() + 1;
-  }
-
-  private Integer highestPosition() {
-    return requests.stream()
-      .filter(Request::isOpen)
-      .map(request -> request.asJson().getInteger("position"))
-      .max(naturalOrder()).orElse(0);
+  public void add(Request newRequest) {
+    // NOTE: assumes Collection supports add
+    requests.add(newRequest);
+    orderRequests();
   }
 
   public void remove(Request request) {
-    requests = removeInCollection(request);
-    request.removePosition();
-    removeGapsInPositions();
-  }
-
-  private List<Request> removeInCollection(Request request) {
-    return requests.stream()
+    // NOTE: tests use Arrays.asList which produces a collection which
+    // does not support remove
+    requests = requests.stream()
       .filter(r -> !r.getId().equals(request.getId()))
       .collect(Collectors.toList());
+    request.removePosition();
+    orderRequests();
   }
 
-  private void removeGapsInPositions() {
-    Integer currentPosition = 1;
-
-    for (Request request : requests) {
-      request.changePosition(currentPosition);
-      currentPosition++;
-    }
+  private void orderRequests() {
+    requests = requests.stream()
+      .sorted(REQUEST_DATE_COMPARATOR)
+      .collect(Collectors.toList());
+    final AtomicInteger position = new AtomicInteger(1);
+    requests.forEach(req -> req.changePosition(position.getAndIncrement()));
   }
 
   public Integer size() {

--- a/src/main/java/org/folio/circulation/domain/RequestServiceUtility.java
+++ b/src/main/java/org/folio/circulation/domain/RequestServiceUtility.java
@@ -21,12 +21,9 @@ public class RequestServiceUtility {
   private RequestServiceUtility() {
 
   }
-  
-  static RequestAndRelatedRecords setRequestQueuePosition(RequestAndRelatedRecords requestAndRelatedRecords) {
-    // TODO: Extract to method to add to queue
-    requestAndRelatedRecords.withRequest(requestAndRelatedRecords.getRequest()
-      .changePosition(requestAndRelatedRecords.getRequestQueue().nextAvailablePosition()));
 
+  static RequestAndRelatedRecords setRequestQueuePosition(RequestAndRelatedRecords requestAndRelatedRecords) {
+    requestAndRelatedRecords.getRequestQueue().add(requestAndRelatedRecords.getRequest());
     return requestAndRelatedRecords;
   }
 

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -136,12 +136,26 @@ public class UpdateRequestQueue {
     }
   }
 
-  CompletableFuture<Result<RequestAndRelatedRecords>> onMoved(
+  CompletableFuture<Result<RequestAndRelatedRecords>> onMovedFrom(
     RequestAndRelatedRecords requestAndRelatedRecords) {
     final Request request = requestAndRelatedRecords.getRequest();
-    final RequestQueue requestQueue = requestAndRelatedRecords.getRequestQueue();
     if (requestAndRelatedRecords.getSourceItemId().equals(request.getItemId())) {
+      final RequestQueue requestQueue = requestAndRelatedRecords.getRequestQueue();
       requestQueue.remove(request);
+      return requestQueueRepository.updateRequestsWithChangedPositions(requestQueue)
+            .thenApply(r -> r.map(requestAndRelatedRecords::withRequestQueue));
+    }
+    else {
+      return completedFuture(succeeded(requestAndRelatedRecords));
+    }
+  }
+
+  CompletableFuture<Result<RequestAndRelatedRecords>> onMovedTo(
+    RequestAndRelatedRecords requestAndRelatedRecords) {
+    final Request request = requestAndRelatedRecords.getRequest();
+    if (requestAndRelatedRecords.getDestinationItemId().equals(request.getItemId())) {
+      final RequestQueue requestQueue = requestAndRelatedRecords.getRequestQueue();
+      requestQueue.add(request);
       return requestQueueRepository.updateRequestsWithChangedPositions(requestQueue)
             .thenApply(r -> r.map(requestAndRelatedRecords::withRequestQueue));
     }

--- a/src/main/java/org/folio/circulation/domain/representations/RequestProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/RequestProperties.java
@@ -9,6 +9,7 @@ public class RequestProperties {
   public static final String PROXY_USER_ID = "proxyUserId";
   public static final String POSITION = "position";
   public static final String HOLD_SHELF_EXPIRATION_DATE = "holdShelfExpirationDate";
+  public static final String REQUEST_DATE = "requestDate";
   public static final String REQUEST_EXPIRATION_DATE = "requestExpirationDate";
   public static final String CANCELLATION_ADDITIONAL_INFORMATION = "cancellationAdditionalInformation";
   public static final String CANCELLATION_REASON_ID = "cancellationReasonId";

--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -343,7 +343,7 @@ public class MoveRequestTests extends APITests {
   }
 
   @Test
-  public void canMoveAHoldShelfRequestReorderingDestinationReuqestQueue()
+  public void canMoveAHoldShelfRequestReorderingDestinationRequestQueue()
     throws InterruptedException,
     ExecutionException,
     TimeoutException,

--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -1,5 +1,6 @@
 package api.requests.scenarios;
 
+import static api.support.builders.RequestBuilder.OPEN_AWAITING_PICKUP;
 import static org.folio.circulation.domain.representations.RequestProperties.REQUEST_TYPE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -46,6 +47,7 @@ import junitparams.JUnitParamsRunner;
  *
  * @see <a href="https://issues.folio.org/browse/UIREQ-269">UIREQ-269</a>
  * @see <a href="https://issues.folio.org/browse/CIRC-316">CIRC-316</a>
+ * @see <a href="https://issues.folio.org/browse/CIRC-395">CIRC-395</a>
  */
 @RunWith(JUnitParamsRunner.class)
 public class MoveRequestTests extends APITests {
@@ -372,12 +374,98 @@ public class MoveRequestTests extends APITests {
     IndividualResource requestByCharlotte = requestsFixture.placeHoldShelfRequest(
       smallAngryPlanet, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(3));
 
+    // make requests for uponInterestingTimes
+    IndividualResource requestByRebecca = requestsFixture.placeHoldShelfRequest(
+      uponInterestingTimes, rebecca, DateTime.now(DateTimeZone.UTC).minusHours(5));
+
+    IndividualResource requestByJames = requestsFixture.placeHoldShelfRequest(
+      uponInterestingTimes, james, DateTime.now(DateTimeZone.UTC).minusHours(1));
+
+    // move jessica's hold shelf request from smallAngryPlanet to uponInterestingTimes
+    IndividualResource moveRequest = requestsFixture.move(new MoveRequestBuilder(
+      requestByJessica.getId(),
+      uponInterestingTimes.getId(),
+      null
+    ));
+
+    assertThat("Move request should have correct item id",
+      moveRequest.getJson().getString("itemId"), is(uponInterestingTimes.getId().toString()));
+
+    // check positioning on smallAngryPlanet
+    requestBySteve = requestsClient.get(requestBySteve);
+    assertThat(requestBySteve.getJson().getInteger("position"), is(1));
+    assertThat(requestBySteve.getJson().getString("itemId"), is(smallAngryPlanet.getId().toString()));
+    retainsStoredSummaries(requestBySteve);
+
+    requestByCharlotte = requestsClient.get(requestByCharlotte);
+    assertThat(requestByCharlotte.getJson().getInteger("position"), is(2));
+    assertThat(requestByCharlotte.getJson().getString("itemId"), is(smallAngryPlanet.getId().toString()));
+    retainsStoredSummaries(requestByCharlotte);
+
+    // check positioning on uponInterestingTimes
+    requestByRebecca = requestsClient.get(requestByRebecca);
+    assertThat(requestByRebecca.getJson().getInteger("position"), is(1));
+    assertThat(requestByRebecca.getJson().getString("itemId"), is(uponInterestingTimes.getId().toString()));
+    retainsStoredSummaries(requestByRebecca);
+
+    requestByJessica = requestsClient.get(requestByJessica);
+    assertThat(requestByJessica.getJson().getInteger("position"), is(2));
+    assertThat(requestByJessica.getJson().getString("itemId"), is(uponInterestingTimes.getId().toString()));
+    retainsStoredSummaries(requestByJessica);
+
+    requestByJames = requestsClient.get(requestByJames);
+    assertThat(requestByJames.getJson().getInteger("position"), is(3));
+    assertThat(requestByJames.getJson().getString("itemId"), is(uponInterestingTimes.getId().toString()));
+    retainsStoredSummaries(requestByJames);
+
+    // check item queues are correct size
+    MultipleRecords<JsonObject> smallAngryPlanetQueue = requestsFixture.getQueueFor(smallAngryPlanet);
+    assertThat(smallAngryPlanetQueue.getTotalRecords(), is(2));
+
+    MultipleRecords<JsonObject> uponInterestingTimesQueue = requestsFixture.getQueueFor(uponInterestingTimes);
+    assertThat(uponInterestingTimesQueue.getTotalRecords(), is(3));
+  }
+  
+  @Test
+  public void canMoveAHoldShelfRequestPreventDisplacingOpenRequest()
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException,
+    MalformedURLException {
+
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    IndividualResource uponInterestingTimes = itemsFixture.basedUponInterestingTimes();
+    
+    IndividualResource james = usersFixture.james();
+    IndividualResource jessica = usersFixture.jessica();
+    IndividualResource steve = usersFixture.steve();
+    IndividualResource charlotte = usersFixture.charlotte();
+    IndividualResource rebecca = usersFixture.rebecca();
+
+    // james checks out basedUponSmallAngryPlanet
+    loansFixture.checkOutByBarcode(smallAngryPlanet, james);
+    
+    // charlotte checks out basedUponInterestingTimes
+    loansFixture.checkOutByBarcode(uponInterestingTimes, charlotte);
+
+    // make requests for smallAngryPlanet
+    IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
+      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC).minusHours(4));
+
+    IndividualResource requestBySteve = requestsFixture.placeHoldShelfRequest(
+      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC).minusHours(5));
+
+    IndividualResource requestByCharlotte = requestsFixture.placeHoldShelfRequest(
+      smallAngryPlanet, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(3));
+
     IndividualResource requestByRebecca = requestsFixture.placeHoldShelfRequest(
       smallAngryPlanet, rebecca, DateTime.now(DateTimeZone.UTC).minusHours(2));
 
     // make requests for uponInterestingTimes
     IndividualResource requestByJames = requestsFixture.placeHoldShelfRequest(
       uponInterestingTimes, james, DateTime.now(DateTimeZone.UTC).minusHours(1));
+
+    loansFixture.checkInByBarcode(uponInterestingTimes);
 
     // move jessica's hold shelf request from smallAngryPlanet to uponInterestingTimes
     IndividualResource moveRequest = requestsFixture.move(new MoveRequestBuilder(
@@ -406,15 +494,16 @@ public class MoveRequestTests extends APITests {
     retainsStoredSummaries(requestByRebecca);
 
     // check positioning on uponInterestingTimes
-    requestByJessica = requestsClient.get(requestByJessica);
-    assertThat(requestByJessica.getJson().getInteger("position"), is(1));
-    assertThat(requestByJessica.getJson().getString("itemId"), is(uponInterestingTimes.getId().toString()));
-    retainsStoredSummaries(requestByJessica);
-
     requestByJames = requestsClient.get(requestByJames);
-    assertThat(requestByJames.getJson().getInteger("position"), is(2));
+    assertThat(requestByJames.getJson().getString("status"), is(OPEN_AWAITING_PICKUP));
+    assertThat(requestByJames.getJson().getInteger("position"), is(1));
     assertThat(requestByJames.getJson().getString("itemId"), is(uponInterestingTimes.getId().toString()));
     retainsStoredSummaries(requestByJames);
+
+    requestByJessica = requestsClient.get(requestByJessica);
+    assertThat(requestByJessica.getJson().getInteger("position"), is(2));
+    assertThat(requestByJessica.getJson().getString("itemId"), is(uponInterestingTimes.getId().toString()));
+    retainsStoredSummaries(requestByJessica);
 
     // check item queues are correct size
     MultipleRecords<JsonObject> smallAngryPlanetQueue = requestsFixture.getQueueFor(smallAngryPlanet);

--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -236,7 +236,7 @@ public class MoveRequestTests extends APITests {
       smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC).minusHours(5));
 
     IndividualResource requestBySteve = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC).minusHours(4), RequestType.RECALL.getValue());
+      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.RECALL.getValue());
 
     IndividualResource requestByCharlotte = requestsFixture.placeHoldShelfRequest(
       smallAngryPlanet, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(3));
@@ -246,7 +246,7 @@ public class MoveRequestTests extends APITests {
 
     // make requests for uponInterestingTimes
     IndividualResource requestByJames = requestsFixture.placeHoldShelfRequest(
-      uponInterestingTimes, james, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.RECALL.getValue());
+      uponInterestingTimes, james, DateTime.now(DateTimeZone.UTC).minusHours(4), RequestType.RECALL.getValue());
 
     // move steve's recall request from smallAngryPlanet to uponInterestingTimes
     IndividualResource moveRequest = requestsFixture.move(new MoveRequestBuilder(
@@ -341,7 +341,7 @@ public class MoveRequestTests extends APITests {
   }
 
   @Test
-  public void canMoveAHoldShelfRequest()
+  public void canMoveAHoldShelfRequestReorderingDestinationReuqestQueue()
     throws InterruptedException,
     ExecutionException,
     TimeoutException,
@@ -364,10 +364,10 @@ public class MoveRequestTests extends APITests {
 
     // make requests for smallAngryPlanet
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC).minusHours(5));
+      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC).minusHours(4));
 
     IndividualResource requestBySteve = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC).minusHours(4));
+      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC).minusHours(5));
 
     IndividualResource requestByCharlotte = requestsFixture.placeHoldShelfRequest(
       smallAngryPlanet, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(3));
@@ -406,15 +406,15 @@ public class MoveRequestTests extends APITests {
     retainsStoredSummaries(requestByRebecca);
 
     // check positioning on uponInterestingTimes
-    requestByJames = requestsClient.get(requestByJames);
-    assertThat(requestByJames.getJson().getInteger("position"), is(1));
-    assertThat(requestByJames.getJson().getString("itemId"), is(uponInterestingTimes.getId().toString()));
-    retainsStoredSummaries(requestByJames);
-
     requestByJessica = requestsClient.get(requestByJessica);
-    assertThat(requestByJessica.getJson().getInteger("position"), is(2));
+    assertThat(requestByJessica.getJson().getInteger("position"), is(1));
     assertThat(requestByJessica.getJson().getString("itemId"), is(uponInterestingTimes.getId().toString()));
     retainsStoredSummaries(requestByJessica);
+
+    requestByJames = requestsClient.get(requestByJames);
+    assertThat(requestByJames.getJson().getInteger("position"), is(2));
+    assertThat(requestByJames.getJson().getString("itemId"), is(uponInterestingTimes.getId().toString()));
+    retainsStoredSummaries(requestByJames);
 
     // check item queues are correct size
     MultipleRecords<JsonObject> smallAngryPlanetQueue = requestsFixture.getQueueFor(smallAngryPlanet);
@@ -448,7 +448,7 @@ public class MoveRequestTests extends APITests {
 
     // make requests for smallAngryPlanet
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC));
+      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC).minusHours(5));
 
     IndividualResource requestBySteve = requestsFixture.placeHoldShelfRequest(
       smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC).minusHours(4), RequestType.RECALL.getValue());
@@ -457,11 +457,11 @@ public class MoveRequestTests extends APITests {
       smallAngryPlanet, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(3));
 
     IndividualResource requestByRebecca = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, rebecca, DateTime.now(DateTimeZone.UTC).minusHours(2), RequestType.RECALL.getValue());
+      smallAngryPlanet, rebecca, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.RECALL.getValue());
 
     // make requests for uponInterestingTimes
     IndividualResource requestByJames = requestsFixture.placeHoldShelfRequest(
-      uponInterestingTimes, james, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.RECALL.getValue());
+      uponInterestingTimes, james, DateTime.now(DateTimeZone.UTC).minusHours(2), RequestType.RECALL.getValue());
 
     // move rebecca's recall request from smallAngryPlanet to uponInterestingTimes
     IndividualResource moveRequest = requestsFixture.move(new MoveRequestBuilder(


### PR DESCRIPTION
## Purpose
Resolves: [CIRC-395](https://issues.folio.org/browse/CIRC-395)

## Approach
- new remove method on request queue
- order request queue by date and not displaceable
- updating request positions accordingly
- update source and destination request queues
- test expecting reorder
- test preventing reorder of request not displaceable

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] Were any API paths or methods changed, added or removed? No
  - [x] Were there any schema changes? No
  - [x] Did any of the interface versions change? No
  - [x] Were permissions changed, added, or removed? No
  - [x] Are there new interface dependencies? No
  - [x] There are no breaking changes in this PR. No
