### PR TITLE
Disallow patron group at check out property from storage loan CIRC-415

### DIFF
--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -104,7 +104,8 @@ public class FakeOkapi extends AbstractVerticle {
       .withRecordName("loan")
       .withRootPath("/loan-storage/loans")
       .withRequiredProperties("itemId", "loanDate", "action")
-      .withDisallowedProperties("checkinServicePoint", "checkoutServicePoint", "borrower", "item")
+      .withDisallowedProperties("checkinServicePoint", "checkoutServicePoint",
+        "patronGroupAtCheckout", "borrower", "item")
       .withChangeMetadata()
       .create().register(router);
 
@@ -290,7 +291,7 @@ public class FakeOkapi extends AbstractVerticle {
           newOrUpdatedRequest.getString("id")))
         .filter(request -> Objects.equals(request.getString("itemId"),
           newOrUpdatedRequest.getString("itemId")))
-        .filter(request -> newOrUpdatedRequest.getInteger("position") != null && 
+        .filter(request -> newOrUpdatedRequest.getInteger("position") != null &&
           Objects.equals(request.getInteger("position"),
           newOrUpdatedRequest.getInteger("position")))
         .findAny()


### PR DESCRIPTION
## Purpose

This is an extension to the previous [fix](https://github.com/folio-org/mod-circulation/pull/318) for [CIRC-415](https://issues.folio.org/browse/CIRC-415) to disallow the unexpected property in the fake storage modules, to stop this issue from recurring.

#### TODOS and Open Questions
This is another example of a common class of integration issues we have encountered with mod-circulation.

Over the longer term, there are two changes which need to happen to improve this
* Validate the loan storage schema during the API tests
* Separate the storage of loans from the core domain representation, and stop basing the representation on the business logic representation

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
