### PR TITLE
CIRC-407 Sending patron loan notices, make number of emails to be processed in a given timeframe configurable

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Configuration.java
+++ b/src/main/java/org/folio/circulation/domain/Configuration.java
@@ -2,12 +2,12 @@ package org.folio.circulation.domain;
 
 import io.vertx.core.json.JsonObject;
 
-public class TimeZoneConfig {
+public class Configuration {
   private static final String VALUE_KEY = "value";
 
   private String value;
 
-  TimeZoneConfig(JsonObject jsonObject) {
+  Configuration(JsonObject jsonObject) {
     value = jsonObject.getString(VALUE_KEY);
   }
 

--- a/src/main/java/org/folio/circulation/domain/ConfigurationRepository.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationRepository.java
@@ -1,17 +1,25 @@
 package org.folio.circulation.domain;
 
-import static org.folio.circulation.domain.MultipleRecords.from;
-import static org.folio.circulation.support.CqlQuery.exactMatch;
-
-import java.util.concurrent.CompletableFuture;
-
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.CqlQuery;
 import org.folio.circulation.support.Result;
 import org.joda.time.DateTimeZone;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import static org.folio.circulation.domain.MultipleRecords.from;
+import static org.folio.circulation.support.CqlQuery.exactMatch;
+
 public class ConfigurationRepository {
+
+  private static final String CONFIGS_KEY = "configs";
+  private static final String MODULE_NAME_KEY = "module";
+  private static final String CONFIG_NAME_KEY = "configName";
+
+  private static final int DEFAULT_PAGE_LIMIT = 1;
+
   private final CollectionResourceClient configurationClient;
 
   public ConfigurationRepository(Clients clients) {
@@ -25,17 +33,37 @@ public class ConfigurationRepository {
       .thenApply(result -> result.map(relatedRecords::withTimeZone));
   }
 
+  public CompletableFuture<Result<Integer>> lookupSchedulerNoticesProcessingLimit() {
+    Result<CqlQuery> cqlQueryResult = defineCqlQueryResult("NOTIFICATION_SCHEDULER", "noticesLimit");
+    return lookupConfigurations(cqlQueryResult, applySearchSchedulerNoticesLimit());
+  }
+
   private CompletableFuture<Result<DateTimeZone>> findTimeZoneConfiguration() {
-    final ConfigurationService configurationService = new ConfigurationService();
+    Result<CqlQuery> cqlQueryResult = defineCqlQueryResult("ORG", "localeSettings");
+    return lookupConfigurations(cqlQueryResult, applySearchDateTimeZone());
+  }
 
-    final Result<CqlQuery> moduleQuery = exactMatch("module", "ORG");
-    final Result<CqlQuery> configNameQuery = exactMatch("configName", "localeSettings");
+  private <T> CompletableFuture<Result<T>> lookupConfigurations(Result<CqlQuery> cqlQueryResult,
+                                                                Function<MultipleRecords<Configuration>, T> searchStrategy) {
 
-    return moduleQuery.combine(configNameQuery, CqlQuery::and)
-      .after(query -> configurationClient.getMany(query, 1))
-      .thenApply(result -> result.next(response ->
-        from(response, TimeZoneConfig::new, "configs")))
-      .thenApply(result -> result.map(configurations ->
-        configurationService.findDateTimeZone(configurations.getRecords())));
+    return cqlQueryResult
+      .after(query -> configurationClient.getMany(query, DEFAULT_PAGE_LIMIT))
+      .thenApply(result -> result.next(response -> from(response, Configuration::new, CONFIGS_KEY)))
+      .thenApply(result -> result.map(searchStrategy));
+  }
+
+  private Result<CqlQuery> defineCqlQueryResult(String moduleName, String configName) {
+    final Result<CqlQuery> moduleQuery = exactMatch(MODULE_NAME_KEY, moduleName);
+    final Result<CqlQuery> configNameQuery = exactMatch(CONFIG_NAME_KEY, configName);
+
+    return moduleQuery.combine(configNameQuery, CqlQuery::and);
+  }
+
+  private Function<MultipleRecords<Configuration>, DateTimeZone> applySearchDateTimeZone() {
+    return configurations -> new ConfigurationService().findDateTimeZone(configurations.getRecords());
+  }
+
+  private Function<MultipleRecords<Configuration>, Integer> applySearchSchedulerNoticesLimit() {
+    return configurations -> new ConfigurationService().findSchedulerNoticesLimit(configurations.getRecords());
   }
 }

--- a/src/main/java/org/folio/circulation/domain/ConfigurationRepository.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationRepository.java
@@ -1,16 +1,16 @@
 package org.folio.circulation.domain;
 
+import static org.folio.circulation.domain.MultipleRecords.from;
+import static org.folio.circulation.support.CqlQuery.exactMatch;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.CqlQuery;
 import org.folio.circulation.support.Result;
 import org.joda.time.DateTimeZone;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
-
-import static org.folio.circulation.domain.MultipleRecords.from;
-import static org.folio.circulation.support.CqlQuery.exactMatch;
 
 public class ConfigurationRepository {
 
@@ -34,12 +34,12 @@ public class ConfigurationRepository {
   }
 
   public CompletableFuture<Result<Integer>> lookupSchedulerNoticesProcessingLimit() {
-    Result<CqlQuery> cqlQueryResult = defineCqlQueryResult("NOTIFICATION_SCHEDULER", "noticesLimit");
+    Result<CqlQuery> cqlQueryResult = defineModuleNameAndConfigNameFilter("NOTIFICATION_SCHEDULER", "noticesLimit");
     return lookupConfigurations(cqlQueryResult, applySearchSchedulerNoticesLimit());
   }
 
   private CompletableFuture<Result<DateTimeZone>> findTimeZoneConfiguration() {
-    Result<CqlQuery> cqlQueryResult = defineCqlQueryResult("ORG", "localeSettings");
+    Result<CqlQuery> cqlQueryResult = defineModuleNameAndConfigNameFilter("ORG", "localeSettings");
     return lookupConfigurations(cqlQueryResult, applySearchDateTimeZone());
   }
 
@@ -52,7 +52,7 @@ public class ConfigurationRepository {
       .thenApply(result -> result.map(searchStrategy));
   }
 
-  private Result<CqlQuery> defineCqlQueryResult(String moduleName, String configName) {
+  private Result<CqlQuery> defineModuleNameAndConfigNameFilter(String moduleName, String configName) {
     final Result<CqlQuery> moduleQuery = exactMatch(MODULE_NAME_KEY, moduleName);
     final Result<CqlQuery> configNameQuery = exactMatch(CONFIG_NAME_KEY, configName);
 

--- a/src/main/java/org/folio/circulation/domain/ConfigurationService.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationService.java
@@ -14,7 +14,7 @@ import static org.folio.circulation.domain.MultipleRecords.from;
 class ConfigurationService {
   private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private static final int SCHEDULED_NOTICES_PROCESSING_LIMIT = 100;
+  private static final int DEFAULT_SCHEDULED_NOTICES_PROCESSING_LIMIT = 100;
   private static final DateTimeZone DEFAULT_DATE_TIME_ZONE = DateTimeZone.UTC;
   private static final String TIMEZONE_KEY = "timezone";
   private static final String RECORDS_NAME = "configs";
@@ -41,7 +41,7 @@ class ConfigurationService {
     final Integer noticesLimit = configurations.stream()
       .map(this::applySchedulerNoticesLimit)
       .findFirst()
-      .orElse(SCHEDULED_NOTICES_PROCESSING_LIMIT);
+      .orElse(DEFAULT_SCHEDULED_NOTICES_PROCESSING_LIMIT);
 
     log.info("Scheduled notices processing limit: `{}`", noticesLimit);
 
@@ -52,7 +52,7 @@ class ConfigurationService {
     String value = config.getValue();
     return StringUtils.isNumeric(value)
       ? Integer.valueOf(value)
-      : SCHEDULED_NOTICES_PROCESSING_LIMIT;
+      : DEFAULT_SCHEDULED_NOTICES_PROCESSING_LIMIT;
   }
 
   private DateTimeZone applyTimeZone(Configuration config) {

--- a/src/main/java/org/folio/circulation/domain/ConfigurationService.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationService.java
@@ -1,15 +1,16 @@
 package org.folio.circulation.domain;
 
-import io.vertx.core.json.JsonObject;
+import static org.folio.circulation.domain.MultipleRecords.from;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.invoke.MethodHandles;
-import java.util.Collection;
-
-import static org.folio.circulation.domain.MultipleRecords.from;
+import io.vertx.core.json.JsonObject;
 
 class ConfigurationService {
   private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/src/test/java/api/support/fixtures/ConfigurationExample.java
+++ b/src/test/java/api/support/fixtures/ConfigurationExample.java
@@ -7,9 +7,12 @@ import io.vertx.core.json.JsonObject;
 
 public class ConfigurationExample {
 
-  private static final String DEFAULT_MOD = "ORG";
-  private static final String DEFAULT_NAME = "localeSettings";
+  private static final String DEFAULT_TIME_ZONE_MOD_NAME = "ORG";
+  private static final String DEFAULT_TIME_ZONE_CONFIG_NAME = "localeSettings";
   private static final String US_LOCALE = "en-US";
+
+  private static final String DEFAULT_NOTIFICATION_SCHEDULER_MOD_NAME = "NOTIFICATION_SCHEDULER";
+  private static final String DEFAULT_NOTIFICATION_SCHEDULER_CONFIG_NAME = "noticesLimit";
 
   private ConfigurationExample() {
     // not use
@@ -24,11 +27,16 @@ public class ConfigurationExample {
   }
 
   private static ConfigRecordBuilder getLocaleAndTimeZoneConfiguration(String timezone) {
-    return new ConfigRecordBuilder(DEFAULT_MOD, DEFAULT_NAME,
-      combinedConfiguration(timezone).encodePrettily());
+    return new ConfigRecordBuilder(DEFAULT_TIME_ZONE_MOD_NAME, DEFAULT_TIME_ZONE_CONFIG_NAME,
+      combinedTimeZoneConfig(timezone).encodePrettily());
   }
 
-  private static JsonObject combinedConfiguration(String timezone) {
+  public static ConfigRecordBuilder schedulerNoticesLimitConfiguration(String limit){
+    return new ConfigRecordBuilder(DEFAULT_NOTIFICATION_SCHEDULER_MOD_NAME,
+      DEFAULT_NOTIFICATION_SCHEDULER_CONFIG_NAME, limit);
+  }
+
+  private static JsonObject combinedTimeZoneConfig(String timezone) {
     final JsonObject encodedValue = new JsonObject();
     write(encodedValue, "locale", US_LOCALE);
     write(encodedValue, "timezone", timezone);

--- a/src/test/java/api/support/fixtures/ConfigurationExample.java
+++ b/src/test/java/api/support/fixtures/ConfigurationExample.java
@@ -7,11 +7,11 @@ import io.vertx.core.json.JsonObject;
 
 public class ConfigurationExample {
 
-  private static final String DEFAULT_TIME_ZONE_MOD_NAME = "ORG";
+  private static final String DEFAULT_TIME_ZONE_MODULE_NAME = "ORG";
   private static final String DEFAULT_TIME_ZONE_CONFIG_NAME = "localeSettings";
   private static final String US_LOCALE = "en-US";
 
-  private static final String DEFAULT_NOTIFICATION_SCHEDULER_MOD_NAME = "NOTIFICATION_SCHEDULER";
+  private static final String DEFAULT_NOTIFICATION_SCHEDULER_MODULE_NAME = "NOTIFICATION_SCHEDULER";
   private static final String DEFAULT_NOTIFICATION_SCHEDULER_CONFIG_NAME = "noticesLimit";
 
   private ConfigurationExample() {
@@ -27,12 +27,12 @@ public class ConfigurationExample {
   }
 
   private static ConfigRecordBuilder getLocaleAndTimeZoneConfiguration(String timezone) {
-    return new ConfigRecordBuilder(DEFAULT_TIME_ZONE_MOD_NAME, DEFAULT_TIME_ZONE_CONFIG_NAME,
+    return new ConfigRecordBuilder(DEFAULT_TIME_ZONE_MODULE_NAME, DEFAULT_TIME_ZONE_CONFIG_NAME,
       combinedTimeZoneConfig(timezone).encodePrettily());
   }
 
   public static ConfigRecordBuilder schedulerNoticesLimitConfiguration(String limit){
-    return new ConfigRecordBuilder(DEFAULT_NOTIFICATION_SCHEDULER_MOD_NAME,
+    return new ConfigRecordBuilder(DEFAULT_NOTIFICATION_SCHEDULER_MODULE_NAME,
       DEFAULT_NOTIFICATION_SCHEDULER_CONFIG_NAME, limit);
   }
 


### PR DESCRIPTION
## Purpose
The purpose of this story is to make this parameter configurable and set 100 as default value. 
Value should be stored in mod-configuration

Resolves: [CIRC-407](https://issues.folio.org/browse/CIRC-407)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  