### PR TITLE
CIRC-567: Add endpoint for marking loan(item) lost

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -222,6 +222,19 @@
         },
         {
           "methods": [
+            "PUT"
+          ],
+          "pathPattern": "/circulation/loans/{id}/declare-lost",
+          "permissionsRequired": [
+            "circulation.loans.item.declare.lost"
+          ],
+          "modulePermissions": [
+            "inventory-storage.items.item.put",
+            "modperms.circulation.loans.item.put"
+          ]
+        },
+        {
+          "methods": [
             "GET"
           ],
           "pathPattern": "/circulation/requests",
@@ -650,7 +663,7 @@
   "requires": [
     {
       "id": "loan-storage",
-      "version": "5.3 6.0"
+      "version": "6.4"
     },
     {
       "id": "circulation-rules-storage",
@@ -815,6 +828,11 @@
       "permissionName": "circulation.loans.item.delete",
       "displayName": "circulation - delete individual loan",
       "description": "delete individual loan"
+    },
+    {
+      "permissionName": "circulation.loans.item.declare.lost",
+      "displayName": "circulation - declare loan and item lost",
+      "description": "declare loan and item lost"
     },
     {
       "permissionName": "circulation.rules.get",

--- a/src/main/java/org/folio/circulation/CirculationVerticle.java
+++ b/src/main/java/org/folio/circulation/CirculationVerticle.java
@@ -5,6 +5,7 @@ import java.lang.invoke.MethodHandles;
 import org.folio.circulation.resources.CheckInByBarcodeResource;
 import org.folio.circulation.resources.CheckOutByBarcodeResource;
 import org.folio.circulation.resources.CirculationRulesResource;
+import org.folio.circulation.resources.DeclareLostResource;
 import org.folio.circulation.resources.EndPatronActionSessionResource;
 import org.folio.circulation.resources.ItemsInTransitResource;
 import org.folio.circulation.resources.ExpiredSessionProcessingResource;
@@ -103,6 +104,7 @@ public class CirculationVerticle extends AbstractVerticle {
     new ExpiredSessionProcessingResource(client).register(router);
 
     new LoanAnonymizationResource(client).register(router);
+    new DeclareLostResource(client).register(router);
     new ScheduledAnonymizationProcessingResource(client).register(router);
 
     new EndPatronActionSessionResource(client).register(router);

--- a/src/main/java/org/folio/circulation/domain/ItemStatus.java
+++ b/src/main/java/org/folio/circulation/domain/ItemStatus.java
@@ -14,7 +14,8 @@ public enum ItemStatus {
   MISSING("Missing"),
   PAGED("Paged"),
   ON_ORDER("On order"),
-  IN_PROCESS("In process");
+  IN_PROCESS("In process"),
+  LOST("Declared lost");
 
   public static ItemStatus from(String value, String date) {
     return Arrays.stream(values())

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -29,12 +29,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.policy.LoanPolicy;
 import org.folio.circulation.domain.representations.LoanProperties;
 import org.folio.circulation.support.Result;
+import org.folio.circulation.support.StringUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import io.vertx.core.json.JsonObject;
 
 public class Loan implements ItemRelatedRecord, UserRelatedRecord {
+  private static final String DECLARED_LOST_ACTION_NAME = "declaredLost";
   private final JsonObject representation;
   private final Item item;
   private final User user;
@@ -134,6 +136,15 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   private void changeCheckInServicePointId(UUID servicePointId) {
     write(representation, "checkinServicePointId", servicePointId);
+  }
+
+  private void changeItemStatusToDeclaredLost(){
+
+    Item item = getItem();
+    if (item != null) {
+      item.changeStatus(ItemStatus.LOST);
+    }
+    changeItemStatus(ItemStatus.LOST.getValue());
   }
 
   private void changeStatus(String status) {
@@ -349,6 +360,16 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     return this;
   }
 
+  public Loan declareItemLost(String comment) {
+    changeAction(DECLARED_LOST_ACTION_NAME);
+    if (StringUtils.isNotBlank(comment)) {
+      changeActionComment(comment);
+    }
+    changeItemStatusToDeclaredLost();
+    changeDeclaredLostDateTime(DateTime.now());
+    return this;
+  }
+
   private void incrementRenewalCount() {
     write(representation, "renewalCount", getRenewalCount() + 1);
   }
@@ -393,5 +414,9 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   public void changeItemStatus(String itemStatus) {
     representation.put(LoanProperties.ITEM_STATUS, itemStatus);
+  }
+
+  public void changeDeclaredLostDateTime(DateTime dateTime) {
+    write(representation, LoanProperties.DECLARED_LOST_DATE, dateTime);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepository.java
@@ -75,6 +75,15 @@ public class LoanRepository {
       .thenApply(mapResult(loanAndRelatedRecords::withLoan));
   }
 
+  public CompletableFuture<Result<Loan>> updateLoanItemInStorage(Loan loan) {
+    if (loan == null || loan.getItem() == null) {
+      return completedFuture(of(() -> null));
+    }
+
+    itemRepository.updateItem(loan.getItem());
+    return completedFuture(succeeded(loan));
+  }
+
   public CompletableFuture<Result<LoanAndRelatedRecords>> updateLoan(
     LoanAndRelatedRecords loanAndRelatedRecords) {
 

--- a/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
@@ -19,4 +19,5 @@ public class LoanProperties {
   public static final String FEESANDFINES = "feesAndFines";
   public static final String PATRON_GROUP_ID_AT_CHECKOUT = "patronGroupIdAtCheckout";
   public static final String PATRON_GROUP_AT_CHECKOUT = "patronGroupAtCheckout";
+  public static final String DECLARED_LOST_DATE = "declaredLostDate";
 }

--- a/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
+++ b/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
@@ -1,0 +1,38 @@
+package org.folio.circulation.resources;
+
+import io.vertx.core.http.HttpClient;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import org.folio.circulation.domain.LoanRepository;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.NoContentResult;
+import org.folio.circulation.support.http.server.WebContext;
+
+public class DeclareLostResource extends Resource {
+
+  public DeclareLostResource(HttpClient client) {
+    super(client);
+  }
+
+  @Override
+  public void register(Router router) {
+    router.put("/circulation/loans/:id/declare-lost")
+      .handler(this::declareLost);
+  }
+
+  private void declareLost(RoutingContext routingContext) {
+    final WebContext context = new WebContext(routingContext);
+    final Clients clients = Clients.create(context, client);
+    final LoanRepository loanRepository = new LoanRepository(clients);
+
+    final String loanId = routingContext.request().getParam("id");
+    final String comment = routingContext.getBodyAsJson().getString("comment");
+
+    loanRepository.getById(loanId)
+      .thenApply(r -> r.map(loan -> loan.declareItemLost(comment)))
+      .thenApply(r -> r.after(loanRepository::updateLoan)
+        .thenCompose(r1 -> r1.after(loanRepository::updateLoanItemInStorage)
+        .thenApply(NoContentResult::from)
+        .thenAccept(result -> result.writeTo(routingContext.response()))));
+  }
+}

--- a/src/main/java/org/folio/circulation/support/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/support/ItemRepository.java
@@ -113,6 +113,13 @@ public class ItemRepository {
       location.getPrimaryServicePointId());
   }
 
+  public CompletableFuture<Response> updateItem(Item item) {
+    if (item == null) {
+      return completedFuture(null);
+    }
+    return itemsClient.put(item.getItemId(), item.getItem());
+  }
+
   private CompletableFuture<Result<Item>> fetchMaterialType(Result<Item> result) {
     return fetchMaterialType
       ? result.combineAfter(materialTypeRepository::getFor, Item::withMaterialType)

--- a/src/test/java/api/loans/DeclareLostAPITests.java
+++ b/src/test/java/api/loans/DeclareLostAPITests.java
@@ -1,0 +1,93 @@
+package api.loans;
+
+import static api.support.matchers.LoanMatchers.hasLoanProperty;
+import static api.support.matchers.LoanMatchers.hasOpenStatus;
+import static api.support.matchers.LoanMatchers.loanItemIsDeclaredLost;
+import static org.folio.circulation.support.JsonPropertyWriter.write;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import java.net.MalformedURLException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import api.support.APITests;
+import api.support.http.InterfaceUrls;
+import api.support.http.InventoryItemResource;
+import io.vertx.core.json.JsonObject;
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.http.client.ResponseHandler;
+import org.junit.Test;
+
+public class DeclareLostAPITests extends APITests {
+  private static final int TIMEOUT_SECONDS = 10;
+
+  private InventoryItemResource item;
+  private IndividualResource user;
+  private JsonObject loanJson;
+  @Override
+  public void beforeEach()
+    throws MalformedURLException, InterruptedException, ExecutionException,
+    TimeoutException {
+    super.beforeEach();
+    item = itemsFixture.basedUponSmallAngryPlanet();
+    user = usersFixture.charlotte();
+
+    loanJson = loansFixture.checkOutByBarcode(item, user).getJson();
+  }
+
+  @Test
+  public void canDeclareItemLostWithComment()
+    throws InterruptedException, ExecutionException, TimeoutException,
+    MalformedURLException {
+
+    UUID loanID = UUID.fromString(loanJson.getString("id"));
+    String comment = "testing comment";
+
+    declareItemLost(loanID.toString(), comment);
+
+    JsonObject actualLoan = loansClient.getById(loanID).getJson();
+
+    assertThat(actualLoan, loanItemIsDeclaredLost());
+    assertThat(actualLoan, hasOpenStatus());
+    assertThat(actualLoan, hasLoanProperty("action", "declaredLost"));
+    assertThat(actualLoan, hasLoanProperty("actionComment", comment));
+  }
+
+  @Test
+  public void canDeclareItemLostWithoutComment()
+    throws InterruptedException, ExecutionException, TimeoutException,
+    MalformedURLException {
+
+    UUID loanID = UUID.fromString(loanJson.getString("id"));
+
+    declareItemLost(loanID.toString(), null);
+
+    JsonObject actualLoan = loansClient.getById(loanID).getJson();
+
+    assertThat(actualLoan, loanItemIsDeclaredLost());
+    assertThat(actualLoan, hasOpenStatus());
+    assertThat(actualLoan, hasLoanProperty("action", "declaredLost"));
+    assertThat(actualLoan, not(hasLoanProperty("actionComment")));
+
+  }
+
+  private void declareItemLost(String id, String comment)
+    throws InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
+    JsonObject payload = new JsonObject();
+    write(payload, "comment", comment);
+    client.put(InterfaceUrls.declareLoanLostURL(id), payload, ResponseHandler.any(createCompleted));
+    createCompleted.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    //Without this, the loan/item is NOT fully not updated by the time the future completes!
+    Thread.sleep(10);
+  }
+
+}

--- a/src/test/java/api/support/fakes/StorageSchema.java
+++ b/src/test/java/api/support/fakes/StorageSchema.java
@@ -8,7 +8,7 @@ public class StorageSchema {
   private StorageSchema() { }
 
   public static JsonSchemaValidator validatorForStorageLoanSchema() throws IOException {
-    return JsonSchemaValidator.fromResource("/storage-loan-6-2.json");
+    return JsonSchemaValidator.fromResource("/storage-loan-6-3.json");
   }
 
   public static JsonSchemaValidator validatorForLocationInstSchema() throws IOException {

--- a/src/test/java/api/support/http/InterfaceUrls.java
+++ b/src/test/java/api/support/http/InterfaceUrls.java
@@ -168,6 +168,10 @@ public class InterfaceUrls {
     return circulationModuleUrl("/circulation/scheduled-anonymize-processing/");
   }
 
+  public static URL declareLoanLostURL(String subPath) {
+    return circulationModuleUrl(String.format("/circulation/loans/%s/declare-lost", subPath));
+  }
+
   public static URL endSessionUrl() {
     return circulationModuleUrl("/circulation/end-patron-action-session");
   }

--- a/src/test/resources/storage-loan-6-3.json
+++ b/src/test/resources/storage-loan-6-3.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "Loan",
+  "description": "Links the item with the patron and applies certain conditions based on policies",
+  "properties": {
+    "id": {
+      "description": "Unique ID (generated UUID) of the loan",
+      "type": "string"
+    },
+    "userId": {
+      "description": "ID of the patron the item was lent to. Required for open loans, not required for closed loans (for anonymization).",
+      "type": "string"
+    },
+    "proxyUserId": {
+      "description": "ID of the user representing a proxy for the patron",
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "itemId": {
+      "description": "ID of the item lent to the patron",
+      "type": "string"
+    },
+    "status": {
+      "description": "Overall status of the loan",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the status (currently can be any value, values commonly used are Open and Closed)",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "loanDate": {
+      "description": "Date time when the loan began (typically represented according to rfc3339 section-5.6. Has not had the date-time format validation applied as was not supported at point of introduction and would now be a breaking change)",
+      "type": "string"
+    },
+    "dueDate": {
+      "description": "Date time when the item is due to be returned",
+      "type": "string",
+      "format": "date-time"
+    },
+    "returnDate": {
+      "description": "Date time when the item is returned and the loan ends (typically represented according to rfc3339 section-5.6. Has not had the date-time format validation applied as was not supported at point of introduction and would now be a breaking change)",
+      "type": "string"
+    },
+    "systemReturnDate" : {
+      "description": "Date time when the returned item is actually processed",
+      "type" : "string",
+      "format": "date-time"
+    },
+    "action": {
+      "description": "Last action performed on a loan (currently can be any value, values commonly used are checkedout and checkedin)",
+      "type": "string"
+    },
+    "actionComment": {
+      "description": "Comment to last action performed on a loan",
+      "type": "string"
+    },
+    "itemStatus": {
+      "description": "Last item status used in relation to this loan (currently can be any value, values commonly used are Checked out and Available)",
+      "type": "string"
+    },
+    "renewalCount": {
+      "description": "Count of how many times a loan has been renewed (incremented by the client)",
+      "type": "integer"
+    },
+    "loanPolicyId": {
+      "description": "ID of last policy used in relation to this loan",
+      "type": "string"
+    },
+    "checkoutServicePointId": {
+      "description": "ID of the Service Point where the last checkout occured",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "checkinServicePointId": {
+      "description": "ID of the Service Point where the last checkin occured",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "patronGroupIdAtCheckout": {
+      "description": "Patron Group Id at checkout",
+      "type": "string"
+    },
+    "dueDateChangedByRecall": {
+      "description": "Indicates whether or not this loan had its due date modified by a recall on the loaned item",
+      "type": "boolean"
+    },
+    "declaredLostDate" : {
+      "description": "Date and time loan was declared lost",
+      "type": "string",
+      "format": "date-time"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes to loan, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "itemId",
+    "loanDate",
+    "action"
+  ]
+}


### PR DESCRIPTION
## Purpose

The backend for marking item lost feature. 

Create new interaction resulting in item status Declared lost, in order for the library to distinguish between checked out items (which are expected to be returned) and items the patron has lost and needs to pay for. 

This resolves: CIRC-567, see also CIRCSTORE-175

## Approach

### Summary of changes: :shipit:

-  When declared lost, loan remains open, and just the status of the item changes.
- The comment is saved in the loans' action history
-  The declared lost date is saved to a loan and to be displayed in the loan details under Lost field instead of TODO.

![Untitled Diagram(1)](https://user-images.githubusercontent.com/49403013/69630039-4d197500-1055-11ea-9c38-aee0c2bec577.png)

#### Example request/response
```
PUT {{backendbaseurl}}/circulation/loans/{ID}/declare-lost
Content-Type: application/json
X-Okapi-Tenant: {{tenant}}
X-Okapi-Token: {{FOLIO_TOKEN}}
Accept: application/json

{
"comment" : "declare lost comment"
}
```
Response is 204: No Content if everything is OK.
