### PR TITLE
CIRC-367: Anonymize closed loans setting of "X interval after loan cl…

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -534,6 +534,57 @@
           ],
           "unit": "minute",
           "delay": "2"
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/circulation/scheduled-anonymize-processing",
+          "modulePermissions": [
+            "circulation-storage.loans.item.put",
+            "circulation-storage.loans.item.get",
+            "circulation-storage.loans.collection.get",
+            "circulation.rules.loan-policy.get",
+            "circulation.rules.request-policy.get",
+            "circulation-storage.requests.collection.get",
+            "circulation-storage.requests.item.put",
+            "inventory-storage.items.item.put",
+            "inventory-storage.items.item.get",
+            "inventory-storage.items.collection.get",
+            "inventory-storage.locations.item.get",
+            "inventory-storage.locations.collection.get",
+            "inventory-storage.location-units.institutions.item.get",
+            "inventory-storage.location-units.campuses.item.get",
+            "inventory-storage.location-units.libraries.item.get",
+            "inventory-storage.holdings.collection.get",
+            "inventory-storage.holdings.item.get",
+            "inventory-storage.instances.collection.get",
+            "inventory-storage.instances.item.get",
+            "inventory-storage.material-types.item.get",
+            "inventory-storage.material-types.collection.get",
+            "inventory-storage.service-points.collection.get",
+            "inventory-storage.service-points.item.get",
+            "inventory-storage.loan-types.item.get",
+            "users.item.get",
+            "users.collection.get",
+            "proxiesfor.collection.get",
+            "circulation-storage.loan-policies.item.get",
+            "circulation-storage.loan-policies.collection.get",
+            "circulation-storage.request-policies.item.get",
+            "circulation-storage.fixed-due-date-schedules.item.get",
+            "circulation-storage.fixed-due-date-schedules.collection.get",
+            "configuration.entries.collection.get",
+            "circulation.rules.notice-policy.get",
+            "circulation-storage.patron-notice-policies.item.get",
+            "scheduled-notice-storage.scheduled-notices.collection.delete",
+            "scheduled-notice-storage.scheduled-notices.item.post",
+            "patron-notice.post",
+            "anonymize-storage-loans.post",
+            "accounts.collection.get",
+            "feefineactions.collection.get"
+          ],
+          "unit": "minute",
+          "delay": "1"
         }
       ]
     }
@@ -1164,7 +1215,8 @@
         "scheduled-notice-storage.scheduled-notices.collection.delete",
         "scheduled-notice-storage.scheduled-notices.item.post",
         "patron-notice.post",
-        "anonymize-storage-loans.post"
+        "anonymize-storage-loans.post",
+        "feefineactions.collection.get"
       ],
       "visible": false
     },
@@ -1283,7 +1335,9 @@
         "inventory-storage.locations.collection.get",
         "accounts.collection.get",
         "usergroups.collection.get",
-        "usergroups.item.get"
+        "usergroups.item.get",
+        "feefineactions.collection.get",
+        "feefineactions.item.get"
       ],
       "visible": false
     },

--- a/src/main/java/org/folio/circulation/CirculationVerticle.java
+++ b/src/main/java/org/folio/circulation/CirculationVerticle.java
@@ -24,6 +24,7 @@ import org.folio.circulation.resources.RequestHoldShelfClearanceResource;
 import org.folio.circulation.resources.RequestQueueResource;
 import org.folio.circulation.resources.DueDateScheduledNoticeProcessingResource;
 import org.folio.circulation.resources.RequestScheduledNoticeProcessingResource;
+import org.folio.circulation.resources.ScheduledAnonymizationProcessingResource;
 import org.folio.circulation.support.logging.Logging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,6 +97,7 @@ public class CirculationVerticle extends AbstractVerticle {
     new RequestScheduledNoticeProcessingResource(client).register(router);
 
     new LoanAnonymizationResource(client).register(router);
+    new ScheduledAnonymizationProcessingResource(client).register(router);
 
     new EndPatronActionSessionResource(client).register(router);
 

--- a/src/main/java/org/folio/circulation/domain/Account.java
+++ b/src/main/java/org/folio/circulation/domain/Account.java
@@ -3,14 +3,32 @@ package org.folio.circulation.domain;
 import static org.folio.circulation.support.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Optional;
+
+import org.joda.time.DateTime;
+
+import com.google.inject.internal.util.Lists;
+
 import io.vertx.core.json.JsonObject;
 
 public class Account {
 
   private final JsonObject representation;
+  private Collection<FeeFineAction> feeFineActions = Lists.newArrayList();
 
   public Account(JsonObject representation) {
     this.representation = representation;
+  }
+
+  private Account(JsonObject representation, Collection<FeeFineAction> actions) {
+    this.representation = representation;
+    this.feeFineActions = actions;
+  }
+
+  public static Account from(JsonObject representation) {
+    return new Account(representation);
   }
 
   public String getId() {
@@ -29,15 +47,23 @@ public class Account {
     return getNestedStringProperty(representation, "status", "name");
   }
 
+  public Optional<DateTime> getClosedDate() {
+
+    return feeFineActions.stream()
+      .filter(ffa -> ffa.getBalance() == 0d)
+      .max(Comparator.comparing(FeeFineAction::getDateAction))
+      .map(FeeFineAction::getDateAction);
+  }
+
+  public Account withFeefineActions(Collection<FeeFineAction> actions) {
+    return new Account(representation, actions);
+  }
+
   public boolean isClosed() {
     return getStatus().equalsIgnoreCase("closed");
   }
 
   public boolean isOpen() {
     return getStatus().equalsIgnoreCase("open");
-  }
-
-  public static Account from(JsonObject representation) {
-    return new Account(representation);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/AccountRepository.java
+++ b/src/main/java/org/folio/circulation/domain/AccountRepository.java
@@ -20,10 +20,13 @@ import org.folio.circulation.support.Result;
 public class AccountRepository {
 
   private static final String LOAN_ID_FIELD_NAME = "loanId";
+  private static final String ACCOUNT_ID_FIELD_NAME = "accountId";
   private final CollectionResourceClient accountsStorageClient;
+  private final CollectionResourceClient feefineActionsStorageClient;
 
   public AccountRepository(Clients clients) {
     accountsStorageClient = clients.accountsStorageClient();
+    feefineActionsStorageClient = clients.feefineActionsStorageClient();
   }
 
   public CompletableFuture<Result<Loan>> findAccountsForLoan(Result<Loan> loanResult) {
@@ -37,7 +40,9 @@ public class AccountRepository {
 
   private CompletableFuture<Result<Collection<Account>>> fetchAccountsForLoan(String loanId) {
 
-    return createAccountsFetcher().findByQuery(exactMatch(LOAN_ID_FIELD_NAME, loanId))
+    return createAccountsFetcher().findByQuery(
+      exactMatch(LOAN_ID_FIELD_NAME, loanId))
+      .thenCompose(r -> r.after(this::findFeeFineActionsForAccounts))
       .thenApply(r -> r.map(MultipleRecords::getRecords));
   }
 
@@ -64,12 +69,45 @@ public class AccountRepository {
         .collect(Collectors.toSet());
 
     return createAccountsFetcher().findByIndexName(loanIds, LOAN_ID_FIELD_NAME)
-      .thenComposeAsync(r -> r.after(multipleRecords -> completedFuture(succeeded(
-        multipleRecords.getRecords().stream().collect(
-          Collectors.groupingBy(Account::getLoanId))))));
+      .thenCompose(r -> r.after(this::findFeeFineActionsForAccounts))
+      .thenComposeAsync(r -> r.after(multipleRecords -> completedFuture(succeeded(multipleRecords.getRecords()
+        .stream()
+        .collect(Collectors.groupingBy(Account::getLoanId))))));
+  }
+
+  public CompletableFuture<Result<MultipleRecords<Account>>> findFeeFineActionsForAccounts(
+      MultipleRecords<Account> multipleLoans) {
+
+    if (multipleLoans.getRecords().isEmpty()) {
+      return completedFuture(succeeded(multipleLoans));
+    }
+
+    return getFeeFineActionsForAccounts(multipleLoans.getRecords())
+        .thenApply(r -> r.map(accountMap -> multipleLoans.mapRecords(
+            loan -> loan.withFeefineActions(accountMap.getOrDefault(loan.getId(),
+                new ArrayList<>())))));
+  }
+
+  private CompletableFuture<Result<Map<String, List<FeeFineAction>>>> getFeeFineActionsForAccounts(Collection<Account> accounts) {
+
+    final Collection<String> loanIds =
+    accounts.stream()
+      .filter(Objects::nonNull)
+      .map(Account::getId)
+      .filter(Objects::nonNull)
+      .collect(Collectors.toSet());
+
+    return createFeeFineActionFetcher().findByIndexName(loanIds, ACCOUNT_ID_FIELD_NAME)
+        .thenComposeAsync(r -> r.after(multipleRecords -> completedFuture(succeeded(
+            multipleRecords.getRecords().stream().collect(
+                Collectors.groupingBy(FeeFineAction::getAccountId))))));
   }
 
   private MultipleRecordFetcher<Account> createAccountsFetcher() {
     return new MultipleRecordFetcher<>(accountsStorageClient, "accounts", Account::from);
+  }
+
+  private MultipleRecordFetcher<FeeFineAction> createFeeFineActionFetcher() {
+    return new MultipleRecordFetcher<>(feefineActionsStorageClient, "feefineactions", FeeFineAction::from);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/ConfigurationRepository.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationRepository.java
@@ -3,9 +3,12 @@ package org.folio.circulation.domain;
 import static org.folio.circulation.domain.MultipleRecords.from;
 import static org.folio.circulation.support.CqlQuery.exactMatch;
 
+import io.vertx.core.json.JsonObject;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import org.folio.circulation.domain.anonymization.config.LoanHistorySettings;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.CqlQuery;
@@ -29,6 +32,27 @@ public class ConfigurationRepository {
   public CompletableFuture<Result<Integer>> lookupSchedulerNoticesProcessingLimit() {
     Result<CqlQuery> cqlQueryResult = defineModuleNameAndConfigNameFilter("NOTIFICATION_SCHEDULER", "noticesLimit");
     return lookupConfigurations(cqlQueryResult, applySearchSchedulerNoticesLimit());
+  }
+
+  /**
+   * Gets loan history tenant configuration - settings for loan anonymization
+   *
+   */
+  public CompletableFuture<Result<LoanHistorySettings>> loanHistoryConfiguration() {
+    return defineModuleNameAndConfigNameFilter("LOAN_HISTORY", "loan_history")
+      .after(query -> configurationClient.getMany(query, DEFAULT_PAGE_LIMIT))
+      .thenApply(result -> result.next(response -> from(response, Configuration::new, CONFIGS_KEY)))
+      .thenApply(r -> r.next(r1 -> r.map(MultipleRecords::getRecords)))
+      .thenApply(r -> r.map(this::getFistConfiguration));
+  }
+
+  private LoanHistorySettings getFistConfiguration(Collection<Configuration> configurations) {
+    final String period = configurations.stream()
+      .map(Configuration::getValue)
+      .findFirst()
+      .orElse("");
+
+    return LoanHistorySettings.from(new JsonObject(period));
   }
 
   public CompletableFuture<Result<DateTimeZone>> findTimeZoneConfiguration() {

--- a/src/main/java/org/folio/circulation/domain/FeeFineAction.java
+++ b/src/main/java/org/folio/circulation/domain/FeeFineAction.java
@@ -1,0 +1,33 @@
+package org.folio.circulation.domain;
+
+import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimeProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
+
+import org.joda.time.DateTime;
+
+import io.vertx.core.json.JsonObject;
+
+public class FeeFineAction {
+
+  private final JsonObject representation;
+
+  public FeeFineAction(JsonObject representation) {
+    this.representation = representation;
+  }
+
+  public String getAccountId() {
+    return getProperty(representation, "accountId");
+  }
+
+  public Double getBalance() {
+    return representation.getDouble("balance");
+  }
+
+  public DateTime getDateAction() {
+    return getDateTimeProperty(representation, "dateAction");
+  }
+
+  public static FeeFineAction from(JsonObject representation) {
+    return new FeeFineAction(representation);
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -375,6 +375,10 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     return !Objects.equals(originalDueDate, getDueDate());
   }
 
+  public DateTime getSystemReturnDate() {
+    return getDateTimeProperty(representation, SYSTEM_RETURN_DATE);
+  }
+
   public DateTime getReturnDate() {
     return getDateTimeProperty(representation, RETURN_DATE);
   }

--- a/src/main/java/org/folio/circulation/domain/anonymization/AnonymizationCheckersProvider.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/AnonymizationCheckersProvider.java
@@ -1,0 +1,82 @@
+package org.folio.circulation.domain.anonymization;
+
+import java.util.List;
+
+import org.folio.circulation.domain.anonymization.checks.AnonymizationChecker;
+import org.folio.circulation.domain.anonymization.checks.AnonymizeLoansImmediatelyChecker;
+import org.folio.circulation.domain.anonymization.checks.AnonymizeLoansWithFeeFinesImmediatelyChecker;
+import org.folio.circulation.domain.anonymization.checks.FeesAndFinesClosePeriodChecker;
+import org.folio.circulation.domain.anonymization.checks.HaveNoAssociatedFeesAndFinesChecker;
+import org.folio.circulation.domain.anonymization.checks.LoanClosePeriodChecker;
+import org.folio.circulation.domain.anonymization.checks.NeverAnonymizeLoansChecker;
+import org.folio.circulation.domain.anonymization.checks.NeverAnonymizeLoansWithFeeFinesChecker;
+import org.folio.circulation.domain.anonymization.config.LoanHistorySettings;
+
+import com.google.inject.internal.util.Lists;
+
+class AnonymizationCheckersProvider {
+
+  private LoanHistorySettings config;
+
+  AnonymizationCheckersProvider(LoanHistorySettings config) {
+    this.config = config;
+  }
+
+  AnonymizationCheckersProvider() {
+  }
+
+  List<AnonymizationChecker> getLoanAnonymizationCheckers() {
+    List<AnonymizationChecker> checkers = Lists.newArrayList();
+
+    if (config == null) {
+      checkers.add(new HaveNoAssociatedFeesAndFinesChecker());
+      return checkers;
+    }
+
+    if (config.treatLoansWithFeesAndFinesDifferently()) {
+      checkers.addAll(getFeesAndFinesCheckers());
+    } else {
+      checkers.addAll(getClosedLoansCheckers());
+    }
+    return checkers;
+  }
+
+  private List<AnonymizationChecker> getClosedLoansCheckers() {
+    List<AnonymizationChecker> result = Lists.newArrayList();
+
+    switch (config.getLoanClosingType()) {
+    case IMMEDIATELY:
+      result.add(new AnonymizeLoansImmediatelyChecker());
+      break;
+    case INTERVAL:
+      result.add(new LoanClosePeriodChecker(config.getLoanClosePeriod()));
+      break;
+    case UNKNOWN:
+    case NEVER:
+      result.add(new NeverAnonymizeLoansChecker());
+      break;
+    default:
+    }
+
+    return result;
+  }
+
+  private List<AnonymizationChecker> getFeesAndFinesCheckers() {
+    List<AnonymizationChecker> result = Lists.newArrayList();
+
+    switch (config.getFeesAndFinesClosingType()) {
+    case IMMEDIATELY:
+      result.add(new AnonymizeLoansWithFeeFinesImmediatelyChecker());
+      break;
+    case INTERVAL:
+      result.add(new FeesAndFinesClosePeriodChecker(config.getFeeFineClosePeriod()));
+      break;
+    case UNKNOWN:
+    case NEVER:
+      result.add(new NeverAnonymizeLoansWithFeeFinesChecker());
+    }
+
+    return result;
+  }
+
+}

--- a/src/main/java/org/folio/circulation/domain/anonymization/DefaultLoanAnonymizationService.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/DefaultLoanAnonymizationService.java
@@ -11,27 +11,29 @@ import org.folio.circulation.domain.anonymization.checks.AnonymizationChecker;
 import org.folio.circulation.support.Result;
 
 /**
- * Checks loan eligibility for anonymization.
- * By default a loan can only be anonymized if it's closed and there are no fees
- * and fines associated with it.
+ * Validates loan eligibility for anonymization. By default a loan can only be anonymized if it's closed and there are no associated
+ * fees and fines associated with it.
  *
  */
 public class DefaultLoanAnonymizationService implements LoanAnonymizationService {
 
   private static final String CAN_BE_ANONYMIZED_KEY = "_";
 
-  private final LoanAnonymizationHelper anonymization;
   private final AnonymizeStorageLoansRepository anonymizeStorageLoansRepository;
+  private final AnonymizationCheckersProvider anonymizationCheckersProvider;
+  private final LoanAnonymizationFinderService loansFinder;
 
-  DefaultLoanAnonymizationService(LoanAnonymizationHelper anonymization) {
-    this.anonymization = anonymization;
+  DefaultLoanAnonymizationService(LoanAnonymizationHelper anonymization,
+      AnonymizationCheckersProvider anonymizationCheckersProvider, LoanAnonymizationFinderService loansFinderService) {
+    this.anonymizationCheckersProvider = anonymizationCheckersProvider;
+    this.loansFinder = loansFinderService;
     anonymizeStorageLoansRepository = new AnonymizeStorageLoansRepository(anonymization.clients());
   }
 
   @Override
   public CompletableFuture<Result<LoanAnonymizationRecords>> anonymizeLoans() {
 
-    return anonymization.loansFinder().findLoansToAnonymize()
+    return loansFinder.findLoansToAnonymize()
       .thenApply(r -> r.map(new LoanAnonymizationRecords()::withLoansFound))
       .thenCompose(this::segregateLoans)
       .thenCompose(r -> r.after(anonymizeStorageLoansRepository::postAnonymizeStorageLoans));
@@ -43,13 +45,15 @@ public class DefaultLoanAnonymizationService implements LoanAnonymizationService
     return completedFuture(anonymizationRecords.map(records -> {
       HashSetValuedHashMap<String, String> multiMap = new HashSetValuedHashMap<>();
       for (Loan loan : records.getLoansFound()) {
-        for (AnonymizationChecker checker : anonymization.anonymizationCheckers()) {
+        boolean loanCanBeAnonymized = true;
+        for (AnonymizationChecker checker : anonymizationCheckersProvider.getLoanAnonymizationCheckers()) {
           if (!checker.canBeAnonymized(loan)) {
             multiMap.put(checker.getReason(), loan.getId());
-          } else {
-            multiMap.put(CAN_BE_ANONYMIZED_KEY, loan.getId());
+            loanCanBeAnonymized = false;
           }
         }
+        if (loanCanBeAnonymized)
+          multiMap.put(CAN_BE_ANONYMIZED_KEY, loan.getId());
       }
 
       return records.withAnonymizedLoans(multiMap.remove(CAN_BE_ANONYMIZED_KEY))

--- a/src/main/java/org/folio/circulation/domain/anonymization/DefaultLoansFinder.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/DefaultLoansFinder.java
@@ -15,12 +15,12 @@ abstract class DefaultLoansFinder implements LoanAnonymizationFinderService {
   private final AccountRepository accountRepository;
   protected LoanAnonymizationHelper anonymization;
 
-  public DefaultLoansFinder(LoanAnonymizationHelper anonymization) {
+  DefaultLoansFinder(LoanAnonymizationHelper anonymization) {
     this.anonymization = anonymization;
     accountRepository = new AccountRepository(anonymization.clients());
   }
 
-  CompletableFuture<Result<Collection<Loan>>> fillLoanInformation(
+  CompletableFuture<Result<Collection<Loan>>> fetchAdditionalLoanInfo(
       Result<MultipleRecords<Loan>> records) {
 
     return records.after(accountRepository::findAccountsForLoans)

--- a/src/main/java/org/folio/circulation/domain/anonymization/LoanAnonymizationHelper.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/LoanAnonymizationHelper.java
@@ -1,11 +1,8 @@
 package org.folio.circulation.domain.anonymization;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Collections;
-import java.util.List;
 
-import org.folio.circulation.domain.anonymization.checks.AnonymizationChecker;
-import org.folio.circulation.domain.anonymization.checks.HaveNoAssociatedFeesAndFines;
+import org.folio.circulation.domain.anonymization.config.LoanHistorySettings;
 import org.folio.circulation.support.Clients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,38 +13,26 @@ public class LoanAnonymizationHelper {
   private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup()
     .lookupClass());
   private final Clients clients;
-  private final LoanAnonymizationService loanAnonymizationService;
-  private final List<AnonymizationChecker> anonymizationCheckers =
-      Collections.singletonList(new HaveNoAssociatedFeesAndFines());
   private LoanAnonymizationFinderService loansFinderService;
 
   public LoanAnonymizationHelper(Clients clients) {
     this.clients = clients;
-    loanAnonymizationService = new DefaultLoanAnonymizationService(this);
   }
 
   public LoanAnonymizationService byUserId(String userId) {
     log.info("Initializing loan anonymization for borrower");
-
     loansFinderService = new LoansForBorrowerFinder(this, userId);
-    return loanAnonymizationService;
+    return new DefaultLoanAnonymizationService(this, new AnonymizationCheckersProvider(), loansFinderService);
   }
 
-  public LoanAnonymizationService byCurrentTenant() {
+  public LoanAnonymizationService byCurrentTenant(LoanHistorySettings config) {
     log.info("Initializing loan anonymization for current tenant");
     loansFinderService = new LoansForTenantFinder(this);
-    return loanAnonymizationService;
+    return new DefaultLoanAnonymizationService(this, new AnonymizationCheckersProvider(config), loansFinderService);
   }
 
   Clients clients() {
     return clients;
   }
 
-  List<AnonymizationChecker> anonymizationCheckers() {
-    return anonymizationCheckers;
-  }
-
-  LoanAnonymizationFinderService loansFinder() {
-    return loansFinderService;
-  }
 }

--- a/src/main/java/org/folio/circulation/domain/anonymization/LoanAnonymizationRecords.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/LoanAnonymizationRecords.java
@@ -13,14 +13,13 @@ public class LoanAnonymizationRecords {
 
   private List<String> anonymizedLoans = new ArrayList<>();
   private List<Loan> loansFound = new ArrayList<>();
-  private MultiValuedMap<String, String> notAnonymizedLoans =
-      new HashSetValuedHashMap<>();
+  private MultiValuedMap<String, String> notAnonymizedLoans = new HashSetValuedHashMap<>();
 
-  public List<Loan> getLoansFound() {
+  List<Loan> getLoansFound() {
     return loansFound;
   }
 
-  public LoanAnonymizationRecords withLoansFound(Collection<Loan> loans) {
+  LoanAnonymizationRecords withLoansFound(Collection<Loan> loans) {
     if (CollectionUtils.isEmpty(loans)) {
       return this;
     }
@@ -42,8 +41,7 @@ public class LoanAnonymizationRecords {
     return newRecords;
   }
 
-  public LoanAnonymizationRecords withNotAnonymizedLoans(
-      MultiValuedMap<String, String> loans) {
+  public LoanAnonymizationRecords withNotAnonymizedLoans(MultiValuedMap<String, String> loans) {
     LoanAnonymizationRecords newRecords = new LoanAnonymizationRecords();
     newRecords.loansFound = new ArrayList<>(loansFound);
     newRecords.anonymizedLoans = new ArrayList<>(anonymizedLoans);
@@ -57,5 +55,12 @@ public class LoanAnonymizationRecords {
 
   public MultiValuedMap<String, String> getNotAnonymizedLoans() {
     return notAnonymizedLoans;
+  }
+
+  @Override
+  public String toString() {
+    return "LoanAnonymizationRecords{" + "anonymizedLoans=" + anonymizedLoans + ","
+        + " notAnonymizedLoans=" + notAnonymizedLoans
+        + '}';
   }
 }

--- a/src/main/java/org/folio/circulation/domain/anonymization/LoansForBorrowerFinder.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/LoansForBorrowerFinder.java
@@ -1,6 +1,6 @@
 package org.folio.circulation.domain.anonymization;
 
-import static org.folio.circulation.domain.anonymization.LoanAnonymizationHelper.*;
+import static org.folio.circulation.domain.anonymization.LoanAnonymizationHelper.FETCH_LOANS_LIMIT;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -14,7 +14,7 @@ public class LoansForBorrowerFinder extends DefaultLoansFinder {
   private final LoanRepository loanRepository;
   private String userId;
 
-  public LoansForBorrowerFinder(LoanAnonymizationHelper anonymization, String userId) {
+  LoansForBorrowerFinder(LoanAnonymizationHelper anonymization, String userId) {
     super(anonymization);
     this.userId = userId;
     loanRepository = new LoanRepository(anonymization.clients());
@@ -24,6 +24,6 @@ public class LoansForBorrowerFinder extends DefaultLoansFinder {
   public CompletableFuture<Result<Collection<Loan>>> findLoansToAnonymize() {
 
     return loanRepository.findClosedLoans(userId, FETCH_LOANS_LIMIT)
-      .thenCompose(this::fillLoanInformation);
+      .thenCompose(this::fetchAdditionalLoanInfo);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/anonymization/LoansForTenantFinder.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/LoansForTenantFinder.java
@@ -13,7 +13,7 @@ public class LoansForTenantFinder extends DefaultLoansFinder {
 
   private final LoanRepository loanRepository;
 
-  public LoansForTenantFinder(LoanAnonymizationHelper anonymization) {
+  LoansForTenantFinder(LoanAnonymizationHelper anonymization) {
     super(anonymization);
     loanRepository = new LoanRepository(anonymization.clients());
   }
@@ -21,6 +21,6 @@ public class LoansForTenantFinder extends DefaultLoansFinder {
   @Override
   public CompletableFuture<Result<Collection<Loan>>> findLoansToAnonymize() {
     return loanRepository.findClosedLoans(FETCH_LOANS_LIMIT)
-      .thenCompose(this::fillLoanInformation);
+      .thenCompose(this::fetchAdditionalLoanInfo);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/anonymization/checks/AnonymizationChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checks/AnonymizationChecker.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain.anonymization.checks;
 
+import org.folio.circulation.domain.Account;
 import org.folio.circulation.domain.Loan;
 
 public interface AnonymizationChecker {
@@ -7,4 +8,12 @@ public interface AnonymizationChecker {
   boolean canBeAnonymized(Loan loan);
 
   String getReason();
+
+  default boolean hasAssociatedFeesAndFines(Loan loan) {
+    return !loan.getAccounts().isEmpty();
+  }
+
+  default boolean allFeesAndFinesClosed(Loan loan) {
+    return loan.getAccounts().stream().allMatch(Account::isClosed);
+  }
 }

--- a/src/main/java/org/folio/circulation/domain/anonymization/checks/AnonymizeLoansImmediatelyChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checks/AnonymizeLoansImmediatelyChecker.java
@@ -1,0 +1,14 @@
+package org.folio.circulation.domain.anonymization.checks;
+
+import org.folio.circulation.domain.Loan;
+
+public class AnonymizeLoansImmediatelyChecker implements AnonymizationChecker {
+
+  @Override
+  public boolean canBeAnonymized(Loan loan) {
+    return loan.isClosed();
+  }
+
+  @Override
+  public String getReason() { return "anonymizeImmediately"; }
+}

--- a/src/main/java/org/folio/circulation/domain/anonymization/checks/AnonymizeLoansWithFeeFinesImmediatelyChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checks/AnonymizeLoansWithFeeFinesImmediatelyChecker.java
@@ -1,0 +1,14 @@
+package org.folio.circulation.domain.anonymization.checks;
+
+import org.folio.circulation.domain.Loan;
+
+public class AnonymizeLoansWithFeeFinesImmediatelyChecker implements AnonymizationChecker {
+
+  @Override
+  public boolean canBeAnonymized(Loan loan) {
+    return allFeesAndFinesClosed(loan) && loan.isClosed();
+  }
+
+  @Override
+  public String getReason() { return "anonymizeLoansWithFeeFinesImmediately"; }
+}

--- a/src/main/java/org/folio/circulation/domain/anonymization/checks/FeesAndFinesClosePeriodChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checks/FeesAndFinesClosePeriodChecker.java
@@ -1,0 +1,37 @@
+package org.folio.circulation.domain.anonymization.checks;
+
+import java.util.Optional;
+
+import org.folio.circulation.domain.Account;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.policy.Period;
+import org.joda.time.DateTime;
+
+public class FeesAndFinesClosePeriodChecker extends TimePeriodChecker {
+
+  public FeesAndFinesClosePeriodChecker(Period period) {
+    super(period);
+  }
+
+  @Override
+  public boolean canBeAnonymized(Loan loan) {
+    return allFeesAndFinesClosed(loan)
+        && findLatestAccountCloseDate(loan).map(this::checkTimePeriodPassed)
+          .orElse(true);
+
+  }
+
+  private Optional<DateTime> findLatestAccountCloseDate(Loan loan) {
+    return loan.getAccounts()
+      .stream()
+      .map(Account::getClosedDate)
+      .filter(Optional::isPresent)
+      .map(Optional::get)
+      .max(DateTime::compareTo);
+  }
+
+  @Override
+  public String getReason() {
+    return "intervalAfterFeesAndFinesCloseNotPassed";
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/anonymization/checks/HaveNoAssociatedFeesAndFinesChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checks/HaveNoAssociatedFeesAndFinesChecker.java
@@ -2,11 +2,12 @@ package org.folio.circulation.domain.anonymization.checks;
 
 import org.folio.circulation.domain.Loan;
 
-public class HaveNoAssociatedFeesAndFines implements AnonymizationChecker {
+public class HaveNoAssociatedFeesAndFinesChecker implements
+    AnonymizationChecker {
 
   @Override
   public boolean canBeAnonymized(Loan loan) {
-    return loan.getAccounts().isEmpty();
+    return !hasAssociatedFeesAndFines(loan);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/anonymization/checks/LoanClosePeriodChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checks/LoanClosePeriodChecker.java
@@ -1,0 +1,21 @@
+package org.folio.circulation.domain.anonymization.checks;
+
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.policy.Period;
+
+public class LoanClosePeriodChecker extends TimePeriodChecker {
+
+  public LoanClosePeriodChecker(Period period) {
+    super(period);
+  }
+
+  @Override
+  public boolean canBeAnonymized(Loan loan) {
+    return loan.isClosed() && checkTimePeriodPassed(loan.getSystemReturnDate());
+  }
+
+  @Override
+  public String getReason() {
+    return "loanClosedPeriodNotPassed";
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/anonymization/checks/NeverAnonymizeLoansChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checks/NeverAnonymizeLoansChecker.java
@@ -1,0 +1,14 @@
+package org.folio.circulation.domain.anonymization.checks;
+
+import org.folio.circulation.domain.Loan;
+
+public class NeverAnonymizeLoansChecker implements AnonymizationChecker {
+
+  @Override
+  public boolean canBeAnonymized(Loan loan) {
+    return false;
+  }
+
+  @Override
+  public String getReason() { return "neverAnonymizeLoans"; }
+}

--- a/src/main/java/org/folio/circulation/domain/anonymization/checks/NeverAnonymizeLoansWithFeeFinesChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checks/NeverAnonymizeLoansWithFeeFinesChecker.java
@@ -1,0 +1,15 @@
+package org.folio.circulation.domain.anonymization.checks;
+
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.anonymization.checks.AnonymizationChecker;
+
+public class NeverAnonymizeLoansWithFeeFinesChecker implements AnonymizationChecker {
+
+  @Override
+  public boolean canBeAnonymized(Loan loan) {
+    return !hasAssociatedFeesAndFines(loan);
+  }
+
+  @Override
+  public String getReason() { return "neverAnonymizeLoansWithFeesAndFines"; }
+}

--- a/src/main/java/org/folio/circulation/domain/anonymization/checks/TimePeriodChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checks/TimePeriodChecker.java
@@ -1,0 +1,18 @@
+package org.folio.circulation.domain.anonymization.checks;
+
+import org.folio.circulation.domain.policy.Period;
+import org.joda.time.DateTime;
+
+abstract class TimePeriodChecker implements AnonymizationChecker {
+
+  private Period period;
+
+  TimePeriodChecker(Period period) {
+    this.period = period;
+  }
+
+  boolean checkTimePeriodPassed(DateTime startDate) {
+    return DateTime.now().isAfter(startDate.plus(period.timePeriod()));
+  }
+
+}

--- a/src/main/java/org/folio/circulation/domain/anonymization/config/ClosingType.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/config/ClosingType.java
@@ -1,0 +1,32 @@
+package org.folio.circulation.domain.anonymization.config;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Enum for loan`s closing type representation.
+ */
+public enum ClosingType {
+
+  IMMEDIATELY("immediately"),
+  INTERVAL("interval"),
+  NEVER("never"),
+  UNKNOWN("Unknown");
+
+  private String representation;
+
+  ClosingType(String representation) {
+    this.representation = representation;
+  }
+
+  public String getRepresentation() {
+    return representation;
+  }
+
+  public static ClosingType from(String value) {
+    return Arrays.stream(values())
+        .filter(v -> Objects.equals(v.getRepresentation(), (value)))
+        .findFirst()
+        .orElse(UNKNOWN);
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/anonymization/config/LoanHistorySettings.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/config/LoanHistorySettings.java
@@ -1,0 +1,62 @@
+package org.folio.circulation.domain.anonymization.config;
+
+import static org.folio.circulation.support.JsonPropertyFetcher.getBooleanProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getNestedIntegerProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getNestedStringProperty;
+
+import org.folio.circulation.domain.policy.Period;
+
+import io.vertx.core.json.JsonObject;
+
+public class LoanHistorySettings {
+
+  private JsonObject representation;
+  private ClosingType loanClosingType;
+  private ClosingType feesAndFinesClosingType;
+  private boolean treatLoansWithFeesAndFinesDifferently;
+  private Period loanClosePeriod;
+  private Period feeFineClosePeriod;
+
+  private LoanHistorySettings(JsonObject representation) {
+    this.representation = representation;
+    this.feesAndFinesClosingType = ClosingType.from(
+        getNestedStringProperty(representation, "closingType", "feeFine"));
+    this.loanClosingType = ClosingType.from(
+        getNestedStringProperty(representation, "closingType", "loan"));
+    this.treatLoansWithFeesAndFinesDifferently = getBooleanProperty(representation, "treatEnabled");
+    this.loanClosePeriod = Period.from(
+      getNestedIntegerProperty(representation, "loan", "duration"),
+      getNestedStringProperty(representation, "loan", "intervalId"));
+    this.feeFineClosePeriod = Period.from(
+      getNestedIntegerProperty(representation, "feeFine", "duration"),
+      getNestedStringProperty(representation, "feeFine", "intervalId"));
+  }
+
+  public static LoanHistorySettings from(JsonObject jsonObject) {
+    return new LoanHistorySettings(jsonObject);
+  }
+
+  public JsonObject getRepresentation() {
+    return representation;
+  }
+
+  public ClosingType getLoanClosingType() {
+    return loanClosingType;
+  }
+
+  public boolean treatLoansWithFeesAndFinesDifferently() {
+    return treatLoansWithFeesAndFinesDifferently;
+  }
+
+  public Period getFeeFineClosePeriod() {
+    return feeFineClosePeriod;
+  }
+
+  public Period getLoanClosePeriod() {
+    return loanClosePeriod;
+  }
+
+  public ClosingType getFeesAndFinesClosingType() {
+    return feesAndFinesClosingType;
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/representations/anonymization/AnonymizeLoansRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/anonymization/AnonymizeLoansRepresentation.java
@@ -3,6 +3,7 @@ package org.folio.circulation.domain.representations.anonymization;
 
 import static org.folio.circulation.support.Result.failed;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -13,12 +14,18 @@ import org.folio.circulation.support.OkJsonResponseResult;
 import org.folio.circulation.support.ResponseWritableResult;
 import org.folio.circulation.support.Result;
 import org.json.JSONArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.vertx.core.json.JsonObject;
 
 public class AnonymizeLoansRepresentation {
 
-  private AnonymizeLoansRepresentation() { }
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup()
+    .lookupClass());
+
+  private AnonymizeLoansRepresentation() {
+  }
 
   public static ResponseWritableResult<JsonObject> from(Result<LoanAnonymizationRecords> records) {
     return records.map(AnonymizeLoansRepresentation::mapToJson)
@@ -27,15 +34,18 @@ public class AnonymizeLoansRepresentation {
 
   private static ResponseWritableResult<JsonObject> mapToJson(LoanAnonymizationRecords records) {
     LoanAnonymizationAPIResponse response = new LoanAnonymizationAPIResponse();
-    response
-        .withAnonymizedLoans(records.getAnonymizedLoans())
-        .withErrors(mapToErrors(records.getNotAnonymizedLoans()));
+    response.withAnonymizedLoans(records.getAnonymizedLoans())
+      .withErrors(mapToErrors(records.getNotAnonymizedLoans()));
+    log.info("Annymized loans count: {}", records.getAnonymizedLoans()
+      .size());
+    log.info("Not Annymized loans count: {}", records.getNotAnonymizedLoans()
+      .values().size());
+    log.debug(records.toString());
     return new OkJsonResponseResult(JsonObject.mapFrom(response));
 
   }
 
-  private static List<Error> mapToErrors(
-      MultiValuedMap<String, String> multiMap) {
+  private static List<Error> mapToErrors(MultiValuedMap<String, String> multiMap) {
 
     return multiMap.keySet()
       .stream()

--- a/src/main/java/org/folio/circulation/resources/LoanAnonymizationResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanAnonymizationResource.java
@@ -3,7 +3,6 @@ package org.folio.circulation.resources;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import org.folio.circulation.domain.anonymization.LoanAnonymizationHelper;
-import org.folio.circulation.domain.anonymization.LoanAnonymizationService;
 import org.folio.circulation.domain.representations.anonymization.AnonymizeLoansRepresentation;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.RouteRegistration;
@@ -32,11 +31,9 @@ public class LoanAnonymizationResource extends Resource {
 
     String borrowerId = routingContext.request().getParam("userId");
 
-    LoanAnonymizationService loanAnonymization =
-      new LoanAnonymizationHelper(clients).byUserId(borrowerId);
-
-    completedFuture(loanAnonymization.anonymizeLoans()
-        .thenApply(AnonymizeLoansRepresentation::from)
-        .thenAccept(result -> result.writeTo(routingContext.response())));
+    completedFuture(new LoanAnonymizationHelper(clients).byUserId(borrowerId)
+      .anonymizeLoans()
+      .thenApply(AnonymizeLoansRepresentation::from)
+      .thenAccept(result -> result.writeTo(routingContext.response())));
   }
 }

--- a/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
@@ -1,0 +1,42 @@
+package org.folio.circulation.resources;
+
+import org.folio.circulation.domain.ConfigurationRepository;
+import org.folio.circulation.domain.anonymization.LoanAnonymizationHelper;
+import org.folio.circulation.domain.representations.anonymization.AnonymizeLoansRepresentation;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.RouteRegistration;
+import org.folio.circulation.support.http.server.WebContext;
+
+import io.vertx.core.http.HttpClient;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Perform automatic loan anonymization based on tenant settings for loan history. 
+ * This process is intended to run in short intervals.
+ *
+ */
+public class ScheduledAnonymizationProcessingResource extends Resource {
+
+  public ScheduledAnonymizationProcessingResource(HttpClient client) {
+    super(client);
+  }
+
+  @Override
+  public void register(Router router) {
+    new RouteRegistration("/circulation/scheduled-anonymize-processing", router)
+    .create(this::scheduledAnonymizeLoans);
+  }
+
+  private void scheduledAnonymizeLoans(RoutingContext routingContext) {
+    final Clients clients = Clients.create(new WebContext(routingContext), client);
+
+    ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
+
+    configurationRepository.loanHistoryConfiguration().thenCompose(c -> c.after(config ->
+        new LoanAnonymizationHelper(clients).byCurrentTenant(config).anonymizeLoans())
+        .thenApply(AnonymizeLoansRepresentation::from)
+        .thenAccept(result -> result.writeTo(routingContext.response())));
+
+  }
+}

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -38,6 +38,7 @@ public class Clients {
   private final CollectionResourceClient configurationStorageClient;
   private final CollectionResourceClient scheduledNoticesStorageClient;
   private final CollectionResourceClient accountsStorageClient;
+  private final CollectionResourceClient feefineActionsStorageClient;
   private final CollectionResourceClient anonymizeStorageLoansClient;
   private final CollectionResourceClient patronActionSessionsStorageClient;
 
@@ -78,6 +79,7 @@ public class Clients {
       configurationStorageClient = createConfigurationStorageClient(client, context);
       scheduledNoticesStorageClient = createScheduledNoticesStorageClient(client, context);
       accountsStorageClient = createAccountsStorageClient(client,context);
+      feefineActionsStorageClient = createFeeFineActionsStorageClient(client,context);
       patronActionSessionsStorageClient = createPatronActionSessionsStorageClient(client,context);
     }
     catch(MalformedURLException e) {
@@ -205,6 +207,10 @@ public class Clients {
 
   public CollectionResourceClient accountsStorageClient() {
     return accountsStorageClient;
+  }
+
+  public CollectionResourceClient feefineActionsStorageClient() {
+    return feefineActionsStorageClient;
   }
 
   public CollectionResourceClient patronActionSessionsStorageClient() {
@@ -465,6 +471,13 @@ public class Clients {
     WebContext context)
     throws MalformedURLException {
     return getCollectionResourceClient(client, context, "/accounts");
+  }
+
+  private CollectionResourceClient createFeeFineActionsStorageClient(
+      OkapiHttpClient client,
+      WebContext context)
+      throws MalformedURLException {
+    return getCollectionResourceClient(client, context, "/feefineactions");
   }
 
   private CollectionResourceClient createPatronActionSessionsStorageClient(

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansAfterXIntervalTests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansAfterXIntervalTests.java
@@ -1,0 +1,411 @@
+package api.loans.anonymization;
+
+import static api.support.matchers.LoanMatchers.hasOpenStatus;
+import static api.support.matchers.LoanMatchers.isAnonymized;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import java.net.MalformedURLException;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.junit.Test;
+
+import api.support.builders.CheckOutByBarcodeRequestBuilder;
+import api.support.builders.ConfigRecordBuilder;
+import api.support.builders.LoanHistoryConfigurationBuilder;
+
+public class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
+
+  /**
+   * Scenario 1
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "X interval after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of
+   *         "Immediately"
+   *         An open loan with an associated fee/fine
+   *     When the item in the loan is checked in
+   *     Then do not anonymize the loan
+  */
+  @Test
+  public void testClosedLoansWithFeesAndFinesNotAnonymizedAfterIntervalNotPassed()
+      throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeAfterXInterval(1, "minute")
+      .feeFineCloseAnonymizeImmediately();
+    ConfigRecordBuilder config = new ConfigRecordBuilder("LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
+      .encodePrettily());
+    configClient.create(config);
+//*********************************************************************
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now().minusMinutes(1));
+
+    anonymizeLoansInTenant();
+//*********************************************************************
+    assertThat(loansStorageClient.getById(loanID)
+      .getJson(), not(isAnonymized()));
+  }
+
+  /**
+   * Scenario 2
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "X interval after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of
+   *         "Immediately"
+   *         An open loan with an associated fee/fine
+   *     When X interval has elapsed after the loan closed
+   *     Then do not anonymize the loan
+   */
+  @Test
+  public void testOpenLoansWithFeesAndFinesNotAnonymizedAfterIntervalNotPassed()
+      throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeAfterXInterval(1, "minute")
+      .feeFineCloseAnonymizeImmediately();
+    ConfigRecordBuilder config = new ConfigRecordBuilder("LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
+      .encodePrettily());
+    configClient.create(config);
+//*********************************************************************
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now().minusMinutes(1));
+
+    assertThat(loanResource.getJson(), hasOpenStatus());
+    DateTimeUtils.setCurrentMillisOffset(ONE_MINUTE_AND_ONE);
+    anonymizeLoansInTenant();
+//*********************************************************************
+    assertThat(loansStorageClient.getById(loanID)
+      .getJson(), not(isAnonymized()));
+  }
+
+  /**
+   * Scenario 3
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "X interval after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of 
+   *         "Immediately"
+   *         A closed loan with an associated fee/fine
+   *     When all fees/fines associated with the loan are closed
+   *     Then anonymize the loan
+   */
+  @Test
+  public void testClosedLoansWithClosedFeesAndFinesAnonymizedAfterIntervalPassed()
+      throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeAfterXInterval(1, "minute")
+      .feeFineCloseAnonymizeImmediately();
+    ConfigRecordBuilder config = new ConfigRecordBuilder("LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
+      .encodePrettily());
+    configClient.create(config);
+//*********************************************************************
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+
+    loansFixture.checkInByBarcode(item1);
+
+    anonymizeLoansInTenant();
+//*********************************************************************
+    assertThat(loansStorageClient.getById(loanID)
+      .getJson(), isAnonymized());
+  }
+
+  /**
+   * Scenario 4
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "X interval after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of
+   *         "X interval after fee/fine closes"
+   *         An open loan with an associated fee/fine
+   *     When the item in the loan is checked in
+   *     Then do not anonymize the loan
+   */
+  @Test
+  public void testOpenLoansWithFeesAndFinesNotAnonymizedAfterFeeFineCloseIntervalNotPassed()
+      throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeAfterXInterval(1, "minute")
+      .feeFineCloseAnonymizeAfterXInterval(20, "minutes");
+    ConfigRecordBuilder config = new ConfigRecordBuilder("LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
+      .encodePrettily());
+    configClient.create(config);
+//*********************************************************************
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+
+    loansFixture.checkInByBarcode(item1);
+
+    anonymizeLoansInTenant();
+//*********************************************************************
+    assertThat(loansStorageClient.getById(loanID)
+      .getJson(), not(isAnonymized()));
+  }
+
+  /**
+   * Scenario 5
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "X interval after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of
+   *         "X interval after fee/fine closes"
+   *         An open loan with an associated fee/fine
+   *     When X interval has elapsed after the loan closed
+   *     Then do not anonymize the loan
+   */
+  @Test
+  public void testOpenLoansWithFeesAndFinesNotAnonymizedAfterFeeFineCloseIntervalPassed()
+      throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeAfterXInterval(1, "minute")
+      .feeFineCloseAnonymizeAfterXInterval(20, "minute");
+    ConfigRecordBuilder config = new ConfigRecordBuilder("LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
+      .encodePrettily());
+    configClient.create(config);
+//*********************************************************************
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+
+    DateTimeUtils.setCurrentMillisOffset(20*ONE_MINUTE_AND_ONE);
+    anonymizeLoansInTenant();
+//*********************************************************************
+    assertThat(loansStorageClient.getById(loanID)
+      .getJson(), not(isAnonymized()));
+  }
+
+  /**
+   * Scenario 6
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "X interval after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of
+   *         "X interval after fee/fine closes"
+   *         A closed loan with an associated fee/fine
+   *     When all fees/fines associated with the loan are closed, and X
+   *     interval after the fee/fine closes has passed
+   *     Then anonymize the loan
+   */
+  @Test
+  public void testClosedLoansWithClosedFeesAndFinesAnonymizedAfterFeeFineCloseIntervalPassed()
+      throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeAfterXInterval(1, "minute")
+      .feeFineCloseAnonymizeAfterXInterval(20, "minute");
+    ConfigRecordBuilder config = new ConfigRecordBuilder("LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
+      .encodePrettily());
+    configClient.create(config);
+//*********************************************************************
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+
+    loansFixture.checkInByBarcode(item1);
+
+    DateTimeUtils.setCurrentMillisOffset(20 * ONE_MINUTE_AND_ONE);
+    anonymizeLoansInTenant();
+//*********************************************************************
+    assertThat(loansStorageClient.getById(loanID)
+      .getJson(), isAnonymized());
+  }
+
+  /**
+   * Scenario 7
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "X interval after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of
+   *         "Never"
+   *         An open loan with an associated fee/fine
+   *     When the item in the loan is checked in
+   *     Then do not anonymize the loan
+   */
+  @Test
+  public void testNeverAnonymizeClosedLoansWithAssociatedFeeFines()
+      throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeAfterXInterval(1, "minute")
+      .feeFineCloseAnonymizeNever();
+    ConfigRecordBuilder config = new ConfigRecordBuilder("LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
+      .encodePrettily());
+    configClient.create(config);
+//*********************************************************************
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+
+    loansFixture.checkInByBarcode(item1);
+
+    anonymizeLoansInTenant();
+//*********************************************************************
+    assertThat(loansStorageClient.getById(loanID)
+      .getJson(), not(isAnonymized()));
+  }
+
+  /**
+   * Scenario 8
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "X interval after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of
+   *         "Never"
+   *         An open loan with an associated fee/fine
+   *     When X interval has elapsed after the loan closed
+   *     Then do not anonymize the loan
+   */
+  @Test
+  public void testNeverAnonymizeClosedLoansWithAssociatedFeeFinesAfterAfterIntervalPassed()
+      throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeAfterXInterval(1, "minute")
+      .feeFineCloseAnonymizeNever();
+    ConfigRecordBuilder config = new ConfigRecordBuilder("LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
+      .encodePrettily());
+    configClient.create(config);
+//*********************************************************************
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+
+    loansFixture.checkInByBarcode(item1);
+
+    DateTimeUtils.setCurrentMillisOffset(ONE_MINUTE_AND_ONE);
+    anonymizeLoansInTenant();
+//*********************************************************************
+    assertThat(loansStorageClient.getById(loanID)
+      .getJson(), not(isAnonymized()));
+  }
+
+  /**
+   * Scenario 9
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "X interval after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of
+   *         "Never"
+   *         A closed loan with an associated fee/fine
+   *     When all fees/fines associated with the loan are closed
+   *     Then do not anonymize the loan
+   */
+  @Test
+  public void testNeverAnonymizeClosedLoansWithAssociatedFeeFinesAfterAfterIntervalNotPassed()
+      throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeAfterXInterval(1, "minute")
+      .feeFineCloseAnonymizeNever();
+    ConfigRecordBuilder config = new ConfigRecordBuilder("LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
+      .encodePrettily());
+    configClient.create(config);
+//*********************************************************************
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+
+    loansFixture.checkInByBarcode(item1);
+
+    anonymizeLoansInTenant();
+//*********************************************************************
+    assertThat(loansStorageClient.getById(loanID)
+      .getJson(), not(isAnonymized()));
+  }
+
+  @Test
+  public void testClosedLoansAnonymizedAfterIntervalPassed()
+      throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder().loanCloseAnonymizeAfterXInterval(1,
+        "minute");
+    ConfigRecordBuilder config = new ConfigRecordBuilder("LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
+        .encodePrettily());
+    configClient.create(config);
+//*********************************************************************
+    IndividualResource loanResource1 = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+        .to(user)
+        .at(servicePoint.getId()));
+    IndividualResource loanResource2 = loansFixture
+        .checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(itemsFixture.basedUponNod())
+            .to(usersFixture.rebecca())
+            .at(servicePoint.getId()));
+
+    UUID loanID = loanResource1.getId();
+
+    loansFixture.checkInByBarcode(item1);
+
+    DateTimeUtils.setCurrentMillisOffset(ONE_MINUTE_AND_ONE);
+    anonymizeLoansInTenant();
+//*********************************************************************
+    assertThat(loansStorageClient.getById(loanID)
+        .getJson(), isAnonymized());
+    assertThat(loansStorageClient.getById(loanResource2.getId())
+        .getJson(), not(isAnonymized()));
+  }
+
+  @Test
+  public void testClosedLoansNotAnonymizedAfterIntervalNotPassed()
+      throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder().loanCloseAnonymizeAfterXInterval(1,
+        "minute");
+    ConfigRecordBuilder config = new ConfigRecordBuilder("LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
+        .encodePrettily());
+    configClient.create(config);
+//*********************************************************************
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+        .to(user)
+        .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    loansFixture.checkInByBarcode(item1);
+
+    anonymizeLoansInTenant();
+//*********************************************************************
+    assertThat(loansStorageClient.getById(loanID)
+        .getJson(), not(isAnonymized()));
+  }
+}

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansByUserIdAPITests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansByUserIdAPITests.java
@@ -1,6 +1,5 @@
 package api.loans.anonymization;
 
-import static api.support.http.InterfaceUrls.circulationAnonymizeLoansURL;
 import static api.support.matchers.LoanMatchers.hasOpenStatus;
 import static api.support.matchers.LoanMatchers.isAnonymized;
 import static org.hamcrest.Matchers.not;
@@ -8,37 +7,19 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
-import org.folio.circulation.support.http.client.ResponseHandler;
-import org.junit.Before;
+import org.joda.time.DateTime;
 import org.junit.Test;
 
-import api.support.APITests;
-import api.support.builders.AccountBuilder;
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
 import api.support.http.InventoryItemResource;
 import io.vertx.core.json.JsonObject;
 
-public class AnonymizeLoansByUserIdAPITests extends APITests {
-
-  private static final int TIMEOUT_SECONDS = 10;
-  private InventoryItemResource item1;
-  private IndividualResource user;
-  private IndividualResource servicePoint;
-
-  @Before
-  public void setup() throws InterruptedException, MalformedURLException,
-      TimeoutException, ExecutionException {
-    item1 = itemsFixture.basedUponSmallAngryPlanet();
-    user = usersFixture.charlotte();
-    servicePoint = servicePointsFixture.cd1();
-  }
+public class AnonymizeLoansByUserIdAPITests extends LoanAnonymizationTests {
 
   @Test
   public void canNotAnonymizeNotClosedLoans()
@@ -121,10 +102,7 @@ public class AnonymizeLoansByUserIdAPITests extends APITests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    accountsClient.create(new AccountBuilder()
-      .withLoan(loanResource)
-      .feeFineStatusClosed()
-      .withRemainingFeeFine(150));
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
 
     loansFixture.checkInByBarcode(item1);
 
@@ -152,10 +130,7 @@ public class AnonymizeLoansByUserIdAPITests extends APITests {
     UUID loanID1 = loanResource1.getId();
     UUID loanID2 = loanResource2.getId();
 
-    accountsClient.create(new AccountBuilder().feeFineStatusOpen()
-      .withLoan(loanResource1)
-      .feeFineStatusOpen()
-      .withRemainingFeeFine(150));
+    createOpenAccountWithFeeFines(loanResource1);
 
     loansFixture.checkInByBarcode(item1);
     loansFixture.checkInByBarcode(item2);
@@ -179,10 +154,7 @@ public class AnonymizeLoansByUserIdAPITests extends APITests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    accountsClient.create(new AccountBuilder().feeFineStatusOpen()
-      .withLoan(loanResource)
-      .feeFineStatusOpen()
-      .withRemainingFeeFine(150));
+    createOpenAccountWithFeeFines(loanResource);
 
     loansFixture.checkInByBarcode(item1);
 
@@ -193,25 +165,5 @@ public class AnonymizeLoansByUserIdAPITests extends APITests {
     assertThat(json, not(isAnonymized()));
   }
 
-  private void anonymizeLoansForUser(UUID userId)
-      throws InterruptedException, ExecutionException, TimeoutException {
-    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
-    client.post(circulationAnonymizeLoansURL(userId.toString()), null, ResponseHandler.any(createCompleted));
-    Response response = createCompleted.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
-    response.getJson().getJsonArray("anonymizedLoans").forEach(this::fakeAnonymizeLoan);
-  }
-
-  private void fakeAnonymizeLoan(Object id) {
-    try {
-      JsonObject payload = loansStorageClient.get(UUID.fromString(id.toString()))
-        .getJson();
-      payload.remove("userId");
-      payload.remove("borrower");
-      loansStorageClient.attemptReplace(UUID.fromString(id.toString()), payload);
-
-    } catch (MalformedURLException | InterruptedException | ExecutionException | TimeoutException e) {
-      e.printStackTrace();
-    }
-  }
 
 }

--- a/src/test/java/api/loans/anonymization/LoanAnonymizationTests.java
+++ b/src/test/java/api/loans/anonymization/LoanAnonymizationTests.java
@@ -1,0 +1,105 @@
+package api.loans.anonymization;
+
+import static api.support.http.InterfaceUrls.circulationAnonymizeLoansInTenantURL;
+import static api.support.http.InterfaceUrls.circulationAnonymizeLoansURL;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.http.client.ResponseHandler;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.junit.Before;
+
+import api.support.APITests;
+import api.support.builders.AccountBuilder;
+import api.support.builders.FeefineActionsBuilder;
+import api.support.http.InventoryItemResource;
+import io.vertx.core.json.JsonObject;
+
+class LoanAnonymizationTests extends APITests {
+
+  private static final int TIMEOUT_SECONDS = 20;
+  protected static final int ONE_MINUTE_AND_ONE = 60001;
+  protected InventoryItemResource item1;
+  protected IndividualResource user;
+  protected IndividualResource servicePoint;
+
+  @Before
+  public void setup() throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+    item1 = itemsFixture.basedUponSmallAngryPlanet();
+    user = usersFixture.charlotte();
+    servicePoint = servicePointsFixture.cd1();
+  }
+
+  void anonymizeLoansInTenant() throws InterruptedException, ExecutionException, TimeoutException {
+    anonymizeLoans(circulationAnonymizeLoansInTenantURL());
+    DateTimeUtils.setCurrentMillisSystem();
+  }
+
+  void anonymizeLoansForUser(UUID userId) throws InterruptedException, ExecutionException, TimeoutException {
+    anonymizeLoans(circulationAnonymizeLoansURL(userId.toString()));
+  }
+
+  private void anonymizeLoans(URL url) throws InterruptedException, ExecutionException, TimeoutException {
+    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
+    client.post(url, null, ResponseHandler.any(createCompleted));
+    Response response = createCompleted.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    response.getJson()
+      .getJsonArray("anonymizedLoans")
+      .forEach(this::fakeAnonymizeLoan);
+  }
+
+  private void fakeAnonymizeLoan(Object id) {
+    try {
+      JsonObject payload = loansStorageClient.get(UUID.fromString(id.toString()))
+        .getJson();
+      payload.remove("userId");
+      payload.remove("borrower");
+      loansStorageClient.attemptReplace(UUID.fromString(id.toString()), payload);
+
+    } catch (MalformedURLException | InterruptedException | ExecutionException | TimeoutException e) {
+      e.printStackTrace();
+    }
+  }
+
+  void createOpenAccountWithFeeFines(IndividualResource loanResource)
+      throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+    IndividualResource account = accountsClient.create(new AccountBuilder().feeFineStatusOpen()
+      .withLoan(loanResource)
+      .feeFineStatusOpen()
+      .withRemainingFeeFine(150));
+
+    FeefineActionsBuilder builder = new FeefineActionsBuilder().forAccount(account.getId())
+      .withBalance(150)
+      .withDate(null);
+    feefineActionsClient.create(builder);
+  }
+
+  void createClosedAccountWithFeeFines(IndividualResource loanResource, DateTime closedDate)
+      throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+
+    IndividualResource account = accountsClient.create(new AccountBuilder().feeFineStatusOpen()
+      .withLoan(loanResource)
+      .feeFineStatusClosed()
+      .withRemainingFeeFine(0));
+
+    FeefineActionsBuilder builder = new FeefineActionsBuilder().forAccount(account.getId())
+      .withBalance(0)
+      .withDate(closedDate);
+
+    FeefineActionsBuilder builder1 = new FeefineActionsBuilder().forAccount(account.getId())
+        .withBalance(0)
+        .withDate(closedDate.minusDays(1));
+
+    feefineActionsClient.create(builder);
+    feefineActionsClient.create(builder1);
+  }
+}

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -81,6 +81,7 @@ public abstract class APITests {
 
   protected final ResourceClient loansClient = ResourceClient.forLoans(client);
   protected final ResourceClient accountsClient = ResourceClient.forAccounts(client);
+  protected final ResourceClient feefineActionsClient = ResourceClient.forFeefineActions(client);
 
   protected final ResourceClient loansStorageClient
     = ResourceClient.forLoansStorage(client);

--- a/src/test/java/api/support/builders/FeefineActionsBuilder.java
+++ b/src/test/java/api/support/builders/FeefineActionsBuilder.java
@@ -1,0 +1,53 @@
+package api.support.builders;
+
+import static org.folio.circulation.support.JsonPropertyWriter.write;
+
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+
+import io.vertx.core.json.JsonObject;
+
+public class FeefineActionsBuilder extends JsonBuilder implements Builder {
+
+  private String id;
+  private DateTime dateAction;
+  private Double balance;
+  private UUID accountId;
+
+  public FeefineActionsBuilder() {
+  }
+
+  public FeefineActionsBuilder(DateTime dateAction, Double balance,
+      UUID accountId) {
+    this.dateAction = dateAction;
+    this.balance = balance;
+    this.accountId = accountId;
+    this.id = UUID.randomUUID().toString();
+  }
+
+  @Override
+  public JsonObject create() {
+    JsonObject object = new JsonObject();
+
+    write(object, "id", id);
+    write(object, "dateAction", dateAction);
+    write(object, "balance", balance);
+    write(object, "accountId", accountId);
+
+    return object;
+  }
+
+  public FeefineActionsBuilder withDate(DateTime dateAction) {
+    return new FeefineActionsBuilder(dateAction, balance,accountId);
+  }
+
+  public FeefineActionsBuilder withBalance(double remaining) {
+    return new FeefineActionsBuilder(dateAction, remaining,accountId);
+  }
+
+  public FeefineActionsBuilder forAccount(UUID accountId) {
+    return new FeefineActionsBuilder(dateAction, balance,accountId);
+  }
+
+}

--- a/src/test/java/api/support/builders/LoanHistoryConfigurationBuilder.java
+++ b/src/test/java/api/support/builders/LoanHistoryConfigurationBuilder.java
@@ -1,0 +1,74 @@
+package api.support.builders;
+
+import io.vertx.core.json.JsonObject;
+
+public class LoanHistoryConfigurationBuilder extends JsonBuilder implements Builder {
+
+  private boolean exceptionForFeesAndFines;
+  private String loanClosingType;
+  private String feeFineClosingType;
+  private Integer loanCloseDuration;
+  private String loanCloseIntervalId;
+  private Integer feeFineCloseDuration;
+  private String feeFineCloseIntervalId;
+
+  public LoanHistoryConfigurationBuilder loanCloseAnonymizeImmediately() {
+    loanClosingType = "immediately";
+    return this;
+  }
+
+  public LoanHistoryConfigurationBuilder loanCloseAnonymizeAfterXInterval(Integer duration, String intervalId) {
+    loanClosingType = "interval";
+    loanCloseDuration = duration;
+    loanCloseIntervalId = intervalId;
+    return this;
+  }
+
+  public LoanHistoryConfigurationBuilder feeFineCloseAnonymizeAfterXInterval(Integer duration, String intervalId) {
+    feeFineClosingType = "interval";
+    feeFineCloseDuration = duration;
+    feeFineCloseIntervalId = intervalId;
+    exceptionForFeesAndFines = true;
+    return this;
+  }
+
+  public LoanHistoryConfigurationBuilder loanCloseAnonymizeNever() {
+    loanClosingType = "never";
+    return this;
+  }
+
+  public LoanHistoryConfigurationBuilder feeFineCloseAnonymizeImmediately() {
+    exceptionForFeesAndFines = true;
+    feeFineClosingType = "immediately";
+    return this;
+  }
+
+  public LoanHistoryConfigurationBuilder feeFineCloseAnonymizeNever() {
+    exceptionForFeesAndFines = true;
+    loanClosingType = "never";
+    return this;
+  }
+
+  @Override
+  public JsonObject create() {
+    JsonObject config = new JsonObject();
+
+    JsonObject closingType = new JsonObject();
+    put(closingType, "loan", loanClosingType);
+    put(closingType, "feeFine", feeFineClosingType);
+
+    JsonObject feeFine = new JsonObject();
+    put(feeFine, "intervalId", feeFineCloseIntervalId);
+    put(feeFine, "duration", feeFineCloseDuration);
+
+    JsonObject loan = new JsonObject();
+    put(loan, "intervalId", loanCloseIntervalId);
+    put(loan, "duration", loanCloseDuration);
+
+    put(config, "closingType", closingType);
+    put(config, "treatEnabled", exceptionForFeesAndFines);
+    put(config, "feeFine", feeFine);
+    put(config, "loan", loan);
+    return config;
+  }
+}

--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -136,6 +136,12 @@ public class FakeOkapi extends AbstractVerticle {
       .create().register(router);
 
     new FakeStorageModuleBuilder()
+        .withRecordName("feefineactions")
+        .withRootPath("/feefineactions")
+        .withCollectionPropertyName("feefineactions")
+        .create().register(router);
+
+    new FakeStorageModuleBuilder()
       .withRecordName("request policy")
       .withRootPath("/request-policy-storage/request-policies")
       .withCollectionPropertyName("requestPolicies")

--- a/src/test/java/api/support/http/InterfaceUrls.java
+++ b/src/test/java/api/support/http/InterfaceUrls.java
@@ -152,12 +152,20 @@ public class InterfaceUrls {
     return circulationModuleUrl("/loan-anonymization/by-user/" + subPath);
   }
 
+  public static URL circulationAnonymizeLoansInTenantURL() {
+    return circulationModuleUrl("/circulation/scheduled-anonymize-processing/");
+  }
+
   public static URL endSessionUrl() {
     return circulationModuleUrl("/circulation/end-patron-action-session");
   }
 
   public static URL accountsUrl(String subPath) {
     return APITestContext.viaOkapiModuleUrl("/accounts" + subPath);
+  }
+
+  public static URL feefineActionsUrl(String subPath) {
+    return APITestContext.viaOkapiModuleUrl("/feefineactions" + subPath);
   }
 
   public static URL circulationRulesUrl() {

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -71,6 +71,10 @@ public class ResourceClient {
       "accounts");
   }
 
+  public static ResourceClient forFeefineActions(OkapiHttpClient client) {
+    return new ResourceClient(client, InterfaceUrls::feefineActionsUrl, "feefineactions");
+  }
+
   public static ResourceClient forLoanPolicies(OkapiHttpClient client) {
     return new ResourceClient(client, InterfaceUrls::loanPoliciesStorageUrl,
       "loan policies", "loanPolicies");


### PR DESCRIPTION


# Automatic loan anonymization based on the loan history setting of "X interval after loan closes"


## Purpose
Anonymizing closed loans through settings.
This resolves: CIRC-367 and is a baseline for other anonymization-related stories, such as CIRC-365, etc.

## Approach
The loan anonymization process is scheduled to run in short intervals; every minute (set in the module-descriptor) okapi makes a call to /circulation/scheduled-anonymize-processing, which kicks off the loan anonymization in the current tenant. It finds all closed loans and anonymizes them based on the loan history settings. Fees and fines settings are to be followed regardless of whether it differs from the general setting for anonymization.
The closing date of a fee/fine is not saved as a field, so is derived from the feefineactions of that fee/fine.

![circ-367](https://user-images.githubusercontent.com/49403013/66990092-3a169b00-f0ce-11e9-9b72-0d4c4e02966b.png)

### Todos and open questions
The interval of one minute was chosen as a minimum discrete time period. The optimal value for it will need to be adjusted empirically based on the ballpark number of loans to be anonymized in a tenant and other parameters.





