### PR TITLE
Revert CIRC-465 store item location at check out

### DIFF
--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -155,11 +155,6 @@
         }
       }
     },
-    "itemEffectiveLocationIdAtCheckOut": {
-      "description": "The effective location, at the time of checkout, of the item loaned to the patron.",
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
-    },
     "status": {
       "description": "Overall status of the loan",
       "type": "object",

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -4,7 +4,6 @@ import static java.lang.Boolean.TRUE;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static org.folio.circulation.domain.representations.LoanProperties.ACTION_COMMENT;
-import static org.folio.circulation.domain.representations.LoanProperties.ITEM_LOCATION_ID_AT_CHECKOUT;
 import static org.folio.circulation.domain.representations.LoanProperties.CHECKIN_SERVICE_POINT_ID;
 import static org.folio.circulation.domain.representations.LoanProperties.CHECKOUT_SERVICE_POINT_ID;
 import static org.folio.circulation.domain.representations.LoanProperties.DUE_DATE;
@@ -143,10 +142,6 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   public void changeActionComment(String comment) {
     representation.put(ACTION_COMMENT, comment);
-  }
-  public Loan changeItemEffectiveLocationIdAtCheckOut(String locationId) {
-    representation.put(ITEM_LOCATION_ID_AT_CHECKOUT, locationId);
-    return this;
   }
 
   private void removeActionComment() {

--- a/src/main/java/org/folio/circulation/domain/LoanAndRelatedRecords.java
+++ b/src/main/java/org/folio/circulation/domain/LoanAndRelatedRecords.java
@@ -42,11 +42,6 @@ public class LoanAndRelatedRecords implements UserRelatedRecord {
     return withLoan(loan.withItem(newItem));
   }
 
-  public LoanAndRelatedRecords withItemEffectiveLocationIdAtCheckOut() {
-    Item item = this.loan.getItem();
-    return withLoan(loan.changeItemEffectiveLocationIdAtCheckOut(item.getLocationId()));
-  }
-
   public LoanAndRelatedRecords withTimeZone(DateTimeZone newTimeZone) {
     return new LoanAndRelatedRecords(loan, requestQueue, newTimeZone);
   }

--- a/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
@@ -14,7 +14,6 @@ public class LoanProperties {
   public static final String CHECKIN_SERVICE_POINT_ID = "checkinServicePointId";
   public static final String CHECKOUT_SERVICE_POINT_ID = "checkoutServicePointId";
   public static final String ACTION_COMMENT = "actionComment";
-  public static final String ITEM_LOCATION_ID_AT_CHECKOUT = "itemEffectiveLocationIdAtCheckOut";
   public static final String BORROWER = "borrower";
   public static final String LOAN_POLICY = "loanPolicy";
   public static final String FEESANDFINES = "feesAndFines";

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -10,7 +10,6 @@ import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 import org.folio.circulation.domain.ConfigurationRepository;
 import org.folio.circulation.domain.Item;
@@ -148,7 +147,6 @@ public class CheckOutByBarcodeResource extends Resource {
       .thenApply(inactiveUserValidator::refuseWhenUserIsInactive)
       .thenApply(inactiveProxyUserValidator::refuseWhenUserIsInactive)
       .thenCombineAsync(itemRepository.fetchByBarcode(itemBarcode), this::addItem)
-      .thenComposeAsync(r -> r.after(this::addItemLocation))
       .thenApply(itemNotFoundValidator::refuseWhenItemNotFound)
       .thenApply(alreadyCheckedOutValidator::refuseWhenItemIsAlreadyCheckedOut)
       .thenApply(itemMissingValidator::refuseWhenItemIsMissing)
@@ -215,10 +213,5 @@ public class CheckOutByBarcodeResource extends Resource {
 
     return Result.combine(loanResult, inventoryRecordsResult,
       LoanAndRelatedRecords::withItem);
-  }
-  private CompletableFuture<Result<LoanAndRelatedRecords>> addItemLocation(
-    LoanAndRelatedRecords relatedRecords) {
-
-    return completedFuture(succeeded(relatedRecords.withItemEffectiveLocationIdAtCheckOut()));
   }
 }

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -14,7 +14,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
@@ -67,21 +66,13 @@ public class CheckInByBarcodeTests extends APITests {
     final IndividualResource homeLocation = locationsFixture.basedUponExampleLocation(
       builder -> builder.withPrimaryServicePoint(checkInServicePointId));
 
-    final String anotherLocationId = locationsFixture.thirdFloor().getId().toString();
-
-    IndividualResource nod = itemsFixture.basedUponNod(
+    final IndividualResource nod = itemsFixture.basedUponNod(
       builder -> builder.withTemporaryLocation(homeLocation.getId()));
 
     final IndividualResource loan = loansFixture.checkOutByBarcode(nod, james,
       new DateTime(2018, 3, 1, 13, 25, 46, DateTimeZone.UTC));
 
     DateTime expectedSystemReturnDate = DateTime.now(DateTimeZone.UTC);
-    // Change the item's effective location to verify itemEffectiveLocationIdAtCheckOut is unchanged
-    JsonObject update = nod.getJson();
-    update.put("temporaryLocationId", anotherLocationId);
-    itemsFixture.updateItem(nod.getId(), update);
-
-    nod = new IndividualResource( itemsFixture.getItem(nod.getId()) );
 
     final CheckInByBarcodeResponse checkInResponse = loansFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
@@ -111,13 +102,6 @@ public class CheckInByBarcodeTests extends APITests {
 
     assertThat("ID should be included for item",
       loanRepresentation.getJsonObject("item").getString("id"), is(nod.getId()));
-
-    assertThat("New location should not equal old location",
-      homeLocation.getId().toString(), not(anotherLocationId));
-    assertThat("The item's temporary location ID should be updated",
-      nod.getJson().getString("temporaryLocationId"), is(anotherLocationId));
-    assertThat("itemEffectiveLocationIdAtCheckOut should match the original location ID at checkout",
-      loanRepresentation.getString("itemEffectiveLocationIdAtCheckOut"), is(homeLocation.getId().toString()));
 
     assertThat("title is taken from item",
       loanRepresentation.getJsonObject("item").getString("title"),

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -62,9 +62,6 @@ public class CheckOutByBarcodeTests extends APITests {
     ExecutionException {
 
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
-    InventoryItemResource smallAngryPlanetRsrc = (InventoryItemResource)smallAngryPlanet;
-    JsonObject holding = smallAngryPlanetRsrc.getHoldingsRecord().getJson();
-
     final IndividualResource steve = usersFixture.steve();
 
     final DateTime loanDate = new DateTime(2018, 3, 18, 11, 43, 54, DateTimeZone.UTC);
@@ -87,9 +84,6 @@ public class CheckOutByBarcodeTests extends APITests {
 
     assertThat("item ID should match barcode",
       loan.getString("itemId"), is(smallAngryPlanet.getId()));
-
-    assertThat("itemEffectiveLocationIdAtCheckOut should match permanent location ID",
-      loan.getString("itemEffectiveLocationIdAtCheckOut"), is(holding.getString("permanentLocationId")));
 
     assertThat("status should be open",
       loan.getJsonObject("status").getString("name"), is("Open"));

--- a/src/test/java/api/support/fakes/StorageSchema.java
+++ b/src/test/java/api/support/fakes/StorageSchema.java
@@ -8,7 +8,7 @@ public class StorageSchema {
   private StorageSchema() { }
 
   public static JsonSchemaValidator validatorForStorageLoanSchema() throws IOException {
-    return JsonSchemaValidator.fromResource("/storage-loan-6-3.json");
+    return JsonSchemaValidator.fromResource("/storage-loan-6-2.json");
   }
 
   public static JsonSchemaValidator validatorForLocationInstSchema() throws IOException {

--- a/src/test/java/api/support/fixtures/ItemsFixture.java
+++ b/src/test/java/api/support/fixtures/ItemsFixture.java
@@ -13,7 +13,6 @@ import java.util.function.Function;
 
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
-import org.folio.circulation.support.http.client.Response;
 
 import api.support.builders.HoldingBuilder;
 import api.support.builders.InstanceBuilder;
@@ -52,17 +51,6 @@ public class ItemsFixture {
 
     contributorNameTypeRecordCreator = new RecordCreator(
       contributorNameTypesClient, nameType -> getProperty(nameType, "name"));
-  }
-
-  public Response updateItem(UUID itemId, JsonObject update)
-      throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
-
-    return itemsClient.attemptReplace(itemId, update);
-  }
-  public Response getItem(UUID itemId)
-      throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
-
-    return itemsClient.getById(itemId);
   }
 
   public void cleanUp()

--- a/src/test/resources/storage-loan-6-2.json
+++ b/src/test/resources/storage-loan-6-2.json
@@ -21,11 +21,6 @@
       "description": "ID of the item lent to the patron",
       "type": "string"
     },
-    "itemEffectiveLocationIdAtCheckOut": {
-      "description": "The effective location, at the time of checkout, of the item loaned to the patron.",
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
-    },
     "status": {
       "description": "Overall status of the loan",
       "type": "object",


### PR DESCRIPTION
## Purpose

The [pull request](https://github.com/folio-org/mod-circulation/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc) for [CIRC-553](https://issues.folio.org/browse/CIRC-553) introduced a change which causes all check outs to fail.

The resolution isn't as simple as I thought it would be, so the original change needs reverting to fix the hosted reference environments. 