### PR TITLE
Fix for CIRC-463 - request position updates in the queue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,12 @@
       <artifactId>jacoco-maven-plugin</artifactId>
       <version>0.8.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/org/folio/circulation/domain/RequestQueueRepository.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueueRepository.java
@@ -16,7 +16,7 @@ import org.folio.circulation.support.Result;
 public class RequestQueueRepository {
   private final RequestRepository requestRepository;
 
-  private RequestQueueRepository(RequestRepository requestRepository) {
+  RequestQueueRepository(RequestRepository requestRepository) {
     this.requestRepository = requestRepository;
   }
 
@@ -85,10 +85,9 @@ public class RequestQueueRepository {
         request = changedRequests.get(++index);
       }
       if (!positionTaken) {
-        CompletableFuture<Result<Request>> updateFuture =
-          requestRepository.update(request);
+        final Request updateRequest = request;
         requestUpdated = requestUpdated.thenComposeAsync(r ->
-          r.after(notUsed -> updateFuture));
+          r.after(notUsed -> requestRepository.update(updateRequest)));
         request.freePreviousPosition();
         changedRequests.remove(index);
       }

--- a/src/test/java/org/folio/circulation/domain/RequestQueueRepositoryTest.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueRepositoryTest.java
@@ -1,0 +1,132 @@
+package org.folio.circulation.domain;
+
+import static java.util.Arrays.asList;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Duration.FIVE_HUNDRED_MILLISECONDS;
+import static org.awaitility.Duration.TWO_HUNDRED_MILLISECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.folio.circulation.support.Result;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+
+import api.support.builders.RequestBuilder;
+
+public class RequestQueueRepositoryTest {
+  /**
+   * Tests the {@code updateRequestsWithChangedPositions} method. Ensures
+   * that each call to update the position of the request in the repository
+   * is done in order by introducing wait times on specific update calls.
+   * While this is not an ideal way to test this code, it does show that the
+   * old code will cause this test to fail, while the newer code passes this
+   * test. If the logic changes around updating request queue positioning,
+   * then this test may be obsolete. This test is strictly for regression
+   * under the current request queue positioning design.
+   *
+   * @throws Exception on catastrophic unexpected error
+   */
+  @Test
+  public void testUpdateRequestsWithChangedPositions() throws Exception {
+    final RequestRepository requestRepository = mock(RequestRepository.class);
+
+    final UUID itemId = UUID.randomUUID();
+
+    final Request firstRequest = requestAtPosition(itemId, 1);
+    final Request secondRequest = requestAtPosition(itemId, 2);
+    final Request thirdRequest = requestAtPosition(itemId, 3);
+    final Request fourthRequest = requestAtPosition(itemId, 4);
+
+    final AtomicBoolean secondMoved = new AtomicBoolean(false);
+    final AtomicBoolean thirdMoved = new AtomicBoolean(false);
+
+    // Mock the update method so we return at different times. For requests
+    // further down the queue, we check to see if the previous request has
+    // already been processed. If it has not, return an error, otherwise
+    // return the updated request. In this way, we can show whether or not
+    // updateRequestsWithChangedPositions is executing updates in order or
+    // all at once.
+    when(requestRepository.update(ArgumentMatchers.any(Request.class)))
+      .thenAnswer(invokation -> {
+        final Object [] args = invokation.getArguments();
+
+        if (((Request) args[0]).getId().equals(secondRequest.getId())) {
+          // Return the new "first" request after a 500 ms delay
+          return CompletableFuture.supplyAsync(() -> {
+            await().pollDelay(FIVE_HUNDRED_MILLISECONDS).until(() -> true);
+            secondMoved.compareAndSet(false, true);
+            return Result.of(() -> secondRequest);
+          });
+        } else if (((Request) args[0]).getId().equals(thirdRequest.getId())) {
+          // Return the new "second" request after a 200 ms delay
+          return CompletableFuture.supplyAsync(() -> {
+            if (secondMoved.get()) {
+              await().pollDelay(TWO_HUNDRED_MILLISECONDS).until(() -> true);
+              thirdMoved.compareAndSet(false, true);
+              return Result.of(() -> thirdRequest);
+            } else {
+              return Result.failed(
+                  new ServerErrorFailure("request already at position 2"));
+            }
+          });
+        } else {
+          // Return the new "third" request immediately
+          return CompletableFuture.supplyAsync(() -> {
+            if (secondMoved.get() && thirdMoved.get()) {
+              return Result.of(() -> fourthRequest);
+            } else {
+              return Result.failed(
+                  new ServerErrorFailure("request already at position 3"));
+            }
+          });
+        }
+      });
+
+    final RequestQueue requestQueue = new RequestQueue(
+        asList(firstRequest, secondRequest, thirdRequest, fourthRequest));
+
+    final RequestQueueRepository requestQueueRepository =
+        new RequestQueueRepository(requestRepository);
+
+    // Cause potential request queue chaos
+    requestQueue.remove(firstRequest);
+
+    // Execute the reorder
+    final CompletableFuture<Result<RequestQueue>> cf = requestQueueRepository
+        .updateRequestsWithChangedPositions(requestQueue);
+
+    final Result<RequestQueue> result = cf.get();
+
+    assertNotNull(result);
+    assertTrue(result.succeeded());
+
+    final RequestQueue reorderedQueue = result.value();
+
+    assertNotNull(reorderedQueue);
+    assertEquals(3, reorderedQueue.getRequests().size());
+
+    // On success, the positions should be in numerical order
+    int position = 1;
+    for (Request request : reorderedQueue.getRequests()) {
+      assertEquals(Integer.valueOf(position++), request.getPosition());
+    }
+  }
+
+  private Request requestAtPosition(UUID itemId, Integer position) {
+    return Request.from(new RequestBuilder()
+      .withId(UUID.randomUUID())
+      .open()
+      .hold()
+      .withItemId(itemId)
+      .withPosition(position)
+      .create());
+  }
+}


### PR DESCRIPTION
## Purpose

In order to ensure that we comply with DB constraints, we need to ensure we process the request updates in an order fashion, one after the other. The problem here is that we execute the updates asynchronously, without waiting for the result of the previous update. In this case, we can have requests being updated to positions that have not been vacated.

[CIRC-463](https://issues.folio.org/browse/CIRC-463)

## Approach

To address this, we now wait to issue the next update until after the previous update has returned. This will prevent, or, at least, severely reduce the chance of a request being moved to an already taken position.

Also added a unit test that fails with the existing code and passes with this fix. In order to mock this, added a test dependency to Mockito and made the `RequestQueueRepository` constructor package-private. Mocking static methods is more challenging and typically requires more heavy-weight mocking frameworks. Typically, package-private constructors are acceptable.

It is not clear that this unit test is really required. I was just using TDD here to prove what I changed fixed the problem and I thought it might be useful to prevent regressions. We can drop the test and changes associated with it if it is too problematic.

#### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.