### PR TITLE
Circ 416 prevent move above page

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -3,6 +3,7 @@ package org.folio.circulation.domain;
 import static org.folio.circulation.domain.ItemStatus.AVAILABLE;
 import static org.folio.circulation.domain.ItemStatus.AWAITING_PICKUP;
 import static org.folio.circulation.domain.ItemStatus.CHECKED_OUT;
+import static org.folio.circulation.domain.ItemStatus.PAGED;
 import static org.folio.circulation.domain.ItemStatus.IN_TRANSIT;
 import static org.folio.circulation.domain.ItemStatus.MISSING;
 import static org.folio.circulation.domain.representations.InstanceProperties.CONTRIBUTORS;
@@ -75,6 +76,10 @@ public class Item {
 
   public boolean isCheckedOut() {
     return isInStatus(CHECKED_OUT);
+  }
+
+  public boolean isPaged() {
+    return isInStatus(PAGED);
   }
 
   public boolean isMissing() {

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -98,14 +98,22 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   public boolean isNotDisplaceable() {
-    return isAwaitingPickup() || isInTransit();
+    return isAwaitingPickup() || isInTransit() || (isItemPaged() && isFirst());
   }
 
-  private boolean isInTransit(){
+  private boolean isItemPaged() {
+    return item != null && item.isPaged();
+  }
+
+  private boolean isFirst() {
+    return hasPosition() && getPosition().equals(1);
+  }
+
+  private boolean isInTransit() {
     return getStatus() == OPEN_IN_TRANSIT;
   }
 
-  private boolean isNotYetFilled(){
+  private boolean isNotYetFilled() {
     return getStatus() == OPEN_NOT_YET_FILLED;
   }
 

--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -697,6 +697,7 @@ public class MoveRequestTests extends APITests {
     assertThat(interestingTimesQueue.getTotalRecords(), is(2));
   }
 
+  //This scenerio utilizes two items of the same instance, but the logic in question applies as well for two separate instances.
   @Test
   public void cannotDisplacePagedRequest()
       throws MalformedURLException,

--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -697,6 +697,80 @@ public class MoveRequestTests extends APITests {
     assertThat(interestingTimesQueue.getTotalRecords(), is(2));
   }
 
+  @Test
+  public void cannotDisplacePagedRequest()
+      throws MalformedURLException,
+      InterruptedException,
+      TimeoutException,
+      ExecutionException {
+
+      final IndividualResource secondFloorEconomics = locationsFixture.secondFloorEconomics();
+      final IndividualResource mezzanineDisplayCase = locationsFixture.mezzanineDisplayCase();
+
+      final IndividualResource itemCopyA = itemsFixture.basedUponTemeraire(
+        holdingBuilder -> holdingBuilder
+          .withPermanentLocation(secondFloorEconomics)
+          .withNoTemporaryLocation(),
+        itemBuilder -> itemBuilder
+          .withNoPermanentLocation()
+          .withNoTemporaryLocation()
+          .withBarcode("10203040506"));
+
+      final IndividualResource itemCopyB = itemsFixture.basedUponTemeraire(
+        holdingBuilder -> holdingBuilder
+          .withPermanentLocation(mezzanineDisplayCase)
+          .withNoTemporaryLocation(),
+        itemBuilder -> itemBuilder
+          .withNoPermanentLocation()
+          .withNoTemporaryLocation()
+          .withBarcode("90806050402"));
+
+    IndividualResource james = usersFixture.james();
+    IndividualResource steve = usersFixture.steve();
+    IndividualResource jessica = usersFixture.jessica();
+
+    // James Checks out Item Copy A
+    loansFixture.checkOutByBarcode(itemCopyA, james, DateTime.now(DateTimeZone.UTC));
+
+    // Steve requests Item Copy B
+    IndividualResource stevesRequest = requestsFixture.placeHoldShelfRequest(
+      itemCopyA, steve, DateTime.now(DateTimeZone.UTC).minusHours(2), RequestType.RECALL.getValue());
+
+    assertThat(stevesRequest.getJson().getInteger("position"), is(1));
+    assertThat(stevesRequest.getJson().getJsonObject("item").getString("barcode"), is(itemCopyA.getBarcode()));
+    assertThat(stevesRequest.getJson().getJsonObject("item").getString("status"), is(ItemStatus.CHECKED_OUT.getValue()));
+    assertThat(stevesRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
+
+    // Jessica requests Item Copy B
+    IndividualResource jessicasRequest = requestsFixture.placeHoldShelfRequest(
+      itemCopyB, jessica, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.PAGE.getValue());
+
+    // Confirm Jessica's request is first on Item Copy B and is a paged request
+    assertThat(jessicasRequest.getJson().getInteger("position"), is(1));
+    assertThat(jessicasRequest.getJson().getJsonObject("item").getString("barcode"), is(itemCopyB.getBarcode()));
+    assertThat(jessicasRequest.getJson().getJsonObject("item").getString("status"), is(ItemStatus.PAGED.getValue()));
+    assertThat(jessicasRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
+
+    // Move recallRequestForItemCopyA to Item Copy B
+    requestsFixture.move(new MoveRequestBuilder(
+      stevesRequest.getId(),
+      itemCopyB.getId()
+    ));
+
+    // Confirm Jessica's request is first on Item Copy B and is a paged request
+    jessicasRequest = requestsClient.get(jessicasRequest);
+    assertThat(jessicasRequest.getJson().getInteger("position"), is(1));
+    assertThat(jessicasRequest.getJson().getJsonObject("item").getString("barcode"), is(itemCopyB.getBarcode()));
+    assertThat(jessicasRequest.getJson().getJsonObject("item").getString("status"), is(ItemStatus.PAGED.getValue()));
+
+    // Confirm Steves's request is second on Item Copy B and (is not a paged request (?))
+    stevesRequest = requestsClient.get(stevesRequest);
+    assertThat(stevesRequest.getJson().getInteger("position"), is(2));
+    assertThat(stevesRequest.getJson().getJsonObject("item").getString("barcode"), is(itemCopyB.getBarcode()));
+    assertThat(stevesRequest.getJson().getJsonObject("item").getString("status"), is(ItemStatus.PAGED.getValue()));
+
+  }
+
   private void retainsStoredSummaries(IndividualResource request) {
     assertThat("Updated request in queue should retain stored item summary",
       request.getJson().containsKey("item"), is(true));

--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -732,7 +732,7 @@ public class MoveRequestTests extends APITests {
     // James Checks out Item Copy A
     loansFixture.checkOutByBarcode(itemCopyA, james, DateTime.now(DateTimeZone.UTC));
 
-    // Steve requests Item Copy B
+    // Steve requests Item Copy A
     IndividualResource stevesRequest = requestsFixture.placeHoldShelfRequest(
       itemCopyA, steve, DateTime.now(DateTimeZone.UTC).minusHours(2), RequestType.RECALL.getValue());
 


### PR DESCRIPTION
## Purpose

Preventing the displacement of a request when it is in position one of the queue and the associated item is in status PAGED.

## Approach

This PR adds the `isPaged` check to an item and utilized within the Request's check for `isNotDisplaceable`. The strictness of `isNotDisplaceable` is was increased to include checks both the request's position (position 1) and the disposition of the item (`isPaged`).

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [X] Code coverage on new code is 80% or greater
  - [X] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [X] There are no breaking changes in this PR.
  