### PR TITLE
[CIRC-438] rename "Item recalled", "Hold Expiration" fields

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -536,7 +536,7 @@
     },
     {
       "id": "patron-notice-policy-storage",
-      "version": "0.9"
+      "version": "1.0"
     },
     {
       "id": "patron-notice",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -536,7 +536,7 @@
     },
     {
       "id": "patron-notice-policy-storage",
-      "version": "1.0"
+      "version": "0.11"
     },
     {
       "id": "patron-notice",

--- a/src/main/java/org/folio/circulation/domain/notice/NoticeEventType.java
+++ b/src/main/java/org/folio/circulation/domain/notice/NoticeEventType.java
@@ -13,11 +13,11 @@ public enum NoticeEventType {
   PAGING_REQUEST("Paging request"),
   HOLD_REQUEST("Hold request"),
   RECALL_REQUEST("Recall request"),
-  RECALL_TO_LOANEE("Recall loanee"),
+  ITEM_RECALLED("Item recalled"),
   REQUEST_CANCELLATION("Request cancellation"),
   AVAILABLE("Available"),
   REQUEST_EXPIRATION("Request expiration"),
-  HOLD_EXPIRATION("Hold Expiration"),
+  HOLD_EXPIRATION("Hold expiration"),
   UNKNOWN("Unknown");
 
 

--- a/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
@@ -119,7 +119,7 @@ public class RequestNoticeSender {
     PatronNoticeEvent itemRecalledEvent = new PatronNoticeEventBuilder()
       .withItem(loan.getItem())
       .withUser(loan.getUser())
-      .withEventType(NoticeEventType.RECALL_TO_LOANEE)
+      .withEventType(NoticeEventType.ITEM_RECALLED)
       .withTiming(NoticeTiming.UPON_AT)
       .withNoticeContext(TemplateContextUtil.createLoanNoticeContext(loan))
       .build();

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -83,7 +83,7 @@ public class RequestsAPICreationTests extends APITests {
   private static final String PAGING_REQUEST_EVENT = "Paging request";
   private static final String HOLD_REQUEST_EVENT = "Hold request";
   private static final String RECALL_REQUEST_EVENT = "Recall request";
-  private static final String RECALL_TO_LOANEE = "Recall loanee";
+  private static final String ITEM_RECALLED = "Item recalled";
 
   @Test
   public void canCreateARequest()
@@ -1639,7 +1639,7 @@ public class RequestsAPICreationTests extends APITests {
       .create();
     JsonObject recallToLoaneeConfiguration = new NoticeConfigurationBuilder()
       .withTemplateId(recallToLoaneeTemplateId)
-      .withEventType(RECALL_TO_LOANEE)
+      .withEventType(ITEM_RECALLED)
       .create();
     JsonObject pageConfirmationConfiguration = new NoticeConfigurationBuilder()
       .withTemplateId(UUID.randomUUID())
@@ -1730,7 +1730,7 @@ public class RequestsAPICreationTests extends APITests {
     UUID recallToLoanOwnerTemplateId = UUID.randomUUID();
     JsonObject recallToLoanOwnerNoticeConfiguration = new NoticeConfigurationBuilder()
       .withTemplateId(recallToLoanOwnerTemplateId)
-      .withEventType(RECALL_TO_LOANEE)
+      .withEventType(ITEM_RECALLED)
       .create();
     NoticePolicyBuilder noticePolicy = new NoticePolicyBuilder()
       .withName("Policy with recall notice")

--- a/src/test/java/api/requests/scenarios/MoveRequestPolicyTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestPolicyTests.java
@@ -67,7 +67,7 @@ public class MoveRequestPolicyTests extends APITests {
     UUID recallToLoaneeTemplateId = UUID.randomUUID();
     JsonObject recallToLoaneeConfiguration = new NoticeConfigurationBuilder()
       .withTemplateId(recallToLoaneeTemplateId)
-      .withEventType(NoticeEventType.RECALL_TO_LOANEE.getRepresentation())
+      .withEventType(NoticeEventType.ITEM_RECALLED.getRepresentation())
       .create();
 
     noticePolicy = new NoticePolicyBuilder()
@@ -244,7 +244,7 @@ public class MoveRequestPolicyTests extends APITests {
     // jessica places recall request on interestingTimes
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
       interestingTimes, jessica, DateTime.now(DateTimeZone.UTC), RequestType.RECALL.getValue());
-    
+
     assertThat(patronNoticesClient.getAll().size(), is(1));
 
     // move jessica's recall request from interestingTimes to smallAngryPlanet

--- a/src/test/java/api/support/builders/NoticeConfigurationBuilder.java
+++ b/src/test/java/api/support/builders/NoticeConfigurationBuilder.java
@@ -74,7 +74,7 @@ public class NoticeConfigurationBuilder extends JsonBuilder implements Builder {
   }
 
   public NoticeConfigurationBuilder withHoldShelfExpirationEvent() {
-    return withEventType("Hold Expiration");
+    return withEventType("Hold expiration");
   }
 
   private NoticeConfigurationBuilder withTiming(String timing, JsonObject timingPeriod) {


### PR DESCRIPTION
## Purpose
To rename "Item recalled" and "Hold Expiration" triggering event options since they have been renamed in mod-circulation-store
To update version of `patron-notice-policy-storage`

Resolves story: [CIRC-438](https://issues.folio.org/browse/CIRC-438)

## Approach
- renamed "Hold Expiration" to "Hold expiration" and "Recall loanee" to "Item recalled"
- updated version of `patron-notice-policy-storage`

## Notes
To be merged together with https://github.com/folio-org/mod-circulation-storage/pull/202

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [x] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.