### PR TITLE
CIRC-594 make move request due date tests use millisecond precision

### DIFF
--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -944,8 +944,8 @@ public class MoveRequestTests extends APITests {
         .equals(interestingTimesItem.getId().toString()))
       .findFirst().orElse(new JsonObject());
 
-    assertThat(smallAngryPlanetLoan.getInstant("dueDate"), is(expectedJamesLoanDueDate));
-    assertThat(interestingTimesLoan.getInstant("dueDate"), is(expectedJessicaLoanDueDate));
+    assertThat(smallAngryPlanetLoan.getString("dueDate"), isEquivalentTo(expectedJamesLoanDueDate));
+    assertThat(interestingTimesLoan.getString("dueDate"), isEquivalentTo(expectedJessicaLoanDueDate));
   }
 
   @Test

--- a/src/test/java/api/support/matchers/TextDateTimeMatcher.java
+++ b/src/test/java/api/support/matchers/TextDateTimeMatcher.java
@@ -31,25 +31,7 @@ public class TextDateTimeMatcher {
   }
 
   public static Matcher<String> isEquivalentTo(ZonedDateTime expected) {
-    return new TypeSafeMatcher<String>() {
-      @Override
-      public void describeTo(Description description) {
-        description.appendText(String.format(
-          "a zoned date time matching: %s", expected.toString()));
-      }
-
-      @Override
-      protected boolean matchesSafely(String textRepresentation) {
-        //response representation might vary from request representation
-        ZonedDateTime actual = ZonedDateTime.parse(textRepresentation);
-
-        //The zoned date time could have a higher precision than milliseconds
-        //This makes comparison to an ISO formatted date time using milliseconds
-        //excessively precise and brittle
-        //Discovered when using JDK 13.0.1 instead of JDK 1.8.0_202-b08
-        return expected.truncatedTo(MILLIS).isEqual(actual);
-      }
-    };
+    return isEquivalentTo(expected.toInstant());
   }
 
   public static Matcher<String> isEquivalentTo(Instant expected) {
@@ -57,7 +39,7 @@ public class TextDateTimeMatcher {
       @Override
       public void describeTo(Description description) {
         description.appendText(String.format(
-          "a zoned date time matching: %s", expected.toString()));
+          "a date and time matching: %s", expected.toString()));
       }
 
       @Override

--- a/src/test/java/api/support/matchers/TextDateTimeMatcher.java
+++ b/src/test/java/api/support/matchers/TextDateTimeMatcher.java
@@ -2,6 +2,7 @@ package api.support.matchers;
 
 import static java.time.temporal.ChronoUnit.MILLIS;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 import org.hamcrest.Description;
@@ -47,6 +48,28 @@ public class TextDateTimeMatcher {
         //excessively precise and brittle
         //Discovered when using JDK 13.0.1 instead of JDK 1.8.0_202-b08
         return expected.truncatedTo(MILLIS).isEqual(actual);
+      }
+    };
+  }
+
+  public static Matcher<String> isEquivalentTo(Instant expected) {
+    return new TypeSafeMatcher<String>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText(String.format(
+          "a zoned date time matching: %s", expected.toString()));
+      }
+
+      @Override
+      protected boolean matchesSafely(String textRepresentation) {
+        //response representation might vary from request representation
+        Instant actual = Instant.parse(textRepresentation);
+
+        //The zoned date time could have a higher precision than milliseconds
+        //This makes comparison to an ISO formatted date time using milliseconds
+        //excessively precise and brittle
+        //Discovered when using JDK 13.0.1 instead of JDK 1.8.0_202-b08
+        return expected.truncatedTo(MILLIS).equals(actual);
       }
     };
   }


### PR DESCRIPTION
## Purpose

To improve the reliability of the move request API tests. 

Under some circumstances (e.g. using JVM 13) the time can be more precise than millseconds, which is the precision used in our APIs, this can result in false failures.

## Approach

Use the hamcrest matchers that limit the precision of the expected date and time to milliseconds. A new matcher variant has been added to support `Instant` and the implementations consolidated.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
