### PR TITLE
CIRC-596 Make rest assured client an instance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.3.0</version>
+      <version>4.1.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/api/support/APITestContext.java
+++ b/src/test/java/api/support/APITestContext.java
@@ -184,7 +184,7 @@ public class APITestContext {
     }
   }
 
-  static OkapiHeaders getOkapiHeadersFromContext() {
+  public static OkapiHeaders getOkapiHeadersFromContext() {
     return new OkapiHeaders(okapiUrl(), getTenantId(), getToken(), getUserId());
   }
 

--- a/src/test/java/api/support/APITestContext.java
+++ b/src/test/java/api/support/APITestContext.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import api.support.fakes.FakeOkapi;
 import api.support.fakes.FakeStorageModule;
+import api.support.http.OkapiHeaders;
 import api.support.http.URLHelper;
 import io.vertx.core.Vertx;
 
@@ -181,6 +182,10 @@ public class APITestContext {
     } catch (MalformedURLException ex) {
       throw new IllegalArgumentException("Invalid Okapi URL configured for tests");
     }
+  }
+
+  static OkapiHeaders getOkapiHeaders() {
+    return new OkapiHeaders(okapiUrl(), getTenantId(), getToken(), getUserId());
   }
 
   private static String createFakeRequestId() {

--- a/src/test/java/api/support/APITestContext.java
+++ b/src/test/java/api/support/APITestContext.java
@@ -184,7 +184,7 @@ public class APITestContext {
     }
   }
 
-  static OkapiHeaders getOkapiHeaders() {
+  static OkapiHeaders getOkapiHeadersFromContext() {
     return new OkapiHeaders(okapiUrl(), getTenantId(), getToken(), getUserId());
   }
 

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -1,5 +1,6 @@
 package api.support;
 
+import static api.support.APITestContext.getOkapiHeadersFromContext;
 import static io.restassured.RestAssured.given;
 import static org.folio.circulation.support.http.OkapiHeader.OKAPI_URL;
 import static org.folio.circulation.support.http.OkapiHeader.TENANT;
@@ -29,13 +30,6 @@ public class RestAssuredClient {
       .setAccept("application/json, text/plain")
       .setContentType("application/json")
       .build();
-  }
-
-  private static RequestSpecification headersFromApiTestContext(String requestId) {
-    final OkapiHeaders okapiHeaders = APITestContext.getOkapiHeaders()
-      .withRequestId(requestId);
-
-    return standardHeaders(okapiHeaders);
   }
 
   private static RequestSpecification timeoutConfig() {
@@ -71,7 +65,7 @@ public class RestAssuredClient {
 
     return given()
       .log().all()
-      .spec(headersFromApiTestContext(requestId))
+      .spec(standardHeaders(getOkapiHeadersFromContext().withRequestId(requestId)))
       .spec(timeoutConfig(10000))
       .when().post(url)
       .then()
@@ -88,7 +82,7 @@ public class RestAssuredClient {
 
     return given()
       .log().all()
-      .spec(headersFromApiTestContext(requestId))
+      .spec(standardHeaders(getOkapiHeadersFromContext().withRequestId(requestId)))
       .spec(timeoutConfig())
       .body(representation.encodePrettily())
       .when().post(url)
@@ -105,7 +99,7 @@ public class RestAssuredClient {
 
     return given()
       .log().all()
-      .spec(headersFromApiTestContext(requestId))
+      .spec(standardHeaders(getOkapiHeadersFromContext().withRequestId(requestId)))
       .spec(timeoutConfig())
       .body(representation.encodePrettily())
       .when().post(url)
@@ -121,7 +115,7 @@ public class RestAssuredClient {
 
     return given()
       .log().all()
-      .spec(headersFromApiTestContext(requestId))
+      .spec(standardHeaders(getOkapiHeadersFromContext().withRequestId(requestId)))
       .spec(timeoutConfig())
       .when().get(url)
       .then()
@@ -135,7 +129,7 @@ public class RestAssuredClient {
     String requestId) {
 
     return given()
-      .spec(headersFromApiTestContext(requestId))
+      .spec(standardHeaders(getOkapiHeadersFromContext().withRequestId(requestId)))
       .queryParams(queryStringParameters)
       .spec(timeoutConfig())
       .when().get(url)

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -30,7 +30,7 @@ public class RestAssuredClient {
   public Response get(URL url, Map<String, String> queryStringParameters,
       int expectedStatusCode, String requestId) {
 
-    return from(given()
+    return toResponse(given()
       .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
       .queryParams(queryStringParameters)
       .spec(timeoutConfig())
@@ -42,7 +42,7 @@ public class RestAssuredClient {
   }
 
   public Response get(URL url, int expectedStatusCode, String requestId) {
-    return from(given()
+    return toResponse(given()
       .log().all()
       .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
       .spec(timeoutConfig())
@@ -60,7 +60,7 @@ public class RestAssuredClient {
       ? timeoutConfig(timeoutInMilliseconds)
       : timeoutConfig();
 
-    return from(given()
+    return toResponse(given()
       .log().all()
       .spec(standardHeaders(getOkapiHeadersFromContext().withRequestId(requestId)))
       .spec(timeoutConfig)
@@ -72,7 +72,7 @@ public class RestAssuredClient {
   }
 
   public Response post(JsonObject representation, URL url, String requestId) {
-    return from(given()
+    return toResponse(given()
       .log().all()
       .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
       .spec(timeoutConfig())
@@ -86,7 +86,7 @@ public class RestAssuredClient {
   public Response post(JsonObject representation, URL url,
     int expectedStatusCode, String requestId) {
 
-    return from(given()
+    return toResponse(given()
       .log().all()
       .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
       .spec(timeoutConfig())
@@ -101,7 +101,7 @@ public class RestAssuredClient {
   public Response post(JsonObject representation, URL location,
     int expectedStatusCode, OkapiHeaders okapiHeaders) {
 
-    return from(given()
+    return toResponse(given()
       .log().all()
       .spec(standardHeaders(okapiHeaders))
       .spec(timeoutConfig())
@@ -147,7 +147,7 @@ public class RestAssuredClient {
       .build();
   }
 
-  public static Response from(io.restassured.response.Response response) {
+  private static Response toResponse(io.restassured.response.Response response) {
     final CaseInsensitiveHeaders mappedHeaders = new CaseInsensitiveHeaders();
 
     response.headers().iterator().forEachRemaining(h -> {

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -52,6 +52,24 @@ public class RestAssuredClient {
       .extract().response());
   }
 
+  public Response post(URL url, int expectedStatusCode, String requestId,
+      Integer timeoutInMilliseconds) {
+
+    final RequestSpecification timeoutConfig = timeoutInMilliseconds != null
+      ? timeoutConfig(timeoutInMilliseconds)
+      : timeoutConfig();
+
+    return from(given()
+      .log().all()
+      .spec(standardHeaders(getOkapiHeadersFromContext().withRequestId(requestId)))
+      .spec(timeoutConfig)
+      .when().post(url)
+      .then()
+      .log().all()
+      .statusCode(expectedStatusCode)
+      .extract().response());
+  }
+
   private static RequestSpecification standardHeaders(OkapiHeaders okapiHeaders) {
     return new RequestSpecBuilder()
       .addHeader(OKAPI_URL, okapiHeaders.getUrl().toString())
@@ -88,22 +106,6 @@ public class RestAssuredClient {
 
     return new Response(response.statusCode(), response.body().print(),
       response.contentType(), mappedHeaders, null);
-  }
-
-  public static io.restassured.response.Response manuallyStartTimedTask(
-    URL url,
-    int expectedStatusCode,
-    String requestId) {
-
-    return given()
-      .log().all()
-      .spec(standardHeaders(getOkapiHeadersFromContext().withRequestId(requestId)))
-      .spec(timeoutConfig(10000))
-      .when().post(url)
-      .then()
-      .log().all()
-      .statusCode(expectedStatusCode)
-      .extract().response();
   }
 
   public static io.restassured.response.Response post(

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -18,7 +18,6 @@ import io.restassured.specification.RequestSpecification;
 import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.json.JsonObject;
 
-//TODO: Make methods non-static
 public class RestAssuredClient {
   private static RequestSpecification standardHeaders(OkapiHeaders okapiHeaders) {
     return new RequestSpecBuilder()
@@ -33,10 +32,8 @@ public class RestAssuredClient {
   }
 
   private static RequestSpecification headersFromApiTestContext(String requestId) {
-    final OkapiHeaders okapiHeaders = new OkapiHeaders(
-      APITestContext.okapiUrl(),
-      APITestContext.getTenantId(), APITestContext.getToken(),
-      APITestContext.getUserId(), requestId);
+    final OkapiHeaders okapiHeaders = APITestContext.getOkapiHeaders()
+      .withRequestId(requestId);
 
     return standardHeaders(okapiHeaders);
   }

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -20,6 +20,38 @@ import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.json.JsonObject;
 
 public class RestAssuredClient {
+  private final OkapiHeaders defaultHeaders;
+
+  public RestAssuredClient(OkapiHeaders defaultHeaders) {
+    this.defaultHeaders = defaultHeaders;
+  }
+
+  public Response get(URL url, Map<String, String> queryStringParameters,
+      int expectedStatusCode, String requestId) {
+
+    return from(given()
+      .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
+      .queryParams(queryStringParameters)
+      .spec(timeoutConfig())
+      .when().get(url)
+      .then()
+      .log().all()
+      .statusCode(expectedStatusCode)
+      .extract().response());
+  }
+
+  public Response get(URL url, int expectedStatusCode, String requestId) {
+    return from(given()
+      .log().all()
+      .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
+      .spec(timeoutConfig())
+      .when().get(url)
+      .then()
+      .log().all()
+      .statusCode(expectedStatusCode)
+      .extract().response());
+  }
+
   private static RequestSpecification standardHeaders(OkapiHeaders okapiHeaders) {
     return new RequestSpecBuilder()
       .addHeader(OKAPI_URL, okapiHeaders.getUrl().toString())
@@ -105,37 +137,6 @@ public class RestAssuredClient {
       .when().post(url)
       .then()
       .log().all()
-      .extract().response();
-  }
-
-  public static io.restassured.response.Response get(
-    URL url,
-    int expectedStatusCode,
-    String requestId) {
-
-    return given()
-      .log().all()
-      .spec(standardHeaders(getOkapiHeadersFromContext().withRequestId(requestId)))
-      .spec(timeoutConfig())
-      .when().get(url)
-      .then()
-      .log().all()
-      .statusCode(expectedStatusCode)
-      .extract().response();
-  }
-
-  public static io.restassured.response.Response get(
-    URL url, Map<String, String> queryStringParameters, int expectedStatusCode,
-    String requestId) {
-
-    return given()
-      .spec(standardHeaders(getOkapiHeadersFromContext().withRequestId(requestId)))
-      .queryParams(queryStringParameters)
-      .spec(timeoutConfig())
-      .when().get(url)
-      .then()
-      .log().all()
-      .statusCode(expectedStatusCode)
       .extract().response();
   }
 }

--- a/src/test/java/api/support/fixtures/EndPatronSessionClient.java
+++ b/src/test/java/api/support/fixtures/EndPatronSessionClient.java
@@ -1,14 +1,14 @@
 package api.support.fixtures;
 
-import static api.support.RestAssuredClient.from;
-import static api.support.RestAssuredClient.post;
+import static api.support.APITestContext.getOkapiHeadersFromContext;
 import static api.support.http.InterfaceUrls.endSessionUrl;
 
 import java.util.UUID;
 
-import io.vertx.core.json.JsonArray;
 import org.folio.circulation.support.http.client.Response;
 
+import api.support.RestAssuredClient;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class EndPatronSessionClient {
@@ -41,6 +41,7 @@ public class EndPatronSessionClient {
   }
 
   private Response attemptEndPatronSession(JsonObject body, int expectedStatus) {
-    return from(post(body, endSessionUrl(), expectedStatus, REQUEST_ID));
+    return new RestAssuredClient(getOkapiHeadersFromContext())
+      .post(body, endSessionUrl(), expectedStatus, REQUEST_ID);
   }
 }

--- a/src/test/java/api/support/fixtures/ExpiredSessionProcessingClient.java
+++ b/src/test/java/api/support/fixtures/ExpiredSessionProcessingClient.java
@@ -1,14 +1,20 @@
 package api.support.fixtures;
 
 import static api.support.APITestContext.circulationModuleUrl;
-import static api.support.RestAssuredClient.manuallyStartTimedTask;
 
 import java.net.URL;
 
-public class ExpiredSessionProcessingClient {
+import api.support.APITestContext;
+import api.support.RestAssuredClient;
 
+public class ExpiredSessionProcessingClient {
   public void runRequestExpiredSessionsProcessing(int expectedStatusCode) {
+    final RestAssuredClient restAssuredClient = new RestAssuredClient(
+      APITestContext.getOkapiHeadersFromContext());
+
     URL url = circulationModuleUrl("/circulation/notice-session-expiration-by-timeout");
-    manuallyStartTimedTask(url, expectedStatusCode, "notice-session-expiration-by-timeout-request");
+
+    restAssuredClient.post(url, expectedStatusCode,
+      "notice-session-expiration-by-timeout-request", 10000);
   }
 }

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -1,8 +1,6 @@
 package api.support.fixtures;
 
 import static api.support.APITestContext.getOkapiHeadersFromContext;
-import static api.support.RestAssuredClient.from;
-import static api.support.RestAssuredClient.post;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
 import static api.support.http.CqlQuery.noQuery;
 import static api.support.http.InterfaceUrls.checkInByBarcodeUrl;
@@ -44,6 +42,7 @@ import api.support.builders.RenewByIdRequestBuilder;
 import api.support.http.CqlQuery;
 import api.support.http.Limit;
 import api.support.http.Offset;
+import api.support.http.OkapiHeaders;
 import io.vertx.core.json.JsonObject;
 
 public class LoansFixture {
@@ -109,17 +108,17 @@ public class LoansFixture {
   public Response attemptToCreateLoan(
     LoanBuilder loanBuilder, int expectedStatusCode) {
 
-    return from(post(loanBuilder.create(), loansUrl(),
-      expectedStatusCode, "post-loan"));
+    return restAssuredClient.post(loanBuilder.create(), loansUrl(),
+      expectedStatusCode, "post-loan");
   }
 
-  public Response declareItemLost(DeclareItemLostRequestBuilder builder) {
+  public Response declareItemLost(UUID loanId,
+      DeclareItemLostRequestBuilder builder) {
 
     JsonObject request = builder.create();
 
-    return from(
-      post(request, declareLoanItemLostURL(builder.getLoanId().toString()),
-        "declare-item-lost-request"));
+    return restAssuredClient.post(request,
+      declareLoanItemLostURL(loanId.toString()), "declare-item-lost-request");
   }
 
   public IndividualResource checkOutByBarcode(IndividualResource item)
@@ -167,8 +166,8 @@ public class LoansFixture {
     JsonObject request = builder.create();
 
     return new IndividualResource(
-      from(post(request, checkOutByBarcodeUrl(), 201,
-        "check-out-by-barcode-request")));
+      restAssuredClient.post(request, checkOutByBarcodeUrl(), 201,
+        "check-out-by-barcode-request"));
   }
 
   public Response attemptCheckOutByBarcode(
@@ -193,8 +192,8 @@ public class LoansFixture {
 
     JsonObject request = builder.create();
 
-    return from(post(request, checkOutByBarcodeUrl(),
-      expectedStatusCode, "check-out-by-barcode-request"));
+    return restAssuredClient.post(request, checkOutByBarcodeUrl(),
+      expectedStatusCode, "check-out-by-barcode-request");
   }
 
   public IndividualResource renewLoan(
@@ -206,13 +205,12 @@ public class LoansFixture {
       .forUser(user)
       .create();
 
-    return new IndividualResource(from(post(request, renewByBarcodeUrl(), 200,
-      "renewal-by-barcode-request")));
+    return new IndividualResource(restAssuredClient.post(request,
+      renewByBarcodeUrl(), 200, "renewal-by-barcode-request"));
   }
 
-  public IndividualResource overrideRenewalByBarcode(
-    IndividualResource item,
-    IndividualResource user, String comment, String dueDate) {
+  public IndividualResource overrideRenewalByBarcode(IndividualResource item,
+      IndividualResource user, String comment, String dueDate) {
 
     JsonObject request =
       new OverrideRenewalByBarcodeRequestBuilder()
@@ -222,42 +220,36 @@ public class LoansFixture {
         .withDueDate(dueDate)
         .create();
 
-    return new IndividualResource(from(post(request, overrideRenewalByBarcodeUrl(), 200,
-      "override-renewal-by-barcode-request")));
+    return new IndividualResource(restAssuredClient.post(request,
+      overrideRenewalByBarcodeUrl(), 200, "override-renewal-by-barcode-request"));
   }
 
-  public IndividualResource renewLoanById(
-    IndividualResource item,
-    IndividualResource user) {
+  public IndividualResource renewLoanById(IndividualResource item,
+      IndividualResource user) {
 
     JsonObject request = new RenewByIdRequestBuilder()
       .forItem(item)
       .forUser(user)
       .create();
 
-    return new IndividualResource(from(post(request, renewByIdUrl(), 200,
-      "renewal-by-id-request")));
+    return new IndividualResource(restAssuredClient.post(request, renewByIdUrl(),
+      200, "renewal-by-id-request"));
   }
 
-  public Response attemptRenewal(
-    IndividualResource item,
-    IndividualResource user) {
-
+  public Response attemptRenewal(IndividualResource item, IndividualResource user) {
     return attemptRenewal(422, item, user);
   }
 
-  public Response attemptRenewal(
-    int expectedStatusCode,
-    IndividualResource item,
-    IndividualResource user) {
+  public Response attemptRenewal(int expectedStatusCode, IndividualResource item,
+      IndividualResource user) {
 
     JsonObject request = new RenewByBarcodeRequestBuilder()
       .forItem(item)
       .forUser(user)
       .create();
 
-    return from(post(request, renewByBarcodeUrl(),
-      expectedStatusCode, "renewal-by-barcode-request"));
+    return restAssuredClient.post(request, renewByBarcodeUrl(),
+      expectedStatusCode, "renewal-by-barcode-request");
   }
 
   public Response attemptOverride(
@@ -267,10 +259,8 @@ public class LoansFixture {
     return attemptOverride(422, item, user, comment, dueDate);
   }
 
-  public Response attemptOverride(
-    int expectedStatusCode,
-    IndividualResource item,
-    IndividualResource user, String comment, String dueDate) {
+  public Response attemptOverride(int expectedStatusCode, IndividualResource item,
+      IndividualResource user, String comment, String dueDate) {
 
     JsonObject request =
       new OverrideRenewalByBarcodeRequestBuilder()
@@ -280,36 +270,34 @@ public class LoansFixture {
         .withDueDate(dueDate)
         .create();
 
-    return from(post(request, overrideRenewalByBarcodeUrl(),
-      expectedStatusCode, "override-renewal-by-barcode-request"));
+    return restAssuredClient.post(request, overrideRenewalByBarcodeUrl(),
+      expectedStatusCode, "override-renewal-by-barcode-request");
   }
 
-  public Response attemptRenewalById(
-    IndividualResource item,
-    IndividualResource user) {
+  public Response attemptRenewalById(IndividualResource item,
+      IndividualResource user) {
 
     JsonObject request = new RenewByIdRequestBuilder()
       .forItem(item)
       .forUser(user)
       .create();
 
-    return from(post(request, renewByIdUrl(),
-      422, "renewal-by-id-request"));
+    return restAssuredClient.post(request, renewByIdUrl(),
+      422, "renewal-by-id-request");
   }
 
   public Response attemptCheckInByBarcode(
     CheckInByBarcodeRequestBuilder builder) {
 
-    return from(post(builder.create(), checkInByBarcodeUrl(),
-        "check-in-by-barcode-request"));
+    return restAssuredClient.post(builder.create(), checkInByBarcodeUrl(),
+        "check-in-by-barcode-request");
   }
 
   public CheckInByBarcodeResponse checkInByBarcode(
     CheckInByBarcodeRequestBuilder builder) {
 
-    return new CheckInByBarcodeResponse(
-      from(post(builder.create(), checkInByBarcodeUrl(), 200,
-        "check-in-by-barcode-request")));
+    return new CheckInByBarcodeResponse(restAssuredClient.post(builder.create(),
+      checkInByBarcodeUrl(), 200, "check-in-by-barcode-request"));
   }
 
   public CheckInByBarcodeResponse checkInByBarcode(IndividualResource item)
@@ -335,6 +323,19 @@ public class LoansFixture {
       .at(servicePointId));
   }
 
+  public void checkInByBarcode(IndividualResource item, DateTime checkInDate,
+      UUID servicePointId, OkapiHeaders okapiHeaders) {
+
+    final JsonObject representation = new CheckInByBarcodeRequestBuilder()
+      .forItem(item)
+      .on(checkInDate)
+      .at(servicePointId).create();
+
+    restAssuredClient.post(representation, checkInByBarcodeUrl(), 200,
+      okapiHeaders);
+  }
+
+
   private IndividualResource defaultServicePoint()
     throws InterruptedException,
     MalformedURLException,
@@ -350,8 +351,8 @@ public class LoansFixture {
     JsonObject request = builder.create();
 
     return new IndividualResource(
-      from(post(request, overrideCheckOutByBarcodeUrl(), 201,
-        "override-check-out-by-barcode-request")));
+      restAssuredClient.post(request, overrideCheckOutByBarcodeUrl(), 201,
+        "override-check-out-by-barcode-request"));
   }
 
   public Response attemptOverrideCheckOutByBarcode(
@@ -366,8 +367,8 @@ public class LoansFixture {
 
     JsonObject request = builder.create();
 
-    return from(post(request, overrideCheckOutByBarcodeUrl(),
-      expectedStatusCode, "override-check-out-by-barcode-request"));
+    return restAssuredClient.post(request, overrideCheckOutByBarcodeUrl(),
+      expectedStatusCode, "override-check-out-by-barcode-request");
   }
 
   public IndividualResource getLoanById(UUID id) {

--- a/src/test/java/api/support/fixtures/RequestsFixture.java
+++ b/src/test/java/api/support/fixtures/RequestsFixture.java
@@ -1,5 +1,7 @@
 package api.support.fixtures;
 
+import static api.support.APITestContext.getOkapiHeadersFromContext;
+
 import java.net.MalformedURLException;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -22,6 +24,7 @@ public class RequestsFixture {
   private final ResourceClient requestsClient;
   private final CancellationReasonsFixture cancellationReasonsFixture;
   private final ServicePointsFixture servicePointsFixture;
+  private final RestAssuredClient restAssuredClient;
 
   public RequestsFixture(
     ResourceClient requestsClient,
@@ -31,6 +34,7 @@ public class RequestsFixture {
     this.requestsClient = requestsClient;
     this.cancellationReasonsFixture = cancellationReasonsFixture;
     this.servicePointsFixture = servicePointsFixture;
+    restAssuredClient = new RestAssuredClient(getOkapiHeadersFromContext());
   }
 
   public IndividualResource place(RequestBuilder requestToBuild)
@@ -198,12 +202,11 @@ public class RequestsFixture {
     return requestsClient.attemptMove(requestToBuild);
   }
 
+  //TODO: Replace return type with MultipleJsonRecords
   public MultipleRecords<JsonObject> getQueueFor(IndividualResource item) {
-    //TODO: Replace with better parsing
     return MultipleRecords.from(
-      RestAssuredClient.from(
-        RestAssuredClient.get(InterfaceUrls.requestQueueUrl(item.getId()),
-      200, "request-queue-request")),
+        restAssuredClient.get(InterfaceUrls.requestQueueUrl(item.getId()),
+      200, "request-queue-request"),
       Function.identity() ,"requests").value();
   }
 }

--- a/src/test/java/api/support/fixtures/ScheduledNoticeProcessingClient.java
+++ b/src/test/java/api/support/fixtures/ScheduledNoticeProcessingClient.java
@@ -1,22 +1,32 @@
 package api.support.fixtures;
 
 import static api.support.APITestContext.circulationModuleUrl;
-import static api.support.http.TimedTaskClient.manuallyStartTimedTask;
+import static api.support.APITestContext.getOkapiHeadersFromContext;
 
 import java.net.URL;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 
+import api.support.http.TimedTaskClient;
+
 public class ScheduledNoticeProcessingClient {
+  private final TimedTaskClient timedTaskClient;
+
+  public ScheduledNoticeProcessingClient() {
+    timedTaskClient = new TimedTaskClient(getOkapiHeadersFromContext());
+  }
 
   public void runDueDateNoticesProcessing(DateTime mockSystemTime) {
     runWithFrozenTime(this::runDueDateNoticesProcessing, mockSystemTime);
   }
 
   public void runDueDateNoticesProcessing() {
-    URL url = circulationModuleUrl("/circulation/due-date-scheduled-notices-processing");
-    manuallyStartTimedTask(url, 204, "due-date-scheduled-notices-processing-request");
+    URL url = circulationModuleUrl(
+      "/circulation/due-date-scheduled-notices-processing");
+
+    timedTaskClient.start(url, 204,
+      "due-date-scheduled-notices-processing-request");
   }
 
   public void runDueDateNotRealTimeNoticesProcessing(DateTime mockSystemTime) {
@@ -24,8 +34,11 @@ public class ScheduledNoticeProcessingClient {
   }
 
   public void runDueDateNotRealTimeNoticesProcessing() {
-    URL url = circulationModuleUrl("/circulation/due-date-not-real-time-scheduled-notices-processing");
-    manuallyStartTimedTask(url, 204, "due-date-not-real-time-scheduled-notices-processing-request");
+    URL url = circulationModuleUrl(
+      "/circulation/due-date-not-real-time-scheduled-notices-processing");
+
+    timedTaskClient.start(url, 204,
+      "due-date-not-real-time-scheduled-notices-processing-request");
   }
 
   public void runRequestNoticesProcessing(DateTime mockSystemTime) {
@@ -33,8 +46,11 @@ public class ScheduledNoticeProcessingClient {
   }
 
   public void runRequestNoticesProcessing() {
-    URL url = circulationModuleUrl("/circulation/request-scheduled-notices-processing");
-    manuallyStartTimedTask(url, 204, "request-scheduled-notices-processing-request");
+    URL url = circulationModuleUrl(
+      "/circulation/request-scheduled-notices-processing");
+
+    timedTaskClient.start(url, 204,
+      "request-scheduled-notices-processing-request");
   }
 
   private void runWithFrozenTime(Runnable runnable, DateTime mockSystemTime) {

--- a/src/test/java/api/support/fixtures/ScheduledNoticeProcessingClient.java
+++ b/src/test/java/api/support/fixtures/ScheduledNoticeProcessingClient.java
@@ -1,7 +1,7 @@
 package api.support.fixtures;
 
 import static api.support.APITestContext.circulationModuleUrl;
-import static api.support.RestAssuredClient.manuallyStartTimedTask;
+import static api.support.http.TimedTaskClient.manuallyStartTimedTask;
 
 import java.net.URL;
 

--- a/src/test/java/api/support/http/OkapiHeaders.java
+++ b/src/test/java/api/support/http/OkapiHeaders.java
@@ -28,6 +28,11 @@ public class OkapiHeaders {
       requestId);
   }
 
+  public OkapiHeaders withUserId(String userId) {
+    return new OkapiHeaders(this.url, this.tenantId, this.token, userId,
+      this.requestId);
+  }
+
   public URL getUrl() {
     return url;
   }
@@ -42,6 +47,10 @@ public class OkapiHeaders {
 
   public String getUserId() {
     return userId;
+  }
+
+  public boolean hasUserId() {
+    return userId != null;
   }
 
   public String getRequestId() {

--- a/src/test/java/api/support/http/OkapiHeaders.java
+++ b/src/test/java/api/support/http/OkapiHeaders.java
@@ -1,0 +1,41 @@
+package api.support.http;
+
+import java.net.URL;
+
+public class OkapiHeaders {
+  private final URL url;
+  private final String tenantId;
+  private final String token;
+  private final String userId;
+  private final String requestId;
+
+  public OkapiHeaders(URL url, String tenantId, String token, String userId,
+      String requestId) {
+
+    this.url = url;
+    this.tenantId = tenantId;
+    this.token = token;
+    this.userId = userId;
+    this.requestId = requestId;
+  }
+
+  public URL getUrl() {
+    return url;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public String getRequestId() {
+    return requestId;
+  }
+}

--- a/src/test/java/api/support/http/OkapiHeaders.java
+++ b/src/test/java/api/support/http/OkapiHeaders.java
@@ -9,6 +9,10 @@ public class OkapiHeaders {
   private final String userId;
   private final String requestId;
 
+  public OkapiHeaders(URL url, String tenantId, String token, String userId) {
+    this(url, tenantId, token, userId, null);
+  }
+
   public OkapiHeaders(URL url, String tenantId, String token, String userId,
       String requestId) {
 
@@ -17,6 +21,11 @@ public class OkapiHeaders {
     this.token = token;
     this.userId = userId;
     this.requestId = requestId;
+  }
+
+  public OkapiHeaders withRequestId(String requestId) {
+    return new OkapiHeaders(this.url, this.tenantId, this.token, this.userId,
+      requestId);
   }
 
   public URL getUrl() {

--- a/src/test/java/api/support/http/TimedTaskClient.java
+++ b/src/test/java/api/support/http/TimedTaskClient.java
@@ -1,0 +1,18 @@
+package api.support.http;
+
+import static api.support.APITestContext.getOkapiHeadersFromContext;
+
+import java.net.URL;
+
+import org.folio.circulation.support.http.client.Response;
+
+import api.support.RestAssuredClient;
+
+public class TimedTaskClient {
+  public static Response manuallyStartTimedTask(URL url, int expectedStatusCode,
+      String requestId) {
+
+    return new RestAssuredClient(getOkapiHeadersFromContext())
+      .post(url, expectedStatusCode, requestId, 10000);
+  }
+}

--- a/src/test/java/api/support/http/TimedTaskClient.java
+++ b/src/test/java/api/support/http/TimedTaskClient.java
@@ -1,7 +1,5 @@
 package api.support.http;
 
-import static api.support.APITestContext.getOkapiHeadersFromContext;
-
 import java.net.URL;
 
 import org.folio.circulation.support.http.client.Response;
@@ -9,10 +7,14 @@ import org.folio.circulation.support.http.client.Response;
 import api.support.RestAssuredClient;
 
 public class TimedTaskClient {
-  public static Response manuallyStartTimedTask(URL url, int expectedStatusCode,
-      String requestId) {
+  private final OkapiHeaders defaultHeaders;
 
-    return new RestAssuredClient(getOkapiHeadersFromContext())
+  public TimedTaskClient(OkapiHeaders defaultHeaders) {
+    this.defaultHeaders = defaultHeaders;
+  }
+
+  public Response start(URL url, int expectedStatusCode, String requestId) {
+    return new RestAssuredClient(defaultHeaders)
       .post(url, expectedStatusCode, requestId, 10000);
   }
 }


### PR DESCRIPTION
## Purpose

In order to reduce the coupling and reuse between the API tests and the main code, we can start to replace the use of OkapiHttpClient with RestAssured.

This reduces the chances that tests are affected by unintentional changes in the production code. Hopefully it also reduces the amount of code and improves the readability of the tests.

This also reduces the dependency upon vert.x 3.x HttpClient (some of the methods used in mod-circulation are deprecated), which helps with the eventual migration to vert.x 4.0. Eventually, the remaining production usage will be replaced with the WebClient.

## Approach

This is the second in a series of changes to use Rest Assured instead of a custom client in the API tests for mod-circulation.

The conversion to an instance means that the implicit coupling between the RestAssuredClient and the APITestContext can be relaxed and allows for better configuration.

It was also an opportunity to refine the APIs a little, to make it easier for clients (and reduce the leakage of Rest Assured classes).

#### TODOS and Open Questions
* To use the RestAssuredClient internally to the CollectionResourceClient
* Remove the CollectionResourceClient, or shrink it to a thin wrapper around the RestAssuredClient

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
