### PR TITLE
[CIRC-427] Expand check-out endpoint error response with loan policy info

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -83,11 +84,11 @@ public class LoanPolicy {
       }
 
       if (isNotLoanable()) {
-        errors.add(errorForPolicy("item is not loanable"));
+        errors.add(loanPolicyValidationError("item is not loanable"));
         return failedValidation(errors);
       }
       if (isNotRenewable()) {
-        errors.add(errorForPolicy("loan is not renewable"));
+        errors.add(loanPolicyValidationError("loan is not renewable"));
         return failedValidation(errors);
       }
 
@@ -158,7 +159,7 @@ public class LoanPolicy {
 
   private Result<DateTime> errorWhenEarlierOrSameDueDate(Loan loan, DateTime proposedDueDate) {
     if (isSameOrBefore(loan, proposedDueDate)) {
-      return failedValidation(errorForPolicy(
+      return failedValidation(loanPolicyValidationError(
         RENEWAL_WOULD_NOT_CHANGE_THE_DUE_DATE));
     }
     return Result.succeeded(proposedDueDate);
@@ -185,15 +186,20 @@ public class LoanPolicy {
       "renewal date falls outside of the date ranges in the loan policy, " +
       "items cannot be renewed when there is an active recall request";
 
-    return errorForPolicy(reason);
+    return loanPolicyValidationError(reason);
   }
 
-  private ValidationError errorForPolicy(String reason) {
-    HashMap<String, String> parameters = new HashMap<>();
+  private ValidationError loanPolicyValidationError(String message) {
+    return loanPolicyValidationError(message, Collections.emptyMap());
+  }
+
+  public ValidationError loanPolicyValidationError(
+    String message, Map<String, String> additionalParameters) {
+
+    Map<String, String> parameters = new HashMap<>(additionalParameters);
     parameters.put("loanPolicyId", getId());
     parameters.put("loanPolicyName", getName());
-
-    return new ValidationError(reason, parameters);
+    return new ValidationError(message, parameters);
   }
 
   private boolean isNotRenewable() {
@@ -202,7 +208,7 @@ public class LoanPolicy {
 
   private void errorWhenReachedRenewalLimit(Loan loan, List<ValidationError> errors) {
     if (hasReachedRenewalLimit(loan)) {
-      errors.add(errorForPolicy("loan at maximum renewal number"));
+      errors.add(loanPolicyValidationError("loan at maximum renewal number"));
     }
   }
 
@@ -212,7 +218,7 @@ public class LoanPolicy {
     List<ValidationError> errors) {
 
     if(isSameOrBefore(loan, proposedDueDate)) {
-      errors.add(errorForPolicy(RENEWAL_WOULD_NOT_CHANGE_THE_DUE_DATE));
+      errors.add(loanPolicyValidationError(RENEWAL_WOULD_NOT_CHANGE_THE_DUE_DATE));
     }
   }
 
@@ -244,33 +250,33 @@ public class LoanPolicy {
     //TODO: Temporary until have better logic for missing loans policy
     if(loansPolicy == null) {
       return new UnknownDueDateStrategy(getId(), getName(), "", isRenewal,
-        this::errorForPolicy);
+        this::loanPolicyValidationError);
     }
 
     if(isRolling(loansPolicy)) {
       if(isRenewal) {
         return new RollingRenewalDueDateStrategy(getId(), getName(),
           systemDate, getRenewFrom(), getRenewalPeriod(loansPolicy, renewalsPolicy),
-          getRenewalDueDateLimitSchedules(), this::errorForPolicy);
+          getRenewalDueDateLimitSchedules(), this::loanPolicyValidationError);
       }
       else {
         return new RollingCheckOutDueDateStrategy(getId(), getName(),
-          getPeriod(loansPolicy), fixedDueDateSchedules, this::errorForPolicy);
+          getPeriod(loansPolicy), fixedDueDateSchedules, this::loanPolicyValidationError);
       }
     }
     else if(isFixed(loansPolicy)) {
       if(isRenewal) {
         return new FixedScheduleRenewalDueDateStrategy(getId(), getName(),
-          getRenewalFixedDueDateSchedules(), systemDate, this::errorForPolicy);
+          getRenewalFixedDueDateSchedules(), systemDate, this::loanPolicyValidationError);
       }
       else {
         return new FixedScheduleCheckOutDueDateStrategy(getId(), getName(),
-          fixedDueDateSchedules, this::errorForPolicy);
+          fixedDueDateSchedules, this::loanPolicyValidationError);
       }
     }
     else {
       return new UnknownDueDateStrategy(getId(), getName(),
-        getProfileId(loansPolicy), isRenewal, this::errorForPolicy);
+        getProfileId(loansPolicy), isRenewal, this::loanPolicyValidationError);
     }
   }
 
@@ -524,9 +530,9 @@ public class LoanPolicy {
 
     if (representation.containsKey(key)) {
       result = getPeriod(representation, key).addTo(initialDateTime,
-          () -> errorForPolicy(format("the \"%s\" in the loan policy is not recognized", key)),
-          interval -> errorForPolicy(format("the interval \"%s\" in \"%s\" is not recognized", interval, key)),
-          duration -> errorForPolicy(format("the duration \"%s\" in \"%s\" is invalid", duration, key)));
+          () -> loanPolicyValidationError(format("the \"%s\" in the loan policy is not recognized", key)),
+          interval -> loanPolicyValidationError(format("the interval \"%s\" in \"%s\" is not recognized", interval, key)),
+          duration -> loanPolicyValidationError(format("the duration \"%s\" in \"%s\" is invalid", duration, key)));
     } else {
       result = succeeded(defaultDateTime);
     }

--- a/src/main/java/org/folio/circulation/resources/RegularCheckOutStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/RegularCheckOutStrategy.java
@@ -16,7 +16,6 @@ import org.folio.circulation.domain.policy.LoanPolicy;
 import org.folio.circulation.domain.policy.library.ClosedLibraryStrategyService;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.Result;
-import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
 
 import io.vertx.core.json.JsonObject;
@@ -51,10 +50,9 @@ public class RegularCheckOutStrategy implements CheckOutStrategy {
 
       Map<String, String> parameters = new HashMap<>();
       parameters.put(ITEM_BARCODE, itemBarcode);
-      parameters.put("loanPolicyId", loanPolicy.getId());
-      parameters.put("loanPolicyName", loanPolicy.getName());
       return failed(singleValidationError(
-        new ValidationError("Item is not loanable", parameters)));
+        loanPolicy.loanPolicyValidationError(
+          "Item is not loanable", parameters)));
     }
     return succeeded(relatedRecords);
   }

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -955,6 +955,7 @@ public class CheckOutByBarcodeTests extends APITests {
       new LoanPolicyBuilder()
         .withName("Not Loanable Policy")
         .withLoanable(false));
+
     useLoanPolicyAsFallback(
       notLoanablePolicy.getId(),
       requestPoliciesFixture.allowAllRequestPolicy().getId(),

--- a/src/test/java/api/support/matchers/CheckOutByBarcodeResponseMatchers.java
+++ b/src/test/java/api/support/matchers/CheckOutByBarcodeResponseMatchers.java
@@ -1,6 +1,7 @@
 package api.support.matchers;
 
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
+import static org.hamcrest.CoreMatchers.allOf;
 
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.server.ValidationError;
@@ -21,5 +22,12 @@ public class CheckOutByBarcodeResponseMatchers {
 
   public static Matcher<ValidationError> hasServicePointParameter(String servicePoint) {
     return hasParameter("checkoutServicePointId", servicePoint);
+  }
+
+  public static Matcher<ValidationError> hasLoanPolicyParameters(IndividualResource loanPolicy) {
+    return allOf(
+      hasParameter("loanPolicyId", loanPolicy.getId().toString()),
+      hasParameter("loanPolicyName", loanPolicy.getJson().getString("name"))
+    );
   }
 }


### PR DESCRIPTION
## Purpose
Add loan policy id and name to error response when cannot check-out item due to not loanable policy. 
Resolves: [CIRC-427](https://issues.folio.org/browse/CIRC-427)
Required for UI story: [UICHKOUT-534](https://issues.folio.org/browse/UICHKOUT-534)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
 
