### PR TITLE
[CIRC-492] Fix failing tests

### DIFF
--- a/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
+++ b/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
@@ -139,7 +139,9 @@ public class CheckoutWithRequestScenarioTests extends APITests {
       requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.inactiveNotice().getId());
 
-    loansFixture.checkOutByBarcode(smallAngryPlanet, usersFixture.steve());
+    DateTime loanDate = new DateTime(2019, 9, 20, 11, 32, 12, DateTimeZone.UTC);
+
+    loansFixture.checkOutByBarcode(smallAngryPlanet, usersFixture.steve(), loanDate);
 
     requestsClient.create(new RequestBuilder()
       .hold()
@@ -154,8 +156,6 @@ public class CheckoutWithRequestScenarioTests extends APITests {
       .by(james));
 
     loansFixture.checkInByBarcode(smallAngryPlanet);
-
-    final DateTime loanDate = new DateTime(2019, 9, 20, 11, 32, 12, DateTimeZone.UTC);
 
     final IndividualResource loan = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder()
       .forItem(smallAngryPlanet)

--- a/src/test/java/api/requests/RequestScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/requests/RequestScheduledNoticesProcessingTests.java
@@ -104,12 +104,15 @@ public class RequestScheduledNoticesProcessingTests extends APITests {
       .until(scheduledNoticesClient::getAll, hasSize(1));
 
     //close request
-    requestsClient.replace(request.getId(),
-      request.getJson().put("status", "Closed - Unfilled"));
+    IndividualResource requestInStorage = requestsStorageClient.get(request);
+    requestsStorageClient.replace(request.getId(),
+      requestInStorage.getJson().put("status", "Closed - Unfilled"));
+
     scheduledNoticeProcessingClient.runRequestNoticesProcessing();
-    List<JsonObject> notices = patronNoticesClient.getAll();
 
     assertThat(scheduledNoticesClient.getAll(), hasSize(0));
+
+    List<JsonObject> notices = patronNoticesClient.getAll();
     assertThat(notices, hasSize(1));
     assertThat(notices.get(0), getTemplateContextMatcher(templateId, request));
   }


### PR DESCRIPTION
## Purpose
Fix failing API tests
Resolves: [CIRC-492](https://issues.folio.org/browse/CIRC-492)

## Approach
- `checkingOutWithHoldRequestAppliesAlternatePeriodAndScheduledForFixedPolicy` test fails due to the fact the **fixed due to date schedule** was hardcoded to September, but **loan date** was taken as now (just not specified in check-in request).
- `aUponAtRequestExpirationNoticeShouldBeSentAndDeletedWhenRequestExpirationDateHasPassed` fails because request was closed using `mod-circulation` API instead of  `mod-circulation-storage` API;


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
 