### PR TITLE
Use millisecond precision when checking zoned date time

### DIFF
--- a/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
+++ b/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
@@ -9,6 +9,7 @@ import static api.support.builders.RequestBuilder.OPEN_IN_TRANSIT;
 import static api.support.builders.RequestBuilder.OPEN_NOT_YET_FILLED;
 import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
 import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
+import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static org.folio.HttpStatus.HTTP_OK;
 import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfTheDay;
 import static org.hamcrest.CoreMatchers.is;
@@ -22,7 +23,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -95,11 +95,11 @@ public class HoldShelfExpirationDateTests extends APITests{
     final JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
 
     assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
-        storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
+      storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
 
     assertThat("request hold shelf expiration date is " + amount + " " + interval.toString() + " in the future",
       storedRequest.getString("holdShelfExpirationDate"),
-      is(toIsoString(interval.addTo(ZonedDateTime.now(clock), amount))));
+      isEquivalentTo(interval.addTo(ZonedDateTime.now(clock), amount)));
   }
 
   @Test
@@ -144,7 +144,7 @@ public class HoldShelfExpirationDateTests extends APITests{
 
     assertThat("request hold shelf expiration date is " + amount + " " + interval.toString() + " in the future",
       storedRequest.getString("holdShelfExpirationDate"),
-      is(toIsoString(expectedExpirationDate)));
+      isEquivalentTo(expectedExpirationDate));
   }
 
   @Test
@@ -182,7 +182,7 @@ public class HoldShelfExpirationDateTests extends APITests{
 
     assertThat(storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
     assertThat(storedRequest.getString("holdShelfExpirationDate"),
-      is(toIsoString(expectedExpirationDate)));
+      isEquivalentTo(expectedExpirationDate));
   }
 
   @Test
@@ -220,7 +220,7 @@ public class HoldShelfExpirationDateTests extends APITests{
 
     assertThat(storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
     assertThat(storedRequest.getString("holdShelfExpirationDate"),
-      is(toIsoString(expectedExpirationDate)));
+      isEquivalentTo(expectedExpirationDate));
   }
 
   @Test
@@ -257,8 +257,8 @@ public class HoldShelfExpirationDateTests extends APITests{
       ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30));
 
     assertThat("request hold shelf expiration date is 30 days in the future",
-      storedRequest.getString("holdShelfExpirationDate"), is(
-        expectedExpirationDate.format(DateTimeFormatter.ISO_INSTANT)));
+      storedRequest.getString("holdShelfExpirationDate"),
+      isEquivalentTo(expectedExpirationDate));
 
     Clock not30Days = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC);
 
@@ -282,8 +282,8 @@ public class HoldShelfExpirationDateTests extends APITests{
       ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30));
 
     assertThat("request hold shelf expiration date is 30 days in the future and has not been updated",
-        storedRequest.getString("holdShelfExpirationDate"),
-      is(expectedExpirationDateAfterUpdate.format(DateTimeFormatter.ISO_INSTANT)));
+      storedRequest.getString("holdShelfExpirationDate"),
+      isEquivalentTo(expectedExpirationDateAfterUpdate));
   }
 
   @Test
@@ -313,17 +313,17 @@ public class HoldShelfExpirationDateTests extends APITests{
     JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
 
     assertThat("Item status snapshot in storage is " + AWAITING_PICKUP,
-        nod, hasItemStatus(AWAITING_PICKUP));
+      nod, hasItemStatus(AWAITING_PICKUP));
 
     assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
-        storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
+      storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
 
     final ZonedDateTime expectedExpirationDate = atEndOfTheDay(
       ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30));
 
     assertThat("request hold shelf expiration date is 30 days in the future",
       storedRequest.getString("holdShelfExpirationDate"),
-      is(expectedExpirationDate.format(DateTimeFormatter.ISO_INSTANT)));
+      isEquivalentTo(expectedExpirationDate));
 
     loansFixture.checkInByBarcode(
         new CheckInByBarcodeRequestBuilder()
@@ -333,10 +333,10 @@ public class HoldShelfExpirationDateTests extends APITests{
     final JsonObject storedSecondCheckInRequest = requestsClient.getById(request.getId()).getJson();
 
     assertThat("request status snapshot in storage is " + OPEN_IN_TRANSIT,
-        storedSecondCheckInRequest.getString("status"), is(OPEN_IN_TRANSIT));
+      storedSecondCheckInRequest.getString("status"), is(OPEN_IN_TRANSIT));
 
     assertThat("request hold shelf expiration date is not set",
-        storedSecondCheckInRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
+      storedSecondCheckInRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
   }
 
   @Test
@@ -366,14 +366,14 @@ public class HoldShelfExpirationDateTests extends APITests{
     final JsonObject storedRequest = getByIdResponse.getJson();
 
     assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
-        storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
+      storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
 
     final ZonedDateTime expectedExpirationDate = atEndOfTheDay(
       ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30));
 
     assertThat("request hold shelf expiration date is 30 days in the future",
       storedRequest.getString("holdShelfExpirationDate"),
-      is(expectedExpirationDate.format(DateTimeFormatter.ISO_INSTANT)));
+      isEquivalentTo(expectedExpirationDate));
   }
 
   @Test
@@ -398,10 +398,10 @@ public class HoldShelfExpirationDateTests extends APITests{
     JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
 
     assertThat("Item status snapshot in storage is " + CHECKED_OUT,
-        nod, hasItemStatus(CHECKED_OUT));
+      nod, hasItemStatus(CHECKED_OUT));
 
     assertThat("request status snapshot in storage is " + OPEN_NOT_YET_FILLED,
-        storedRequest.getString("status"), is(OPEN_NOT_YET_FILLED));
+      storedRequest.getString("status"), is(OPEN_NOT_YET_FILLED));
 
     loansFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
@@ -411,10 +411,10 @@ public class HoldShelfExpirationDateTests extends APITests{
     storedRequest = requestsClient.getById(request.getId()).getJson();
 
     assertThat("request status snapshot in storage is " + OPEN_IN_TRANSIT,
-        storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
+      storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
 
     assertThat("request hold shelf expiration date is not set",
-        storedRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
+      storedRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
   }
 
   @Test
@@ -438,10 +438,10 @@ public class HoldShelfExpirationDateTests extends APITests{
     JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
 
     assertThat("Item status snapshot in storage is " + PAGED,
-        nod, hasItemStatus(PAGED));
+      nod, hasItemStatus(PAGED));
 
     assertThat("request status snapshot in storage is " + OPEN_NOT_YET_FILLED,
-        storedRequest.getString("status"), is(OPEN_NOT_YET_FILLED));
+      storedRequest.getString("status"), is(OPEN_NOT_YET_FILLED));
 
     loansFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
@@ -451,10 +451,10 @@ public class HoldShelfExpirationDateTests extends APITests{
     storedRequest = requestsClient.getById(request.getId()).getJson();
 
     assertThat("request status snapshot in storage is " + OPEN_IN_TRANSIT,
-        storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
+      storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
 
     assertThat("request hold shelf expiration date is not set",
-        storedRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
+      storedRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
   }
 
   @Test
@@ -485,13 +485,13 @@ public class HoldShelfExpirationDateTests extends APITests{
     JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
 
     assertThat("Item status snapshot in storage is " + IN_TRANSIT,
-        nod, hasItemStatus(IN_TRANSIT));
+      nod, hasItemStatus(IN_TRANSIT));
 
     assertThat("request status snapshot in storage is " + OPEN_IN_TRANSIT,
-        storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
+      storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
 
     assertThat("request hold shelf expiration date is not set",
-        storedRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
+      storedRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
 
     loansFixture.checkInByBarcode(
         new CheckInByBarcodeRequestBuilder()
@@ -503,16 +503,12 @@ public class HoldShelfExpirationDateTests extends APITests{
     storedRequest = requestsClient.getById(request.getId()).getJson();
 
     assertThat("Item status snapshot in storage is " + IN_TRANSIT,
-        nod, hasItemStatus(IN_TRANSIT));
+      nod, hasItemStatus(IN_TRANSIT));
 
     assertThat("request status snapshot in storage is " + OPEN_IN_TRANSIT,
-        storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
+      storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
 
     assertThat("request hold shelf expiration date is not set",
-        storedRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
-  }
-
-  private String toIsoString(ZonedDateTime dateTime) {
-    return dateTime.format(DateTimeFormatter.ISO_INSTANT);
+      storedRequest.getString("holdShelfExpirationDate"), emptyOrNullString());
   }
 }

--- a/src/test/java/api/support/matchers/TextDateTimeMatcher.java
+++ b/src/test/java/api/support/matchers/TextDateTimeMatcher.java
@@ -1,5 +1,9 @@
 package api.support.matchers;
 
+import static java.time.temporal.ChronoUnit.MILLIS;
+
+import java.time.ZonedDateTime;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -21,6 +25,28 @@ public class TextDateTimeMatcher {
         DateTime actual = DateTime.parse(textRepresentation);
 
         return expected.isEqual(actual);
+      }
+    };
+  }
+
+  public static Matcher<String> isEquivalentTo(ZonedDateTime expected) {
+    return new TypeSafeMatcher<String>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText(String.format(
+          "a zoned date time matching: %s", expected.toString()));
+      }
+
+      @Override
+      protected boolean matchesSafely(String textRepresentation) {
+        //response representation might vary from request representation
+        ZonedDateTime actual = ZonedDateTime.parse(textRepresentation);
+
+        //The zoned date time could have a higher precision than milliseconds
+        //This makes comparison to an ISO formatted date time using milliseconds
+        //excessively precise and brittle
+        //Discovered when using JDK 13.0.1 instead of JDK 1.8.0_202-b08
+        return expected.truncatedTo(MILLIS).isEqual(actual);
       }
     };
   }


### PR DESCRIPTION
## Purpose
I use JDK 13 locally when building mod-circulation. Whilst preparing a hot fix release for [CIRC-543](https://issues.folio.org/browse/CIRC-543) the hold shelf expiration tests failed.

This was caused by the `clock.now()` method generating a `ZonedDateTime` with a precision beyond milliseconds (nanoseconds?). 

When this was compared to the ISO formatted date time in the API response it did not match.

## Approach
* Create a new text date time matcher that uses `ZonedDateTime`
* Use it within one of the failing hold shelf expiration tests
* Limit the precision of the both `ZonedDateTime`s within the matcher to milliseconds
* Use this matcher within all of the hold shelf expiration date tests.
* Run the tests using both `JDK 1.8.0_202-b08` and `OpenJDK 13.0.1`

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
