### PR TITLE
[CIRC-477] Send available notice once at the check-in

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -301,10 +301,13 @@ public class Item {
 
   Item changeStatus(ItemStatus newStatus) {
     //TODO: Check if status is null
+
+    if (isNotSameStatus(newStatus)) {
+      changed = true;
+    }
+
     write(itemRepresentation, "status",
       new JsonObject().put("name", newStatus.getValue()));
-
-    changed = true;
 
     //TODO: Remove this hack to remove destination service point
     // needs refactoring of how in transit for pickup is done

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -106,7 +106,7 @@ public class Item {
     return getStatus().equals(status);
   }
 
-  boolean hasChanged() {
+  public boolean hasChanged() {
     return changed;
   }
 

--- a/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
@@ -190,7 +190,7 @@ class CheckInProcessAdapter {
 
   private Result<CheckInProcessRecords> sendAvailableNotice(Request request, User user, CheckInProcessRecords records) {
     Item item = records.getItem();
-    if (item.isAwaitingPickup()) {
+    if (item.isAwaitingPickup() && item.hasChanged()) {
       PatronNoticeEvent noticeEvent = new PatronNoticeEventBuilder()
         .withItem(item)
         .withUser(user)

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -38,7 +38,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.Seconds;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import api.support.APITests;
@@ -572,7 +571,6 @@ public class CheckInByBarcodeTests extends APITests {
   }
 
   @Test
-  @Ignore("Not fixed yet")
   public void availableNoticeIsSentOnceWhenItemStatusIsChangedToAwaitingPickup()
     throws InterruptedException,
     MalformedURLException,

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -11,6 +11,8 @@ import static java.util.Arrays.asList;
 import static org.folio.HttpStatus.HTTP_VALIDATION_ERROR;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -36,6 +38,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.Seconds;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import api.support.APITests;
@@ -427,7 +430,7 @@ public class CheckInByBarcodeTests extends APITests {
 
     Awaitility.await()
       .atMost(1, TimeUnit.SECONDS)
-      .until(patronNoticesClient::getAll, Matchers.hasSize(1));
+      .until(patronNoticesClient::getAll, hasSize(1));
     List<JsonObject> sentNotices = patronNoticesClient.getAll();
 
     Map<String, Matcher<String>> noticeContextMatchers = new HashMap<>();
@@ -515,7 +518,7 @@ public class CheckInByBarcodeTests extends APITests {
       .withName("Policy notice")
       .withLoanNotices(Collections
         .singletonList(new NoticeConfigurationBuilder()
-          .withTemplateId(availableNoticeTemplateId).withEventType("Available").create()));
+          .withTemplateId(availableNoticeTemplateId).withAvailableEvent().create()));
 
     useLoanPolicyAsFallback(
       loanPoliciesFixture.canCirculateRolling().getId(),
@@ -554,7 +557,7 @@ public class CheckInByBarcodeTests extends APITests {
       .withName("Policy notice")
       .withLoanNotices(Collections
         .singletonList(new NoticeConfigurationBuilder()
-          .withTemplateId(availableNoticeTemplateId).withEventType("Available").create()));
+          .withTemplateId(availableNoticeTemplateId).withAvailableEvent().create()));
 
     useLoanPolicyAsFallback(
       loanPoliciesFixture.canCirculateRolling().getId(),
@@ -568,6 +571,53 @@ public class CheckInByBarcodeTests extends APITests {
     checkPatronNoticeEvent(request, requester, item, availableNoticeTemplateId);
   }
 
+  @Test
+  @Ignore("Not fixed yet")
+  public void availableNoticeIsSentOnceWhenItemStatusIsChangedToAwaitingPickup()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException  {
+
+    JsonObject availableNoticeConfig = new NoticeConfigurationBuilder()
+      .withTemplateId(UUID.randomUUID())
+      .withAvailableEvent()
+      .create();
+    NoticePolicyBuilder noticePolicy = new NoticePolicyBuilder()
+      .withName("Policy with available notice")
+      .withLoanNotices(Collections.singletonList(availableNoticeConfig));
+
+    useLoanPolicyAsFallback(
+      loanPoliciesFixture.canCirculateRolling().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.create(noticePolicy).getId());
+
+    InventoryItemResource requestedItem = itemsFixture.basedUponNod();
+    UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+
+    DateTime requestDate = new DateTime(2019, 10, 9, 10, 0);
+    requestsFixture.place(new RequestBuilder()
+      .page()
+      .forItem(requestedItem)
+      .by(usersFixture.steve())
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequestDate(requestDate));
+
+    DateTime checkInDate = new DateTime(2019, 10, 10, 12, 30);
+
+    loansFixture.checkInByBarcode(requestedItem, checkInDate, pickupServicePointId);
+    Awaitility.await()
+      .atMost(1, TimeUnit.SECONDS)
+      .until(patronNoticesClient::getAll, hasSize(1));
+    patronNoticesClient.deleteAll();
+
+    //Check-in again and verify no notice are sent
+    loansFixture.checkInByBarcode(requestedItem, checkInDate, pickupServicePointId);
+    Awaitility.await()
+      .atMost(1, TimeUnit.SECONDS)
+      .until(patronNoticesClient::getAll, empty());
+  }
+
   private void checkPatronNoticeEvent(
     IndividualResource request, IndividualResource requester,
     InventoryItemResource item, UUID expectedTemplateId)
@@ -575,7 +625,7 @@ public class CheckInByBarcodeTests extends APITests {
 
     Awaitility.await()
       .atMost(1, TimeUnit.SECONDS)
-      .until(patronNoticesClient::getAll, Matchers.hasSize(1));
+      .until(patronNoticesClient::getAll, hasSize(1));
 
     List<JsonObject> sentNotices = patronNoticesClient.getAll();
 

--- a/src/test/java/api/support/builders/NoticeConfigurationBuilder.java
+++ b/src/test/java/api/support/builders/NoticeConfigurationBuilder.java
@@ -73,6 +73,10 @@ public class NoticeConfigurationBuilder extends JsonBuilder implements Builder {
     return withEventType("Due date");
   }
 
+  public NoticeConfigurationBuilder withAvailableEvent() {
+    return withEventType("Available");
+  }
+
   public NoticeConfigurationBuilder withRequestExpirationEvent() {
     return withEventType("Request expiration");
   }


### PR DESCRIPTION
## Purpose
**Available** notice (or **awaiting pickup** notice) should be sent only the first time when the item becomes "awaiting for pickup".
Resolves: [CIRC-477](https://issues.folio.org/browse/CIRC-477)
## Approach
- add test demonstrating the issue; 
- set `changed` flag for the `Item` only when it is actually changed;
- use `changed` flag to detect whether the item was changed before sending **available** notice.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.