### PR TITLE
Verbose doc of criterium syntax, complete example, heading for "!" and "all"

### DIFF
--- a/doc/circulationrules.md
+++ b/doc/circulationrules.md
@@ -74,13 +74,26 @@ implemented in the circulation rules engine yet causing these rules to never mat
 
 A criterium consists of a single letter criterium type and a name selection of that type.
 
-If it has one or more names of that type like `g visitor undergrad` then it matches
-any patron group listed.
+If it has one or more names of that type it matches any patron group listed. If the patron
+group is `visitor` or `undergrad` this rule matches:
 
-If it has one or more negated names of that type like `g !visitor !undergrad` then it matches
-any patron group that is not listed, for example `staff`.
+```
+g visitor undergrad: policy-a
+```
 
-Use the keyword `all` for the name selection like `g all` to match all patron groups.
+### "!" and "all"
+
+If the criterium has one or more negated names (name with exclamation mark prepended) then it matches
+any patron group that is not listed, for example this rule matches `staff` but neither `visitor` nor `undergrad`:
+
+```
+g !visitor !undergrad: policy-b
+```
+
+Use the keyword `all` for the name selection to match all patron groups, for example
+```
+g all: policy-c
+```
 This is needed to alter the rule priority, see below.
 
 ## Criteria


### PR DESCRIPTION
The current documentation about the criterium syntax is illegible, it hides the syntax,
and we cannot expect people to read the document but we must assume that they only
skim through it.

Therefore the explanation needs to be verbose by using complete examples that stands
out instead of the in-line examples.

A heading needs to be added for the "!" and "all" syntax to catch the eye.