### PR TITLE
CIRC-596 use rest assured for loans api tests

### DIFF
--- a/src/main/java/org/folio/circulation/support/JsonArrayHelper.java
+++ b/src/main/java/org/folio/circulation/support/JsonArrayHelper.java
@@ -49,6 +49,13 @@ public class JsonArrayHelper {
     return mapToList(within.getJsonArray(arrayPropertyName), mapper);
   }
 
+  public static List<JsonObject> mapToList(
+    JsonObject within,
+    String arrayPropertyName) {
+
+    return mapToList(within, arrayPropertyName, Function.identity());
+  }
+
   public static Stream<JsonObject> toStream(
     JsonObject within,
     String arrayPropertyName) {

--- a/src/main/java/org/folio/circulation/support/JsonArrayHelper.java
+++ b/src/main/java/org/folio/circulation/support/JsonArrayHelper.java
@@ -24,9 +24,8 @@ public class JsonArrayHelper {
       .collect(Collectors.toList());
   }
 
-  public static <T> List<T> mapToList(
-    JsonArray array,
-    Function<JsonObject, T> mapper) {
+  public static <T> List<T> mapToList(JsonArray array,
+      Function<JsonObject, T> mapper) {
 
     if(array == null) {
       return Collections.emptyList();
@@ -37,10 +36,8 @@ public class JsonArrayHelper {
       .collect(Collectors.toList());
   }
 
-  public static <T> List<T> mapToList(
-    JsonObject within,
-    String arrayPropertyName,
-    Function<JsonObject, T> mapper) {
+  public static <T> List<T> mapToList(JsonObject within, String arrayPropertyName,
+      Function<JsonObject, T> mapper) {
 
     if(within == null || !within.containsKey(arrayPropertyName)) {
       return Collections.emptyList();
@@ -49,16 +46,14 @@ public class JsonArrayHelper {
     return mapToList(within.getJsonArray(arrayPropertyName), mapper);
   }
 
-  public static List<JsonObject> mapToList(
-    JsonObject within,
-    String arrayPropertyName) {
+  public static List<JsonObject> mapToList(JsonObject within,
+      String arrayPropertyName) {
 
     return mapToList(within, arrayPropertyName, Function.identity());
   }
 
-  public static Stream<JsonObject> toStream(
-    JsonObject within,
-    String arrayPropertyName) {
+  public static Stream<JsonObject> toStream(JsonObject within,
+      String arrayPropertyName) {
 
     if(within == null || !within.containsKey(arrayPropertyName)) {
       return Stream.empty();

--- a/src/test/java/api/loans/CheckInByReplacingLoanTests.java
+++ b/src/test/java/api/loans/CheckInByReplacingLoanTests.java
@@ -42,7 +42,7 @@ public class CheckInByReplacingLoanTests extends APITests {
 
     final IndividualResource james = usersFixture.james();
 
-    IndividualResource loan = loansClient.create(new LoanBuilder()
+    IndividualResource loan = loansFixture.createLoan(new LoanBuilder()
       .withLoanDate(loanDate)
       .withUserId(james.getId())
       .withItem(itemsFixture.basedUponNod()));
@@ -119,7 +119,7 @@ public class CheckInByReplacingLoanTests extends APITests {
 
     final IndividualResource james = usersFixture.james();
 
-    IndividualResource loan = loansClient.create(
+    IndividualResource loan = loansFixture.createLoan(
       new LoanBuilder().withLoanDate(loanDate)
         .withUserId(james.getId()).withItem(itemsFixture.basedUponNod()));
 
@@ -153,7 +153,7 @@ public class CheckInByReplacingLoanTests extends APITests {
 
     final IndividualResource james = usersFixture.james();
 
-    IndividualResource loan = loansClient.create(
+    IndividualResource loan = loansFixture.createLoan(
       new LoanBuilder().withLoanDate(loanDate)
         .withUserId(james.getId()).withItem(itemsFixture.basedUponNod()));
 

--- a/src/test/java/api/loans/LoanAPIPolicyTests.java
+++ b/src/test/java/api/loans/LoanAPIPolicyTests.java
@@ -146,7 +146,7 @@ public class LoanAPIPolicyTests extends APITests {
     ExecutionException,
     TimeoutException {
 
-    IndividualResource loanResponse = loansClient.create(new LoanBuilder()
+    IndividualResource loanResponse = loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .withUserId(userId)
       .withItemId(itemId)

--- a/src/test/java/api/loans/LoanAPIProxyTests.java
+++ b/src/test/java/api/loans/LoanAPIProxyTests.java
@@ -43,7 +43,7 @@ public class LoanAPIProxyTests extends APITests {
     DateTime loanDate = new DateTime(2017, 2, 27, 10, 23, 43, DateTimeZone.UTC);
     DateTime dueDate = new DateTime(2017, 3, 29, 10, 23, 43, DateTimeZone.UTC);
 
-    IndividualResource response = loansClient.create(new LoanBuilder()
+    IndividualResource response = loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .open()
       .withUserId(sponsor.getId())
@@ -80,7 +80,7 @@ public class LoanAPIProxyTests extends APITests {
     DateTime loanDate = new DateTime(2017, 2, 27, 10, 23, 43, DateTimeZone.UTC);
     DateTime dueDate = new DateTime(2017, 3, 29, 10, 23, 43, DateTimeZone.UTC);
 
-    IndividualResource response = loansClient.create(new LoanBuilder()
+    IndividualResource response = loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .open()
       .withUserId(sponsor.getId())
@@ -265,7 +265,7 @@ public class LoanAPIProxyTests extends APITests {
     DateTime loanDate = new DateTime(2017, 2, 27, 10, 23, 43, DateTimeZone.UTC);
     DateTime dueDate = new DateTime(2017, 3, 29, 10, 23, 43, DateTimeZone.UTC);
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .open()
       .withUserId(sponsor.getId())
@@ -311,7 +311,7 @@ public class LoanAPIProxyTests extends APITests {
     DateTime loanDate = new DateTime(2017, 2, 27, 10, 23, 43, DateTimeZone.UTC);
     DateTime dueDate = new DateTime(2017, 3, 29, 10, 23, 43, DateTimeZone.UTC);
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .open()
       .withUserId(sponsor.getId())
@@ -358,7 +358,7 @@ public class LoanAPIProxyTests extends APITests {
     DateTime loanDate = new DateTime(2017, 2, 27, 10, 23, 43, DateTimeZone.UTC);
     DateTime dueDate = new DateTime(2017, 3, 29, 10, 23, 43, DateTimeZone.UTC);
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .open()
       .withUserId(otherUser.getId())
@@ -404,7 +404,7 @@ public class LoanAPIProxyTests extends APITests {
     DateTime loanDate = new DateTime(2017, 2, 27, 10, 23, 43, DateTimeZone.UTC);
     DateTime dueDate = new DateTime(2017, 3, 29, 10, 23, 43, DateTimeZone.UTC);
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .open()
       .withUserId(requestingUser.getId())

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -1444,10 +1444,10 @@ public class LoanAPITests extends APITests {
     String queryTemplate = "userId=%s";
 
     Response firstPageResponse = loansFixture.getLoans(
-      query(String.format(queryTemplate, firstUserId)));
+      CqlQuery.queryFromTemplate(queryTemplate, firstUserId));
 
     Response secondPageResponse = loansFixture.getLoans(
-      query(String.format(queryTemplate, secondUserId)));
+      CqlQuery.queryFromTemplate(queryTemplate, secondUserId));
 
     assertThat(String.format("Failed to get loans for first user: %s",
       firstPageResponse.getBody()),
@@ -1481,7 +1481,7 @@ public class LoanAPITests extends APITests {
     UUID firstUserId = UUID.randomUUID();
 
     Response firstPageResponse = loansFixture.getLoans(
-      query(String.format("userId=%s", firstUserId)));
+      CqlQuery.queryFromTemplate("userId=%s", firstUserId));
 
     assertThat(String.format("Failed to get loans for first user: %s",
       firstPageResponse.getBody()),

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -73,7 +73,7 @@ public class LoanAPITests extends APITests {
     DateTime loanDate = new DateTime(2017, 2, 27, 10, 23, 43, DateTimeZone.UTC);
     DateTime dueDate = new DateTime(2017, 3, 29, 10, 23, 43, DateTimeZone.UTC);
 
-    IndividualResource response = loansClient.create(new LoanBuilder()
+    IndividualResource response = loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .open()
       .withUserId(userId)
@@ -188,7 +188,7 @@ public class LoanAPITests extends APITests {
     DateTime loanDate = new DateTime(2017, 2, 27, 10, 23, 43, DateTimeZone.UTC);
     DateTime dueDate = new DateTime(2017, 3, 29, 10, 23, 43, DateTimeZone.UTC);
 
-    IndividualResource response = loansClient.create(new LoanBuilder()
+    IndividualResource response = loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .open()
       .withUserId(userId)
@@ -208,7 +208,6 @@ public class LoanAPITests extends APITests {
     loanHasFeeFinesProperties(loan, 0);
   }
 
-
   @Test
   public void canGetMultipleFeesFinesForSingleLoan()
     throws InterruptedException,
@@ -226,7 +225,7 @@ public class LoanAPITests extends APITests {
     DateTime loanDate = new DateTime(2017, 2, 27, 10, 23, 43, DateTimeZone.UTC);
     DateTime dueDate = new DateTime(2017, 3, 29, 10, 23, 43, DateTimeZone.UTC);
 
-    IndividualResource response = loansClient.create(new LoanBuilder()
+    IndividualResource response = loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .open()
       .withUserId(userId)
@@ -717,17 +716,15 @@ public class LoanAPITests extends APITests {
     DateTime dueDate = new DateTime(2017, 3, 29, 10, 23, 43, DateTimeZone.UTC);
     DateTime systemReturnDate = new DateTime(2017, 4, 1, 12, 0, 0, DateTimeZone.UTC);
 
-    JsonObject builtRequest = new LoanBuilder()
-      .closed()
-      .withId(id)
-      .withUserId(userId)
-      .withItemId(itemId)
-      .withLoanDate(loanDate)
-      .withDueDate(dueDate)
-      .withSystemReturnDate(systemReturnDate)
-      .create();
-
-    IndividualResource response = loansClient.create(builtRequest);
+    IndividualResource response = loansFixture.createLoan(
+      new LoanBuilder()
+        .closed()
+        .withId(id)
+        .withUserId(userId)
+        .withItemId(itemId)
+        .withLoanDate(loanDate)
+        .withDueDate(dueDate)
+        .withSystemReturnDate(systemReturnDate));
 
     JsonObject loan = response.getJson();
 
@@ -808,7 +805,7 @@ public class LoanAPITests extends APITests {
 
     UUID userId = usersFixture.charlotte().getId();
 
-    IndividualResource response = loansClient.create(new LoanBuilder()
+    IndividualResource response = loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .withUserId(userId)
       .withItemId(itemId)
@@ -860,7 +857,7 @@ public class LoanAPITests extends APITests {
 
     UUID userId = usersFixture.charlotte().getId();
 
-    IndividualResource response = loansClient.create(new LoanBuilder()
+    IndividualResource response = loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .withUserId(userId)
       .withItemId(itemId)
@@ -920,7 +917,7 @@ public class LoanAPITests extends APITests {
 
     DateTime dueDate = new DateTime(2016, 11, 15, 8, 26, 53, DateTimeZone.UTC);
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .withUserId(userId)
       .withItemId(itemId)
@@ -1073,7 +1070,7 @@ public class LoanAPITests extends APITests {
 
     UUID userId = usersFixture.charlotte().getId();
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withId(id)
       .withUserId(userId)
       .withItemId(itemId)
@@ -1187,7 +1184,7 @@ public class LoanAPITests extends APITests {
     UUID checkinServicePointId = servicePointsFixture.cd1().getId();
 
 
-    IndividualResource loan = loansClient.create(new LoanBuilder()
+    IndividualResource loan = loansFixture.createLoan(new LoanBuilder()
       .open()
       .withUserId(jessica.getId())
       .withItemId(itemId)
@@ -1264,7 +1261,7 @@ public class LoanAPITests extends APITests {
 
     final IndividualResource jessica = usersFixture.jessica();
 
-    IndividualResource loan = loansClient.create(new LoanBuilder()
+    IndividualResource loan = loansFixture.createLoan(new LoanBuilder()
       .open()
       .withUserId(jessica.getId())
       .withItemId(itemId));
@@ -1413,31 +1410,31 @@ public class LoanAPITests extends APITests {
     IndividualResource secondUser = usersFixture.jessica();
     UUID secondUserId = secondUser.getId();
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withItem(itemsFixture.basedUponSmallAngryPlanet())
       .withUserId(firstUserId));
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withItem(itemsFixture.basedUponNod())
       .withUserId(firstUserId));
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withItem(itemsFixture.basedUponSmallAngryPlanet())
       .withUserId(firstUserId));
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withItem(itemsFixture.basedUponTemeraire())
       .withUserId(firstUserId));
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withItem(itemsFixture.basedUponUprooted())
       .withUserId(secondUserId));
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withItem(itemsFixture.basedUponNod())
       .withUserId(secondUserId));
 
-    loansClient.create(new LoanBuilder().withItem(
+    loansFixture.createLoan(new LoanBuilder().withItem(
       itemsFixture.basedUponInterestingTimes())
       .withUserId(secondUserId));
 
@@ -1516,38 +1513,38 @@ public class LoanAPITests extends APITests {
     IndividualResource user = usersFixture.charlotte();
     UUID userId = user.getId();
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withUserId(userId)
       .withStatus("Open")
       .withItem(itemsFixture.basedUponSmallAngryPlanet())
       .withRandomPastLoanDate());
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withUserId(userId)
       .withStatus("Open")
       .withItem(itemsFixture.basedUponNod())
       .withRandomPastLoanDate());
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withUserId(userId)
       .withItem(
         itemsFixture.basedUponNod())
       .withStatus("Closed")
       .withRandomPastLoanDate());
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withUserId(userId)
       .withStatus("Closed")
       .withItem(itemsFixture.basedUponTemeraire())
       .withRandomPastLoanDate());
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withUserId(userId)
       .withStatus("Closed")
       .withItem(itemsFixture.basedUponUprooted())
       .withRandomPastLoanDate());
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withUserId(userId)
       .withStatus("Closed")
       .withItem(itemsFixture.basedUponInterestingTimes())
@@ -1709,7 +1706,7 @@ public class LoanAPITests extends APITests {
     UUID checkinServicePointId = servicePointsFixture.cd1().getId();
     UUID checkoutServicePointId = servicePointsFixture.cd2().getId();
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withId(loanId)
       .open()
       .withUserId(userId)
@@ -1751,7 +1748,7 @@ public class LoanAPITests extends APITests {
     UUID loan3Id = UUID.randomUUID();
     UUID item3Id = itemsFixture.basedUponUprooted().getId();
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withId(loan1Id)
       .open()
       .withUserId(userId)
@@ -1761,7 +1758,7 @@ public class LoanAPITests extends APITests {
       .withCheckinServicePointId(checkinServicePointId)
       .withCheckoutServicePointId(checkoutServicePointId));
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withId(loan2Id)
       .open()
       .withUserId(userId)
@@ -1771,7 +1768,7 @@ public class LoanAPITests extends APITests {
       .withCheckinServicePointId(checkinServicePointId)
       .withCheckoutServicePointId(checkoutServicePointId));
 
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withId(loan3Id)
       .open()
       .withUserId(userId)
@@ -1861,7 +1858,7 @@ public class LoanAPITests extends APITests {
     UUID checkinServicePointId = servicePointsFixture.cd1().getId();
     UUID checkoutServicePointId = servicePointsFixture.cd2().getId();
     UUID loanId = UUID.randomUUID();
-    loansClient.create(new LoanBuilder()
+    loansFixture.createLoan(new LoanBuilder()
       .withId(loanId)
       .open()
       .withUserId(userId)

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -2,7 +2,6 @@ package api.loans;
 
 import static api.requests.RequestsAPICreationTests.setupMissingItem;
 import static api.support.JsonCollectionAssistant.getRecordById;
-import static api.support.RestAssuredClient.from;
 import static api.support.RestAssuredClient.get;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
 import static api.support.http.InterfaceUrls.loansUrl;
@@ -48,7 +47,6 @@ import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
 import api.support.APITests;
-import api.support.RestAssuredClient;
 import api.support.builders.AccountBuilder;
 import api.support.builders.ItemBuilder;
 import api.support.builders.LoanBuilder;
@@ -206,7 +204,7 @@ public class LoanAPITests extends APITests {
       .withRemainingFeeFine(150)
     );
 
-    JsonObject loan = getLoanById(id).getJson();
+    JsonObject loan = loansFixture.getLoanById(id).getJson();
 
     loanHasFeeFinesProperties(loan, 0);
   }
@@ -242,7 +240,7 @@ public class LoanAPITests extends APITests {
       .withRemainingFeeFine(150)
     );
 
-    JsonObject loan = getLoanById(id).getJson();
+    JsonObject loan = loansFixture.getLoanById(id).getJson();
 
     loanHasFeeFinesProperties(loan, 150d);
 
@@ -252,7 +250,7 @@ public class LoanAPITests extends APITests {
       .withRemainingFeeFine(150)
     );
 
-    loan = getLoanById(id).getJson();
+    loan = loansFixture.getLoanById(id).getJson();
 
     loanHasFeeFinesProperties(loan, 300d);
   }
@@ -1200,7 +1198,7 @@ public class LoanAPITests extends APITests {
 
     loansClient.replace(loan.getId(), updatedLoanRequest);
 
-    final JsonObject updatedLoan = getLoanById(loan.getId()).getJson();
+    final JsonObject updatedLoan = loansFixture.getLoanById(loan.getId()).getJson();
 
     assertThat("Should be closed",
       updatedLoan.getJsonObject("status").getString("name"), is("Closed"));
@@ -1918,7 +1916,7 @@ public class LoanAPITests extends APITests {
 
      loansStorageClient.replace(individualResource.getId(), savedLoan);
 
-     JsonObject loan = getLoanById(individualResource.getId()).getJson();
+     JsonObject loan = loansFixture.getLoanById(individualResource.getId()).getJson();
 
      loanHasPatronGroupProperties(loan, "Regular Group");
   }
@@ -2080,8 +2078,4 @@ public class LoanAPITests extends APITests {
     return JsonArrayHelper.toList(page.getJsonArray("loans"));
   }
 
-  private IndividualResource getLoanById(UUID id) {
-    return new IndividualResource(from(get(
-      loansUrl(String.format("/%s", id)), 200, "get-loan-by-id")));
-  }
 }

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -1472,36 +1472,21 @@ public class LoanAPITests extends APITests {
   }
 
   @Test
-  public void canFindNoResultsFromSearch()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
+  public void canFindNoResultsFromSearch() {
     UUID firstUserId = UUID.randomUUID();
-    UUID secondUserId = UUID.randomUUID();
 
     Response firstPageResponse = loansFixture.getLoans(String.format("userId=%s", firstUserId));
-    Response secondPageResponse = loansFixture.getLoans(String.format("userId=%s", secondUserId));
 
     assertThat(String.format("Failed to get loans for first user: %s",
       firstPageResponse.getBody()),
       firstPageResponse.getStatusCode(), is(200));
 
-    assertThat(String.format("Failed to get loans for second user: %s",
-      secondPageResponse.getBody()),
-      secondPageResponse.getStatusCode(), is(200));
-
     JsonObject firstPage = firstPageResponse.getJson();
-    JsonObject secondPage = secondPageResponse.getJson();
 
     List<JsonObject> firstPageLoans = getLoans(firstPage);
-    List<JsonObject> secondPageLoans = getLoans(secondPage);
 
     assertThat(firstPageLoans.size(), is(0));
     assertThat(firstPage.getInteger("totalRecords"), is(0));
-
-    assertThat(secondPageLoans.size(), is(0));
-    assertThat(secondPage.getInteger("totalRecords"), is(0));
   }
 
   @Test
@@ -2077,5 +2062,4 @@ public class LoanAPITests extends APITests {
   private List<JsonObject> getLoans(JsonObject page) {
     return JsonArrayHelper.toList(page.getJsonArray("loans"));
   }
-
 }

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -2,7 +2,6 @@ package api.loans;
 
 import static api.requests.RequestsAPICreationTests.setupMissingItem;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
-import static api.support.http.CqlQuery.query;
 import static api.support.http.CqlQuery.queryFromTemplate;
 import static api.support.http.InterfaceUrls.loansUrl;
 import static api.support.http.Limit.limit;
@@ -1545,10 +1544,10 @@ public class LoanAPITests extends APITests {
     String queryTemplate = "userId=\"%s\" and status.name=\"%s\"";
 
     Response openLoansResponse = loansFixture.getLoans(
-      query(String.format(queryTemplate, userId, "Open")));
+      queryFromTemplate(queryTemplate, userId, "Open"));
 
     Response closedLoansResponse = loansFixture.getLoans(
-      query(String.format(queryTemplate, userId, "Closed")));
+      queryFromTemplate(queryTemplate, userId, "Closed"));
 
     assertThat(String.format("Failed to get open loans: %s",
       openLoansResponse.getBody()),

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -1342,12 +1342,7 @@ public class LoanAPITests extends APITests {
 
     itemsClient.delete(item.getId());
 
-    CompletableFuture<Response> pageCompleted = new CompletableFuture<>();
-
-    client.get(loansUrl(),
-      ResponseHandler.json(pageCompleted));
-
-    Response pageResponse = pageCompleted.get(5, TimeUnit.SECONDS);
+    Response pageResponse = loansFixture.getLoans();
 
     assertThat(String.format("Failed to get page of loans: %s",
       pageResponse.getBody()),
@@ -1376,17 +1371,8 @@ public class LoanAPITests extends APITests {
     loansFixture.checkOutByBarcode(itemsFixture.basedUponUprooted(),user);
     loansFixture.checkOutByBarcode(itemsFixture.basedUponInterestingTimes(),user);
 
-    CompletableFuture<Response> firstPageCompleted = new CompletableFuture<>();
-    CompletableFuture<Response> secondPageCompleted = new CompletableFuture<>();
-
-    client.get(loansUrl() + "?limit=3",
-      ResponseHandler.json(firstPageCompleted));
-
-    client.get(loansUrl() + "?limit=3&offset=3",
-      ResponseHandler.json(secondPageCompleted));
-
-    Response firstPageResponse = firstPageCompleted.get(5, TimeUnit.SECONDS);
-    Response secondPageResponse = secondPageCompleted.get(5, TimeUnit.SECONDS);
+    Response firstPageResponse = loansFixture.getLoans(3);
+    Response secondPageResponse = loansFixture.getLoans(3, 3);
 
     assertThat(String.format("Failed to get first page of loans: %s",
       firstPageResponse.getBody()),

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -2,6 +2,8 @@ package api.loans;
 
 import static api.requests.RequestsAPICreationTests.setupMissingItem;
 import static api.support.JsonCollectionAssistant.getRecordById;
+import static api.support.RestAssuredClient.from;
+import static api.support.RestAssuredClient.get;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
 import static api.support.http.InterfaceUrls.loansUrl;
 import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
@@ -46,6 +48,7 @@ import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
 import api.support.APITests;
+import api.support.RestAssuredClient;
 import api.support.builders.AccountBuilder;
 import api.support.builders.ItemBuilder;
 import api.support.builders.LoanBuilder;
@@ -2077,10 +2080,8 @@ public class LoanAPITests extends APITests {
     return JsonArrayHelper.toList(page.getJsonArray("loans"));
   }
 
-  private IndividualResource getLoanById(UUID id)
-    throws MalformedURLException, InterruptedException, ExecutionException,
-    TimeoutException {
-
-    return loansClient.get(id);
+  private IndividualResource getLoanById(UUID id) {
+    return new IndividualResource(from(get(
+      loansUrl(String.format("/%s", id)), 200, "get-loan-by-id")));
   }
 }

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -2,7 +2,6 @@ package api.loans;
 
 import static api.requests.RequestsAPICreationTests.setupMissingItem;
 import static api.support.JsonCollectionAssistant.getRecordById;
-import static api.support.RestAssuredClient.get;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
 import static api.support.http.InterfaceUrls.loansUrl;
 import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
@@ -13,8 +12,10 @@ import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasMessageContaining;
 import static api.support.matchers.ValidationErrorMatchers.hasNullParameter;
 import static api.support.matchers.ValidationErrorMatchers.hasUUIDParameter;
+import static java.lang.Integer.MAX_VALUE;
 import static org.folio.HttpStatus.HTTP_VALIDATION_ERROR;
 import static org.folio.circulation.domain.representations.ItemProperties.CALL_NUMBER_COMPONENTS;
+import static org.folio.circulation.support.JsonArrayHelper.mapToList;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -2063,10 +2064,7 @@ public class LoanAPITests extends APITests {
     return JsonArrayHelper.toList(page.getJsonArray("loans"));
   }
 
-  private List<JsonObject> getAllLoans()
-    throws MalformedURLException, InterruptedException, ExecutionException,
-    TimeoutException {
-
-    return loansClient.getAll();
+  private List<JsonObject> getAllLoans() {
+    return mapToList(loansFixture.getLoans(MAX_VALUE).getJson(), "loans");
   }
 }

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -203,7 +203,7 @@ public class LoanAPITests extends APITests {
       .withRemainingFeeFine(150)
     );
 
-    JsonObject loan = loansClient.get(id).getJson();
+    JsonObject loan = getLoanById(id).getJson();
 
     loanHasFeeFinesProperties(loan, 0);
   }
@@ -239,7 +239,7 @@ public class LoanAPITests extends APITests {
       .withRemainingFeeFine(150)
     );
 
-    JsonObject loan = loansClient.get(id).getJson();
+    JsonObject loan = getLoanById(id).getJson();
 
     loanHasFeeFinesProperties(loan, 150d);
 
@@ -249,7 +249,7 @@ public class LoanAPITests extends APITests {
       .withRemainingFeeFine(150)
     );
 
-    loan = loansClient.get(id).getJson();
+    loan = getLoanById(id).getJson();
 
     loanHasFeeFinesProperties(loan, 300d);
   }
@@ -1197,7 +1197,7 @@ public class LoanAPITests extends APITests {
 
     loansClient.replace(loan.getId(), updatedLoanRequest);
 
-    final JsonObject updatedLoan = loansClient.get(loan.getId()).getJson();
+    final JsonObject updatedLoan = getLoanById(loan.getId()).getJson();
 
     assertThat("Should be closed",
       updatedLoan.getJsonObject("status").getString("name"), is("Closed"));
@@ -1915,7 +1915,7 @@ public class LoanAPITests extends APITests {
 
      loansStorageClient.replace(individualResource.getId(), savedLoan);
 
-     JsonObject loan = loansClient.get(individualResource.getId()).getJson();
+     JsonObject loan = getLoanById(individualResource.getId()).getJson();
 
      loanHasPatronGroupProperties(loan, "Regular Group");
   }
@@ -2075,5 +2075,12 @@ public class LoanAPITests extends APITests {
 
   private List<JsonObject> getLoans(JsonObject page) {
     return JsonArrayHelper.toList(page.getJsonArray("loans"));
+  }
+
+  private IndividualResource getLoanById(UUID id)
+    throws MalformedURLException, InterruptedException, ExecutionException,
+    TimeoutException {
+
+    return loansClient.get(id);
   }
 }

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -2,6 +2,7 @@ package api.loans;
 
 import static api.requests.RequestsAPICreationTests.setupMissingItem;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
+import static api.support.http.CqlQuery.query;
 import static api.support.http.InterfaceUrls.loansUrl;
 import static api.support.http.Limit.limit;
 import static api.support.http.Offset.offset;
@@ -54,6 +55,7 @@ import api.support.builders.AccountBuilder;
 import api.support.builders.ItemBuilder;
 import api.support.builders.LoanBuilder;
 import api.support.fixtures.ConfigurationExample;
+import api.support.http.CqlQuery;
 import api.support.http.InterfaceUrls;
 import api.support.http.InventoryItemResource;
 import io.vertx.core.json.JsonArray;
@@ -1441,8 +1443,11 @@ public class LoanAPITests extends APITests {
 
     String queryTemplate = "userId=%s";
 
-    Response firstPageResponse = loansFixture.getLoans(String.format(queryTemplate, firstUserId));
-    Response secondPageResponse = loansFixture.getLoans(String.format(queryTemplate, secondUserId));
+    Response firstPageResponse = loansFixture.getLoans(
+      query(String.format(queryTemplate, firstUserId)));
+
+    Response secondPageResponse = loansFixture.getLoans(
+      query(String.format(queryTemplate, secondUserId)));
 
     assertThat(String.format("Failed to get loans for first user: %s",
       firstPageResponse.getBody()),
@@ -1475,7 +1480,8 @@ public class LoanAPITests extends APITests {
   public void canFindNoResultsFromSearch() {
     UUID firstUserId = UUID.randomUUID();
 
-    Response firstPageResponse = loansFixture.getLoans(String.format("userId=%s", firstUserId));
+    Response firstPageResponse = loansFixture.getLoans(
+      query(String.format("userId=%s", firstUserId)));
 
     assertThat(String.format("Failed to get loans for first user: %s",
       firstPageResponse.getBody()),
@@ -1538,8 +1544,11 @@ public class LoanAPITests extends APITests {
 
     String queryTemplate = "userId=\"%s\" and status.name=\"%s\"";
 
-    Response openLoansResponse = loansFixture.getLoans(String.format(queryTemplate, userId, "Open"));
-    Response closedLoansResponse = loansFixture.getLoans(String.format(queryTemplate, userId, "Closed"));
+    Response openLoansResponse = loansFixture.getLoans(
+      query(String.format(queryTemplate, userId, "Open")));
+
+    Response closedLoansResponse = loansFixture.getLoans(
+      query(String.format(queryTemplate, userId, "Closed")));
 
     assertThat(String.format("Failed to get open loans: %s",
       openLoansResponse.getBody()),

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -3,6 +3,7 @@ package api.loans;
 import static api.requests.RequestsAPICreationTests.setupMissingItem;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
 import static api.support.http.CqlQuery.query;
+import static api.support.http.CqlQuery.queryFromTemplate;
 import static api.support.http.InterfaceUrls.loansUrl;
 import static api.support.http.Limit.limit;
 import static api.support.http.Offset.offset;
@@ -55,7 +56,6 @@ import api.support.builders.AccountBuilder;
 import api.support.builders.ItemBuilder;
 import api.support.builders.LoanBuilder;
 import api.support.fixtures.ConfigurationExample;
-import api.support.http.CqlQuery;
 import api.support.http.InterfaceUrls;
 import api.support.http.InventoryItemResource;
 import io.vertx.core.json.JsonArray;
@@ -1444,10 +1444,10 @@ public class LoanAPITests extends APITests {
     String queryTemplate = "userId=%s";
 
     Response firstPageResponse = loansFixture.getLoans(
-      CqlQuery.queryFromTemplate(queryTemplate, firstUserId));
+      queryFromTemplate(queryTemplate, firstUserId));
 
     Response secondPageResponse = loansFixture.getLoans(
-      CqlQuery.queryFromTemplate(queryTemplate, secondUserId));
+      queryFromTemplate(queryTemplate, secondUserId));
 
     assertThat(String.format("Failed to get loans for first user: %s",
       firstPageResponse.getBody()),
@@ -1481,7 +1481,7 @@ public class LoanAPITests extends APITests {
     UUID firstUserId = UUID.randomUUID();
 
     Response firstPageResponse = loansFixture.getLoans(
-      CqlQuery.queryFromTemplate("userId=%s", firstUserId));
+      queryFromTemplate("userId=%s", firstUserId));
 
     assertThat(String.format("Failed to get loans for first user: %s",
       firstPageResponse.getBody()),

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -299,7 +299,7 @@ public class LoanAPITests extends APITests {
       .withRemainingFeeFine(1000)
     );
 
-    List<JsonObject> loans = loansClient.getAll();
+    List<JsonObject> loans = getAllLoans();
 
     JsonObject fetchedLoan1 = getRecordById(loans, loan1.getId()).get();
     JsonObject fetchedLoan2 = getRecordById(loans, loan2.getId()).get();
@@ -1027,7 +1027,7 @@ public class LoanAPITests extends APITests {
 
     final IndividualResource loanPolicy = loanPoliciesFixture.canCirculateRolling();
 
-    List<JsonObject> loans = loansClient.getAll();
+    List<JsonObject> loans = getAllLoans();
 
     loans.forEach(loanJson -> loanHasLoanPolicyProperties(loanJson, loanPolicy));
   }
@@ -1246,7 +1246,7 @@ public class LoanAPITests extends APITests {
 
     loansClient.replace(loan2.getId(), updatedLoanRequest);
 
-    List<JsonObject> loans = loansClient.getAll();
+    List<JsonObject> loans = getAllLoans();
 
     loans.forEach(this::hasNoBorrowerProperties);
   }
@@ -1598,7 +1598,7 @@ public class LoanAPITests extends APITests {
       .withCheckinServicePointId(checkinServicePointId2)
       .withNoUserId());
 
-    final List<JsonObject> multipleLoans = loansClient.getAll();
+    final List<JsonObject> multipleLoans = getAllLoans();
 
     assertThat("Should have two loans",
       multipleLoans.size(), is(2));
@@ -1633,7 +1633,7 @@ public class LoanAPITests extends APITests {
       .withCheckinServicePointId(checkinServicePointId2)
       .withUserId(usersFixture.jessica().getId()));
 
-    final List<JsonObject> multipleLoans = loansClient.getAll();
+    final List<JsonObject> multipleLoans = getAllLoans();
 
      assertThat("Should have different 'userId' for different loans",
        multipleLoans.get(0).getString("userId"),
@@ -1936,7 +1936,7 @@ public class LoanAPITests extends APITests {
 
     loansStorageClient.replace(secondLoan.getId(), secondSavedLoan);
 
-    List<JsonObject> loans = loansClient.getAll();
+    List<JsonObject> loans = getAllLoans();
 
     JsonObject fetchedLoan1 = getRecordById(loans, firstLoan.getId()).get();
     JsonObject fetchedLoan2 = getRecordById(loans, secondLoan.getId()).get();
@@ -2061,5 +2061,12 @@ public class LoanAPITests extends APITests {
 
   private List<JsonObject> getLoans(JsonObject page) {
     return JsonArrayHelper.toList(page.getJsonArray("loans"));
+  }
+
+  private List<JsonObject> getAllLoans()
+    throws MalformedURLException, InterruptedException, ExecutionException,
+    TimeoutException {
+
+    return loansClient.getAll();
   }
 }

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -3,6 +3,8 @@ package api.loans;
 import static api.requests.RequestsAPICreationTests.setupMissingItem;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
 import static api.support.http.InterfaceUrls.loansUrl;
+import static api.support.http.Limit.limit;
+import static api.support.http.Offset.offset;
 import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static api.support.matchers.UUIDMatcher.is;
@@ -13,7 +15,6 @@ import static api.support.matchers.ValidationErrorMatchers.hasNullParameter;
 import static api.support.matchers.ValidationErrorMatchers.hasUUIDParameter;
 import static org.folio.HttpStatus.HTTP_VALIDATION_ERROR;
 import static org.folio.circulation.domain.representations.ItemProperties.CALL_NUMBER_COMPONENTS;
-import static org.folio.circulation.support.JsonArrayHelper.mapToList;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -1368,10 +1369,8 @@ public class LoanAPITests extends APITests {
     loansFixture.checkOutByBarcode(itemsFixture.basedUponUprooted(),user);
     loansFixture.checkOutByBarcode(itemsFixture.basedUponInterestingTimes(),user);
 
-    CompletableFuture<Response> secondPageCompleted = new CompletableFuture<>();
-
-    Response firstPageResponse = loansFixture.getLoans(3);
-    Response secondPageResponse = loansFixture.getLoans(3, 3);
+    Response firstPageResponse = loansFixture.getLoans(limit(3));
+    Response secondPageResponse = loansFixture.getLoans(limit(3), offset(3));
 
     assertThat(String.format("Failed to get first page of loans: %s",
       firstPageResponse.getBody()),

--- a/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
+++ b/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
@@ -303,7 +303,7 @@ public class LoanDueDatesAfterRecallTests extends APITests {
 
     freezeTime(loanDate);
 
-    final IndividualResource loan = loansClient.create(new LoanBuilder()
+    final IndividualResource loan = loansFixture.createLoan(new LoanBuilder()
         .open()
         .withItemId(smallAngryPlanet.getId())
         .withUserId(steve.getId())

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -190,8 +190,8 @@ public abstract class APITests {
   protected final UsersFixture usersFixture = new UsersFixture(usersClient,
     patronGroupsFixture);
 
-  protected final LoansFixture loansFixture = new LoansFixture(loansClient,
-    usersFixture, servicePointsFixture);
+  protected final LoansFixture loansFixture = new LoansFixture(
+          usersFixture, servicePointsFixture);
 
   protected final CancellationReasonsFixture cancellationReasonsFixture
     = new CancellationReasonsFixture(ResourceClient.forCancellationReasons(client));

--- a/src/test/java/api/support/JsonCollectionAssistant.java
+++ b/src/test/java/api/support/JsonCollectionAssistant.java
@@ -1,18 +1,25 @@
 package api.support;
 
-import io.vertx.core.json.JsonObject;
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.vertx.core.json.JsonObject;
 
 public class JsonCollectionAssistant {
   public static Optional<JsonObject> getRecordById(
-    Collection<JsonObject> collection,
-    UUID id) {
+    Collection<JsonObject> collection, UUID id) {
 
-    return collection.stream()
+    return getRecordById(collection.stream(), id);
+  }
+
+  public static Optional<JsonObject> getRecordById(
+    Stream<JsonObject> stream, UUID id) {
+
+    return stream
       .filter(request -> StringUtils.equals(request.getString("id"), id.toString()))
       .findFirst();
   }

--- a/src/test/java/api/support/MultipleJsonRecords.java
+++ b/src/test/java/api/support/MultipleJsonRecords.java
@@ -1,0 +1,34 @@
+package api.support;
+
+import static api.support.JsonCollectionAssistant.getRecordById;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import io.vertx.core.json.JsonObject;
+
+public class MultipleJsonRecords {
+  private final List<JsonObject> records;
+
+  public MultipleJsonRecords(List<JsonObject> records) {
+    this.records = records;
+  }
+
+  public JsonObject getById(UUID id) {
+    return getRecordById(records.stream(), id).orElse(null);
+  }
+
+  public Stream<JsonObject> stream() {
+    return records.stream();
+  }
+
+  public void forEach(Consumer<JsonObject> consumer) {
+    records.forEach(consumer);
+  }
+
+  public int size() {
+    return records.size();
+  }
+}

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -5,6 +5,7 @@ import static org.folio.circulation.support.http.OkapiHeader.OKAPI_URL;
 import static org.folio.circulation.support.http.OkapiHeader.TENANT;
 
 import java.net.URL;
+import java.util.Map;
 
 import org.folio.circulation.support.http.OkapiHeader;
 import org.folio.circulation.support.http.client.Response;
@@ -114,6 +115,21 @@ public class RestAssuredClient {
     return given()
       .log().all()
       .spec(defaultHeaders(requestId))
+      .spec(timeoutConfig())
+      .when().get(url)
+      .then()
+      .log().all()
+      .statusCode(expectedStatusCode)
+      .extract().response();
+  }
+
+  public static io.restassured.response.Response get(
+    URL url, Map<String, String> queryStringParameters, int expectedStatusCode,
+    String requestId) {
+
+    return given()
+      .spec(defaultHeaders(requestId))
+      .queryParams(queryStringParameters)
       .spec(timeoutConfig())
       .when().get(url)
       .then()

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -358,6 +358,11 @@ public class LoansFixture {
       expectedStatusCode, "override-check-out-by-barcode-request"));
   }
 
+  public IndividualResource getLoanById(UUID id) {
+    return new IndividualResource(from(get(
+      loansUrl(String.format("/%s", id)), 200, "get-loan-by-id")));
+  }
+
   public Response getLoans() {
     return getLoans(null, null, null);
   }

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -1,11 +1,13 @@
 package api.support.fixtures;
 
 import static api.support.RestAssuredClient.from;
+import static api.support.RestAssuredClient.get;
 import static api.support.RestAssuredClient.post;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
 import static api.support.http.InterfaceUrls.checkInByBarcodeUrl;
 import static api.support.http.InterfaceUrls.checkOutByBarcodeUrl;
 import static api.support.http.InterfaceUrls.declareLoanItemLostURL;
+import static api.support.http.InterfaceUrls.loansUrl;
 import static api.support.http.InterfaceUrls.overrideCheckOutByBarcodeUrl;
 import static api.support.http.InterfaceUrls.overrideRenewalByBarcodeUrl;
 import static api.support.http.InterfaceUrls.renewByBarcodeUrl;
@@ -14,11 +16,11 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import api.support.builders.DeclareItemLostRequestBuilder;
 import org.folio.HttpStatus;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
@@ -28,6 +30,7 @@ import org.joda.time.DateTimeZone;
 import api.support.CheckInByBarcodeResponse;
 import api.support.builders.CheckInByBarcodeRequestBuilder;
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
+import api.support.builders.DeclareItemLostRequestBuilder;
 import api.support.builders.LoanBuilder;
 import api.support.builders.OverrideCheckOutByBarcodeRequestBuilder;
 import api.support.builders.OverrideRenewalByBarcodeRequestBuilder;
@@ -371,5 +374,18 @@ public class LoansFixture {
 
     return from(post(request, overrideCheckOutByBarcodeUrl(),
       expectedStatusCode, "override-check-out-by-barcode-request"));
+  }
+
+  public Response getLoans() {
+    return from(get(loansUrl(), 200, "get-loans"));
+  }
+
+  public Response getLoans(final int limit) throws MalformedURLException {
+    return from(get(new URL(loansUrl() + "?limit=" + limit), 200, "get-loans"));
+  }
+
+  public Response getLoans(int limit, int offset) throws MalformedURLException {
+    return from(get(new URL(loansUrl() + "?limit=" + limit + "&offset=" + offset),
+      200, "get-loans"));
   }
 }

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -17,6 +17,7 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -388,4 +389,13 @@ public class LoansFixture {
     return from(get(new URL(loansUrl() + "?limit=" + limit + "&offset=" + offset),
       200, "get-loans"));
   }
+
+    public Response getLoans(String query) {
+      final HashMap<String, String> queryStringParameters = new HashMap<>();
+
+      queryStringParameters.put("query", query);
+
+      return from(get(loansUrl(),
+        queryStringParameters, 200, "get-loans"));
+    }
 }

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -12,8 +12,6 @@ import static api.support.http.InterfaceUrls.overrideCheckOutByBarcodeUrl;
 import static api.support.http.InterfaceUrls.overrideRenewalByBarcodeUrl;
 import static api.support.http.InterfaceUrls.renewByBarcodeUrl;
 import static api.support.http.InterfaceUrls.renewByIdUrl;
-import static api.support.http.Limit.limit;
-import static java.lang.Integer.MAX_VALUE;
 
 import java.net.MalformedURLException;
 import java.util.HashMap;
@@ -406,6 +404,7 @@ public class LoansFixture {
 
   public MultipleJsonRecords getAllLoans() {
     return new MultipleJsonRecords(
-      JsonArrayHelper.mapToList(getLoans(limit(MAX_VALUE)).getJson(), "loans"));
+      JsonArrayHelper.mapToList(getLoans(Limit.maximumLimit()).getJson(), "loans"));
   }
+
 }

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -12,6 +12,7 @@ import static api.support.http.InterfaceUrls.overrideCheckOutByBarcodeUrl;
 import static api.support.http.InterfaceUrls.overrideRenewalByBarcodeUrl;
 import static api.support.http.InterfaceUrls.renewByBarcodeUrl;
 import static api.support.http.InterfaceUrls.renewByIdUrl;
+import static api.support.http.Limit.limit;
 import static java.lang.Integer.MAX_VALUE;
 
 import java.net.MalformedURLException;
@@ -37,6 +38,8 @@ import api.support.builders.OverrideCheckOutByBarcodeRequestBuilder;
 import api.support.builders.OverrideRenewalByBarcodeRequestBuilder;
 import api.support.builders.RenewByBarcodeRequestBuilder;
 import api.support.builders.RenewByIdRequestBuilder;
+import api.support.http.Limit;
+import api.support.http.Offset;
 import io.vertx.core.json.JsonObject;
 
 public class LoansFixture {
@@ -370,11 +373,11 @@ public class LoansFixture {
     return getLoans(null, null, null);
   }
 
-  public Response getLoans(final Integer limit) {
+  public Response getLoans(Limit limit) {
     return getLoans(null, limit, null);
   }
 
-  public Response getLoans(Integer limit, Integer offset) {
+  public Response getLoans(Limit limit, Offset offset) {
     return getLoans(null, limit, offset);
   }
 
@@ -382,7 +385,7 @@ public class LoansFixture {
     return getLoans(query, null, null);
   }
 
-  public Response getLoans(String query, Integer limit, Integer offset) {
+  public Response getLoans(String query, Limit limit, Offset offset) {
     final HashMap<String, String> queryStringParameters = new HashMap<>();
 
     if (StringUtils.isNotBlank(query)) {
@@ -390,11 +393,11 @@ public class LoansFixture {
     }
 
     if (limit != null) {
-      queryStringParameters.put("limit", limit.toString());
+      queryStringParameters.put("limit", Integer.toString(limit.getLimit()));
     }
 
     if (offset != null) {
-      queryStringParameters.put("offset", offset.toString());
+      queryStringParameters.put("offset", Integer.toString(offset.getOffset()));
     }
 
     return from(get(loansUrl(),
@@ -403,6 +406,6 @@ public class LoansFixture {
 
   public MultipleJsonRecords getAllLoans() {
     return new MultipleJsonRecords(
-      JsonArrayHelper.mapToList(getLoans(MAX_VALUE).getJson(), "loans"));
+      JsonArrayHelper.mapToList(getLoans(limit(MAX_VALUE)).getJson(), "loans"));
   }
 }

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -12,6 +12,7 @@ import static api.support.http.InterfaceUrls.overrideCheckOutByBarcodeUrl;
 import static api.support.http.InterfaceUrls.overrideRenewalByBarcodeUrl;
 import static api.support.http.InterfaceUrls.renewByBarcodeUrl;
 import static api.support.http.InterfaceUrls.renewByIdUrl;
+import static java.lang.Integer.MAX_VALUE;
 
 import java.net.MalformedURLException;
 import java.util.HashMap;
@@ -20,12 +21,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.folio.circulation.support.JsonArrayHelper;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import api.support.CheckInByBarcodeResponse;
+import api.support.MultipleJsonRecords;
 import api.support.builders.CheckInByBarcodeRequestBuilder;
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
 import api.support.builders.DeclareItemLostRequestBuilder;
@@ -396,5 +399,10 @@ public class LoansFixture {
 
     return from(get(loansUrl(),
       queryStringParameters, 200, "get-loans"));
+  }
+
+  public MultipleJsonRecords getAllLoans() {
+    return new MultipleJsonRecords(
+      JsonArrayHelper.mapToList(getLoans(MAX_VALUE).getJson(), "loans"));
   }
 }

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -4,6 +4,7 @@ import static api.support.RestAssuredClient.from;
 import static api.support.RestAssuredClient.get;
 import static api.support.RestAssuredClient.post;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
+import static api.support.http.CqlQuery.noQuery;
 import static api.support.http.InterfaceUrls.checkInByBarcodeUrl;
 import static api.support.http.InterfaceUrls.checkOutByBarcodeUrl;
 import static api.support.http.InterfaceUrls.declareLoanItemLostURL;
@@ -36,6 +37,7 @@ import api.support.builders.OverrideCheckOutByBarcodeRequestBuilder;
 import api.support.builders.OverrideRenewalByBarcodeRequestBuilder;
 import api.support.builders.RenewByBarcodeRequestBuilder;
 import api.support.builders.RenewByIdRequestBuilder;
+import api.support.http.CqlQuery;
 import api.support.http.Limit;
 import api.support.http.Offset;
 import io.vertx.core.json.JsonObject;
@@ -368,26 +370,26 @@ public class LoansFixture {
   }
 
   public Response getLoans() {
-    return getLoans(null, null, null);
+    return getLoans(noQuery());
   }
 
   public Response getLoans(Limit limit) {
-    return getLoans(null, limit, null);
+    return getLoans(noQuery(), limit, null);
   }
 
   public Response getLoans(Limit limit, Offset offset) {
-    return getLoans(null, limit, offset);
+    return getLoans(noQuery(), limit, offset);
   }
 
-  public Response getLoans(String query) {
+  public Response getLoans(CqlQuery query) {
     return getLoans(query, null, null);
   }
 
-  public Response getLoans(String query, Limit limit, Offset offset) {
+  public Response getLoans(CqlQuery query, Limit limit, Offset offset) {
     final HashMap<String, String> queryStringParameters = new HashMap<>();
 
-    if (StringUtils.isNotBlank(query)) {
-      queryStringParameters.put("query", query);
+    if (StringUtils.isNotBlank(query.getQuery())) {
+      queryStringParameters.put("query", query.getQuery());
     }
 
     if (limit != null) {
@@ -398,13 +400,11 @@ public class LoansFixture {
       queryStringParameters.put("offset", Integer.toString(offset.getOffset()));
     }
 
-    return from(get(loansUrl(),
-      queryStringParameters, 200, "get-loans"));
+    return from(get(loansUrl(), queryStringParameters, 200, "get-loans"));
   }
 
   public MultipleJsonRecords getAllLoans() {
     return new MultipleJsonRecords(
       JsonArrayHelper.mapToList(getLoans(Limit.maximumLimit()).getJson(), "loans"));
   }
-
 }

--- a/src/test/java/api/support/http/CqlQuery.java
+++ b/src/test/java/api/support/http/CqlQuery.java
@@ -7,18 +7,14 @@ import org.apache.commons.lang3.StringUtils;
 public class CqlQuery implements QueryStringParameter {
   private final String query;
 
-  public static CqlQuery query(String query) {
-    return new CqlQuery(query);
-  }
-
   public static CqlQuery queryFromTemplate(String queryTemplate,
       Object... parameters) {
 
-    return query(String.format(queryTemplate, parameters));
+    return new CqlQuery(String.format(queryTemplate, parameters));
   }
 
   public static CqlQuery noQuery() {
-    return query(null);
+    return new CqlQuery(null);
   }
 
   private CqlQuery(String query) {

--- a/src/test/java/api/support/http/CqlQuery.java
+++ b/src/test/java/api/support/http/CqlQuery.java
@@ -1,6 +1,6 @@
 package api.support.http;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -26,7 +26,7 @@ public class CqlQuery implements QueryStringParameter {
   }
 
   @Override
-  public void collectInto(HashMap<String, String> queryStringParameters) {
+  public void collectInto(Map<String, String> queryStringParameters) {
     if (StringUtils.isNotBlank(getQuery())) {
       queryStringParameters.put("query", getQuery());
     }

--- a/src/test/java/api/support/http/CqlQuery.java
+++ b/src/test/java/api/support/http/CqlQuery.java
@@ -1,6 +1,10 @@
 package api.support.http;
 
-public class CqlQuery {
+import java.util.HashMap;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class CqlQuery implements QueryStringParameter {
   private final String query;
 
   public static CqlQuery query(String query) {
@@ -21,8 +25,14 @@ public class CqlQuery {
     this.query = query;
   }
 
-
   public String getQuery() {
     return query;
+  }
+
+  @Override
+  public void collectInto(HashMap<String, String> queryStringParameters) {
+    if (StringUtils.isNotBlank(getQuery())) {
+      queryStringParameters.put("query", getQuery());
+    }
   }
 }

--- a/src/test/java/api/support/http/CqlQuery.java
+++ b/src/test/java/api/support/http/CqlQuery.java
@@ -1,0 +1,28 @@
+package api.support.http;
+
+public class CqlQuery {
+  private final String query;
+
+  public static CqlQuery query(String query) {
+    return new CqlQuery(query);
+  }
+
+  public static CqlQuery queryFromTemplate(String queryTemplate,
+      Object... parameters) {
+
+    return query(String.format(queryTemplate, parameters));
+  }
+
+  public static CqlQuery noQuery() {
+    return query(null);
+  }
+
+  private CqlQuery(String query) {
+    this.query = query;
+  }
+
+
+  public String getQuery() {
+    return query;
+  }
+}

--- a/src/test/java/api/support/http/Limit.java
+++ b/src/test/java/api/support/http/Limit.java
@@ -1,5 +1,7 @@
 package api.support.http;
 
+import static java.lang.Integer.MAX_VALUE;
+
 public class Limit {
   private final int limit;
 
@@ -7,9 +9,14 @@ public class Limit {
     return new Limit(limit);
   }
 
+  public static Limit maximumLimit() {
+    return limit(MAX_VALUE);
+  }
+
   private Limit(int limit) {
     this.limit = limit;
   }
+
 
   public int getLimit() {
     return limit;

--- a/src/test/java/api/support/http/Limit.java
+++ b/src/test/java/api/support/http/Limit.java
@@ -1,0 +1,17 @@
+package api.support.http;
+
+public class Limit {
+  private final int limit;
+
+  public static Limit limit(int limit) {
+    return new Limit(limit);
+  }
+
+  private Limit(int limit) {
+    this.limit = limit;
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+}

--- a/src/test/java/api/support/http/Limit.java
+++ b/src/test/java/api/support/http/Limit.java
@@ -2,8 +2,10 @@ package api.support.http;
 
 import static java.lang.Integer.MAX_VALUE;
 
-public class Limit {
-  private final int limit;
+import java.util.HashMap;
+
+public class Limit implements QueryStringParameter {
+  private final Integer limit;
 
   public static Limit limit(int limit) {
     return new Limit(limit);
@@ -13,12 +15,18 @@ public class Limit {
     return limit(MAX_VALUE);
   }
 
-  private Limit(int limit) {
+  public static Limit noLimit() {
+    return new Limit(null);
+  }
+
+  private Limit(Integer limit) {
     this.limit = limit;
   }
 
-
-  public int getLimit() {
-    return limit;
+  public void collectInto(HashMap<String, String> queryStringParameters) {
+    //TODO: Replace with null value pattern
+    if (limit != null) {
+      queryStringParameters.put("limit", limit.toString());
+    }
   }
 }

--- a/src/test/java/api/support/http/Limit.java
+++ b/src/test/java/api/support/http/Limit.java
@@ -2,7 +2,7 @@ package api.support.http;
 
 import static java.lang.Integer.MAX_VALUE;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class Limit implements QueryStringParameter {
   private final Integer limit;
@@ -23,7 +23,7 @@ public class Limit implements QueryStringParameter {
     this.limit = limit;
   }
 
-  public void collectInto(HashMap<String, String> queryStringParameters) {
+  public void collectInto(Map<String, String> queryStringParameters) {
     //TODO: Replace with null value pattern
     if (limit != null) {
       queryStringParameters.put("limit", limit.toString());

--- a/src/test/java/api/support/http/Offset.java
+++ b/src/test/java/api/support/http/Offset.java
@@ -1,0 +1,17 @@
+package api.support.http;
+
+public class Offset {
+  private final int offset;
+
+  public Offset(int offset) {
+    this.offset = offset;
+  }
+
+  public static Offset offset(int offset) {
+    return new Offset(offset);
+  }
+
+  public int getOffset() {
+    return offset;
+  }
+}

--- a/src/test/java/api/support/http/Offset.java
+++ b/src/test/java/api/support/http/Offset.java
@@ -1,17 +1,26 @@
 package api.support.http;
 
-public class Offset {
-  private final int offset;
+import java.util.HashMap;
 
-  public Offset(int offset) {
-    this.offset = offset;
-  }
+public class Offset implements QueryStringParameter {
+  private final Integer offset;
 
   public static Offset offset(int offset) {
     return new Offset(offset);
   }
 
-  public int getOffset() {
-    return offset;
+  public static Offset noOffset() {
+    return new Offset(null);
+  }
+
+  private Offset(Integer offset) {
+    this.offset = offset;
+  }
+
+  @Override
+  public void collectInto(HashMap<String, String> queryStringParameters) {
+    if (offset != null) {
+      queryStringParameters.put("offset", offset.toString());
+    }
   }
 }

--- a/src/test/java/api/support/http/Offset.java
+++ b/src/test/java/api/support/http/Offset.java
@@ -1,6 +1,6 @@
 package api.support.http;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class Offset implements QueryStringParameter {
   private final Integer offset;
@@ -18,7 +18,7 @@ public class Offset implements QueryStringParameter {
   }
 
   @Override
-  public void collectInto(HashMap<String, String> queryStringParameters) {
+  public void collectInto(Map<String, String> queryStringParameters) {
     if (offset != null) {
       queryStringParameters.put("offset", offset.toString());
     }

--- a/src/test/java/api/support/http/QueryStringParameter.java
+++ b/src/test/java/api/support/http/QueryStringParameter.java
@@ -1,6 +1,7 @@
 package api.support.http;
 
-import java.util.HashMap;
+import java.util.Map;
+
 public interface QueryStringParameter {
-  void collectInto(HashMap<String, String> queryStringParameters);
+  void collectInto(Map<String, String> queryStringParameters);
 }

--- a/src/test/java/api/support/http/QueryStringParameter.java
+++ b/src/test/java/api/support/http/QueryStringParameter.java
@@ -1,0 +1,6 @@
+package api.support.http;
+
+import java.util.HashMap;
+public interface QueryStringParameter {
+  void collectInto(HashMap<String, String> queryStringParameters);
+}


### PR DESCRIPTION
## Purpose
In order to reduce the coupling and reuse between the API tests and the main code, we can start to replace the use of `OkapiHttpClient` with `RestAssured`.

This reduces the chances that tests are affected by unintentional changes in the production code. Hopefully it also reduces the amount of code and improves the readability of the tests.

This also reduces the dependency upon vert.x 3.x HttpClient (some of the methods used in mod-circulation are deprecated), which helps with the eventual migration to vert.x 4.0. Eventually, the remaining production usage will be replaced with the WebClient.

## Approach
Rather than try to do this in a single pull request, this first pull request only replaces the use of `ResourceCollectionClient` in the `LoansApiTests` and the `LoansFixture`.

Hopefully this can generate feedback on the approach and keep the individual changes smaller and incremental.

#### TODOS and Open Questions
- [ ] Replace the use of OkapiHttpClient in the CollectionResourceClient
- [ ] Use RestAssured in all of the fixtures
- [ ] Use RestAssured in the test clean up
- [ ] Make the RestAssuredClient an instance so that standard headers can be better configured


## Learning
RestAssured provides features, like query string parameters, that are considerably easier to use than the vert.x client. 

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
