### PR TITLE
CIRC-409: Missing permission in module permission set

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1261,6 +1261,7 @@
         "inventory-storage.locations.collection.get",
         "inventory-storage.location-units.institutions.item.get",
         "inventory-storage.location-units.campuses.item.get",
+        "inventory-storage.location-units.libraries.collection.get",
         "inventory-storage.location-units.libraries.item.get",
         "inventory-storage.holdings.collection.get",
         "inventory-storage.holdings.item.get",


### PR DESCRIPTION
CIRC-409: Missing permission in module permission set for /circulation/loans 

## Purpose
Adding a missing permission in module permission set for /circulation/loans. 
See https://issues.folio.org/browse/CIRC-409

## Approach
Added a line to ModuleDescriptor
