### PR TITLE
CIRC-424 cannot create request after overridden check out

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -5,6 +5,7 @@ import static org.folio.circulation.domain.RequestType.RECALL;
 import static org.folio.circulation.support.JsonPropertyFetcher.getBooleanProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getIntegerProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getNestedIntegerProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getNestedObjectProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.Result.succeeded;
@@ -420,12 +421,13 @@ public class LoanPolicy {
     return LoanPolicyPeriod.getProfileByName(intervalId);
   }
 
-  private int getDuration(String val) {
-    JsonObject loansPolicyObj = representation.getJsonObject(LOANS_POLICY_KEY);
-    JsonObject period = loansPolicyObj.getJsonObject(val);
+  private int getDuration(String propertyName) {
+    JsonObject period = getNestedObjectProperty(representation, LOANS_POLICY_KEY, propertyName);
+
     if (Objects.isNull(period)) {
       return 0;
     }
+
     return period.getInteger("duration");
   }
 

--- a/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyService.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyService.java
@@ -57,6 +57,7 @@ public class ClosedLibraryStrategyService {
   private Result<DateTime> applyStrategy(
     Loan loan, LoanPolicy loanPolicy, AdjacentOpeningDays openingDays, DateTimeZone timeZone) {
     DateTime initialDueDate = loan.getDueDate();
+
     ClosedLibraryStrategy strategy = determineClosedLibraryStrategy(loanPolicy, currentDateTime, timeZone);
 
     return strategy.calculateDueDate(initialDueDate, openingDays)

--- a/src/test/java/api/loans/OverrideCheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideCheckOutByBarcodeTests.java
@@ -290,7 +290,7 @@ public class OverrideCheckOutByBarcodeTests extends APITests {
   }
 
   @Test
-  public void cannotCreateRecallRequestAfterOverriddenCheckout()
+  public void canCreateRecallRequestAfterOverriddenCheckout()
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
@@ -318,7 +318,7 @@ public class OverrideCheckOutByBarcodeTests extends APITests {
       .by(charlotte)
       .fulfilToHoldShelf(servicePointsFixture.cd1()));
 
-    assertThat(placeRequestResponse.getStatusCode(), is(500));
+    assertThat(placeRequestResponse.getStatusCode(), is(201));
   }
 
   private void setNotLoanablePolicy()

--- a/src/test/java/api/support/builders/LoanPolicyBuilder.java
+++ b/src/test/java/api/support/builders/LoanPolicyBuilder.java
@@ -1,10 +1,11 @@
 package api.support.builders;
 
-import io.vertx.core.json.JsonObject;
-import org.folio.circulation.domain.policy.Period;
-
 import java.util.Objects;
 import java.util.UUID;
+
+import org.folio.circulation.domain.policy.Period;
+
+import io.vertx.core.json.JsonObject;
 
 public class LoanPolicyBuilder extends JsonBuilder implements Builder {
   private static final String RENEW_FROM_SYSTEM_DATE = "SYSTEM_DATE";
@@ -105,32 +106,34 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
     put(request, "loanable", loanable);
     put(request, "renewable", renewable);
 
-    JsonObject loansPolicy = new JsonObject();
+    if(loanable) {
+      JsonObject loansPolicy = new JsonObject();
 
-    put(loansPolicy, "profileId", profile);
+      put(loansPolicy, "profileId", profile);
 
-    //TODO: Replace with sub-builders
-    if(Objects.equals(profile, "Rolling")) {
-      put(loansPolicy, "period", loanPeriod);
+      //TODO: Replace with sub-builders
+      if(Objects.equals(profile, "Rolling")) {
+        put(loansPolicy, "period", loanPeriod);
 
-      //Due date limited rolling policy, maybe should be separate property
-      put(loansPolicy, "fixedDueDateScheduleId", fixedDueDateScheduleId);
+        //Due date limited rolling policy, maybe should be separate property
+        put(loansPolicy, "fixedDueDateScheduleId", fixedDueDateScheduleId);
 
-      put(loansPolicy, "closedLibraryDueDateManagementId",
-        closedLibraryDueDateManagementId);
+        put(loansPolicy, "closedLibraryDueDateManagementId",
+          closedLibraryDueDateManagementId);
 
-      put(loansPolicy, "openingTimeOffset", openingTimeOffsetPeriod);
+        put(loansPolicy, "openingTimeOffset", openingTimeOffsetPeriod);
+      }
+      else if(Objects.equals(profile, "Fixed")) {
+        put(loansPolicy, "fixedDueDateScheduleId", fixedDueDateScheduleId);
+
+        put(loansPolicy, "closedLibraryDueDateManagementId",
+          closedLibraryDueDateManagementId);
+
+        put(loansPolicy, "openingTimeOffset", openingTimeOffsetPeriod);
+      }
+
+      put(request, "loansPolicy", loansPolicy);
     }
-    else if(Objects.equals(profile, "Fixed")) {
-      put(loansPolicy, "fixedDueDateScheduleId", fixedDueDateScheduleId);
-
-      put(loansPolicy, "closedLibraryDueDateManagementId",
-        closedLibraryDueDateManagementId);
-
-      put(loansPolicy, "openingTimeOffset", openingTimeOffsetPeriod);
-    }
-
-    put(request, "loansPolicy", loansPolicy);
 
     if(renewable) {
       JsonObject renewalsPolicy = new JsonObject();


### PR DESCRIPTION
## Purpose

Fixes the null pointer exception that occurs when trying to create a recall request after an overridden check out of an item that is not loanable, see [CIRC-424](https://issues.folio.org/browse/CIRC-424) for more details

## Approach
* Write a test to demonstrate the failure
* Identify the cause and fix it, changing the test to a positive case at the same time

## Learning
* The loan policy builder was incorrect including loan policy properties even when not loanable, this stopped the issue from being reproduce-able
* The approach to traversing JSON deep in the domain is brittle and means that it is difficult to identify these kind of issues
* Closed due date management shouldn't really be applied unless the due date has changed

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
