### PR TITLE
CIRC-437 [Spike] Delivery requests: request processing once an item is checked in

### DIFF
--- a/src/main/java/org/folio/circulation/domain/CheckOutByBarcodeCommand.java
+++ b/src/main/java/org/folio/circulation/domain/CheckOutByBarcodeCommand.java
@@ -1,0 +1,178 @@
+package org.folio.circulation.domain;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import static org.folio.circulation.domain.representations.CheckOutByBarcodeRequest.ITEM_BARCODE;
+import static org.folio.circulation.domain.representations.CheckOutByBarcodeRequest.PROXY_USER_BARCODE;
+import static org.folio.circulation.domain.representations.CheckOutByBarcodeRequest.SERVICE_POINT_ID;
+import static org.folio.circulation.domain.representations.CheckOutByBarcodeRequest.USER_BARCODE;
+import static org.folio.circulation.support.Result.succeeded;
+import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.vertx.core.json.JsonObject;
+
+import org.folio.circulation.domain.notice.schedule.DueDateScheduledNoticeService;
+import org.folio.circulation.domain.notice.schedule.ScheduledNoticesRepository;
+import org.folio.circulation.domain.policy.LoanPolicyRepository;
+import org.folio.circulation.domain.policy.PatronNoticePolicyRepository;
+import org.folio.circulation.domain.representations.CheckOutByBarcodeRequest;
+import org.folio.circulation.domain.validation.AlreadyCheckedOutValidator;
+import org.folio.circulation.domain.validation.ExistingOpenLoanValidator;
+import org.folio.circulation.domain.validation.InactiveUserValidator;
+import org.folio.circulation.domain.validation.ItemMissingValidator;
+import org.folio.circulation.domain.validation.ItemNotFoundValidator;
+import org.folio.circulation.domain.validation.ProxyRelationshipValidator;
+import org.folio.circulation.domain.validation.RequestedByAnotherPatronValidator;
+import org.folio.circulation.domain.validation.ServicePointOfCheckoutPresentValidator;
+import org.folio.circulation.resources.CheckOutStrategy;
+import org.folio.circulation.resources.LoanNoticeSender;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.ItemRepository;
+import org.folio.circulation.support.Result;
+
+public class CheckOutByBarcodeCommand {
+
+  private Clients clients;
+  private CheckOutStrategy checkOutStrategy;
+
+  private JsonObject jsonRequest;
+  private CheckOutByBarcodeRequest request;
+
+
+  public CheckOutByBarcodeCommand(CheckOutStrategy checkOutStrategy, Clients clients) {
+    this.checkOutStrategy = checkOutStrategy;
+    this.clients = clients;
+  }
+
+  public CompletableFuture<Result<Loan>> execute(Loan loan, JsonObject jsonRequest) {
+    this.request = CheckOutByBarcodeRequest.from(jsonRequest);
+    this.jsonRequest = jsonRequest;
+
+    return prepare(succeeded(new LoanAndRelatedRecords(loan)))
+            .thenCompose(this::validate)
+            .thenCompose(this::doWork)
+            .thenCompose(this::finalize)
+            .thenApply(this::getResult);
+  }
+
+  private CompletableFuture<Result<LoanAndRelatedRecords>> prepare(Result<LoanAndRelatedRecords> loanAndRelatedRecords) {
+    UserRepository userRepository = new UserRepository(clients);
+    ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
+    RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
+    ConfigurationRepository configurationRepository= new ConfigurationRepository(clients);
+
+    return completedFuture(loanAndRelatedRecords)
+      .thenCombineAsync(userRepository.getUserByBarcode(request.getUserBarcode()), this::addUser)
+      .thenCombineAsync(userRepository.getProxyUserByBarcode(request.getProxyUserBarcode()), this::addProxyUser)
+      .thenCombineAsync(itemRepository.fetchByBarcode(request.getItemBarcode()), this::addItem)
+      .thenComposeAsync(r -> r.after(requestQueueRepository::get))
+      .thenCompose(r -> r.combineAfter(configurationRepository::findTimeZoneConfiguration,
+        LoanAndRelatedRecords::withTimeZone));
+  }
+
+  private CompletableFuture<Result<LoanAndRelatedRecords>> validate(
+      Result<LoanAndRelatedRecords> loanAndRelatedRecords) {
+    ServicePointOfCheckoutPresentValidator servicePointOfCheckoutPresentValidator
+      = new ServicePointOfCheckoutPresentValidator(message ->
+      singleValidationError(message, SERVICE_POINT_ID, request.getServicePointId()));
+
+    InactiveUserValidator inactiveUserValidator = InactiveUserValidator.forUser(request.getUserBarcode());
+    InactiveUserValidator inactiveProxyUserValidator = InactiveUserValidator.forProxy(request.getProxyUserBarcode());
+
+    RequestedByAnotherPatronValidator requestedByAnotherPatronValidator = new RequestedByAnotherPatronValidator(
+      message -> singleValidationError(message, USER_BARCODE, request.getUserBarcode()));
+
+    AlreadyCheckedOutValidator alreadyCheckedOutValidator = new AlreadyCheckedOutValidator(
+      message -> singleValidationError(message, ITEM_BARCODE, request.getItemBarcode()));
+
+    ItemNotFoundValidator itemNotFoundValidator = new ItemNotFoundValidator(
+      () -> singleValidationError(String.format("No item with barcode %s could be found", request.getItemBarcode()),
+        ITEM_BARCODE, request.getItemBarcode()));
+
+    ItemMissingValidator itemMissingValidator = new ItemMissingValidator(
+      message -> singleValidationError(message, ITEM_BARCODE, request.getItemBarcode()));
+
+    LoanRepository loanRepository = new LoanRepository(clients);
+    ExistingOpenLoanValidator openLoanValidator = new ExistingOpenLoanValidator(
+      loanRepository, message -> singleValidationError(message, ITEM_BARCODE, request.getItemBarcode()));
+
+    ProxyRelationshipValidator proxyRelationshipValidator = new ProxyRelationshipValidator(
+      clients, () -> singleValidationError(
+      "Cannot check out item via proxy when relationship is invalid",
+      PROXY_USER_BARCODE, request.getProxyUserBarcode()));
+
+    return completedFuture(loanAndRelatedRecords)
+      .thenApply(servicePointOfCheckoutPresentValidator::refuseCheckOutWhenServicePointIsNotPresent)
+      .thenApply(inactiveUserValidator::refuseWhenUserIsInactive)
+      .thenApply(inactiveProxyUserValidator::refuseWhenUserIsInactive)
+      .thenApply(itemNotFoundValidator::refuseWhenItemNotFound)
+      .thenApply(alreadyCheckedOutValidator::refuseWhenItemIsAlreadyCheckedOut)
+      .thenApply(itemMissingValidator::refuseWhenItemIsMissing)
+      .thenComposeAsync(r -> r.after(proxyRelationshipValidator::refuseWhenInvalid))
+      .thenComposeAsync(r -> r.after(openLoanValidator::refuseWhenHasOpenLoan))
+      .thenApply(requestedByAnotherPatronValidator::refuseWhenRequestedByAnotherPatron);
+  }
+
+  private CompletableFuture<Result<LoanAndRelatedRecords>> doWork(
+      Result<LoanAndRelatedRecords> loanAndRelatedRecords) {
+    LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
+    UpdateRequestQueue requestQueueUpdate = UpdateRequestQueue.using(clients);
+    UpdateItem updateItem = new UpdateItem(clients);
+    LoanService loanService = new LoanService(clients);
+    PatronGroupRepository patronGroupRepository = new PatronGroupRepository(clients);
+    LoanRepository loanRepository = new LoanRepository(clients);
+
+    return completedFuture(loanAndRelatedRecords)
+      .thenComposeAsync(r -> r.after(loanPolicyRepository::lookupLoanPolicy))
+      .thenComposeAsync(r -> r.after(relatedRecords -> checkOutStrategy.checkOut(relatedRecords, jsonRequest, clients)))
+      .thenComposeAsync(r -> r.after(requestQueueUpdate::onCheckOut))
+      .thenComposeAsync(r -> r.after(updateItem::onCheckOut))
+      .thenComposeAsync(r -> r.after(loanService::truncateLoanWhenItemRecalled))
+      .thenComposeAsync(r -> r.after(patronGroupRepository::findPatronGroupForLoanAndRelatedRecords))
+      .thenComposeAsync(r -> r.after(loanRepository::createLoan));
+  }
+
+  private CompletableFuture<Result<LoanAndRelatedRecords>> finalize(
+      Result<LoanAndRelatedRecords> loanAndRelatedRecords) {
+    PatronNoticePolicyRepository patronNoticePolicyRepository = new PatronNoticePolicyRepository(clients);
+    LoanNoticeSender loanNoticeSender = LoanNoticeSender.using(clients);
+
+    ScheduledNoticesRepository scheduledNoticesRepository = ScheduledNoticesRepository.using(clients);
+    DueDateScheduledNoticeService scheduledNoticeService =
+      new DueDateScheduledNoticeService(scheduledNoticesRepository, patronNoticePolicyRepository);
+
+    return completedFuture(loanAndRelatedRecords)
+      .thenApply(r -> r.next(loanNoticeSender::sendCheckOutPatronNotice))
+      .thenApply(r -> r.next(scheduledNoticeService::scheduleNoticesForLoanDueDate));
+  }
+
+  private Result<Loan> getResult(Result<LoanAndRelatedRecords> loanAndRelatedRecords) {
+    return loanAndRelatedRecords.map(LoanAndRelatedRecords::getLoan);
+  }
+
+  private Result<LoanAndRelatedRecords> addProxyUser(
+    Result<LoanAndRelatedRecords> loanResult,
+    Result<User> getUserResult) {
+
+    return Result.combine(loanResult, getUserResult,
+      LoanAndRelatedRecords::withProxyingUser);
+  }
+
+  private Result<LoanAndRelatedRecords> addUser(
+    Result<LoanAndRelatedRecords> loanResult,
+    Result<User> getUserResult) {
+
+    return Result.combine(loanResult, getUserResult,
+      LoanAndRelatedRecords::withRequestingUser);
+  }
+
+  private Result<LoanAndRelatedRecords> addItem(
+    Result<LoanAndRelatedRecords> loanResult,
+    Result<Item> inventoryRecordsResult) {
+
+    return Result.combine(loanResult, inventoryRecordsResult,
+      LoanAndRelatedRecords::withItem);
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/representations/CheckOutByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/domain/representations/CheckOutByBarcodeRequest.java
@@ -8,7 +8,7 @@ public class CheckOutByBarcodeRequest {
   public static final String USER_BARCODE = "userBarcode";
   public static final String PROXY_USER_BARCODE = "proxyUserBarcode";
   public static final String SERVICE_POINT_ID = "servicePointId";
-  public static final String LOAD_DATE = "loanDate";
+  public static final String LOAN_DATE = "loanDate";
 
   private String itemBarcode;
   private String userBarcode;
@@ -31,7 +31,7 @@ public class CheckOutByBarcodeRequest {
     String userBarcode = request.getString(USER_BARCODE);
     String proxyUserBarcode = request.getString(PROXY_USER_BARCODE);
     String servicePointId = request.getString(SERVICE_POINT_ID);
-    String loanDate = request.getString(LOAD_DATE);
+    String loanDate = request.getString(LOAN_DATE);
 
     return new CheckOutByBarcodeRequest(itemBarcode, userBarcode, proxyUserBarcode, servicePointId, loanDate);
   }

--- a/src/main/java/org/folio/circulation/domain/representations/CheckOutByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/domain/representations/CheckOutByBarcodeRequest.java
@@ -1,10 +1,58 @@
 package org.folio.circulation.domain.representations;
 
+import io.vertx.core.json.JsonObject;
+
 public class CheckOutByBarcodeRequest {
-  private CheckOutByBarcodeRequest() { }
 
   public static final String ITEM_BARCODE = "itemBarcode";
   public static final String USER_BARCODE = "userBarcode";
   public static final String PROXY_USER_BARCODE = "proxyUserBarcode";
   public static final String SERVICE_POINT_ID = "servicePointId";
+  public static final String LOAD_DATE = "loanDate";
+
+  private String itemBarcode;
+  private String userBarcode;
+  private String proxyUserBarcode;
+  private String servicePointId;
+  private String loanDate;
+
+
+  private CheckOutByBarcodeRequest(String itemBarcode, String userBarcode, String proxyUserBarcode, String servicePointId,
+                                  String loanDate) {
+    this.itemBarcode = itemBarcode;
+    this.userBarcode = userBarcode;
+    this.proxyUserBarcode = proxyUserBarcode;
+    this.servicePointId = servicePointId;
+    this.loanDate = loanDate;
+  }
+
+  public static CheckOutByBarcodeRequest from(JsonObject request) {
+    String itemBarcode = request.getString(ITEM_BARCODE);
+    String userBarcode = request.getString(USER_BARCODE);
+    String proxyUserBarcode = request.getString(PROXY_USER_BARCODE);
+    String servicePointId = request.getString(SERVICE_POINT_ID);
+    String loanDate = request.getString(LOAD_DATE);
+
+    return new CheckOutByBarcodeRequest(itemBarcode, userBarcode, proxyUserBarcode, servicePointId, loanDate);
+  }
+
+  public String getItemBarcode() {
+    return itemBarcode;
+  }
+
+  public String getUserBarcode() {
+    return userBarcode;
+  }
+
+  public String getProxyUserBarcode() {
+    return proxyUserBarcode;
+  }
+
+  public String getServicePointId() {
+    return servicePointId;
+  }
+
+  public String getLoanDate() {
+    return loanDate;
+  }
 }

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -1,56 +1,27 @@
 package org.folio.circulation.resources;
 
-import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.folio.circulation.domain.representations.CheckOutByBarcodeRequest.ITEM_BARCODE;
-import static org.folio.circulation.domain.representations.CheckOutByBarcodeRequest.PROXY_USER_BARCODE;
 import static org.folio.circulation.domain.representations.CheckOutByBarcodeRequest.SERVICE_POINT_ID;
-import static org.folio.circulation.domain.representations.CheckOutByBarcodeRequest.USER_BARCODE;
 import static org.folio.circulation.support.Result.failed;
-import static org.folio.circulation.support.Result.succeeded;
-import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 
 import java.util.UUID;
-
-import org.folio.circulation.domain.ConfigurationRepository;
-import org.folio.circulation.domain.Item;
-import org.folio.circulation.domain.Loan;
-import org.folio.circulation.domain.LoanAndRelatedRecords;
-import org.folio.circulation.domain.LoanRepository;
-import org.folio.circulation.domain.LoanRepresentation;
-import org.folio.circulation.domain.LoanService;
-import org.folio.circulation.domain.PatronGroupRepository;
-import org.folio.circulation.domain.RequestQueueRepository;
-import org.folio.circulation.domain.UpdateItem;
-import org.folio.circulation.domain.UpdateRequestQueue;
-import org.folio.circulation.domain.User;
-import org.folio.circulation.domain.UserRepository;
-import org.folio.circulation.domain.notice.schedule.DueDateScheduledNoticeService;
-import org.folio.circulation.domain.notice.schedule.ScheduledNoticesRepository;
-import org.folio.circulation.domain.policy.LoanPolicyRepository;
-import org.folio.circulation.domain.policy.PatronNoticePolicyRepository;
-import org.folio.circulation.domain.representations.LoanProperties;
-import org.folio.circulation.domain.validation.AlreadyCheckedOutValidator;
-import org.folio.circulation.domain.validation.ExistingOpenLoanValidator;
-import org.folio.circulation.domain.validation.InactiveUserValidator;
-import org.folio.circulation.domain.validation.ItemMissingValidator;
-import org.folio.circulation.domain.validation.ItemNotFoundValidator;
-import org.folio.circulation.domain.validation.ProxyRelationshipValidator;
-import org.folio.circulation.domain.validation.RequestedByAnotherPatronValidator;
-import org.folio.circulation.domain.validation.ServicePointOfCheckoutPresentValidator;
-import org.folio.circulation.support.Clients;
-import org.folio.circulation.support.ClockManager;
-import org.folio.circulation.support.CreatedJsonResponseResult;
-import org.folio.circulation.support.ItemRepository;
-import org.folio.circulation.support.ResponseWritableResult;
-import org.folio.circulation.support.Result;
-import org.folio.circulation.support.RouteRegistration;
-import org.folio.circulation.support.http.server.WebContext;
-import org.joda.time.format.ISODateTimeFormat;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import org.joda.time.format.ISODateTimeFormat;
+
+import org.folio.circulation.domain.CheckOutByBarcodeCommand;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.LoanRepresentation;
+import org.folio.circulation.domain.representations.LoanProperties;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.ClockManager;
+import org.folio.circulation.support.CreatedJsonResponseResult;
+import org.folio.circulation.support.ResponseWritableResult;
+import org.folio.circulation.support.Result;
+import org.folio.circulation.support.RouteRegistration;
+import org.folio.circulation.support.http.server.WebContext;
 
 public class CheckOutByBarcodeResource extends Resource {
 
@@ -77,93 +48,17 @@ public class CheckOutByBarcodeResource extends Resource {
 
     final JsonObject loanJson = new JsonObject();
     loanJson.put("id", UUID.randomUUID().toString());
-
     copyOrDefaultLoanDate(request, loanJson);
+    loanJson.put(LoanProperties.CHECKOUT_SERVICE_POINT_ID, request.getString(SERVICE_POINT_ID));
 
-    final String itemBarcode = request.getString(ITEM_BARCODE);
-    final String userBarcode = request.getString(USER_BARCODE);
-    final String proxyUserBarcode = request.getString(PROXY_USER_BARCODE);
-    final String checkoutServicePointId = request.getString(SERVICE_POINT_ID);
-
-    loanJson.put(LoanProperties.CHECKOUT_SERVICE_POINT_ID, checkoutServicePointId);
     Loan loan = Loan.from(loanJson);
 
     final Clients clients = Clients.create(context, client);
 
-    final UserRepository userRepository = new UserRepository(clients);
-    final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
-    final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
-    final LoanRepository loanRepository = new LoanRepository(clients);
-    final LoanService loanService = new LoanService(clients);
-    final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
-    final PatronNoticePolicyRepository patronNoticePolicyRepository = new PatronNoticePolicyRepository(clients);
-    final LoanNoticeSender loanNoticeSender = LoanNoticeSender.using(clients);
-    final PatronGroupRepository patronGroupRepository = new PatronGroupRepository(clients);
-    final ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
-    final ScheduledNoticesRepository scheduledNoticesRepository = ScheduledNoticesRepository.using(clients);
-    final DueDateScheduledNoticeService scheduledNoticeService =
-      new DueDateScheduledNoticeService(scheduledNoticesRepository, patronNoticePolicyRepository);
+    CheckOutByBarcodeCommand cmd = new CheckOutByBarcodeCommand(checkOutStrategy, clients);
 
-    final ProxyRelationshipValidator proxyRelationshipValidator = new ProxyRelationshipValidator(
-      clients, () -> singleValidationError(
-      "Cannot check out item via proxy when relationship is invalid",
-      PROXY_USER_BARCODE, proxyUserBarcode));
-
-    final ServicePointOfCheckoutPresentValidator servicePointOfCheckoutPresentValidator
-      = new ServicePointOfCheckoutPresentValidator(message ->
-      singleValidationError(message, SERVICE_POINT_ID, checkoutServicePointId));
-
-    final RequestedByAnotherPatronValidator requestedByAnotherPatronValidator = new RequestedByAnotherPatronValidator(
-      message -> singleValidationError(message, USER_BARCODE, userBarcode));
-
-    final AlreadyCheckedOutValidator alreadyCheckedOutValidator = new AlreadyCheckedOutValidator(
-      message -> singleValidationError(message, ITEM_BARCODE, itemBarcode));
-
-    final ItemNotFoundValidator itemNotFoundValidator = new ItemNotFoundValidator(
-      () -> singleValidationError(String.format("No item with barcode %s could be found", itemBarcode),
-        ITEM_BARCODE, itemBarcode));
-
-    final ItemMissingValidator itemMissingValidator = new ItemMissingValidator(
-      message -> singleValidationError(message, ITEM_BARCODE, itemBarcode));
-
-    final InactiveUserValidator inactiveUserValidator = InactiveUserValidator.forUser(userBarcode);
-    final InactiveUserValidator inactiveProxyUserValidator = InactiveUserValidator.forProxy(proxyUserBarcode);
-
-    final ExistingOpenLoanValidator openLoanValidator = new ExistingOpenLoanValidator(
-      loanRepository, message -> singleValidationError(message, ITEM_BARCODE, itemBarcode));
-
-    final UpdateItem updateItem = new UpdateItem(clients);
-    final UpdateRequestQueue requestQueueUpdate = UpdateRequestQueue.using(clients);
-
-    final LoanRepresentation loanRepresentation = new LoanRepresentation();
-
-    completedFuture(succeeded(new LoanAndRelatedRecords(loan)))
-      .thenApply(servicePointOfCheckoutPresentValidator::refuseCheckOutWhenServicePointIsNotPresent)
-      .thenCombineAsync(userRepository.getUserByBarcode(userBarcode), this::addUser)
-      .thenCombineAsync(userRepository.getProxyUserByBarcode(proxyUserBarcode), this::addProxyUser)
-      .thenApply(inactiveUserValidator::refuseWhenUserIsInactive)
-      .thenApply(inactiveProxyUserValidator::refuseWhenUserIsInactive)
-      .thenCombineAsync(itemRepository.fetchByBarcode(itemBarcode), this::addItem)
-      .thenApply(itemNotFoundValidator::refuseWhenItemNotFound)
-      .thenApply(alreadyCheckedOutValidator::refuseWhenItemIsAlreadyCheckedOut)
-      .thenApply(itemMissingValidator::refuseWhenItemIsMissing)
-      .thenComposeAsync(r -> r.after(proxyRelationshipValidator::refuseWhenInvalid))
-      .thenComposeAsync(r -> r.after(openLoanValidator::refuseWhenHasOpenLoan))
-      .thenComposeAsync(r -> r.after(requestQueueRepository::get))
-      .thenApply(requestedByAnotherPatronValidator::refuseWhenRequestedByAnotherPatron)
-      .thenCompose(r -> r.combineAfter(configurationRepository::findTimeZoneConfiguration,
-        LoanAndRelatedRecords::withTimeZone))
-      .thenComposeAsync(r -> r.after(loanPolicyRepository::lookupLoanPolicy))
-      .thenComposeAsync(r -> r.after(relatedRecords -> checkOutStrategy.checkOut(relatedRecords, request, clients)))
-      .thenComposeAsync(r -> r.after(requestQueueUpdate::onCheckOut))
-      .thenComposeAsync(r -> r.after(updateItem::onCheckOut))
-      .thenComposeAsync(r -> r.after(loanService::truncateLoanWhenItemRecalled))
-      .thenComposeAsync(r -> r.after(patronGroupRepository::findPatronGroupForLoanAndRelatedRecords))
-      .thenComposeAsync(r -> r.after(loanRepository::createLoan))
-      .thenApply(r -> r.next(loanNoticeSender::sendCheckOutPatronNotice))
-      .thenApply(r -> r.next(scheduledNoticeService::scheduleNoticesForLoanDueDate))
-      .thenApply(r -> r.map(LoanAndRelatedRecords::getLoan))
-      .thenApply(r -> r.map(loanRepresentation::extendedLoan))
+    cmd.execute(loan, request)
+      .thenApply(this::toExtendedLoan)
       .thenApply(this::createdLoanFrom)
       .thenAccept(result -> result.writeTo(routingContext.response()));
   }
@@ -179,6 +74,11 @@ public class CheckOutByBarcodeResource extends Resource {
     }
   }
 
+  private Result<JsonObject> toExtendedLoan(Result<Loan> r) {
+    final LoanRepresentation loanRepresentation = new LoanRepresentation();
+    return r.map(loanRepresentation::extendedLoan);
+  }
+
   private ResponseWritableResult<JsonObject> createdLoanFrom(Result<JsonObject> result) {
     if (result.failed()) {
       return failed(result.cause());
@@ -188,27 +88,4 @@ public class CheckOutByBarcodeResource extends Resource {
     }
   }
 
-  private Result<LoanAndRelatedRecords> addProxyUser(
-    Result<LoanAndRelatedRecords> loanResult,
-    Result<User> getUserResult) {
-
-    return Result.combine(loanResult, getUserResult,
-      LoanAndRelatedRecords::withProxyingUser);
-  }
-
-  private Result<LoanAndRelatedRecords> addUser(
-    Result<LoanAndRelatedRecords> loanResult,
-    Result<User> getUserResult) {
-
-    return Result.combine(loanResult, getUserResult,
-      LoanAndRelatedRecords::withRequestingUser);
-  }
-
-  private Result<LoanAndRelatedRecords> addItem(
-    Result<LoanAndRelatedRecords> loanResult,
-    Result<Item> inventoryRecordsResult) {
-
-    return Result.combine(loanResult, inventoryRecordsResult,
-      LoanAndRelatedRecords::withItem);
-  }
 }


### PR DESCRIPTION
## Purpose
This pull request demonstrates how Check In operation can be combined with Check Out operation. The need for such thing originated from Delivery Request requirements:
- [UICHKIN-113](https://issues.folio.org/browse/UICHKIN-113) Implement Delivery Requests Status Changes and Routing

Also technical approach discussion can be found in [CIRC-437](https://issues.folio.org/browse/CIRC-437)

It's important to note that this PR **is not final or completely finished solution** rather a POC. It shows the idea to understand if it's feasible or not. So please do not verify the code but the approach.

## Approach
Implementation of Option#1 (see [this comment](https://issues.folio.org/browse/CIRC-437?focusedCommentId=60433&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-60433) in related spike)
What is done:
- `CheckOutByBarcodeResource` refactored. Most of its code migrated into new class `CheckOutByBarcodeAction`. 
- `CheckOutByBarcodeAction` implements all logic of Check Out process. it has a single method to be called 'execute()'.  An argument of this method is a regular check out request, the same that is accepted by `CheckOutByBarcodeResource`
- `CheckOutByBarcodeResource` delegates all the work to `CheckOutByBarcodeAction` except for response generation
- `CheckInByBarcodeResource` modified so that at the very end of processing chain there is a call to new `checkOutIfDelivery()` method:
![image](https://user-images.githubusercontent.com/42244720/66040335-dd3cb180-e51f-11e9-8922-5a17c7a474e3.png)
The method tests if the topmost request is a delivery request:
- if it's true --> call `CheckOutByBarcodeAction` to perform automatic checkout
- if it's not --> do nothing
 