### PR TITLE
CIRC-333: Change Paged Item's Status To Available When Queue is Emptied (Requests Are Cancelled or Moved)

### DIFF
--- a/src/main/java/org/folio/circulation/domain/MoveRequestService.java
+++ b/src/main/java/org/folio/circulation/domain/MoveRequestService.java
@@ -43,6 +43,7 @@ public class MoveRequestService {
         .thenComposeAsync(r -> r.after(moveRequestProcessAdapter::findSourceItem))
         .thenComposeAsync(r -> r.after(moveRequestProcessAdapter::getSourceRequestQueue))
         .thenCompose(r -> r.after(updateRequestQueue::onMovedFrom))
+        .thenCompose(r -> r.after(updateUponRequest.updateItem::onRequestQueueChanged))
         .thenComposeAsync(r -> r.after(moveRequestProcessAdapter::findDestinationItem))
         .thenComposeAsync(r -> r.after(moveRequestProcessAdapter::getDestinationRequestQueue));
   }

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -107,8 +107,10 @@ public class RequestCollectionResource extends CollectionResource {
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final RequestNoticeSender requestNoticeSender = RequestNoticeSender.using(clients);
 
+    final UpdateItem updateItem = new UpdateItem(clients);
+
     final UpdateUponRequest updateUponRequest = new UpdateUponRequest(
-        new UpdateItem(clients),
+        updateItem,
         new UpdateLoan(clients, loanRepository, loanPolicyRepository),
         new UpdateLoanActionHistory(clients));
 
@@ -123,7 +125,8 @@ public class RequestCollectionResource extends CollectionResource {
         requestRepository,
         UpdateRequestQueue.using(clients),
         new ClosedRequestValidator(RequestRepository.using(clients)),
-        requestNoticeSender);
+        requestNoticeSender,
+        updateItem);
 
     final RequestFromRepresentationService requestFromRepresentationService =
       new RequestFromRepresentationService(


### PR DESCRIPTION
## Purpose
Resolves: [CIRC-333](https://issues.folio.org/browse/CIRC-333)

## Approach
- add `onRequestQueueChanged` to `UpdateItem`
- call `onRequestQueueChanged` after move and cancel
- test `ItemStatus` change from Paged to Available on move request and queue becomes empty
- test `ItemStatus` change from Paged to Available on cancel request and queue becomes empty

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] Were any API paths or methods changed, added or removed? No
  - [x] Were there any schema changes? No
  - [x] Did any of the interface versions change? No
  - [x] Were permissions changed, added, or removed? No
  - [x] Are there new interface dependencies? No
  - [x] There are no breaking changes in this PR. No
