### PR TITLE
CIRC-421 validate loan storage schema in api tests

### DIFF
--- a/doc/automated-testing.md
+++ b/doc/automated-testing.md
@@ -1,0 +1,35 @@
+# Automated Testing
+
+## API Tests
+
+### Fake Modules
+
+The API tests use a fake implementation of interfaces that are used to fetch 
+or update records
+
+These fakes are configured in the FakeOkapi class.
+
+#### Schema Validation
+
+In order to try to identify potentially mismatches between the fake modules and 
+the reference implementations, it is possible to configure them to use a copy of
+an interface JSON schema to validate incoming representations during creation or 
+update of records.
+
+##### Location of Schemas
+
+Copies of the relevant storage schema are kept in the test resources directory.
+
+They are kept in the root in order to make it easier for schema references to be
+resolved, as the shared RAML definitions are included in the main resources
+
+They are named after the record and interface version, for example, the loan 
+record from the `loan-storage 6.1` interface is named `storage-loan-6-1`.
+
+##### Updating a Schema
+
+When an interface dependency is updated, any schema that are used within the 
+tests should also be updated, other the tests might produce false results.
+
+As the names include the interface version, the file should also be renamed. 
+And the paths in the `StorageSchema` class need to be changed.

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -3,6 +3,11 @@
 This is a guide meant to help you both use the `mod-circulation` module and
 enable you to contribute to the module.
 
+## Automated Testing
+
+See [companion document](automated-testing.md) for information on the automated testing approach 
+used in mod-circulation. 
+
 ## Storage
 
 This circulation module has no persistent storage of its own. Therefore, it

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,12 @@
         <filtering>true</filtering>
       </resource>
     </resources>
-
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,10 @@
       <name>FOLIO Maven repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
     </repository>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
   </repositories>
 
   <properties>
@@ -87,6 +91,11 @@
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>2.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.everit-org.json-schema</groupId>
+      <artifactId>org.everit.json.schema</artifactId>
+      <version>1.11.1</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,10 @@
         <directory>src/main/resources</directory>
         <filtering>true</filtering>
       </resource>
+      <resource>
+        <directory>ramls</directory>
+        <filtering>true</filtering>
+      </resource>
     </resources>
 
     <plugins>

--- a/src/main/java/org/folio/circulation/domain/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepository.java
@@ -3,8 +3,11 @@ package org.folio.circulation.domain;
 import static java.lang.String.format;
 import static java.util.Objects.nonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.domain.representations.LoanProperties.PATRON_GROUP_AT_CHECKOUT;
+import static org.folio.circulation.domain.representations.LoanProperties.PATRON_GROUP_ID_AT_CHECKOUT;
 import static org.folio.circulation.support.CqlQuery.exactMatch;
 import static org.folio.circulation.support.CqlQuery.exactMatchAny;
+import static org.folio.circulation.support.JsonPropertyWriter.write;
 import static org.folio.circulation.support.Result.failed;
 import static org.folio.circulation.support.Result.of;
 import static org.folio.circulation.support.Result.succeeded;
@@ -219,16 +222,19 @@ public class LoanRepository {
     storageLoan.remove("item");
     storageLoan.remove("checkinServicePoint");
     storageLoan.remove("checkoutServicePoint");
-    storageLoan.remove(LoanProperties.PATRON_GROUP_AT_CHECKOUT);
+    storageLoan.remove(PATRON_GROUP_AT_CHECKOUT);
   }
 
  private static void keepPatronGroupIdAtCheckoutProperties(Loan loan, JsonObject storageLoan) {
     if (nonNull(loan.getUser()) && nonNull(loan.getUser().getPatronGroup())) {
-      storageLoan.put(LoanProperties.PATRON_GROUP_ID_AT_CHECKOUT, loan.getUser().getPatronGroup().getId());
+      write(storageLoan, PATRON_GROUP_ID_AT_CHECKOUT,
+        loan.getUser().getPatronGroup().getId());
     }
-    if (storageLoan.containsKey(LoanProperties.PATRON_GROUP_AT_CHECKOUT)){
-      storageLoan.put(LoanProperties.PATRON_GROUP_ID_AT_CHECKOUT,
-       storageLoan.getJsonObject(LoanProperties.PATRON_GROUP_AT_CHECKOUT).getValue("id"));
+
+    //TODO: Should this really be re-writing the value?
+    if (storageLoan.containsKey(PATRON_GROUP_AT_CHECKOUT)) {
+      write(storageLoan, PATRON_GROUP_ID_AT_CHECKOUT,
+        storageLoan.getJsonObject(PATRON_GROUP_AT_CHECKOUT).getString("id"));
     }
  }
 

--- a/src/main/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidator.java
+++ b/src/main/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidator.java
@@ -1,13 +1,34 @@
 package org.folio.circulation.infrastructure.serialization;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.everit.json.schema.Schema;
+import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
+import org.json.JSONTokener;
 
 class JsonSchemaValidator {
   private final Schema schema;
 
-  JsonSchemaValidator(Schema schema) {
+  private JsonSchemaValidator(Schema schema) {
     this.schema = schema;
+  }
+
+  static JsonSchemaValidator fromResource(String path) throws IOException {
+    final Schema schema = getSchema(path);
+
+    return new JsonSchemaValidator(schema);
+  }
+
+  private static Schema getSchema(String path) throws IOException {
+    try (InputStream inputStream = JsonSchemaValidator.class
+        .getResourceAsStream(path)) {
+
+      JSONObject rawSchema = new JSONObject(new JSONTokener(inputStream));
+
+      return SchemaLoader.load(rawSchema);
+    }
   }
 
   void validate(String json) {

--- a/src/main/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidator.java
+++ b/src/main/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidator.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
+import org.everit.json.schema.loader.SchemaClient;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.folio.circulation.support.BadRequestFailure;
 import org.folio.circulation.support.Result;
@@ -40,7 +41,13 @@ class JsonSchemaValidator {
 
       JSONObject rawSchema = new JSONObject(new JSONTokener(inputStream));
 
-      return SchemaLoader.load(rawSchema);
+      SchemaLoader schemaLoader = SchemaLoader.builder()
+        .schemaClient(SchemaClient.classPathAwareClient())
+        .schemaJson(rawSchema)
+        .resolutionScope("classpath:///") // setting the default resolution scope
+        .build();
+
+      return schemaLoader.load().build();
     }
   }
 

--- a/src/main/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidator.java
+++ b/src/main/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidator.java
@@ -1,0 +1,16 @@
+package org.folio.circulation.infrastructure.serialization;
+
+import org.everit.json.schema.Schema;
+import org.json.JSONObject;
+
+class JsonSchemaValidator {
+  private final Schema schema;
+
+  JsonSchemaValidator(Schema schema) {
+    this.schema = schema;
+  }
+
+  void validate(String json) {
+    schema.validate(new JSONObject(json));
+  }
+}

--- a/src/main/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidator.java
+++ b/src/main/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidator.java
@@ -51,7 +51,7 @@ public class JsonSchemaValidator {
     }
   }
 
-  Result<String> validate(String json) {
+  public Result<String> validate(String json) {
     try {
       schema.validate(new JSONObject(json));
 

--- a/src/main/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidator.java
+++ b/src/main/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidator.java
@@ -1,10 +1,14 @@
 package org.folio.circulation.infrastructure.serialization;
 
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.everit.json.schema.Schema;
+import org.everit.json.schema.ValidationException;
 import org.everit.json.schema.loader.SchemaLoader;
+import org.folio.circulation.support.Result;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 
@@ -31,7 +35,14 @@ class JsonSchemaValidator {
     }
   }
 
-  void validate(String json) {
-    schema.validate(new JSONObject(json));
+  Result<String> validate(String json) {
+    try {
+      schema.validate(new JSONObject(json));
+
+      return Result.succeeded(json);
+    }
+    catch (ValidationException e) {
+      return failedValidation(String.format(e.getMessage()), null, null);
+    }
   }
 }

--- a/src/main/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidator.java
+++ b/src/main/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidator.java
@@ -22,14 +22,14 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 
-class JsonSchemaValidator {
+public class JsonSchemaValidator {
   private final Schema schema;
 
   private JsonSchemaValidator(Schema schema) {
     this.schema = schema;
   }
 
-  static JsonSchemaValidator fromResource(String path) throws IOException {
+  public static JsonSchemaValidator fromResource(String path) throws IOException {
     final Schema schema = getSchema(path);
 
     return new JsonSchemaValidator(schema);

--- a/src/main/java/org/folio/circulation/support/BadRequestFailure.java
+++ b/src/main/java/org/folio/circulation/support/BadRequestFailure.java
@@ -1,7 +1,8 @@
 package org.folio.circulation.support;
 
-import io.vertx.core.http.HttpServerResponse;
 import org.folio.circulation.support.http.server.ClientErrorResponse;
+
+import io.vertx.core.http.HttpServerResponse;
 
 public class BadRequestFailure implements HttpFailure {
   private final String reason;

--- a/src/main/java/org/folio/circulation/support/FailedResult.java
+++ b/src/main/java/org/folio/circulation/support/FailedResult.java
@@ -1,10 +1,11 @@
 package org.folio.circulation.support;
 
-import io.vertx.core.http.HttpServerResponse;
+import java.lang.invoke.MethodHandles;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.invoke.MethodHandles;
+import io.vertx.core.http.HttpServerResponse;
 
 public class FailedResult<T> implements ResponseWritableResult<T> {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -38,6 +39,6 @@ public class FailedResult<T> implements ResponseWritableResult<T> {
 
   @Override
   public String toString() {
-    return String.format("Failed Http Result with cause %s", cause.toString());
+    return String.format("failed result due to a %s", cause.toString());
   }
 }

--- a/src/main/java/org/folio/circulation/support/ValidationErrorFailure.java
+++ b/src/main/java/org/folio/circulation/support/ValidationErrorFailure.java
@@ -80,7 +80,7 @@ public class ValidationErrorFailure implements HttpFailure {
 
   @Override
   public String toString() {
-    return String.format("Validation failure:%n%s",
+    return String.format("validation failure:%n%s",
       errors.stream()
         .map(ValidationError::toString)
         .collect(Collectors.joining("%n")));

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -1232,21 +1232,25 @@ public class LoanAPITests extends APITests {
             .closed()
             .withCheckinServicePointId(checkinServicePointId2)
             .withUserId(user.getId()));
+
     JsonObject updatedLoanRequest = loan1.copyJson();
+
     updatedLoanRequest.getJsonObject("status").put("name", "Closed");
     updatedLoanRequest.remove("userId");
+
     loansClient.replace(loan1.getId(), updatedLoanRequest);
 
     updatedLoanRequest = loan2.copyJson();
+
     updatedLoanRequest.getJsonObject("status").put("name", "Closed");
     updatedLoanRequest.remove("userId");
+
     loansClient.replace(loan2.getId(), updatedLoanRequest);
 
     List<JsonObject> loans = loansClient.getAll();
 
     loans.forEach(this::hasNoBorrowerProperties);
   }
-
 
   @Test
   public void cannotUpdateAnOpenLoanWithoutAUserId()
@@ -1838,7 +1842,7 @@ public class LoanAPITests extends APITests {
     });
 
   }
-  
+
   @Test
   public void canGetPagedLoansWithMoreItemsThanDefaultPageLimit()
       throws InterruptedException,
@@ -1848,7 +1852,7 @@ public class LoanAPITests extends APITests {
     createLoans(50);
     queryLoans(50);
   }
-  
+
   @Test
   public void canGetPagedLoansWhenIdQueryWouldExceedQueryStringLengthLimit()
       throws InterruptedException,
@@ -1890,7 +1894,7 @@ public class LoanAPITests extends APITests {
     case 1: return usersFixture.james().getId();
     case 2: return usersFixture.jessica().getId();
     case 3: return usersFixture.rebecca().getId();
-    default: return usersFixture.steve().getId(); 
+    default: return usersFixture.steve().getId();
     }
   }
 

--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -1,5 +1,6 @@
 package api.support.fakes;
 
+import static api.support.fakes.StorageSchema.validatorForStorageLoanSchema;
 import static api.support.fixtures.CalendarExamples.CASE_CALENDAR_IS_EMPTY_SERVICE_POINT_ID;
 import static api.support.fixtures.CalendarExamples.getCalendarById;
 import static api.support.fixtures.LibraryHoursExamples.CASE_CALENDAR_IS_UNAVAILABLE_SERVICE_POINT_ID;
@@ -8,6 +9,7 @@ import static api.support.fixtures.LibraryHoursExamples.CASE_CLOSED_LIBRARY_SERV
 import static api.support.fixtures.LibraryHoursExamples.getLibraryHoursById;
 import static org.folio.circulation.support.results.CommonFailures.failedDueToServerError;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.Objects;
@@ -45,7 +47,7 @@ public class FakeOkapi extends AbstractVerticle {
   }
 
   @Override
-  public void start(Future<Void> startFuture) {
+  public void start(Future<Void> startFuture) throws IOException {
     log.debug("Starting fake loan storage module");
 
     Router router = Router.router(vertx);
@@ -103,9 +105,7 @@ public class FakeOkapi extends AbstractVerticle {
     new FakeStorageModuleBuilder()
       .withRecordName("loan")
       .withRootPath("/loan-storage/loans")
-      .withRequiredProperties("itemId", "loanDate", "action")
-      .withDisallowedProperties("checkinServicePoint", "checkoutServicePoint",
-        "patronGroupAtCheckout", "borrower", "item")
+      .validateRecordsWith(validatorForStorageLoanSchema())
       .withChangeMetadata()
       .create().register(router);
 

--- a/src/test/java/api/support/fakes/FakeStorageModule.java
+++ b/src/test/java/api/support/fakes/FakeStorageModule.java
@@ -67,12 +67,12 @@ public class FakeStorageModule extends AbstractVerticle {
     String collectionPropertyName,
     String tenantId,
     JsonSchemaValidator recordValidator,
-    Collection<String> requiredProperties,
+    @Deprecated Collection<String> requiredProperties,
     boolean hasCollectionDelete,
     boolean hasDeleteByQuery,
     String recordTypeName,
     Collection<String> uniqueProperties,
-    Collection<String> disallowedProperties,
+    @Deprecated Collection<String> disallowedProperties,
     Boolean includeChangeMetadata,
     BiFunction<Collection<JsonObject>, JsonObject, Result<Object>> constraint) {
 

--- a/src/test/java/api/support/fakes/FakeStorageModuleBuilder.java
+++ b/src/test/java/api/support/fakes/FakeStorageModuleBuilder.java
@@ -146,6 +146,11 @@ public class FakeStorageModuleBuilder {
       validator);
   }
 
+  @Deprecated()
+  /**
+   * Deprecated in favour of schema validation
+   * {@link #validateRecordsWith(JsonSchemaValidator) }
+   */
   private FakeStorageModuleBuilder withRequiredProperties(
     Collection<String> requiredProperties) {
 
@@ -162,14 +167,19 @@ public class FakeStorageModuleBuilder {
       this.includeChangeMetadata,
       this.constraint,
       this.recordValidator);
-    }
+  }
 
+  @Deprecated()
+  /**
+   * Deprecated in favour of schema validation
+   * {@link #validateRecordsWith(JsonSchemaValidator) }
+   */
   FakeStorageModuleBuilder withRequiredProperties(String... requiredProperties) {
     return withRequiredProperties(Arrays.asList(requiredProperties));
   }
 
-  private FakeStorageModuleBuilder withUniqueProperties(
-    Collection<String> uniqueProperties) {
+    private FakeStorageModuleBuilder withUniqueProperties(
+      Collection<String> uniqueProperties) {
 
     return new FakeStorageModuleBuilder(
       this.rootPath,
@@ -190,6 +200,11 @@ public class FakeStorageModuleBuilder {
     return withUniqueProperties(Arrays.asList(uniqueProperties));
   }
 
+  @Deprecated()
+  /**
+   * Deprecated in favour of schema validation
+   * {@link #validateRecordsWith(JsonSchemaValidator) }
+   */
   private FakeStorageModuleBuilder withDisallowedProperties(
     Collection<String> disallowedProperties) {
 
@@ -208,6 +223,11 @@ public class FakeStorageModuleBuilder {
       this.recordValidator);
   }
 
+  @Deprecated()
+  /**
+   * Deprecated in favour of schema validation
+   * {@link #validateRecordsWith(JsonSchemaValidator) }
+   */
   FakeStorageModuleBuilder withDisallowedProperties(String... disallowedProperties) {
     return withDisallowedProperties(Arrays.asList(disallowedProperties));
   }

--- a/src/test/java/api/support/fakes/FakeStorageModuleBuilder.java
+++ b/src/test/java/api/support/fakes/FakeStorageModuleBuilder.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.BiFunction;
 
+import org.folio.circulation.infrastructure.serialization.JsonSchemaValidator;
 import org.folio.circulation.support.Result;
 
 import api.support.APITestContext;
@@ -22,6 +23,7 @@ public class FakeStorageModuleBuilder {
   private final String recordName;
   private final Boolean includeChangeMetadata;
   private final BiFunction<Collection<JsonObject>, JsonObject, Result<Object>> constraint;
+  private final JsonSchemaValidator recordValidator;
 
   FakeStorageModuleBuilder() {
     this(
@@ -35,7 +37,8 @@ public class FakeStorageModuleBuilder {
       new ArrayList<>(),
       false,
       false,
-      (c, r) -> Result.succeeded(null));
+      (c, r) -> Result.succeeded(null),
+      null);
   }
 
   private FakeStorageModuleBuilder(
@@ -48,7 +51,9 @@ public class FakeStorageModuleBuilder {
     String recordName,
     Collection<String> uniqueProperties,
     Boolean hasDeleteByQuery,
-    Boolean includeChangeMetadata, BiFunction<Collection<JsonObject>, JsonObject, Result<Object>> constraint) {
+    Boolean includeChangeMetadata,
+    BiFunction<Collection<JsonObject>, JsonObject, Result<Object>> constraint,
+    JsonSchemaValidator recordValidator) {
 
     this.rootPath = rootPath;
     this.collectionPropertyName = collectionPropertyName;
@@ -61,12 +66,14 @@ public class FakeStorageModuleBuilder {
     this.hasDeleteByQuery = hasDeleteByQuery;
     this.includeChangeMetadata = includeChangeMetadata;
     this.constraint = constraint;
+    this.recordValidator = recordValidator;
   }
 
   public FakeStorageModule create() {
     return new FakeStorageModule(rootPath, collectionPropertyName, tenantId,
-      requiredProperties, hasCollectionDelete, hasDeleteByQuery, recordName, uniqueProperties,
-      disallowedProperties, includeChangeMetadata, constraint);
+      recordValidator, requiredProperties, hasCollectionDelete, hasDeleteByQuery,
+      recordName, uniqueProperties, disallowedProperties, includeChangeMetadata,
+      constraint);
   }
 
   FakeStorageModuleBuilder withRootPath(String rootPath) {
@@ -85,7 +92,8 @@ public class FakeStorageModuleBuilder {
       this.uniqueProperties,
       this.hasDeleteByQuery,
       this.includeChangeMetadata,
-      this.constraint);
+      this.constraint,
+      this.recordValidator);
   }
 
   FakeStorageModuleBuilder withCollectionPropertyName(
@@ -102,7 +110,8 @@ public class FakeStorageModuleBuilder {
       this.uniqueProperties,
       this.hasDeleteByQuery,
       this.includeChangeMetadata,
-      this.constraint);
+      this.constraint,
+      this.recordValidator);
   }
 
   FakeStorageModuleBuilder withRecordName(String recordName) {
@@ -117,7 +126,24 @@ public class FakeStorageModuleBuilder {
       this.uniqueProperties,
       this.hasDeleteByQuery,
       this.includeChangeMetadata,
-      this.constraint);
+      this.constraint,
+      this.recordValidator);
+  }
+
+  FakeStorageModuleBuilder validateRecordsWith(JsonSchemaValidator validator) {
+    return new FakeStorageModuleBuilder(
+      this.rootPath,
+      this.collectionPropertyName,
+      this.tenantId,
+      requiredProperties,
+      this.disallowedProperties,
+      this.hasCollectionDelete,
+      this.recordName,
+      this.uniqueProperties,
+      this.hasDeleteByQuery,
+      this.includeChangeMetadata,
+      this.constraint,
+      validator);
   }
 
   private FakeStorageModuleBuilder withRequiredProperties(
@@ -134,7 +160,8 @@ public class FakeStorageModuleBuilder {
       this.uniqueProperties,
       this.hasDeleteByQuery,
       this.includeChangeMetadata,
-      this.constraint);
+      this.constraint,
+      this.recordValidator);
     }
 
   FakeStorageModuleBuilder withRequiredProperties(String... requiredProperties) {
@@ -155,7 +182,8 @@ public class FakeStorageModuleBuilder {
       uniqueProperties,
       this.hasDeleteByQuery,
       this.includeChangeMetadata,
-      this.constraint);
+      this.constraint,
+      this.recordValidator);
   }
 
   FakeStorageModuleBuilder withUniqueProperties(String... uniqueProperties) {
@@ -176,7 +204,8 @@ public class FakeStorageModuleBuilder {
       this.uniqueProperties,
       this.hasDeleteByQuery,
       this.includeChangeMetadata,
-      this.constraint);
+      this.constraint,
+      this.recordValidator);
   }
 
   FakeStorageModuleBuilder withDisallowedProperties(String... disallowedProperties) {
@@ -195,7 +224,8 @@ public class FakeStorageModuleBuilder {
       this.uniqueProperties,
       this.hasDeleteByQuery,
       this.includeChangeMetadata,
-      this.constraint);
+      this.constraint,
+      this.recordValidator);
   }
 
   FakeStorageModuleBuilder allowDeleteByQuery() {
@@ -210,7 +240,8 @@ public class FakeStorageModuleBuilder {
       this.uniqueProperties,
       true,
       this.includeChangeMetadata,
-      this.constraint);
+      this.constraint,
+      this.recordValidator);
   }
 
   FakeStorageModuleBuilder withChangeMetadata() {
@@ -225,7 +256,8 @@ public class FakeStorageModuleBuilder {
       this.uniqueProperties,
       this.hasDeleteByQuery,
       true,
-      this.constraint);
+      this.constraint,
+      this.recordValidator);
   }
 
   FakeStorageModuleBuilder withRecordConstraint(
@@ -242,6 +274,7 @@ public class FakeStorageModuleBuilder {
       this.uniqueProperties,
       this.hasDeleteByQuery,
       this.includeChangeMetadata,
-      constraint);
+      constraint,
+      this.recordValidator);
   }
 }

--- a/src/test/java/api/support/fakes/StorageSchema.java
+++ b/src/test/java/api/support/fakes/StorageSchema.java
@@ -1,0 +1,13 @@
+package api.support.fakes;
+
+import java.io.IOException;
+
+import org.folio.circulation.infrastructure.serialization.JsonSchemaValidator;
+
+public class StorageSchema {
+  private StorageSchema() { }
+
+  public static JsonSchemaValidator validatorForStorageLoanSchema() throws IOException {
+    return JsonSchemaValidator.fromResource("/storage-loan-6-1.json");
+  }
+}

--- a/src/test/java/api/support/matchers/ResultMatchers.java
+++ b/src/test/java/api/support/matchers/ResultMatchers.java
@@ -1,0 +1,29 @@
+package api.support.matchers;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import org.folio.circulation.support.Result;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+public class ResultMatchers {
+  public static TypeSafeDiagnosingMatcher<Result> succeeded() {
+    return new TypeSafeDiagnosingMatcher<Result>() {
+      @Override
+      public void describeTo(Description description) {
+        description
+          .appendText("a successful result");
+      }
+
+      @Override
+      protected boolean matchesSafely(Result result, Description description) {
+        final Matcher<Boolean> successMatcher = is(true);
+
+        description.appendText("is a " + result.toString());
+
+        return successMatcher.matches(result.succeeded());
+      }
+    };
+  }
+}

--- a/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
@@ -46,6 +46,7 @@ public class JsonSchemaValidationTest {
     final Result<String> result = validator.validate(checkInRequest.encode());
 
     assertThat(result.succeeded(), is(false));
+
     assertThat(result.cause(), isErrorWith(allOf(
       hasMessage("#: required key [servicePointId] not found"),
       hasParameter(null, null))));
@@ -67,8 +68,35 @@ public class JsonSchemaValidationTest {
     final Result<String> result = validator.validate(checkInRequest.encode());
 
     assertThat(result.succeeded(), is(false));
+
     assertThat(result.cause(), isErrorWith(allOf(
       hasMessage("#: extraneous key [unexpectedProperty] is not permitted"),
+      hasParameter(null, null))));
+  }
+
+  @Test
+  public void validationFailsForMultipleReasons() throws IOException {
+    final JsonSchemaValidator validator = JsonSchemaValidator
+      .fromResource("/check-in-by-barcode-request.json");
+
+    final JsonObject checkInRequest = new CheckInByBarcodeRequestBuilder()
+      .withItemBarcode("246650492")
+      .on(DateTime.now())
+      .atNoServicePoint()
+      .create();
+
+    checkInRequest.put("unexpectedProperty", "foo");
+
+    final Result<String> result = validator.validate(checkInRequest.encode());
+
+    assertThat(result.succeeded(), is(false));
+
+    assertThat(result.cause(), isErrorWith(allOf(
+      hasMessage("#: extraneous key [unexpectedProperty] is not permitted"),
+      hasParameter(null, null))));
+
+    assertThat(result.cause(), isErrorWith(allOf(
+      hasMessage("#: required key [servicePointId] not found"),
       hasParameter(null, null))));
   }
 }

--- a/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
@@ -20,9 +20,11 @@ import api.support.builders.CheckInByBarcodeRequestBuilder;
 import io.vertx.core.json.JsonObject;
 
 public class JsonSchemaValidationTest {
+
   @Test
   public void validationSucceedWithCompleteExample() throws IOException {
-    Schema schema = getCheckInByBarcodeSchema();
+    final Schema schema = getSchema("/check-in-by-barcode-request.json");
+    final JsonSchemaValidator validator = new JsonSchemaValidator(schema);
 
     final JsonObject checkInRequest = new CheckInByBarcodeRequestBuilder()
       .withItemBarcode("246650492")
@@ -30,9 +32,7 @@ public class JsonSchemaValidationTest {
       .at(UUID.randomUUID())
       .create();
 
-    final JSONObject example = new JSONObject(checkInRequest.encodePrettily());
-
-    schema.validate(example);
+    validator.validate(checkInRequest.encodePrettily());
   }
 
   @Rule
@@ -40,7 +40,8 @@ public class JsonSchemaValidationTest {
 
   @Test
   public void validationFailsWhenRequiredPropertyMissing() throws IOException {
-    Schema schema = getCheckInByBarcodeSchema();
+    final Schema schema = getSchema("/check-in-by-barcode-request.json");
+    final JsonSchemaValidator validator = new JsonSchemaValidator(schema);
 
     final JsonObject checkInRequest = new CheckInByBarcodeRequestBuilder()
       .withItemBarcode("246650492")
@@ -48,17 +49,15 @@ public class JsonSchemaValidationTest {
       .atNoServicePoint()
       .create();
 
-    final JSONObject example = new JSONObject(checkInRequest.encodePrettily());
-
     exceptionRule.expect(ValidationException.class);
     exceptionRule.expectMessage(is("#: required key [servicePointId] not found"));
 
-    schema.validate(example);
+    validator.validate(checkInRequest.encodePrettily());
   }
 
-  private Schema getCheckInByBarcodeSchema() throws IOException {
+  private Schema getSchema(String path) throws IOException {
     try (InputStream inputStream = getClass()
-        .getResourceAsStream("/check-in-by-barcode-request.json")) {
+        .getResourceAsStream(path)) {
 
       JSONObject rawSchema = new JSONObject(new JSONTokener(inputStream));
 

--- a/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
@@ -20,20 +20,15 @@ import org.junit.rules.ExpectedException;
 public class JsonSchemaValidationTest {
   @Test
   public void validationSucceedWithCompleteExample() throws IOException {
-    try (InputStream inputStream = getClass().getResourceAsStream(
-      "/check-in-by-barcode-request.json")) {
+    Schema schema = getCheckInByBarcodeSchema();
 
-      JSONObject rawSchema = new JSONObject(new JSONTokener(inputStream));
-      Schema schema = SchemaLoader.load(rawSchema);
+    final JSONObject example = new JSONObject();
 
-      final JSONObject example = new JSONObject();
+    example.put("itemBarcode", "246650492");
+    example.put("servicePointId", UUID.randomUUID().toString());
+    example.put("checkInDate", DateTime.now().toString(ISODateTimeFormat.dateTime()));
 
-      example.put("itemBarcode", "246650492");
-      example.put("servicePointId", UUID.randomUUID().toString());
-      example.put("checkInDate", DateTime.now().toString(ISODateTimeFormat.dateTime()));
-
-      schema.validate(example);
-    }
+    schema.validate(example);
   }
 
   @Rule
@@ -41,20 +36,26 @@ public class JsonSchemaValidationTest {
 
   @Test
   public void validationFailsWhenRequiredPropertyMissing() throws IOException {
-    try (InputStream inputStream = getClass().getResourceAsStream(
-      "/check-in-by-barcode-request.json")) {
+    Schema schema = getCheckInByBarcodeSchema();
+
+    final JSONObject example = new JSONObject();
+
+    example.put("itemBarcode", "246650492");
+    example.put("checkInDate", DateTime.now().toString(ISODateTimeFormat.dateTime()));
+
+    exceptionRule.expect(ValidationException.class);
+    exceptionRule.expectMessage(is("#: required key [servicePointId] not found"));
+
+    schema.validate(example);
+  }
+
+  private Schema getCheckInByBarcodeSchema() throws IOException {
+    try (InputStream inputStream = getClass()
+        .getResourceAsStream("/check-in-by-barcode-request.json")) {
 
       JSONObject rawSchema = new JSONObject(new JSONTokener(inputStream));
-      Schema schema = SchemaLoader.load(rawSchema);
 
-      final JSONObject example = new JSONObject();
-
-      example.put("itemBarcode", "246650492");
-      example.put("checkInDate", DateTime.now().toString(ISODateTimeFormat.dateTime()));
-
-      exceptionRule.expect(ValidationException.class);
-      exceptionRule.expectMessage(is("#: required key [servicePointId] not found"));
-      schema.validate(example);
+      return SchemaLoader.load(rawSchema);
     }
   }
 }

--- a/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
@@ -10,23 +10,27 @@ import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import api.support.builders.CheckInByBarcodeRequestBuilder;
+import io.vertx.core.json.JsonObject;
+
 public class JsonSchemaValidationTest {
   @Test
   public void validationSucceedWithCompleteExample() throws IOException {
     Schema schema = getCheckInByBarcodeSchema();
 
-    final JSONObject example = new JSONObject();
+    final JsonObject checkInRequest = new CheckInByBarcodeRequestBuilder()
+      .withItemBarcode("246650492")
+      .on(DateTime.now())
+      .at(UUID.randomUUID())
+      .create();
 
-    example.put("itemBarcode", "246650492");
-    example.put("servicePointId", UUID.randomUUID().toString());
-    example.put("checkInDate", DateTime.now().toString(ISODateTimeFormat.dateTime()));
+    final JSONObject example = new JSONObject(checkInRequest.encodePrettily());
 
     schema.validate(example);
   }
@@ -38,10 +42,13 @@ public class JsonSchemaValidationTest {
   public void validationFailsWhenRequiredPropertyMissing() throws IOException {
     Schema schema = getCheckInByBarcodeSchema();
 
-    final JSONObject example = new JSONObject();
+    final JsonObject checkInRequest = new CheckInByBarcodeRequestBuilder()
+      .withItemBarcode("246650492")
+      .on(DateTime.now())
+      .atNoServicePoint()
+      .create();
 
-    example.put("itemBarcode", "246650492");
-    example.put("checkInDate", DateTime.now().toString(ISODateTimeFormat.dateTime()));
+    final JSONObject example = new JSONObject(checkInRequest.encodePrettily());
 
     exceptionRule.expect(ValidationException.class);
     exceptionRule.expectMessage(is("#: required key [servicePointId] not found"));

--- a/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
@@ -17,6 +17,7 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 
 import api.support.builders.CheckInByBarcodeRequestBuilder;
+import api.support.builders.RequestBuilder;
 import io.vertx.core.json.JsonObject;
 
 public class JsonSchemaValidationTest {
@@ -32,6 +33,22 @@ public class JsonSchemaValidationTest {
       .create();
 
     assertThat(validator.validate(checkInRequest.encode()).succeeded(), is(true));
+  }
+
+  @Test
+  public void canValidateSchemaWithReferences() throws IOException {
+    final JsonSchemaValidator validator = JsonSchemaValidator
+      .fromResource("/request.json");
+
+    final JsonObject request = new RequestBuilder()
+      .hold()
+      .withItemId(UUID.randomUUID())
+      .withRequesterId(UUID.randomUUID())
+      .fulfilToHoldShelf(UUID.randomUUID())
+      .withRequestDate(DateTime.now())
+      .create();
+
+    assertThat(validator.validate(request.encode()).succeeded(), is(true));
   }
 
   @Test

--- a/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
@@ -1,0 +1,60 @@
+package org.folio.circulation.infrastructure.serialization;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.ValidationException;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class JsonSchemaValidationTest {
+  @Test
+  public void validationSucceedWithCompleteExample() throws IOException {
+    try (InputStream inputStream = getClass().getResourceAsStream(
+      "/check-in-by-barcode-request.json")) {
+
+      JSONObject rawSchema = new JSONObject(new JSONTokener(inputStream));
+      Schema schema = SchemaLoader.load(rawSchema);
+
+      final JSONObject example = new JSONObject();
+
+      example.put("itemBarcode", "246650492");
+      example.put("servicePointId", UUID.randomUUID().toString());
+      example.put("checkInDate", DateTime.now().toString(ISODateTimeFormat.dateTime()));
+
+      schema.validate(example);
+    }
+  }
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Test
+  public void validationFailsWhenRequiredPropertyMissing() throws IOException {
+    try (InputStream inputStream = getClass().getResourceAsStream(
+      "/check-in-by-barcode-request.json")) {
+
+      JSONObject rawSchema = new JSONObject(new JSONTokener(inputStream));
+      Schema schema = SchemaLoader.load(rawSchema);
+
+      final JSONObject example = new JSONObject();
+
+      example.put("itemBarcode", "246650492");
+      example.put("checkInDate", DateTime.now().toString(ISODateTimeFormat.dateTime()));
+
+      exceptionRule.expect(ValidationException.class);
+      exceptionRule.expectMessage(is("#: required key [servicePointId] not found"));
+      schema.validate(example);
+    }
+  }
+}

--- a/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.infrastructure.serialization;
 
+import static api.support.fakes.StorageSchema.validatorForStorageLoanSchema;
 import static api.support.matchers.ResultMatchers.succeeded;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
@@ -55,8 +56,7 @@ public class JsonSchemaValidationTest {
 
   @Test
   public void canValidateStorageSchema() throws IOException {
-    final JsonSchemaValidator validator = JsonSchemaValidator
-      .fromResource("/storage-loan-6-1.json");
+    final JsonSchemaValidator validator = validatorForStorageLoanSchema();
 
     final JsonObject storageLoanRequest = new JsonObject();
 
@@ -70,8 +70,7 @@ public class JsonSchemaValidationTest {
 
   @Test
   public void validationFailsWhenUnexpectedPropertyIncludedInStorageSchema() throws IOException {
-    final JsonSchemaValidator validator = JsonSchemaValidator
-      .fromResource("/storage-loan-6-1.json");
+    final JsonSchemaValidator validator = validatorForStorageLoanSchema();
 
     final JsonObject storageLoanRequest = new JsonObject()
       .put("unexpectedProperty", "foo");

--- a/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
@@ -3,15 +3,10 @@ package org.folio.circulation.infrastructure.serialization;
 import static org.hamcrest.CoreMatchers.is;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.UUID;
 
-import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
-import org.everit.json.schema.loader.SchemaLoader;
 import org.joda.time.DateTime;
-import org.json.JSONObject;
-import org.json.JSONTokener;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -23,8 +18,8 @@ public class JsonSchemaValidationTest {
 
   @Test
   public void validationSucceedWithCompleteExample() throws IOException {
-    final Schema schema = getSchema("/check-in-by-barcode-request.json");
-    final JsonSchemaValidator validator = new JsonSchemaValidator(schema);
+    final JsonSchemaValidator validator = JsonSchemaValidator
+      .fromResource("/check-in-by-barcode-request.json");
 
     final JsonObject checkInRequest = new CheckInByBarcodeRequestBuilder()
       .withItemBarcode("246650492")
@@ -40,8 +35,8 @@ public class JsonSchemaValidationTest {
 
   @Test
   public void validationFailsWhenRequiredPropertyMissing() throws IOException {
-    final Schema schema = getSchema("/check-in-by-barcode-request.json");
-    final JsonSchemaValidator validator = new JsonSchemaValidator(schema);
+    final JsonSchemaValidator validator = JsonSchemaValidator
+      .fromResource("/check-in-by-barcode-request.json");
 
     final JsonObject checkInRequest = new CheckInByBarcodeRequestBuilder()
       .withItemBarcode("246650492")
@@ -53,15 +48,5 @@ public class JsonSchemaValidationTest {
     exceptionRule.expectMessage(is("#: required key [servicePointId] not found"));
 
     validator.validate(checkInRequest.encodePrettily());
-  }
-
-  private Schema getSchema(String path) throws IOException {
-    try (InputStream inputStream = getClass()
-        .getResourceAsStream(path)) {
-
-      JSONObject rawSchema = new JSONObject(new JSONTokener(inputStream));
-
-      return SchemaLoader.load(rawSchema);
-    }
   }
 }

--- a/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
@@ -4,12 +4,14 @@ import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static api.support.matchers.ValidationErrorMatchers.isErrorWith;
 import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.UUID;
 
+import org.folio.circulation.support.BadRequestFailure;
 import org.folio.circulation.support.Result;
 import org.joda.time.DateTime;
 import org.junit.Test;
@@ -98,5 +100,21 @@ public class JsonSchemaValidationTest {
     assertThat(result.cause(), isErrorWith(allOf(
       hasMessage("#: required key [servicePointId] not found"),
       hasParameter(null, null))));
+  }
+
+  @Test
+  public void validationFailsForInvalidJson() throws IOException {
+    final JsonSchemaValidator validator = JsonSchemaValidator
+      .fromResource("/check-in-by-barcode-request.json");
+
+    final Result<String> result = validator.validate("foo blah");
+
+    assertThat(result.succeeded(), is(false));
+
+    assertThat(result.cause(), instanceOf(BadRequestFailure.class));
+
+    final BadRequestFailure badRequestFailure = (BadRequestFailure)result.cause();
+
+    assertThat(badRequestFailure.getReason(), is("Cannot parse \"foo blah\" as JSON"));
   }
 }

--- a/src/test/resources/storage-loan-6-1.json
+++ b/src/test/resources/storage-loan-6-1.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "Loan",
+  "description": "Links the item with the patron and applies certain conditions based on policies",
+  "properties": {
+    "id": {
+      "description": "Unique ID (generated UUID) of the loan",
+      "type": "string"
+    },
+    "userId": {
+      "description": "ID of the patron the item was lent to. Required for open loans, not required for closed loans (for anonymization).",
+      "type": "string"
+    },
+    "proxyUserId": {
+      "description": "ID of the user representing a proxy for the patron",
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "itemId": {
+      "description": "ID of the item lent to the patron",
+      "type": "string"
+    },
+    "status": {
+      "description": "Overall status of the loan",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the status (currently can be any value, values commonly used are Open and Closed)",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "loanDate": {
+      "description": "Date time when the loan began (typically represented according to rfc3339 section-5.6. Has not had the date-time format validation applied as was not supported at point of introduction and would now be a breaking change)",
+      "type": "string"
+    },
+    "dueDate": {
+      "description": "Date time when the item is due to be returned",
+      "type": "string",
+      "format": "date-time"
+    },
+    "returnDate": {
+      "description": "Date time when the item is returned and the loan ends (typically represented according to rfc3339 section-5.6. Has not had the date-time format validation applied as was not supported at point of introduction and would now be a breaking change)",
+      "type": "string"
+    },
+    "systemReturnDate" : {
+      "description": "Date time when the returned item is actually processed",
+      "type" : "string",
+      "format": "date-time"
+    },
+    "action": {
+      "description": "Last action performed on a loan (currently can be any value, values commonly used are checkedout and checkedin)",
+      "type": "string"
+    },
+    "actionComment": {
+      "description": "Comment to last action performed on a loan",
+      "type": "string"
+    },
+    "itemStatus": {
+      "description": "Last item status used in relation to this loan (currently can be any value, values commonly used are Checked out and Available)",
+      "type": "string"
+    },
+    "renewalCount": {
+      "description": "Count of how many times a loan has been renewed (incremented by the client)",
+      "type": "integer"
+    },
+    "loanPolicyId": {
+      "description": "ID of last policy used in relation to this loan",
+      "type": "string"
+    },
+    "checkoutServicePointId": {
+      "description": "ID of the Service Point where the last checkout occured",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "checkinServicePointId": {
+      "description": "ID of the Service Point where the last checkin occured",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "patronGroupIdAtCheckout": {
+      "description": "Patron Group Id at checkout",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes to loan, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "itemId",
+    "loanDate",
+    "action"
+  ]
+}


### PR DESCRIPTION
## Purpose
We have had numerous bugs where requests to storage modules fail in hosted environments due to incorrectly mapped record representations.

In order to reduce common mapping issues between mod-circulation representations and storage interface representations, we could validate the storage representation schema during the API tests.

The most recent of which was [CIRC-422](https://issues.folio.org/browse/CIRC-422) and I confirmed that this would have caught that issue.

## Approach
Starting with a single record type in order to keep this change as small as possible. Loans were chosen because that is the area where we have had the most 

* Copy the storage schema as a test resource (including copying the production schema as a main resource)
* Create JSON schema validator (based upon the work in [CIRC-293](https://issues.folio.org/browse/CIRC-293)
* Validate the incoming representation for creation and replacement in the fake storage modules

## Learning
The schema validation identified situations where explicit `null` values are being included, I don't know if that would also cause requests to fail with the technology used in RAML Module Builder.

The change history reflects some challenges with interpreting the errors produced by the schema validator (similar to the tooling used by RAML Module Builder) and the now typical challenges with references in schema (which is why the schema are in the root of the resources)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [x] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [x] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
