### PR TITLE
CIRC-364: Add tests for anonymize closed loans setting of "Immediately"

### DIFF
--- a/src/test/java/api/loans/anonymization/AnonymizeLoansImmediatelyAPITests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansImmediatelyAPITests.java
@@ -29,7 +29,7 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
    *     Then do not anonymize the loan
    */
   @Test
-  public void testOpenLoansWithOpenFeesAndFinesIsNotAnonymized()
+  public void testClosedLoanWithOpenFeesAndFinesIsNotAnonymizedForSettingsOfImmediately()
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
@@ -42,7 +42,8 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+    createOpenAccountWithFeeFines(loanResource);
+    loansFixture.checkInByBarcode(item1);
 
     anonymizeLoansInTenant();
 
@@ -61,7 +62,7 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
    *     Then anonymize the loan
    */
   @Test
-  public void testClosedLoansWithClosedFeesAndIsAnonymized()
+  public void testClosedLoanWithClosedFeesAndFinesIsAnonymizedForSettingsOfImmediately()
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
@@ -89,13 +90,13 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
    *
    *     Given:
    *         An Anonymize closed loans setting of "Immediately after loan closes"
-   *         An Anonymize closed loans with associated fees/fines setting of "Immediately after fee/fine closes"
-   *         A closed loan with an associated fee/fine
-   *     When all fees/fines associated with the loan are closed
-   *     Then anonymize the loan
+   *         An Anonymize closed loans with associated fees/fines setting of "Never"
+   *         An open loan with an associated fee/fine
+   *     When the item in the loan is checked in
+   *     Then do not anonymize the loan
    */
   @Test
-  public void testClosedLoansWithOpenFeesAndFinesIsNotAnonymized()
+  public void testClosedLoanWithOpenFeesAndFinesIsNotAnonymizedForSettingsOfNever()
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
@@ -129,7 +130,7 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
    *     Then do not anonymize the loan
    */
   @Test
-  public void testClosedLoansWithClosedFeesAndFinesIsNotAnonymized()
+  public void testOpenLoanWithClosedFeesAndFinesIsNotAnonymizedForSettingsOfNever()
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
@@ -163,7 +164,7 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
    *     Then do not anonymize the loan
    */
   @Test
-  public void testClosedLoansWithOpenFeesAndFinesIsNotAnonymizedWhenIntervalNotPassed()
+  public void testClosedLoanWithClosedFeesAndFinesIsNotAnonymizedWhenIntervalAfterFeeFineClosesNotPassed()
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
@@ -197,7 +198,7 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
    *     Then do not anonymize the loan
    */
   @Test
-  public void testClosedLoansWithOpenFeesAndFinesIsAnonymizedWhenIntervalPassed()
+  public void testClosedLoansWithOpenFeesAndFinesIsAnonymizedWhenIntervaAfterFeeFineCloseslPassed()
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansImmediatelyAPITests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansImmediatelyAPITests.java
@@ -1,0 +1,223 @@
+package api.loans.anonymization;
+
+import static api.support.matchers.LoanMatchers.isAnonymized;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import java.net.MalformedURLException;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import api.support.builders.CheckOutByBarcodeRequestBuilder;
+import api.support.builders.LoanHistoryConfigurationBuilder;
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.junit.Test;
+
+public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
+
+  /**
+   * Scenario 1
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "Immediately after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of "Immediately after fee/fine closes"
+   *         An open loan with an associated fee/fine
+   *     When the item in the loan is checked in
+   *     Then do not anonymize the loan
+   */
+  @Test
+  public void testOpenLoansWithOpenFeesAndFinesIsNotAnonymized()
+    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeImmediately()
+      .feeFineCloseAnonymizeImmediately();
+    createConfiguration(loanHistoryConfig);
+
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+
+    anonymizeLoansInTenant();
+
+    assertThat(loansStorageClient.getById(loanID)
+      .getJson(), not(isAnonymized()));
+  }
+
+  /**
+   * Scenario 2
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "Immediately after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of "Immediately after fee/fine closes"
+   *         A closed loan with an associated fee/fine
+   *     When all fees/fines associated with the loan are closed
+   *     Then anonymize the loan
+   */
+  @Test
+  public void testClosedLoansWithClosedFeesAndIsAnonymized()
+    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeImmediately()
+      .feeFineCloseAnonymizeImmediately();
+    createConfiguration(loanHistoryConfig);
+
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+
+    loansFixture.checkInByBarcode(item1);
+
+    anonymizeLoansInTenant();
+
+    assertThat(loansStorageClient.getById(loanID)
+      .getJson(), isAnonymized());
+  }
+
+  /**
+   * Scenario 3
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "Immediately after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of "Immediately after fee/fine closes"
+   *         A closed loan with an associated fee/fine
+   *     When all fees/fines associated with the loan are closed
+   *     Then anonymize the loan
+   */
+  @Test
+  public void testClosedLoansWithOpenFeesAndFinesIsNotAnonymized()
+    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeImmediately()
+      .feeFineCloseAnonymizeNever();
+    createConfiguration(loanHistoryConfig);
+
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createOpenAccountWithFeeFines(loanResource);
+
+    loansFixture.checkInByBarcode(item1);
+
+    anonymizeLoansInTenant();
+
+    assertThat(loansStorageClient.getById(loanID).getJson(),
+      not(isAnonymized()));
+  }
+
+  /**
+   * Scenario 4
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "Immediately after loan closes"
+   *         An Anonymize closed loans with associated fees/fines setting of "Never"
+   *         An open loan with an associated fee/fine
+   *     When all fees/fines associated with the loan are closed
+   *     Then do not anonymize the loan
+   */
+  @Test
+  public void testClosedLoansWithClosedFeesAndFinesIsNotAnonymized()
+    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeImmediately()
+      .feeFineCloseAnonymizeNever();
+    createConfiguration(loanHistoryConfig);
+
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+
+    loansFixture.checkInByBarcode(item1);
+
+    anonymizeLoansInTenant();
+
+    assertThat(loansStorageClient.getById(loanID).getJson(),
+      not(isAnonymized()));
+  }
+
+  /**
+   * Scenario 1.1
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "Immediately"
+   *         An Anonymize closed loans with associated fees/fines setting of "X interval after fee/fine closes"
+   *         An open loan with an associated fee/fine
+   *     When the item in the loan is checked in
+   *     Then do not anonymize the loan
+   */
+  @Test
+  public void testClosedLoansWithOpenFeesAndFinesIsNotAnonymizedWhenIntervalNotPassed()
+    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeImmediately()
+      .feeFineCloseAnonymizeAfterXInterval(1, "minute");
+    createConfiguration(loanHistoryConfig);
+
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+
+    loansFixture.checkInByBarcode(item1);
+
+    anonymizeLoansInTenant();
+
+    assertThat(loansStorageClient.getById(loanID).getJson(),
+      not(isAnonymized()));
+  }
+
+  /**
+   * Scenario 1.2
+   *
+   *     Given:
+   *         An Anonymize closed loans setting of "Immediately"
+   *         An Anonymize closed loans with associated fees/fines setting of "X interval after fee/fine closes"
+   *         An open loan with an associated fee/fine
+   *     When the item in the loan is checked in
+   *     Then do not anonymize the loan
+   */
+  @Test
+  public void testClosedLoansWithOpenFeesAndFinesIsAnonymizedWhenIntervalPassed()
+    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
+      .loanCloseAnonymizeImmediately()
+      .feeFineCloseAnonymizeAfterXInterval(1, "minute");
+    createConfiguration(loanHistoryConfig);
+
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+
+    loansFixture.checkInByBarcode(item1);
+
+    DateTimeUtils.setCurrentMillisOffset(ONE_MINUTE_AND_ONE);
+    anonymizeLoansInTenant();
+
+    assertThat(loansStorageClient.getById(loanID).getJson(),
+      isAnonymized());
+  }
+}

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansImmediatelyAPITests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansImmediatelyAPITests.java
@@ -19,8 +19,6 @@ import org.junit.Test;
 public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
 
   /**
-   * Scenario 1
-   *
    *     Given:
    *         An Anonymize closed loans setting of "Immediately after loan closes"
    *         An Anonymize closed loans with associated fees/fines setting of "Immediately after fee/fine closes"
@@ -29,7 +27,7 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
    *     Then do not anonymize the loan
    */
   @Test
-  public void testClosedLoanWithOpenFeesAndFinesIsNotAnonymizedForSettingsOfImmediately()
+  public void shouldNotAnonymizeClosedLoansWithOpenFeesAndFinesAndSettingsOfAnonymizeImmediately()
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
@@ -52,8 +50,6 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
   }
 
   /**
-   * Scenario 2
-   *
    *     Given:
    *         An Anonymize closed loans setting of "Immediately after loan closes"
    *         An Anonymize closed loans with associated fees/fines setting of "Immediately after fee/fine closes"
@@ -62,7 +58,7 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
    *     Then anonymize the loan
    */
   @Test
-  public void testClosedLoanWithClosedFeesAndFinesIsAnonymizedForSettingsOfImmediately()
+  public void shouldAnonymizeClosedLoansWhenFeesAndFinesCloseAndSettingsOfAnonymizeImmediately()
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
@@ -86,8 +82,6 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
   }
 
   /**
-   * Scenario 3
-   *
    *     Given:
    *         An Anonymize closed loans setting of "Immediately after loan closes"
    *         An Anonymize closed loans with associated fees/fines setting of "Never"
@@ -96,7 +90,7 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
    *     Then do not anonymize the loan
    */
   @Test
-  public void testClosedLoanWithOpenFeesAndFinesIsNotAnonymizedForSettingsOfNever()
+  public void shouldNotAnonymizeWhenLoansWithOpenFeesAndFinesCloseAndSettingsOfNeverAnonymizeLoansWithFeesAndFines()
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
@@ -120,8 +114,6 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
   }
 
   /**
-   * Scenario 4
-   *
    *     Given:
    *         An Anonymize closed loans setting of "Immediately after loan closes"
    *         An Anonymize closed loans with associated fees/fines setting of "Never"
@@ -130,7 +122,7 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
    *     Then do not anonymize the loan
    */
   @Test
-  public void testOpenLoanWithClosedFeesAndFinesIsNotAnonymizedForSettingsOfNever()
+  public void shouldNotAnonymizeOpenLoansWhenFeesAndFinesCloseAndSettingsOfNeverAnonymizeLoansWithFeesAndFines()
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
@@ -145,8 +137,6 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
 
     createClosedAccountWithFeeFines(loanResource, DateTime.now());
 
-    loansFixture.checkInByBarcode(item1);
-
     anonymizeLoansInTenant();
 
     assertThat(loansStorageClient.getById(loanID).getJson(),
@@ -154,8 +144,6 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
   }
 
   /**
-   * Scenario 1.1
-   *
    *     Given:
    *         An Anonymize closed loans setting of "Immediately"
    *         An Anonymize closed loans with associated fees/fines setting of "X interval after fee/fine closes"
@@ -164,7 +152,7 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
    *     Then do not anonymize the loan
    */
   @Test
-  public void testClosedLoanWithClosedFeesAndFinesIsNotAnonymizedWhenIntervalAfterFeeFineClosesNotPassed()
+  public void shouldNotAnonymizeClosedLoansWithClosedFeesAndFinesWhenAnonymizationIntervalForLoansWithFeesAndFinesHasNotPassed()
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()
@@ -188,17 +176,16 @@ public class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
   }
 
   /**
-   * Scenario 1.2
    *
    *     Given:
    *         An Anonymize closed loans setting of "Immediately"
    *         An Anonymize closed loans with associated fees/fines setting of "X interval after fee/fine closes"
-   *         An open loan with an associated fee/fine
-   *     When the item in the loan is checked in
-   *     Then do not anonymize the loan
+   *         A closed loan with an associated fee/fine
+   *     When all fees/fines associated with the loan are closed, and X interval has elapsed after the fees/fines have closed
+   *     Then anonymize the loan
    */
   @Test
-  public void testClosedLoansWithOpenFeesAndFinesIsAnonymizedWhenIntervaAfterFeeFineCloseslPassed()
+  public void shouldAnonymizeClosedLoansWhenFeesAndFinesCloseAndAnonymizationIntervalForLoansWithFeesAndFinesHasPassed()
     throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
 
     LoanHistoryConfigurationBuilder loanHistoryConfig = new LoanHistoryConfigurationBuilder()


### PR DESCRIPTION
# Purpose

This is just unit test coverage of automatic loan anonymization, the implementation was completed in CIRC-367