### PR TITLE
CIRC-411 Checked out item status changes when moving request

### DIFF
--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -164,7 +164,7 @@ public class UpdateItem {
 
     return (item.getStatus().equals(PAGED) && requestQueue.getRequests().isEmpty())
       ? AVAILABLE
-      : type.equals(RequestType.PAGE)
+      : (item.getStatus().equals(AVAILABLE) && type.equals(RequestType.PAGE))
         ? PAGED
         : item.getStatus();
   }


### PR DESCRIPTION
## Purpose

To rectify a logic error that caused an item with a status of CHECKED_OUT to have its status change to PAGED when a requests of certain types was moved onto such an items.

## Approach

The addition of a check for Item Status of `AVAILABLE` during the `itemStatusOnRequestCreateOrUpdate ` determination of a new item status.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  