### PR TITLE
CIRC-200: Implement period falling logic for rolling renew

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -46,6 +46,9 @@ public class LoanPolicy {
   public static final String CAN_NOT_RENEW_ITEM_ERROR =
     "Items with this loan policy cannot be renewed when there is an active, pending hold request";
 
+  public static final String FIXED_POLICY_HAS_ALTERNATE_PERIOD =
+    "Item's loan policy has fixed profile but alternative renewal period for holds is specified";
+
   private static final String INTERVAL_ID = "intervalId";
   private static final String DURATION = "duration";
   private static final String ALTERNATE_CHECKOUT_LOAN_PERIOD_KEY = "alternateCheckoutLoanPeriod";
@@ -116,6 +119,11 @@ public class LoanPolicy {
           errors.add(loanPolicyValidationError(CAN_NOT_RENEW_ITEM_ERROR));
           return failedValidation(errors);
         }
+        if (isFixed(getLoansPolicy()) && hasAlternateRenewalLoanPeriodForHolds()) {
+          errors.add(loanPolicyValidationError(FIXED_POLICY_HAS_ALTERNATE_PERIOD));
+          return failedValidation(errors);
+        }
+
         isRenewalWithHoldRequest = true;
       }
 

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -9,6 +9,7 @@ import static org.folio.circulation.support.JsonPropertyFetcher.getNestedInteger
 import static org.folio.circulation.support.JsonPropertyFetcher.getNestedObjectProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.Result.failed;
 import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.results.CommonFailures.failedDueToServerError;
@@ -29,6 +30,7 @@ import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.domain.RequestType;
 import org.folio.circulation.support.ClockManager;
 import org.folio.circulation.support.Result;
+import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
@@ -120,8 +122,7 @@ public class LoanPolicy {
           return failedValidation(errors);
         }
         if (isFixed(getLoansPolicy()) && hasAlternateRenewalLoanPeriodForHolds()) {
-          errors.add(loanPolicyValidationError(FIXED_POLICY_HAS_ALTERNATE_PERIOD));
-          return failedValidation(errors);
+          return failed(new ServerErrorFailure(FIXED_POLICY_HAS_ALTERNATE_PERIOD));
         }
 
         isRenewalWithHoldRequest = true;

--- a/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
+++ b/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
@@ -9,14 +9,19 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeConstants.SEPTEMBER;
 
 import java.net.MalformedURLException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import org.folio.circulation.support.ClockManager;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.junit.After;
 import org.junit.Test;
 
 import api.support.APITests;
@@ -27,6 +32,11 @@ import api.support.builders.RequestBuilder;
 import api.support.http.InventoryItemResource;
 
 public class CheckoutWithRequestScenarioTests extends APITests {
+
+  @After
+  public void restoreClocks() {
+    ClockManager.getClockManager().setClock(Clock.systemUTC());
+  }
 
   @Test
   public void canCheckoutPagedItem()
@@ -64,6 +74,14 @@ public class CheckoutWithRequestScenarioTests extends APITests {
     final IndividualResource charlotte = usersFixture.charlotte();
     final IndividualResource james = usersFixture.james();
     final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+
+    DateTime fakeNow = DateTime.now(DateTimeZone.UTC)
+      .withYear(2019)
+      .withMonthOfYear(SEPTEMBER)
+      .withDayOfMonth(1);
+    // Set the current date time
+    ClockManager.getClockManager()
+      .setClock(Clock.fixed(Instant.ofEpochMilli(fakeNow.getMillis()), ZoneOffset.UTC));
 
     final IndividualResource policy = loanPoliciesFixture.create(new LoanPolicyBuilder()
       .withName("Limited loan period for items with hold requests")
@@ -120,6 +138,14 @@ public class CheckoutWithRequestScenarioTests extends APITests {
     final IndividualResource charlotte = usersFixture.charlotte();
     final IndividualResource james = usersFixture.james();
     final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+
+    DateTime now = new DateTime(DateTimeZone.UTC)
+      .withYear(2019)
+      .withMonthOfYear(9)
+      .withDayOfMonth(1);
+
+    ClockManager.getClockManager()
+      .setClock(Clock.fixed(Instant.ofEpochMilli(now.getMillis()), ZoneOffset.UTC));
 
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
       .withName("Fixed Due Date Schedule")

--- a/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
+++ b/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
@@ -9,19 +9,14 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeConstants.SEPTEMBER;
 
 import java.net.MalformedURLException;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import org.folio.circulation.support.ClockManager;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.After;
 import org.junit.Test;
 
 import api.support.APITests;
@@ -32,11 +27,6 @@ import api.support.builders.RequestBuilder;
 import api.support.http.InventoryItemResource;
 
 public class CheckoutWithRequestScenarioTests extends APITests {
-
-  @After
-  public void restoreClocks() {
-    ClockManager.getClockManager().setClock(Clock.systemUTC());
-  }
 
   @Test
   public void canCheckoutPagedItem()
@@ -74,14 +64,6 @@ public class CheckoutWithRequestScenarioTests extends APITests {
     final IndividualResource charlotte = usersFixture.charlotte();
     final IndividualResource james = usersFixture.james();
     final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
-
-    DateTime fakeNow = DateTime.now(DateTimeZone.UTC)
-      .withYear(2019)
-      .withMonthOfYear(SEPTEMBER)
-      .withDayOfMonth(1);
-    // Set the current date time
-    ClockManager.getClockManager()
-      .setClock(Clock.fixed(Instant.ofEpochMilli(fakeNow.getMillis()), ZoneOffset.UTC));
 
     final IndividualResource policy = loanPoliciesFixture.create(new LoanPolicyBuilder()
       .withName("Limited loan period for items with hold requests")
@@ -138,14 +120,6 @@ public class CheckoutWithRequestScenarioTests extends APITests {
     final IndividualResource charlotte = usersFixture.charlotte();
     final IndividualResource james = usersFixture.james();
     final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
-
-    DateTime now = new DateTime(DateTimeZone.UTC)
-      .withYear(2019)
-      .withMonthOfYear(9)
-      .withDayOfMonth(1);
-
-    ClockManager.getClockManager()
-      .setClock(Clock.fixed(Instant.ofEpochMilli(now.getMillis()), ZoneOffset.UTC));
 
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
       .withName("Fixed Due Date Schedule")

--- a/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
+++ b/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
@@ -31,7 +31,6 @@ import api.support.builders.FixedDueDateSchedulesBuilder;
 import api.support.builders.LoanPolicyBuilder;
 import api.support.builders.RequestBuilder;
 import api.support.http.InventoryItemResource;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class RequestsAPILoanRenewalTests extends APITests {
@@ -603,14 +602,12 @@ public class RequestsAPILoanRenewalTests extends APITests {
       .withPickupServicePointId(servicePointsFixture.cd1().getId())
       .by(usersFixture.charlotte()));
 
-    Response response = loansFixture.attemptRenewal(smallAngryPlanet, rebecca);
+    Response response = loansFixture.attemptRenewal(500, smallAngryPlanet, rebecca);
 
-    assertThat(response.getStatusCode(), is(422));
-
-    JsonArray errors = response.getJson().getJsonArray("errors");
-    assertThat(errors.size(), is(1));
-    assertThat(errors.getJsonObject(0).getString("message"),
-      is("Item's loan policy has fixed profile but alternative renewal period for holds is specified"));
+    assertThat(
+      response.getBody(),
+      is("Item's loan policy has fixed profile but alternative renewal period for holds is specified")
+    );
   }
 
   private void loanPolicyWithRollingProfileAndRenewingIsForbiddenWhenHoldIsPending()

--- a/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
+++ b/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
@@ -31,6 +31,7 @@ import api.support.builders.FixedDueDateSchedulesBuilder;
 import api.support.builders.LoanPolicyBuilder;
 import api.support.builders.RequestBuilder;
 import api.support.http.InventoryItemResource;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class RequestsAPILoanRenewalTests extends APITests {
@@ -558,6 +559,58 @@ public class RequestsAPILoanRenewalTests extends APITests {
 
     assertThat(response.getJson(), hasErrorWith(hasMessage(ITEMS_CANNOT_BE_RENEWED_MSG)));
     assertThat(response.getJson(), hasErrorWith(hasMessage(EXPECTED_REASON_LOAN_IS_NOT_LOANABLE)));
+  }
+
+  @Test
+  public void validationErrorWhenRenewalPeriodForHoldsSpecifiedForFixedPolicy()
+    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+    final DateTime from = DateTime.now(DateTimeZone.UTC).minusMonths(3);
+    final DateTime to = DateTime.now(DateTimeZone.UTC).plusMonths(3);
+    final DateTime dueDate = to.plusDays(15);
+
+    final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource rebecca = usersFixture.rebecca();
+
+    loansFixture.checkOutByBarcode(smallAngryPlanet, rebecca);
+
+    IndividualResource schedule = loanPoliciesFixture.createSchedule(new FixedDueDateSchedulesBuilder()
+      .withId(UUID.randomUUID())
+      .withName("Can circulate schedule")
+      .withDescription("descr")
+      .addSchedule(new FixedDueDateSchedule(from, to, dueDate))
+    );
+
+    JsonObject holds = new JsonObject()
+      .put("renewItemsWithRequest", true)
+      .put("alternateRenewalLoanPeriod", Period.weeks(10).asJson());
+
+    IndividualResource fixedPolicy = loanPoliciesFixture.create(new LoanPolicyBuilder()
+      .fixed(schedule.getId())
+      .withName("Fixed with holds")
+      .withDescription("Fixed policy with holds")
+      .withHolds(holds)
+    );
+
+    useLoanPolicyAsFallback(
+      fixedPolicy.getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.activeNotice().getId()
+    );
+
+    requestsFixture.place(new RequestBuilder()
+      .hold()
+      .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
+      .by(usersFixture.charlotte()));
+
+    Response response = loansFixture.attemptRenewal(smallAngryPlanet, rebecca);
+
+    assertThat(response.getStatusCode(), is(422));
+
+    JsonArray errors = response.getJson().getJsonArray("errors");
+    assertThat(errors.size(), is(1));
+    assertThat(errors.getJsonObject(0).getString("message"),
+      is("Item's loan policy has fixed profile but alternative renewal period for holds is specified"));
   }
 
   private void loanPolicyWithRollingProfileAndRenewingIsForbiddenWhenHoldIsPending()

--- a/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
+++ b/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
@@ -16,9 +16,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import api.support.builders.FixedDueDateSchedulesBuilder;
-import api.support.builders.LoanPolicyBuilder;
-
 import org.folio.circulation.domain.policy.LoanPolicy;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.http.client.IndividualResource;
@@ -29,6 +26,9 @@ import org.joda.time.Seconds;
 import org.junit.Test;
 
 import api.support.APITests;
+import api.support.builders.FixedDueDateSchedule;
+import api.support.builders.FixedDueDateSchedulesBuilder;
+import api.support.builders.LoanPolicyBuilder;
 import api.support.builders.RequestBuilder;
 import api.support.http.InventoryItemResource;
 import io.vertx.core.json.JsonObject;
@@ -112,19 +112,25 @@ public class RequestsAPILoanRenewalTests extends APITests {
     assertThat(message, is(LoanPolicy.CAN_NOT_RENEW_ITEM_ERROR));
   }
 
-
   @Test
-  public void allowRenewalLoanByBarcodeWhenProfileIsFixedFirstRequestInQueueIsHoldAndRenewingIsAllowedInLoanPolicy()
-    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
-
-    final DateTime expectedDueDate = DateTime.now(DateTimeZone.UTC).plusWeeks(3);
+  public void allowRenewalWithHoldsWhenProfileIsRollingUseLoanPeriod() throws Exception {
+    final int renewalPeriod = 90;
+    final DateTime expectedDueDate = DateTime.now(DateTimeZone.UTC).plusWeeks(renewalPeriod);
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource rebecca = usersFixture.rebecca();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet, rebecca);
 
+    final LoanPolicyBuilder rollingPolicy = new LoanPolicyBuilder()
+      .withName("Can Circulate Rolling with holding renewal only")
+      .withDescription("Can circulate item")
+      .withHolds(new JsonObject().put("renewItemsWithRequest", true))
+      .rolling(Period.weeks(renewalPeriod))
+      .unlimitedRenewals()
+      .renewFromSystemDate();
+
     useLoanPolicyAsFallback(
-      loanPoliciesFixture.canCirculateFixed().getId(),
+      loanPoliciesFixture.create(rollingPolicy).getId(),
       requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
@@ -144,6 +150,47 @@ public class RequestsAPILoanRenewalTests extends APITests {
     assertThat(response.getJson().getString("dueDate"),
       is(withinSecondsAfter(Seconds.seconds(15), expectedDueDate)));
   }
+
+  @Test
+  public void allowRenewalWithHoldsWhenProfileIsRollingUseRenewalPeriod() throws Exception {
+    final int renewalPeriod = 60;
+    final DateTime expectedDueDate = DateTime.now(DateTimeZone.UTC).plusWeeks(renewalPeriod);
+    final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource rebecca = usersFixture.rebecca();
+
+    loansFixture.checkOutByBarcode(smallAngryPlanet, rebecca);
+
+    final LoanPolicyBuilder rollingPolicy = new LoanPolicyBuilder()
+      .withName("Can Circulate Rolling with holding renewals policy")
+      .withDescription("Can circulate item")
+      .withHolds(new JsonObject().put("renewItemsWithRequest", true))
+      .rolling(Period.weeks(90))
+      .unlimitedRenewals()
+      .renewFromSystemDate()
+      .renewWith(Period.weeks(renewalPeriod));
+
+    useLoanPolicyAsFallback(
+      loanPoliciesFixture.create(rollingPolicy).getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.activeNotice().getId()
+    );
+
+    requestsFixture.place(new RequestBuilder()
+      .hold()
+      .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
+      .by(usersFixture.charlotte()));
+
+    IndividualResource response = loansFixture.renewLoan(smallAngryPlanet, rebecca);
+
+    assertThat(response.getJson().getString("action"), is("renewed"));
+    // Assert no validation issues, so the renewal is allowed
+    assertThat(response.getJson().getJsonArray("errors"), nullValue());
+
+    assertThat(response.getJson().getString("dueDate"),
+      is(withinSecondsAfter(Seconds.seconds(15), expectedDueDate)));
+  }
+
 
   @Test
   public void forbidRenewalLoanByBarcodeWhenLoanProfileIsFixedFirstRequestInQueueIsHoldAndRenewingIsDisallowedInLoanPolicy()
@@ -269,16 +316,37 @@ public class RequestsAPILoanRenewalTests extends APITests {
   }
 
   @Test
-  public void allowRenewalLoanByIdWhenLoanProfileIsFixedFirstRequestInQueueIsHoldAndRenewingIsAllowedInLoanPolicy()
+  public void allowRenewalWithHoldsWhenProfileIsFixedUseRenewalSchedule()
     throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+    final DateTime from = DateTime.now(DateTimeZone.UTC).minusMonths(3);
+    final DateTime to = DateTime.now(DateTimeZone.UTC).plusMonths(3);
+    final DateTime dueDate = to.plusDays(15);
 
     final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource rebecca = usersFixture.rebecca();
 
     loansFixture.checkOutByBarcode(smallAngryPlanet, rebecca);
 
+    IndividualResource schedule = loanPoliciesFixture.createSchedule(new FixedDueDateSchedulesBuilder()
+      .withId(UUID.randomUUID())
+      .withName("Can circulate schedule")
+      .withDescription("descr")
+      .addSchedule(new FixedDueDateSchedule(from, to, dueDate))
+    );
+
+    JsonObject holds = new JsonObject()
+      .put("renewItemsWithRequest", true);
+
+    IndividualResource fixedPolicy = loanPoliciesFixture.create(new LoanPolicyBuilder()
+      .fixed(loanPoliciesFixture.createExampleFixedDueDateSchedule().getId())
+      .renewWith(schedule.getId())
+      .withName("Fixed with holds")
+      .withDescription("Fixed policy with holds")
+      .withHolds(holds)
+    );
+
     useLoanPolicyAsFallback(
-      loanPoliciesFixture.canCirculateFixed().getId(),
+      fixedPolicy.getId(),
       requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId()
     );
@@ -292,7 +360,57 @@ public class RequestsAPILoanRenewalTests extends APITests {
     IndividualResource response = loansFixture.renewLoanById(smallAngryPlanet, rebecca);
 
     assertThat(response.getJson().getString("action"), is("renewed"));
+    assertThat(response.getJson().getString("dueDate"),
+      is(withinSecondsAfter(Seconds.seconds(15), dueDate)));
    }
+
+  @Test
+  public void allowRenewalWithHoldsWhenProfileIsFixedUseLoanSchedule()
+    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+    final DateTime from = DateTime.now(DateTimeZone.UTC).minusMonths(3);
+    final DateTime to = DateTime.now(DateTimeZone.UTC).plusMonths(3);
+    final DateTime dueDate = to.plusDays(15);
+
+    final InventoryItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource rebecca = usersFixture.rebecca();
+
+    loansFixture.checkOutByBarcode(smallAngryPlanet, rebecca);
+
+    IndividualResource schedule = loanPoliciesFixture.createSchedule(new FixedDueDateSchedulesBuilder()
+      .withId(UUID.randomUUID())
+      .withName("Can circulate schedule")
+      .withDescription("descr")
+      .addSchedule(new FixedDueDateSchedule(from, to, dueDate))
+    );
+
+    JsonObject holds = new JsonObject()
+      .put("renewItemsWithRequest", true);
+
+    IndividualResource fixedPolicy = loanPoliciesFixture.create(new LoanPolicyBuilder()
+      .fixed(schedule.getId())
+      .withName("Fixed with holds")
+      .withDescription("Fixed policy with holds")
+      .withHolds(holds)
+    );
+
+    useLoanPolicyAsFallback(
+      fixedPolicy.getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.activeNotice().getId()
+    );
+
+    requestsFixture.place(new RequestBuilder()
+      .hold()
+      .forItem(smallAngryPlanet)
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
+      .by(usersFixture.charlotte()));
+
+    IndividualResource response = loansFixture.renewLoanById(smallAngryPlanet, rebecca);
+
+    assertThat(response.getJson().getString("action"), is("renewed"));
+    assertThat(response.getJson().getString("dueDate"),
+      is(withinSecondsAfter(Seconds.seconds(15), dueDate)));
+  }
 
   @Test
   public void allowRenewalOverrideWhenFirstRequestIsRecall()

--- a/src/test/java/api/support/builders/LoanPolicyBuilder.java
+++ b/src/test/java/api/support/builders/LoanPolicyBuilder.java
@@ -505,7 +505,7 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       this.alternateCheckoutLoanPeriod);
   }
 
-  public Builder renewWith(UUID fixedDueDateScheduleId) {
+  public LoanPolicyBuilder renewWith(UUID fixedDueDateScheduleId) {
     if(!Objects.equals(profile, "Fixed")) {
       throw new IllegalArgumentException("Can only be used with fixed profile");
     }


### PR DESCRIPTION
CIRC-200: Get Alternate Renewal Period For Items With Pending Hold Request - 2nd iteration - [See comment](https://issues.folio.org/browse/CIRC-200?focusedCommentId=61428&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-61428)

## Purpose
* Implement period falling logic for rolling policies, so the period priority is following (for item with pending hold request in the queue):
  1. Period from holds section;
  1. Period from renewals section;
  1. Period from loans section.
* Agreed do not use `Alternate loan period at renewal for items with an active, pending hold request` for fixed policies, so if renewal for items with requests is true, then we will chose FDDS from either:
  1. From renewals section;
  1. From loans section.


## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.

Related PR: https://github.com/folio-org/mod-circulation-storage/pull/207
