### PR TITLE
CIRC-581: Handle the exception when loan history configuration is no …

### DIFF
--- a/src/main/java/org/folio/circulation/domain/ConfigurationRepository.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationRepository.java
@@ -6,6 +6,7 @@ import static org.folio.circulation.support.Result.failed;
 import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -18,9 +19,13 @@ import org.folio.circulation.support.CqlQuery;
 import org.folio.circulation.support.Result;
 import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConfigurationRepository {
 
+  private static final Logger logger = LoggerFactory
+    .getLogger(MethodHandles.lookup().lookupClass());
   private static final String CONFIGS_KEY = "configs";
   private static final String MODULE_NAME_KEY = "module";
   private static final String CONFIG_NAME_KEY = "configName";
@@ -69,8 +74,9 @@ public class ConfigurationRepository {
 
   private Result<Response> refuseWhenNoConfigurationsFound(Response response) {
     if (response.getJson().getInteger("totalRecords") == 0){
+      logger.warn("No loan history settings found for loan anonymization");
       return
-        failed(singleValidationError("No configuration found for loan anonymization ", "moduleName", "LOAN_HISTORY"));
+        failed(singleValidationError("No configuration found for loan anonymization", "moduleName", "LOAN_HISTORY"));
     }
 
     return succeeded(response);

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansAfterXIntervalTests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansAfterXIntervalTests.java
@@ -2,6 +2,7 @@ package api.loans.anonymization;
 
 import static api.support.matchers.LoanMatchers.hasOpenStatus;
 import static api.support.matchers.LoanMatchers.isAnonymized;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -11,6 +12,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.circulation.support.http.client.IndividualResource;
+import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.junit.Test;
@@ -431,5 +433,20 @@ public class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
 
     assertThat(loansStorageClient.getById(loanID)
         .getJson(), not(isAnonymized()));
+  }
+
+  @Test
+  public void testNoConfigurationExceptionIsHandled()
+    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    IndividualResource loanResource = loansFixture.checkOutByBarcode(new CheckOutByBarcodeRequestBuilder().forItem(item1)
+      .to(user)
+      .at(servicePoint.getId()));
+    UUID loanID = loanResource.getId();
+
+    Response response = anonymizeLoansInTenant();
+    assertThat(response.getStatusCode(), is(422));
+    assertThat(loansStorageClient.getById(loanID)
+      .getJson(), not(isAnonymized()));
   }
 }


### PR DESCRIPTION
# Purpose

Handle the exception when loan history configuration is not defined to to stop the stacktrace from being in the log.

See CIRC-581