### PR TITLE
FOLIO-2256 deploy snapshot/release images to ci kubernetes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ buildMvn {
   publishAPI = true
   mvnDeploy = true
   runLintRamlCop = true
+  doKubeDocker = true
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION

## Purpose
Enable kubedeploy step on buildMvn pipeline. This step deploys a container to the ci kubernetes environment when a release or snapshot artifact is built.
