### PR TITLE
CIRC-566: Return country name for staff slip

### DIFF
--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -2,10 +2,17 @@ package org.folio.circulation.domain.notice;
 
 import static java.lang.Math.max;
 import static java.util.stream.Collectors.joining;
+
 import static org.folio.circulation.support.JsonPropertyWriter.write;
 import static org.folio.circulation.support.JsonStringArrayHelper.toStream;
 
+import java.util.Locale;
 import java.util.Optional;
+
+import io.vertx.core.json.JsonObject;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 import org.folio.circulation.domain.CallNumberComponents;
 import org.folio.circulation.domain.CheckInProcessRecords;
@@ -18,10 +25,6 @@ import org.folio.circulation.domain.ServicePoint;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.policy.LoanPolicy;
 import org.folio.circulation.support.JsonArrayHelper;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-
-import io.vertx.core.json.JsonObject;
 
 public class TemplateContextUtil {
 
@@ -99,13 +102,16 @@ public class TemplateContextUtil {
 
     JsonObject userContext = createUserContext(user);
     if(address != null){
+      String countryId = address.getString("countryId", null);
+      String countryName = getCountryName(countryId);
       userContext
         .put("addressLine1", address.getString("addressLine1", null))
         .put("addressLine2", address.getString("addressLine2", null))
         .put("city", address.getString("city", null))
         .put("region", address.getString("region", null))
         .put("postalCode", address.getString("postalCode", null))
-        .put("countryId", address.getString("countryId", null));
+        .put("countryId", countryId)
+        .put("country", countryName);
     }
 
     return userContext;
@@ -224,5 +230,12 @@ public class TemplateContextUtil {
     }
 
     return loanContext;
+  }
+
+  private static String getCountryName(String alpha2Code) {
+    return Optional
+      .ofNullable(alpha2Code)
+      .map(code -> new Locale("", alpha2Code).getDisplayCountry(Locale.ENGLISH))
+      .orElse(null);
   }
 }

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -193,6 +193,7 @@ public class CheckInByBarcodeTests extends APITests {
     assertThat(userContext.getString("region"), is(address.getRegion()));
     assertThat(userContext.getString("postalCode"), is(address.getPostalCode()));
     assertThat(userContext.getString("countryId"), is(address.getCountryId()));
+    assertThat(userContext.getString("country"), is("United Kingdom"));
 
     assertThat(requestContext.getString("deliveryAddressType"), is(addressTypesFixture.home().getJson().getString("addressType")));
     assertThat(requestContext.getString("requestExpirationDate"), is(requestExpiration.toDateTimeAtStartOfDay().toString()));

--- a/src/test/java/api/support/fixtures/AddressExamples.java
+++ b/src/test/java/api/support/fixtures/AddressExamples.java
@@ -21,6 +21,6 @@ public class AddressExamples {
 
   public static Address SiriusBlack() {
     return new Address(HOME_ADDRESS_TYPE, "12 Grimmauld Place",
-      null, "London", "London region", "123456", "UK");
+      null, "London", "London region", "123456", "GB");
   }
 }


### PR DESCRIPTION
# Purpose
Fix bug https://issues.folio.org/browse/CIRC-566, 
We need to return country name from "circulation/check-in-by-barcode" endpoint, 
so that it can be printed on staff slip

## Approach
Use nv-i18n library to convert alpha2 country code into country name

## Learning
It seems that UI  uses files like this to convert countryId into country name:
https://github.com/folio-org/stripes-smart-components/blob/e104573a2ee448fdb520ea5bedf3b3f08cd5e176/lib/AddressFieldGroup/data/countries.js
I compared data from this file with data used in nv-i18n library, and found out that there is no significant difference, it seems that CountryId is stored in [ISO-3166-1 alpha-2 format](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
Here is comparison: https://www.diffchecker.com/U9neNZJ8
Folio data is on the left and nv-i18n is on the right.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.