### PR TITLE
[CIRC-431] Add saving session record on check-out

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -337,7 +337,8 @@
             "circulation.rules.loan-policy.get"
           ],
           "modulePermissions": [
-            "circulation-storage.circulation-rules.get"
+            "circulation-storage.circulation-rules.get",
+            "inventory-storage.locations.item.get"
           ]
         },
         {
@@ -349,7 +350,8 @@
             "circulation.rules.loan-policy-all.get"
           ],
           "modulePermissions": [
-            "circulation-storage.circulation-rules.get"
+            "circulation-storage.circulation-rules.get",
+            "inventory-storage.locations.item.get"
           ]
         },
         {
@@ -361,7 +363,8 @@
             "circulation.rules.request-policy.get"
           ],
           "modulePermissions": [
-            "circulation-storage.circulation-rules.get"
+            "circulation-storage.circulation-rules.get",
+            "inventory-storage.locations.item.get"
           ]
         },
         {
@@ -373,7 +376,8 @@
             "circulation.rules.request-policy-all.get"
           ],
           "modulePermissions": [
-            "circulation-storage.circulation-rules.get"
+            "circulation-storage.circulation-rules.get",
+            "inventory-storage.locations.item.get"
           ]
         },
         {
@@ -385,7 +389,8 @@
             "circulation.rules.notice-policy.get"
           ],
           "modulePermissions": [
-            "circulation-storage.circulation-rules.get"
+            "circulation-storage.circulation-rules.get",
+            "inventory-storage.locations.item.get"
           ]
         },
         {
@@ -397,7 +402,8 @@
             "circulation.rules.notice-policy-all.get"
           ],
           "modulePermissions": [
-            "circulation-storage.circulation-rules.get"
+            "circulation-storage.circulation-rules.get",
+            "inventory-storage.locations.item.get"
           ]
         }
       ]
@@ -587,6 +593,10 @@
     {
       "id": "location-units",
       "version": "1.1"
+    },
+    {
+      "id": "patron-action-session-storage",
+      "version": "0.1"
     }
   ],
   "permissionSets": [
@@ -879,15 +889,13 @@
         "circulation-storage.request-policies.item.get",
         "circulation-storage.fixed-due-date-schedules.item.get",
         "circulation-storage.fixed-due-date-schedules.collection.get",
-        "circulation-storage.patron-notice-policies.item.get",
-        "patron-notice.post",
-        "circulation.rules.notice-policy.get",
         "configuration.entries.collection.get",
         "users.collection.get",
         "inventory-storage.loan-types.item.get",
         "scheduled-notice-storage.scheduled-notices.item.post",
         "usergroups.collection.get",
-        "usergroups.item.get"
+        "usergroups.item.get",
+        "patron-action-session-storage.patron-action-sessions.item.post"
       ],
       "visible": false
     },

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionRepository.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionRepository.java
@@ -1,8 +1,11 @@
 package org.folio.circulation.domain.notice.session;
 
 import static org.folio.circulation.domain.notice.session.PatronActionType.invalidActionTypeErrorMessage;
+import static org.folio.circulation.support.JsonPropertyFetcher.getUUIDProperty;
+import static org.folio.circulation.support.JsonPropertyWriter.write;
 import static org.folio.circulation.support.http.ResponseMapping.flatMapUsingJson;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.circulation.support.Clients;
@@ -42,17 +45,19 @@ public class PatronActionSessionRepository {
   }
 
   private JsonObject mapToJson(PatronSessionRecord patronSessionRecord) {
-    return new JsonObject()
-      .put(ID, patronSessionRecord.getId())
-      .put(PATRON_ID, patronSessionRecord.getPatronId())
-      .put(LOAN_ID, patronSessionRecord.getLoanId())
-      .put(ACTION_TYPE, patronSessionRecord.getActionType().getRepresentation());
+    JsonObject json = new JsonObject();
+    write(json, ID, patronSessionRecord.getId());
+    write(json, PATRON_ID, patronSessionRecord.getPatronId());
+    write(json, LOAN_ID, patronSessionRecord.getLoanId());
+    write(json, ACTION_TYPE, patronSessionRecord.getActionType().getRepresentation());
+
+    return json;
   }
 
   private Result<PatronSessionRecord> mapFromJson(JsonObject json) {
-    String id = json.getString(ID);
-    String patronId = json.getString(PATRON_ID);
-    String loanId = json.getString(LOAN_ID);
+    UUID id = getUUIDProperty(json, ID);
+    UUID patronId = getUUIDProperty(json, PATRON_ID);
+    UUID loanId = getUUIDProperty(json, LOAN_ID);
 
     PatronActionType patronActionType = PatronActionType.from(json.getString(ACTION_TYPE));
     if (!patronActionType.isValid()) {

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionRepository.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionRepository.java
@@ -1,0 +1,58 @@
+package org.folio.circulation.domain.notice.session;
+
+import static org.folio.circulation.support.http.ResponseMapping.flatMapUsingJson;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.CollectionResourceClient;
+import org.folio.circulation.support.Result;
+import org.folio.circulation.support.http.client.ResponseInterpreter;
+
+import io.vertx.core.json.JsonObject;
+
+public class PatronActionSessionRepository {
+
+  private static final String ID = "id";
+  private static final String PATRON_ID = "patronId";
+  private static final String LOAN_ID = "loanId";
+  private static final String ACTION_TYPE = "actionType";
+
+  public static PatronActionSessionRepository using(Clients clients) {
+    return new PatronActionSessionRepository(clients.patronActionSessionsStorageClient());
+  }
+
+  private final CollectionResourceClient patronActionSessionsStorageClient;
+
+  private PatronActionSessionRepository(CollectionResourceClient patronActionSessionsStorageClient) {
+    this.patronActionSessionsStorageClient = patronActionSessionsStorageClient;
+  }
+
+  public CompletableFuture<Result<PatronSessionRecord>> create(PatronSessionRecord patronSessionRecord) {
+    JsonObject representation = mapToJson(patronSessionRecord);
+
+    final ResponseInterpreter<PatronSessionRecord> responseInterpreter
+      = new ResponseInterpreter<PatronSessionRecord>()
+      .flatMapOn(201, flatMapUsingJson(this::mapFromJson));
+
+    return patronActionSessionsStorageClient.post(representation)
+      .thenApply(responseInterpreter::apply);
+  }
+
+  private JsonObject mapToJson(PatronSessionRecord patronSessionRecord) {
+    return new JsonObject()
+      .put(ID, patronSessionRecord.getId())
+      .put(PATRON_ID, patronSessionRecord.getPatronId())
+      .put(LOAN_ID, patronSessionRecord.getLoanId())
+      .put(ACTION_TYPE, patronSessionRecord.getActionType().getRepresentation());
+  }
+
+  private Result<PatronSessionRecord> mapFromJson(JsonObject json) {
+    String id = json.getString(ID);
+    String patronId = json.getString(PATRON_ID);
+    String loanId = json.getString(LOAN_ID);
+
+    return Result.of(() -> PatronActionType.from(json.getString(ACTION_TYPE)))
+      .map(patronActionType -> new PatronSessionRecord(id, patronId, loanId, patronActionType));
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionService.java
@@ -22,11 +22,11 @@ public class PatronActionSessionService {
   }
 
   public CompletableFuture<Result<LoanAndRelatedRecords>> saveCheckOutSessionRecord(LoanAndRelatedRecords records) {
-    String patronId = records.getUserId();
-    String loanId = records.getLoan().getId();
+    UUID patronId = UUID.fromString(records.getUserId());
+    UUID loanId = UUID.fromString(records.getLoan().getId());
 
     PatronSessionRecord patronSessionRecord =
-      new PatronSessionRecord(UUID.randomUUID().toString(),
+      new PatronSessionRecord(UUID.randomUUID(),
         patronId, loanId, PatronActionType.CHECK_OUT);
 
     return patronActionSessionRepository.create(patronSessionRecord)

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionService.java
@@ -1,0 +1,35 @@
+package org.folio.circulation.domain.notice.session;
+
+import static org.folio.circulation.support.ResultBinding.mapResult;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.circulation.domain.LoanAndRelatedRecords;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.Result;
+
+public class PatronActionSessionService {
+
+  public static PatronActionSessionService using(Clients clients) {
+    return new PatronActionSessionService(PatronActionSessionRepository.using(clients));
+  }
+
+  private final PatronActionSessionRepository patronActionSessionRepository;
+
+  public PatronActionSessionService(PatronActionSessionRepository patronActionSessionRepository) {
+    this.patronActionSessionRepository = patronActionSessionRepository;
+  }
+
+  public CompletableFuture<Result<LoanAndRelatedRecords>> saveCheckOutSessionRecord(LoanAndRelatedRecords records) {
+    String patronId = records.getUserId();
+    String loanId = records.getLoan().getId();
+
+    PatronSessionRecord patronSessionRecord =
+      new PatronSessionRecord(UUID.randomUUID().toString(),
+        patronId, loanId, PatronActionType.CHECK_OUT);
+
+    return patronActionSessionRepository.create(patronSessionRecord)
+      .thenApply(mapResult(v -> records));
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionType.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionType.java
@@ -2,11 +2,13 @@ package org.folio.circulation.domain.notice.session;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public enum PatronActionType {
 
   CHECK_OUT("Check-out"),
-  CHECK_IN("Check-in");
+  CHECK_IN("Check-in"),
+  UNKNOWN("");
 
   private String representation;
 
@@ -18,10 +20,23 @@ public enum PatronActionType {
     return representation;
   }
 
+  public boolean isValid() {
+    return this != UNKNOWN;
+  }
+
   public static PatronActionType from(String value) {
     return Arrays.stream(values())
-      .filter(v -> Objects.equals(v.getRepresentation(), (value)))
+      .filter(type -> Objects.equals(type.getRepresentation(), value))
       .findFirst()
-      .orElseThrow(() -> new IllegalArgumentException("Invalid patron action type representation: " + value));
+      .orElse(UNKNOWN);
+  }
+
+  public static String invalidActionTypeErrorMessage() {
+    String joinedRepresentations = Arrays.stream(values())
+      .filter(PatronActionType::isValid)
+      .map(type -> type.representation)
+      .collect(Collectors.joining(", "));
+
+    return "Patron action type must be " + joinedRepresentations;
   }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionType.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionType.java
@@ -1,0 +1,27 @@
+package org.folio.circulation.domain.notice.session;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public enum PatronActionType {
+
+  CHECK_OUT("Check-out"),
+  CHECK_IN("Check-in");
+
+  private String representation;
+
+  PatronActionType(String representation) {
+    this.representation = representation;
+  }
+
+  public String getRepresentation() {
+    return representation;
+  }
+
+  public static PatronActionType from(String value) {
+    return Arrays.stream(values())
+      .filter(v -> Objects.equals(v.getRepresentation(), (value)))
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException("Invalid patron action type representation: " + value));
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionType.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionType.java
@@ -2,13 +2,12 @@ package org.folio.circulation.domain.notice.session;
 
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 public enum PatronActionType {
 
   CHECK_OUT("Check-out"),
-  CHECK_IN("Check-in"),
-  UNKNOWN("");
+  CHECK_IN("Check-in");
 
   private String representation;
 
@@ -20,23 +19,9 @@ public enum PatronActionType {
     return representation;
   }
 
-  public boolean isValid() {
-    return this != UNKNOWN;
-  }
-
-  public static PatronActionType from(String value) {
+  public static Optional<PatronActionType> from(String value) {
     return Arrays.stream(values())
       .filter(type -> Objects.equals(type.getRepresentation(), value))
-      .findFirst()
-      .orElse(UNKNOWN);
-  }
-
-  public static String invalidActionTypeErrorMessage() {
-    String joinedRepresentations = Arrays.stream(values())
-      .filter(PatronActionType::isValid)
-      .map(type -> type.representation)
-      .collect(Collectors.joining(", "));
-
-    return "Patron action type must be " + joinedRepresentations;
+      .findFirst();
   }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronSessionRecord.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronSessionRecord.java
@@ -2,30 +2,32 @@ package org.folio.circulation.domain.notice.session;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.UUID;
+
 public class PatronSessionRecord {
 
-  private final String id;
-  private final String patronId;
-  private final String loanId;
+  private final UUID id;
+  private final UUID patronId;
+  private final UUID loanId;
   private final PatronActionType actionType;
 
-  public PatronSessionRecord(String id, String patronId,
-                             String loanId, PatronActionType actionType) {
+  public PatronSessionRecord(UUID id, UUID patronId,
+                             UUID loanId, PatronActionType actionType) {
     this.id = requireNonNull(id);
     this.patronId = requireNonNull(patronId);
     this.loanId = requireNonNull(loanId);
     this.actionType = requireNonNull(actionType);
   }
 
-  public String getId() {
+  public UUID getId() {
     return id;
   }
 
-  public String getPatronId() {
+  public UUID getPatronId() {
     return patronId;
   }
 
-  public String getLoanId() {
+  public UUID getLoanId() {
     return loanId;
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronSessionRecord.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronSessionRecord.java
@@ -1,0 +1,35 @@
+package org.folio.circulation.domain.notice.session;
+
+import static java.util.Objects.requireNonNull;
+
+public class PatronSessionRecord {
+
+  private final String id;
+  private final String patronId;
+  private final String loanId;
+  private final PatronActionType actionType;
+
+  public PatronSessionRecord(String id, String patronId,
+                             String loanId, PatronActionType actionType) {
+    this.id = requireNonNull(id);
+    this.patronId = requireNonNull(patronId);
+    this.loanId = requireNonNull(loanId);
+    this.actionType = requireNonNull(actionType);
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getPatronId() {
+    return patronId;
+  }
+
+  public String getLoanId() {
+    return loanId;
+  }
+
+  public PatronActionType getActionType() {
+    return actionType;
+  }
+}

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -26,6 +26,7 @@ import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.UserRepository;
 import org.folio.circulation.domain.notice.schedule.DueDateScheduledNoticeService;
 import org.folio.circulation.domain.notice.schedule.ScheduledNoticesRepository;
+import org.folio.circulation.domain.notice.session.PatronActionSessionService;
 import org.folio.circulation.domain.policy.LoanPolicyRepository;
 import org.folio.circulation.domain.policy.PatronNoticePolicyRepository;
 import org.folio.circulation.domain.representations.LoanProperties;
@@ -97,7 +98,6 @@ public class CheckOutByBarcodeResource extends Resource {
     final LoanService loanService = new LoanService(clients);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final PatronNoticePolicyRepository patronNoticePolicyRepository = new PatronNoticePolicyRepository(clients);
-    final LoanNoticeSender loanNoticeSender = LoanNoticeSender.using(clients);
     final PatronGroupRepository patronGroupRepository = new PatronGroupRepository(clients);
     final ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
     final ScheduledNoticesRepository scheduledNoticesRepository = ScheduledNoticesRepository.using(clients);
@@ -137,6 +137,9 @@ public class CheckOutByBarcodeResource extends Resource {
 
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
 
+    final PatronActionSessionService patronActionSessionService =
+      PatronActionSessionService.using(clients);
+
     completedFuture(succeeded(new LoanAndRelatedRecords(loan)))
       .thenApply(servicePointOfCheckoutPresentValidator::refuseCheckOutWhenServicePointIsNotPresent)
       .thenCombineAsync(userRepository.getUserByBarcode(userBarcode), this::addUser)
@@ -160,7 +163,7 @@ public class CheckOutByBarcodeResource extends Resource {
       .thenComposeAsync(r -> r.after(loanService::truncateLoanWhenItemRecalled))
       .thenComposeAsync(r -> r.after(patronGroupRepository::findPatronGroupForLoanAndRelatedRecords))
       .thenComposeAsync(r -> r.after(loanRepository::createLoan))
-      .thenApply(r -> r.next(loanNoticeSender::sendCheckOutPatronNotice))
+      .thenComposeAsync(r -> r.after(patronActionSessionService::saveCheckOutSessionRecord))
       .thenApply(r -> r.next(scheduledNoticeService::scheduleNoticesForLoanDueDate))
       .thenApply(r -> r.map(LoanAndRelatedRecords::getLoan))
       .thenApply(r -> r.map(loanRepresentation::extendedLoan))

--- a/src/main/java/org/folio/circulation/resources/LoanNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/LoanNoticeSender.java
@@ -35,11 +35,6 @@ public class LoanNoticeSender {
     this.loanPolicyRepository = loanPolicyRepository;
   }
 
-  public Result<LoanAndRelatedRecords> sendCheckOutPatronNotice(LoanAndRelatedRecords records) {
-    sendLoanNotice(records, NoticeEventType.CHECK_OUT);
-    return succeeded(records);
-  }
-
   public Result<LoanAndRelatedRecords> sendRenewalPatronNotice(LoanAndRelatedRecords records) {
     sendLoanNotice(records, NoticeEventType.RENEWED);
     return succeeded(records);

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -39,6 +39,7 @@ public class Clients {
   private final CollectionResourceClient scheduledNoticesStorageClient;
   private final CollectionResourceClient accountsStorageClient;
   private final CollectionResourceClient anonymizeStorageLoansClient;
+  private final CollectionResourceClient patronActionSessionsStorageClient;
 
   public static Clients create(WebContext context, HttpClient httpClient) {
     return new Clients(context.createHttpClient(httpClient), context);
@@ -77,6 +78,7 @@ public class Clients {
       configurationStorageClient = createConfigurationStorageClient(client, context);
       scheduledNoticesStorageClient = createScheduledNoticesStorageClient(client, context);
       accountsStorageClient = createAccountsStorageClient(client,context);
+      patronActionSessionsStorageClient = createPatronActionSessionsStorageClient(client,context);
     }
     catch(MalformedURLException e) {
       throw new InvalidOkapiLocationException(context.getOkapiLocation(), e);
@@ -203,6 +205,10 @@ public class Clients {
 
   public CollectionResourceClient accountsStorageClient() {
     return accountsStorageClient;
+  }
+
+  public CollectionResourceClient patronActionSessionsStorageClient() {
+    return patronActionSessionsStorageClient;
   }
 
   private static CollectionResourceClient getCollectionResourceClient(
@@ -459,5 +465,12 @@ public class Clients {
     WebContext context)
     throws MalformedURLException {
     return getCollectionResourceClient(client, context, "/accounts");
+  }
+
+  private CollectionResourceClient createPatronActionSessionsStorageClient(
+    OkapiHttpClient client,
+    WebContext context)
+    throws MalformedURLException {
+    return getCollectionResourceClient(client, context, "/patron-action-session-storage/patron-action-sessions");
   }
 }

--- a/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
+++ b/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
@@ -139,7 +139,9 @@ public class CheckoutWithRequestScenarioTests extends APITests {
       requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.inactiveNotice().getId());
 
-    loansFixture.checkOutByBarcode(smallAngryPlanet, usersFixture.steve());
+    DateTime loanDate = new DateTime(2019, 9, 20, 11, 32, 12, DateTimeZone.UTC);
+
+    loansFixture.checkOutByBarcode(smallAngryPlanet, usersFixture.steve(), loanDate);
 
     requestsClient.create(new RequestBuilder()
       .hold()
@@ -154,8 +156,6 @@ public class CheckoutWithRequestScenarioTests extends APITests {
       .by(james));
 
     loansFixture.checkInByBarcode(smallAngryPlanet);
-
-    final DateTime loanDate = new DateTime(2019, 9, 20, 11, 32, 12, DateTimeZone.UTC);
 
     final IndividualResource loan = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder()
       .forItem(smallAngryPlanet)

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import api.support.fixtures.*;
 import org.folio.circulation.domain.representations.LoanProperties;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
@@ -27,6 +26,25 @@ import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import api.support.fixtures.AddressTypesFixture;
+import api.support.fixtures.CancellationReasonsFixture;
+import api.support.fixtures.CirculationRulesFixture;
+import api.support.fixtures.HoldingsFixture;
+import api.support.fixtures.InstancesFixture;
+import api.support.fixtures.ItemsFixture;
+import api.support.fixtures.LoanPoliciesFixture;
+import api.support.fixtures.LoanTypesFixture;
+import api.support.fixtures.LoansFixture;
+import api.support.fixtures.LocationsFixture;
+import api.support.fixtures.MaterialTypesFixture;
+import api.support.fixtures.NoticePoliciesFixture;
+import api.support.fixtures.PatronGroupsFixture;
+import api.support.fixtures.ProxyRelationshipsFixture;
+import api.support.fixtures.RequestPoliciesFixture;
+import api.support.fixtures.RequestsFixture;
+import api.support.fixtures.ScheduledNoticeProcessingClient;
+import api.support.fixtures.ServicePointsFixture;
+import api.support.fixtures.UsersFixture;
 import api.support.http.InterfaceUrls;
 import api.support.http.ResourceClient;
 import io.vertx.core.json.JsonObject;
@@ -94,6 +112,9 @@ public abstract class APITests {
 
   protected final ResourceClient scheduledNoticesClient =
     ResourceClient.forScheduledNotices(client);
+
+  protected final ResourceClient patronSessionRecordsClient =
+    ResourceClient.forPatronSessionRecords(client);
 
   protected final ServicePointsFixture servicePointsFixture
     = new ServicePointsFixture(servicePointsClient);

--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -274,6 +274,14 @@ public class FakeOkapi extends AbstractVerticle {
       .create()
       .register(router);
 
+
+    new FakeStorageModuleBuilder()
+      .withRecordName("patron action session")
+      .withCollectionPropertyName("patronActionSessions")
+      .withRootPath("/patron-action-session-storage/patron-action-sessions")
+      .create()
+      .register(router);
+
     server.requestHandler(router::accept)
       .listen(PORT_TO_USE, result -> {
         if (result.succeeded()) {

--- a/src/test/java/api/support/http/InterfaceUrls.java
+++ b/src/test/java/api/support/http/InterfaceUrls.java
@@ -181,6 +181,10 @@ public class InterfaceUrls {
     return APITestContext.viaOkapiModuleUrl("/scheduled-notice-storage/scheduled-notices" + subPath);
   }
 
+  static URL patronActionSessionsUrl(String subPath) {
+    return APITestContext.viaOkapiModuleUrl("/patron-action-session-storage/patron-action-sessions" + subPath);
+  }
+
   static URL configurationUrl(String subPath) {
     return APITestContext.viaOkapiModuleUrl("/configurations/entries" + subPath);
   }

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -191,6 +191,11 @@ public class ResourceClient {
       "scheduled notice", "scheduledNotices");
   }
 
+  public static ResourceClient forPatronSessionRecords(OkapiHttpClient client) {
+    return new ResourceClient(client, InterfaceUrls::patronActionSessionsUrl,
+      "patron session records", "patronActionSessions");
+  }
+
   public static ResourceClient forConfiguration(OkapiHttpClient client) {
     return new ResourceClient(client, InterfaceUrls::configurationUrl,
       "configuration entries", "configs");


### PR DESCRIPTION
## Purpose
To save patron session record at the time of check-out
Resolves: [CIRC-431](https://issues.folio.org/browse/CIRC-431)

## Approach

- remove sending patron notice at the time of check-out
- remove related test
- implement `PatronActionSessionService` and `PatronActionSessionRepository` to save session records
- use `PatronActionSessionService` in `CheckOutByBarcodeResource`

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [x] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.