### PR TITLE
CIRC-596 Use rest assured in resource client

### DIFF
--- a/src/test/java/api/CirculationRulesEngineAPITests.java
+++ b/src/test/java/api/CirculationRulesEngineAPITests.java
@@ -1,6 +1,8 @@
 package api;
 
+import static api.support.http.InterfaceUrls.circulationRulesStorageUrl;
 import static api.support.http.InterfaceUrls.circulationRulesUrl;
+import static org.folio.circulation.support.http.client.ResponseHandler.any;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
@@ -28,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import api.support.APITests;
-import api.support.http.ResourceClient;
+import api.support.http.InterfaceUrls;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -57,7 +59,7 @@ public class CirculationRulesEngineAPITests extends APITests {
           + "&patron_type_id="       + patronGroup.id
           + "&location_id="          + location.id
           );
-      client.get(url, ResponseHandler.any(completed));
+      client.get(url, any(completed));
       Response response = completed.get(10, TimeUnit.SECONDS);
       assert response.getStatusCode() == 200;
       JsonObject json = new JsonObject(response.getBody());
@@ -80,7 +82,7 @@ public class CirculationRulesEngineAPITests extends APITests {
           + "&patron_type_id="       + patronGroup.id
           + "&location_id="          + location.id
           );
-      client.get(url, ResponseHandler.any(completed));
+      client.get(url, any(completed));
       Response response = completed.get(10, TimeUnit.SECONDS);
       assert response.getStatusCode() == 200;
       JsonObject json = new JsonObject(response.getBody());
@@ -103,7 +105,7 @@ public class CirculationRulesEngineAPITests extends APITests {
               + "&patron_type_id="       + patronGroup.id
               + "&location_id="          + location.id
               );
-          client.get(url, ResponseHandler.any(completed));
+          client.get(url, any(completed));
           Response response = completed.get(10, TimeUnit.SECONDS);
           assert response.getStatusCode() == 200;
           JsonObject json = new JsonObject(response.getBody());
@@ -199,7 +201,7 @@ public class CirculationRulesEngineAPITests extends APITests {
   public void applyLoanWithoutParameters() throws Exception {
     CompletableFuture<Response> completed = new CompletableFuture<>();
     URL url = circulationRulesUrl("/loan-policy");
-    client.get(url, ResponseHandler.any(completed));
+    client.get(url, any(completed));
     Response response = completed.get(10, TimeUnit.SECONDS);
     assertThat(response.getStatusCode(), is(400));
   }
@@ -208,7 +210,7 @@ public class CirculationRulesEngineAPITests extends APITests {
   public void applyRequestWithoutParameters() throws Exception {
     CompletableFuture<Response> completed = new CompletableFuture<>();
     URL url = circulationRulesUrl("/request-policy");
-    client.get(url, ResponseHandler.any(completed));
+    client.get(url, any(completed));
     Response response = completed.get(10, TimeUnit.SECONDS);
     assertThat(response.getStatusCode(), is(400));
   }
@@ -217,7 +219,7 @@ public class CirculationRulesEngineAPITests extends APITests {
   public void applyNoticeWithoutParameters() throws Exception {
     CompletableFuture<Response> completed = new CompletableFuture<>();
     URL url = circulationRulesUrl("/notice-policy");
-    client.get(url, ResponseHandler.any(completed));
+    client.get(url, any(completed));
     Response response = completed.get(10, TimeUnit.SECONDS);
     assertThat(response.getStatusCode(), is(400));
   }
@@ -226,7 +228,7 @@ public class CirculationRulesEngineAPITests extends APITests {
     String name = missing.substring(0, missing.indexOf("="));
     CompletableFuture<Response> completed = new CompletableFuture<>();
     URL url = circulationRulesUrl("/loan-policy?" + p1 + "&" + p2 + "&" + p3);
-    client.get(url, ResponseHandler.any(completed));
+    client.get(url, any(completed));
     Response response = completed.get(10, TimeUnit.SECONDS);
     assertThat(response.getStatusCode(), is(400));
     assertThat(response.getBody(), containsString(name));
@@ -236,7 +238,7 @@ public class CirculationRulesEngineAPITests extends APITests {
     String name = missing.substring(0, missing.indexOf("="));
     CompletableFuture<Response> completed = new CompletableFuture<>();
     URL url = circulationRulesUrl("/request-policy?" + p1 + "&" + p2 + "&" + p3);
-    client.get(url, ResponseHandler.any(completed));
+    client.get(url, any(completed));
     Response response = completed.get(10, TimeUnit.SECONDS);
     assertThat(response.getStatusCode(), is(400));
     assertThat(response.getBody(), containsString(name));
@@ -246,7 +248,7 @@ public class CirculationRulesEngineAPITests extends APITests {
       String name = missing.substring(0, missing.indexOf("="));
       CompletableFuture<Response> completed = new CompletableFuture<>();
       URL url = circulationRulesUrl("/notice-policy?" + p1 + "&" + p2 + "&" + p3);
-      client.get(url, ResponseHandler.any(completed));
+      client.get(url, any(completed));
       Response response = completed.get(10, TimeUnit.SECONDS);
       assertThat(response.getStatusCode(), is(400));
       assertThat(response.getBody(), containsString(name));
@@ -304,7 +306,7 @@ public class CirculationRulesEngineAPITests extends APITests {
         + "&loan_type_id=" + l
         + "&patron_type_id=" + p
         + "&location_id=" + s);
-    client.get(url, ResponseHandler.any(completed));
+    client.get(url, any(completed));
     Response response;
     try {
       response = completed.get(10, TimeUnit.SECONDS);
@@ -422,7 +424,7 @@ public class CirculationRulesEngineAPITests extends APITests {
         + "&patron_type_id="       + g2
         + "&location_id="          + s2
         );
-    client.get(url, ResponseHandler.any(completed));
+    client.get(url, any(completed));
     Response response = completed.get(10, TimeUnit.SECONDS);
     assertThat(response.getStatusCode() + " " + response.getBody(),
         response.getStatusCode(), is(200));
@@ -457,7 +459,7 @@ public class CirculationRulesEngineAPITests extends APITests {
         + "&patron_type_id="       + g2
         + "&location_id="          + s2
         );
-    client.get(url, ResponseHandler.any(completed));
+    client.get(url, any(completed));
     Response response = completed.get(10, TimeUnit.SECONDS);
     assertThat(response.getStatusCode() + " " + response.getBody(),
         response.getStatusCode(), is(200));
@@ -483,7 +485,7 @@ public class CirculationRulesEngineAPITests extends APITests {
         + "&location_id="          + s2
     );
 
-    client.get(url, ResponseHandler.any(completed));
+    client.get(url, any(completed));
 
     Response response = completed.get(10, TimeUnit.SECONDS);
     assertThat(response.getStatusCode() + " " + response.getBody(),
@@ -526,15 +528,14 @@ public class CirculationRulesEngineAPITests extends APITests {
   }
 
   private void updateCirculationRulesInStorageWithoutInvalidatingCache(String rules)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
-    ResourceClient circulationRulesClient = ResourceClient.forCirculationRules(client);
+    CompletableFuture<Response> putCompleted = new CompletableFuture<>();
 
     JsonObject json = new JsonObject().put("rulesAsText", rules);
 
-    circulationRulesClient.replace(null, json);
+    client.put(circulationRulesStorageUrl(""), json, any(putCompleted));
+
+    putCompleted.get(5, TimeUnit.SECONDS);
   }
 }

--- a/src/test/java/api/CirculationRulesEngineAPITests.java
+++ b/src/test/java/api/CirculationRulesEngineAPITests.java
@@ -25,12 +25,10 @@ import org.folio.circulation.rules.PatronGroup;
 import org.folio.circulation.rules.Policy;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
-import org.folio.circulation.support.http.client.ResponseHandler;
 import org.junit.Before;
 import org.junit.Test;
 
 import api.support.APITests;
-import api.support.http.InterfaceUrls;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 

--- a/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
@@ -37,7 +37,6 @@ import api.support.http.InventoryItemResource;
 import io.vertx.core.json.JsonObject;
 
 public class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests {
-
   @Test
   public void uponAtDueDateNoticesShouldBeSentInGroups()
     throws MalformedURLException,
@@ -375,7 +374,7 @@ public class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests 
     InventoryItemResource nod = itemsFixture.basedUponNod();
     IndividualResource nodToJamesLoan = loansFixture.checkOutByBarcode(nod, james, loanDate);
 
-    usersClient.delete(james);
+    usersFixture.remove(james);
 
     Awaitility.await()
       .atMost(1, TimeUnit.SECONDS)
@@ -436,7 +435,7 @@ public class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests 
 
     loansClient.delete(temeraireToJames);
     itemsClient.delete(times);
-    usersClient.delete(jessica);
+    usersFixture.remove(jessica);
 
     Awaitility.await()
       .atMost(1, TimeUnit.SECONDS)
@@ -471,5 +470,4 @@ public class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests 
       hasEmailNoticeProperties(james.getId(), templateId, noticeToJamesContextMatcher),
       hasEmailNoticeProperties(steve.getId(), templateId, noticeToSteveContextMatcher)));
   }
-
 }

--- a/src/test/java/api/loans/DueDateScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/DueDateScheduledNoticesProcessingTests.java
@@ -375,7 +375,7 @@ public class DueDateScheduledNoticesProcessingTests extends APITests {
 
     JsonObject brokenNotice = createNoticesOverTime(dueDate.minusMinutes(1)::minusHours, 1).get(0);
 
-    usersClient.delete(borrower);
+    usersFixture.remove(borrower);
 
     scheduledNoticesClient.create(brokenNotice);
     scheduledNoticeProcessingClient.runDueDateNoticesProcessing(dueDate.minusSeconds(1));

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -100,7 +100,7 @@ public class OverrideRenewByBarcodeTests extends APITests {
 
     loansFixture.checkOutByBarcode(smallAngryPlanet, steve);
 
-    usersClient.delete(steve.getId());
+    usersFixture.remove(steve);
 
     final Response response = loansFixture.attemptOverride(smallAngryPlanet,
       steve, OVERRIDE_COMMENT, null);

--- a/src/test/java/api/loans/anonymization/LoanAnonymizationTests.java
+++ b/src/test/java/api/loans/anonymization/LoanAnonymizationTests.java
@@ -68,14 +68,14 @@ abstract class LoanAnonymizationTests extends APITests {
       payload.remove("userId");
       payload.remove("borrower");
       loansStorageClient.attemptReplace(UUID.fromString(id.toString()), payload);
-
-    } catch (MalformedURLException | InterruptedException | ExecutionException | TimeoutException e) {
+    } catch (MalformedURLException e) {
       e.printStackTrace();
     }
   }
 
   void createOpenAccountWithFeeFines(IndividualResource loanResource)
-      throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+      throws MalformedURLException {
+
     IndividualResource account = accountsClient.create(new AccountBuilder().feeFineStatusOpen()
       .withLoan(loanResource)
       .feeFineStatusOpen()
@@ -88,7 +88,7 @@ abstract class LoanAnonymizationTests extends APITests {
   }
 
   void createClosedAccountWithFeeFines(IndividualResource loanResource, DateTime closedDate)
-      throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+      throws MalformedURLException {
 
     IndividualResource account = accountsClient.create(new AccountBuilder().feeFineStatusOpen()
       .withLoan(loanResource)
@@ -108,12 +108,13 @@ abstract class LoanAnonymizationTests extends APITests {
   }
 
   protected void createConfiguration(LoanHistoryConfigurationBuilder loanHistoryConfig) {
-    ConfigRecordBuilder configRecordBuilder = new ConfigRecordBuilder("LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
+    ConfigRecordBuilder configRecordBuilder = new ConfigRecordBuilder(
+      "LOAN_HISTORY", "loan_history", loanHistoryConfig.create()
       .encodePrettily());
 
     try {
       configClient.create(configRecordBuilder);
-    } catch (InterruptedException | MalformedURLException | TimeoutException | ExecutionException e) {
+    } catch (MalformedURLException e) {
       e.printStackTrace();
     }
   }

--- a/src/test/java/api/requests/HoldShelfClearanceReportTests.java
+++ b/src/test/java/api/requests/HoldShelfClearanceReportTests.java
@@ -45,7 +45,7 @@ public class HoldShelfClearanceReportTests extends APITests {
     ExecutionException {
 
     final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
-    Response response = ResourceClient.forRequestReport(client).getById(pickupServicePointId);
+    Response response = ResourceClient.forRequestReport().getById(pickupServicePointId);
 
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
@@ -71,7 +71,7 @@ public class HoldShelfClearanceReportTests extends APITests {
       .forItem(smallAngryPlanet)
       .by(usersFixture.rebecca()));
 
-    Response response = ResourceClient.forRequestReport(client).getById(pickupServicePointId);
+    Response response = ResourceClient.forRequestReport().getById(pickupServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
     JsonObject responseJson = response.getJson();
@@ -107,7 +107,7 @@ public class HoldShelfClearanceReportTests extends APITests {
       .by(usersFixture.rebecca()));
     loansFixture.checkInByBarcode(smallAngryPlanet);
 
-    Response response = ResourceClient.forRequestReport(client).getById(pickupServicePointId);
+    Response response = ResourceClient.forRequestReport().getById(pickupServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
     JsonObject responseJson = response.getJson();
@@ -154,7 +154,7 @@ public class HoldShelfClearanceReportTests extends APITests {
         .withStatus(RequestStatus.CLOSED_PICKUP_EXPIRED.getValue()).create()
         .put(CLOSED_DATE_KEY, "2018-02-11T14:45:23.000+0000"));
 
-    Response response = ResourceClient.forRequestReport(client).getById(pickupServicePointId);
+    Response response = ResourceClient.forRequestReport().getById(pickupServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
     JsonObject responseJson = response.getJson();
@@ -198,7 +198,7 @@ public class HoldShelfClearanceReportTests extends APITests {
       requestBuilderOnSmallAngryPlanet.withStatus(RequestStatus.CLOSED_CANCELLED.getValue()).create()
         .put(CLOSED_DATE_KEY, "2018-02-11T14:45:23.000+0000"));
 
-    Response response = ResourceClient.forRequestReport(client).getById(pickupServicePointId);
+    Response response = ResourceClient.forRequestReport().getById(pickupServicePointId);
     verifyResponse(smallAngryPlanet, rebecca, response, RequestStatus.CLOSED_CANCELLED);
   }
 
@@ -236,7 +236,7 @@ public class HoldShelfClearanceReportTests extends APITests {
       requestBuilderOnItem.withStatus(RequestStatus.CLOSED_PICKUP_EXPIRED.getValue()).create()
         .put(CLOSED_DATE_KEY, "2018-03-11T15:45:23.000+0000"));
 
-    Response response = ResourceClient.forRequestReport(client).getById(pickupServicePointId);
+    Response response = ResourceClient.forRequestReport().getById(pickupServicePointId);
     verifyResponse(smallAngryPlanet, rebecca, response, RequestStatus.CLOSED_PICKUP_EXPIRED);
   }
 
@@ -283,7 +283,7 @@ public class HoldShelfClearanceReportTests extends APITests {
       secondRequestBuilderOnItem.withStatus(RequestStatus.CLOSED_CANCELLED.getValue()).create()
         .put(CLOSED_DATE_KEY, laterAwaitingPickupRequestClosedDate));
 
-    Response response = ResourceClient.forRequestReport(client).getById(pickupServicePointId);
+    Response response = ResourceClient.forRequestReport().getById(pickupServicePointId);
     verifyResponse(smallAngryPlanet, rebecca, response, RequestStatus.CLOSED_PICKUP_EXPIRED);
   }
 
@@ -330,7 +330,7 @@ public class HoldShelfClearanceReportTests extends APITests {
       secondRequestBuilderOnItem.withStatus(RequestStatus.CLOSED_CANCELLED.getValue()).create()
         .put(CLOSED_DATE_KEY, emptyRequestClosedDate));
 
-    Response response = ResourceClient.forRequestReport(client).getById(pickupServicePointId);
+    Response response = ResourceClient.forRequestReport().getById(pickupServicePointId);
     verifyResponse(smallAngryPlanet, rebecca, response, RequestStatus.CLOSED_PICKUP_EXPIRED);
   }
 
@@ -354,7 +354,7 @@ public class HoldShelfClearanceReportTests extends APITests {
     IndividualResource request = requestsClient.create(requestBuilder);
     requestsClient.replace(request.getId(), requestBuilder.withStatus(RequestStatus.CLOSED_PICKUP_EXPIRED.getValue()));
 
-    Response response = ResourceClient.forRequestReport(client).getById(pickupServicePointId);
+    Response response = ResourceClient.forRequestReport().getById(pickupServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
     JsonObject responseJson = response.getJson();
@@ -407,11 +407,11 @@ public class HoldShelfClearanceReportTests extends APITests {
         .put(CLOSED_DATE_KEY, firstAwaitingPickupRequestClosedDate));
 
     // #5 get hold shelf expiration report in SP1 >>> not empty
-    Response response = ResourceClient.forRequestReport(client).getById(firstServicePointId);
+    Response response = ResourceClient.forRequestReport().getById(firstServicePointId);
     verifyResponse(smallAngryPlanet, rebeca, response, RequestStatus.CLOSED_PICKUP_EXPIRED);
 
     // #6 get hold shelf expiration report report in SP2 >>> empty
-    response = ResourceClient.forRequestReport(client).getById(secondServicePointId);
+    response = ResourceClient.forRequestReport().getById(secondServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
     assertThat(response.getJson().getInteger(TOTAL_RECORDS), is(0));
 
@@ -423,11 +423,11 @@ public class HoldShelfClearanceReportTests extends APITests {
 
     // #8 Check that hold shelf expiration report doesn't contain data when the item has the status `Awaiting pickup`,
     // first request - CLOSED_PICKUP_EXPIRED and second request - `Awaiting pickup`
-    response = ResourceClient.forRequestReport(client).getById(firstServicePointId);
+    response = ResourceClient.forRequestReport().getById(firstServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
     assertThat(response.getJson().getInteger(TOTAL_RECORDS), is(0));
 
-    response = ResourceClient.forRequestReport(client).getById(secondServicePointId);
+    response = ResourceClient.forRequestReport().getById(secondServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
     assertThat(response.getJson().getInteger(TOTAL_RECORDS), is(0));
 
@@ -437,12 +437,12 @@ public class HoldShelfClearanceReportTests extends APITests {
         .put(CLOSED_DATE_KEY, secondAwaitingPickupRequestClosedDate));
 
     // #10 get hold shelf expiration report in SP1 >>> empty
-    response = ResourceClient.forRequestReport(client).getById(firstServicePointId);
+    response = ResourceClient.forRequestReport().getById(firstServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
     assertThat(response.getJson().getInteger(TOTAL_RECORDS), is(0));
 
     // #11 get hold shelf expiration report in SP2
-    response = ResourceClient.forRequestReport(client).getById(secondServicePointId);
+    response = ResourceClient.forRequestReport().getById(secondServicePointId);
     verifyResponse(smallAngryPlanet, steve, response, RequestStatus.CLOSED_PICKUP_EXPIRED);
   }
 
@@ -492,11 +492,11 @@ public class HoldShelfClearanceReportTests extends APITests {
         .put(CLOSED_DATE_KEY, firstAwaitingPickupRequestClosedDate));
 
     // #5 get hold shelf expiration report in SP1
-    Response response = ResourceClient.forRequestReport(client).getById(firstServicePointId);
+    Response response = ResourceClient.forRequestReport().getById(firstServicePointId);
     verifyResponse(smallAngryPlanet, rebeca, response, RequestStatus.CLOSED_CANCELLED);
 
     // #6 get hold shelf expiration in SP2 >>> empty
-    response = ResourceClient.forRequestReport(client).getById(secondServicePointId);
+    response = ResourceClient.forRequestReport().getById(secondServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
     assertThat(response.getJson().getInteger(TOTAL_RECORDS), is(0));
 
@@ -507,12 +507,12 @@ public class HoldShelfClearanceReportTests extends APITests {
       .at(secondServicePointId));
 
     // #8 get hold shelf expiration report in SP1 >>> empty
-    response = ResourceClient.forRequestReport(client).getById(firstServicePointId);
+    response = ResourceClient.forRequestReport().getById(firstServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
     assertThat(response.getJson().getInteger(TOTAL_RECORDS), is(0));
 
     // #9 get report in SP2 >>> empty
-    response = ResourceClient.forRequestReport(client).getById(secondServicePointId);
+    response = ResourceClient.forRequestReport().getById(secondServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
     assertThat(response.getJson().getInteger(TOTAL_RECORDS), is(0));
 
@@ -545,11 +545,11 @@ public class HoldShelfClearanceReportTests extends APITests {
         .put(CLOSED_DATE_KEY, thirdAwaitingPickupRequestClosedDate));
 
     // #5 get hold shelf expiration report in SP1
-    response = ResourceClient.forRequestReport(client).getById(firstServicePointId);
+    response = ResourceClient.forRequestReport().getById(firstServicePointId);
     verifyResponse(nod, rebeca, response, RequestStatus.CLOSED_CANCELLED);
 
     // #6 get hold shelf expiration in SP2 >>> empty
-    response = ResourceClient.forRequestReport(client).getById(secondServicePointId);
+    response = ResourceClient.forRequestReport().getById(secondServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
     assertThat(response.getJson().getInteger(TOTAL_RECORDS), is(0));
 
@@ -560,12 +560,12 @@ public class HoldShelfClearanceReportTests extends APITests {
       .at(secondServicePointId));
 
     // #8 get hold shelf expiration report in SP1 >>> empty
-    response = ResourceClient.forRequestReport(client).getById(firstServicePointId);
+    response = ResourceClient.forRequestReport().getById(firstServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
     assertThat(response.getJson().getInteger(TOTAL_RECORDS), is(0));
 
     // #9 get report in SP2 >>> empty
-    response = ResourceClient.forRequestReport(client).getById(secondServicePointId);
+    response = ResourceClient.forRequestReport().getById(secondServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
     assertThat(response.getJson().getInteger(TOTAL_RECORDS), is(0));
   }

--- a/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
+++ b/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
@@ -868,54 +868,21 @@ public class InstanceRequestsAPICreationTests extends APITests {
     return requestBody;
   }
 
-  private void placeHoldRequest(IndividualResource item, UUID requestPickupServicePointId,
-                                IndividualResource patron, LocalDate requestExpirationDate){
+  private void placeHoldRequest(IndividualResource item,
+    UUID requestPickupServicePointId, IndividualResource patron,
+    LocalDate requestExpirationDate) throws MalformedURLException {
 
-    IndividualResource holdRequest = null;
-    try {
-      holdRequest = requestsClient.create(
-        new RequestBuilder()
+    IndividualResource holdRequest = requestsClient.create(
+      new RequestBuilder()
         .hold()
         .forItem(item)
         .withPickupServicePointId(requestPickupServicePointId)
         .withRequestExpiration(requestExpirationDate)
         .by(patron));
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    } catch (MalformedURLException e) {
-      e.printStackTrace();
-    } catch (TimeoutException e) {
-      e.printStackTrace();
-    } catch (ExecutionException e) {
-      e.printStackTrace();
-    }
 
-    JsonObject requestedItem = (holdRequest != null) ? holdRequest.getJson().getJsonObject("item") : new JsonObject();
+    JsonObject requestedItem = (holdRequest != null)
+      ? holdRequest.getJson().getJsonObject("item") : new JsonObject();
+
     assertThat(requestedItem.getString("status"), is(ItemStatus.CHECKED_OUT.getValue()));
   }
-
-  private void placePagedRequest(IndividualResource item, UUID requestPickupServicePointId,
-                                IndividualResource patron, LocalDate requestExpirationDate){
-    IndividualResource pagedRequest = null;
-      try {
-        pagedRequest = requestsClient.create(
-          new RequestBuilder()
-            .page()
-            .forItem(item)
-            .withPickupServicePointId(requestPickupServicePointId)
-            .withRequestExpiration(requestExpirationDate)
-            .by(patron));
-      } catch (InterruptedException e) {
-        e.printStackTrace();
-      } catch (MalformedURLException e) {
-        e.printStackTrace();
-      } catch (TimeoutException e) {
-        e.printStackTrace();
-      } catch (ExecutionException e) {
-        e.printStackTrace();
-      }
-
-      JsonObject requestedItem = (pagedRequest != null) ? pagedRequest.getJson().getJsonObject("item") : new JsonObject();
-      assertThat(requestedItem.getString("status"), is(ItemStatus.PAGED.getValue()));
-    }
 }

--- a/src/test/java/api/requests/ItemsInTransitReportTests.java
+++ b/src/test/java/api/requests/ItemsInTransitReportTests.java
@@ -72,7 +72,7 @@ public class ItemsInTransitReportTests extends APITests {
     TimeoutException,
     ExecutionException {
 
-    List<JsonObject> items = ResourceClient.forItemsInTransitReport(client).getAll();
+    List<JsonObject> items = ResourceClient.forItemsInTransitReport().getAll();
 
     assertTrue(items.isEmpty());
   }
@@ -99,7 +99,7 @@ public class ItemsInTransitReportTests extends APITests {
       .on(checkInDate)
       .at(firstServicePointId));
 
-    List<JsonObject> items = ResourceClient.forItemsInTransitReport(client).getAll();
+    List<JsonObject> items = ResourceClient.forItemsInTransitReport().getAll();
 
     assertThat(items.size(), is(1));
     JsonObject itemJson = items.get(0);
@@ -149,7 +149,7 @@ public class ItemsInTransitReportTests extends APITests {
       .on(checkInDate2)
       .at(firsServicePointId));
 
-    List<JsonObject> items = ResourceClient.forItemsInTransitReport(client).getAll();
+    List<JsonObject> items = ResourceClient.forItemsInTransitReport().getAll();
 
     assertThat(items.size(), is(2));
     JsonObject firstItemJson = getRecordById(items, smallAngryPlanet.getId()).get();
@@ -194,7 +194,7 @@ public class ItemsInTransitReportTests extends APITests {
       .on(checkInDate)
       .at(firstServicePointId));
 
-    List<JsonObject> items = ResourceClient.forItemsInTransitReport(client).getAll();
+    List<JsonObject> items = ResourceClient.forItemsInTransitReport().getAll();
 
     assertThat(items.size(), is(1));
     JsonObject itemJson = items.get(0);
@@ -243,7 +243,7 @@ public class ItemsInTransitReportTests extends APITests {
       .on(checkInDate2)
       .at(firstServicePointId));
 
-    List<JsonObject> items = ResourceClient.forItemsInTransitReport(client).getAll();
+    List<JsonObject> items = ResourceClient.forItemsInTransitReport().getAll();
 
     assertThat(items.size(), is(2));
     JsonObject firstItemJson = getRecordById(items, smallAngryPlanet.getId()).get();
@@ -309,7 +309,7 @@ public class ItemsInTransitReportTests extends APITests {
       .on(checkInDate2)
       .at(firstServicePointId));
 
-    List<JsonObject> items = ResourceClient.forItemsInTransitReport(client).getAll();
+    List<JsonObject> items = ResourceClient.forItemsInTransitReport().getAll();
 
     assertThat(items.size(), is(2));
     JsonObject firstItemJson = getRecordById(items, smallAngryPlanet.getId()).get();
@@ -357,7 +357,7 @@ public class ItemsInTransitReportTests extends APITests {
       .on(checkInDate2)
       .at(secondServicePointId));
 
-    List<JsonObject> items = ResourceClient.forItemsInTransitReport(client).getAll();
+    List<JsonObject> items = ResourceClient.forItemsInTransitReport().getAll();
 
     assertThat(items.size(), is(2));
     JsonObject firstItemJson = getRecordById(items, smallAngryPlanet.getId()).get();
@@ -420,7 +420,7 @@ public class ItemsInTransitReportTests extends APITests {
       .on(checkInDate1)
       .at(secondServicePointId));
 
-    List<JsonObject> items = ResourceClient.forItemsInTransitReport(client).getAll();
+    List<JsonObject> items = ResourceClient.forItemsInTransitReport().getAll();
 
     assertThat(items.size(), is(3));
 

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -64,7 +64,7 @@ public class PickSlipsTests extends APITests {
         .forItem(smallAngryPlanet)
         .by(usersFixture.james()));
 
-    Response response = ResourceClient.forPickSlips(client).getById(UUID.randomUUID());
+    Response response = ResourceClient.forPickSlips().getById(UUID.randomUUID());
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
     assertResponseHasItems(response, 0);
@@ -88,7 +88,7 @@ public class PickSlipsTests extends APITests {
         .by(usersFixture.james()));
 
     UUID differentServicePointId = servicePointsFixture.cd2().getId();
-    Response response = ResourceClient.forPickSlips(client).getById(differentServicePointId);
+    Response response = ResourceClient.forPickSlips().getById(differentServicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
     assertResponseHasItems(response, 0);
@@ -103,7 +103,7 @@ public class PickSlipsTests extends APITests {
 
     final UUID servicePointId = servicePointsFixture.cd1().getId();
 
-    Response response = ResourceClient.forPickSlips(client).getById(servicePointId);
+    Response response = ResourceClient.forPickSlips().getById(servicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
     assertResponseHasItems(response, 0);
@@ -127,7 +127,7 @@ public class PickSlipsTests extends APITests {
         .forItem(smallAngryPlanet)
         .by(usersFixture.james()));
 
-    Response response = ResourceClient.forPickSlips(client).getById(servicePointId);
+    Response response = ResourceClient.forPickSlips().getById(servicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
     assertResponseHasItems(response, 0);
@@ -150,7 +150,7 @@ public class PickSlipsTests extends APITests {
         .forItem(smallAngryPlanet)
         .by(usersFixture.james()));
 
-    Response response = ResourceClient.forPickSlips(client).getById(servicePointId);
+    Response response = ResourceClient.forPickSlips().getById(servicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
     assertResponseHasItems(response, 1);
@@ -187,7 +187,7 @@ public class PickSlipsTests extends APITests {
     requestsClient.replace(secondRequest.getId(),
         secondRequestBuilder.withRequestType(RequestType.PAGE.getValue()));
 
-    Response response = ResourceClient.forPickSlips(client).getById(servicePointId);
+    Response response = ResourceClient.forPickSlips().getById(servicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
     assertResponseHasItems(response, 1);
@@ -221,7 +221,7 @@ public class PickSlipsTests extends APITests {
 
     assertThat(expectedItemIds.size(), is(itemsCount));
 
-    Response response = ResourceClient.forPickSlips(client).getById(servicePointId);
+    Response response = ResourceClient.forPickSlips().getById(servicePointId);
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
     assertResponseHasItems(response, itemsCount);
@@ -279,7 +279,7 @@ public class PickSlipsTests extends APITests {
         .forItem(planetThirdFloorCd1)
         .by(usersFixture.charlotte()));
 
-    Response response = ResourceClient.forPickSlips(client).getById(circDesk1);
+    Response response = ResourceClient.forPickSlips().getById(circDesk1);
     assertThat(response.getStatusCode(), is(HTTP_OK));
 
     assertResponseHasItems(response, 2);
@@ -330,7 +330,7 @@ public class PickSlipsTests extends APITests {
         .by(usersFixture.jessica()));
 
     // Report for Circ Desk 1
-    Response responseForCd1 = ResourceClient.forPickSlips(client).getById(circDesk1);
+    Response responseForCd1 = ResourceClient.forPickSlips().getById(circDesk1);
     assertThat(responseForCd1.getStatusCode(), is(HTTP_OK));
 
     assertResponseHasItems(responseForCd1, 1);
@@ -340,7 +340,7 @@ public class PickSlipsTests extends APITests {
 
     // Report for Circ Desk 4
     UUID circDesk4 = servicePointsFixture.cd4().getId();
-    Response responseForCd4 = ResourceClient.forPickSlips(client).getById(circDesk4);
+    Response responseForCd4 = ResourceClient.forPickSlips().getById(circDesk4);
     assertThat(responseForCd4.getStatusCode(), is(HTTP_OK));
 
     assertResponseHasItems(responseForCd4, 1);

--- a/src/test/java/api/requests/RequestsAPIRetrievalTests.java
+++ b/src/test/java/api/requests/RequestsAPIRetrievalTests.java
@@ -265,7 +265,7 @@ public class RequestsAPIRetrievalTests extends APITests {
     ExecutionException,
     TimeoutException {
 
-    Response getResponse = ResourceClient.forRequests(client).getById(UUID.randomUUID());
+    Response getResponse = ResourceClient.forRequests().getById(UUID.randomUUID());
 
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
   }

--- a/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
+++ b/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
@@ -233,7 +233,7 @@ public class SingleOpenHoldShelfRequestTests extends APITests {
     ExecutionException,
     TimeoutException {
 
-    final ResourceClient requestsStorage = forRequestsStorage(client);
+    final ResourceClient requestsStorage = forRequestsStorage();
 
     final Response fetchedRequest = requestsStorage.getById(requestId);
 

--- a/src/test/java/api/support/APITestContext.java
+++ b/src/test/java/api/support/APITestContext.java
@@ -96,11 +96,6 @@ public class APITestContext {
       okapiUrl(), TENANT_ID, TOKEN, USER_ID, REQUEST_ID, exceptionHandler);
   }
 
-  static OkapiHttpClient createClient() {
-    return APITestContext.createClient(exception ->
-      log.error("Request failed:", exception));
-  }
-
   static void deployVerticles()
     throws InterruptedException,
     ExecutionException,

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -14,11 +14,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import api.support.builders.LoanPolicyBuilder;
-import api.support.builders.NoticePolicyBuilder;
-import api.support.fixtures.LostItemFeePoliciesFixture;
-import api.support.fixtures.UserManualBlocksFixture;
-import api.support.fixtures.OverdueFinePoliciesFixture;
 import org.folio.circulation.domain.representations.LoanProperties;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
@@ -31,6 +26,8 @@ import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import api.support.builders.LoanPolicyBuilder;
+import api.support.builders.NoticePolicyBuilder;
 import api.support.fixtures.AddressTypesFixture;
 import api.support.fixtures.CancellationReasonsFixture;
 import api.support.fixtures.CirculationRulesFixture;
@@ -43,8 +40,10 @@ import api.support.fixtures.LoanPoliciesFixture;
 import api.support.fixtures.LoanTypesFixture;
 import api.support.fixtures.LoansFixture;
 import api.support.fixtures.LocationsFixture;
+import api.support.fixtures.LostItemFeePoliciesFixture;
 import api.support.fixtures.MaterialTypesFixture;
 import api.support.fixtures.NoticePoliciesFixture;
+import api.support.fixtures.OverdueFinePoliciesFixture;
 import api.support.fixtures.PatronGroupsFixture;
 import api.support.fixtures.ProxyRelationshipsFixture;
 import api.support.fixtures.RequestPoliciesFixture;
@@ -52,6 +51,7 @@ import api.support.fixtures.RequestQueueFixture;
 import api.support.fixtures.RequestsFixture;
 import api.support.fixtures.ScheduledNoticeProcessingClient;
 import api.support.fixtures.ServicePointsFixture;
+import api.support.fixtures.UserManualBlocksFixture;
 import api.support.fixtures.UsersFixture;
 import api.support.http.InterfaceUrls;
 import api.support.http.ResourceClient;
@@ -496,15 +496,7 @@ public abstract class APITests {
       response.getStatusCode(), is(200));
   }
 
-  private static void deleteOftenCreatedRecords()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
-    OkapiHttpClient cleanupClient = createClient(exception ->
-      log.error("Requests to delete all for clean up failed:", exception));
-
+  private static void deleteOftenCreatedRecords() throws MalformedURLException {
     ResourceClient.forRequests().deleteAll();
     ResourceClient.forLoans().deleteAll();
 
@@ -517,15 +509,7 @@ public abstract class APITests {
     ResourceClient.forAccounts().deleteAll();
   }
 
-  private static void deleteAllRecords()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
-    OkapiHttpClient client = APITestContext.createClient(exception ->
-      log.error("Requests to delete all for clean up failed:", exception));
-
+  private static void deleteAllRecords() throws MalformedURLException {
     ResourceClient.forRequests().deleteAll();
     ResourceClient.forLoans().deleteAll();
 

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -66,70 +66,70 @@ public abstract class APITests {
 
   private final boolean initialiseCirculationRules;
 
-  private final ResourceClient servicePointsClient = ResourceClient.forServicePoints(client);
+  private final ResourceClient servicePointsClient = ResourceClient.forServicePoints();
 
-  private final ResourceClient institutionsClient = ResourceClient.forInstitutions(client);
-  private final ResourceClient campusesClient = ResourceClient.forCampuses(client);
-  private final ResourceClient librariesClient = ResourceClient.forLibraries(client);
-  private final ResourceClient locationsClient = ResourceClient.forLocations(client);
+  private final ResourceClient institutionsClient = ResourceClient.forInstitutions();
+  private final ResourceClient campusesClient = ResourceClient.forCampuses();
+  private final ResourceClient librariesClient = ResourceClient.forLibraries();
+  private final ResourceClient locationsClient = ResourceClient.forLocations();
 
-  protected final ResourceClient configClient = ResourceClient.forConfiguration(client);
+  protected final ResourceClient configClient = ResourceClient.forConfiguration();
 
   private final ResourceClient patronGroupsClient
-    = ResourceClient.forPatronGroups(client);
+    = ResourceClient.forPatronGroups();
 
-  protected final ResourceClient usersClient = ResourceClient.forUsers(client);
+  protected final ResourceClient usersClient = ResourceClient.forUsers();
   private final ResourceClient proxyRelationshipsClient
-    = ResourceClient.forProxyRelationships(client);
+    = ResourceClient.forProxyRelationships();
 
-  protected final ResourceClient instancesClient = ResourceClient.forInstances(client);
-  protected final ResourceClient holdingsClient = ResourceClient.forHoldings(client);
-  protected final ResourceClient itemsClient = ResourceClient.forItems(client);
+  protected final ResourceClient instancesClient = ResourceClient.forInstances();
+  protected final ResourceClient holdingsClient = ResourceClient.forHoldings();
+  protected final ResourceClient itemsClient = ResourceClient.forItems();
 
-  protected final ResourceClient loansClient = ResourceClient.forLoans(client);
-  protected final ResourceClient accountsClient = ResourceClient.forAccounts(client);
-  protected final ResourceClient feeFineActionsClient = ResourceClient.forFeeFineActions(client);
+  protected final ResourceClient loansClient = ResourceClient.forLoans();
+  protected final ResourceClient accountsClient = ResourceClient.forAccounts();
+  protected final ResourceClient feeFineActionsClient = ResourceClient.forFeeFineActions();
 
   protected final ResourceClient loansStorageClient
-    = ResourceClient.forLoansStorage(client);
+    = ResourceClient.forLoansStorage();
 
   protected final ResourceClient requestsStorageClient
-    = ResourceClient.forRequestsStorage(client);
+    = ResourceClient.forRequestsStorage();
 
-  protected final ResourceClient requestsClient = ResourceClient.forRequests(client);
+  protected final ResourceClient requestsClient = ResourceClient.forRequests();
 
   protected final ResourceClient fixedDueDateScheduleClient
-    = ResourceClient.forFixedDueDateSchedules(client);
+    = ResourceClient.forFixedDueDateSchedules();
 
   protected final ResourceClient loanPolicyClient
-    = ResourceClient.forLoanPolicies(client);
+    = ResourceClient.forLoanPolicies();
 
   protected final ResourceClient requestPolicyClient
-    = ResourceClient.forRequestPolicies(client);
+    = ResourceClient.forRequestPolicies();
 
   protected final ResourceClient noticePolicyClient
-    = ResourceClient.forNoticePolicies(client);
+    = ResourceClient.forNoticePolicies();
 
   protected final ResourceClient overdueFinePolicyClient
-    = ResourceClient.forOverdueFinePolicies(client);
+    = ResourceClient.forOverdueFinePolicies();
 
   protected final ResourceClient lostItemFeePolicyClient
-    = ResourceClient.forLostItemFeePolicies(client);
+    = ResourceClient.forLostItemFeePolicies();
 
   private final ResourceClient instanceTypesClient
-    = ResourceClient.forInstanceTypes(client);
+    = ResourceClient.forInstanceTypes();
 
   private final ResourceClient contributorNameTypesClient
-    = ResourceClient.forContributorNameTypes(client);
+    = ResourceClient.forContributorNameTypes();
 
   protected final ResourceClient patronNoticesClient =
-    ResourceClient.forPatronNotices(client);
+    ResourceClient.forPatronNotices();
 
   protected final ResourceClient scheduledNoticesClient =
-    ResourceClient.forScheduledNotices(client);
+    ResourceClient.forScheduledNotices();
 
   protected final ResourceClient patronSessionRecordsClient =
-    ResourceClient.forPatronSessionRecords(client);
+    ResourceClient.forPatronSessionRecords();
 
   protected final EndPatronSessionClient endPatronSessionClient =
     new EndPatronSessionClient();
@@ -138,7 +138,7 @@ public abstract class APITests {
     new ExpiredSessionProcessingClient();
 
   protected final ResourceClient expiredEndSessionClient =
-    ResourceClient.forExpiredSessions(client);
+    ResourceClient.forExpiredSessions();
 
   protected final ServicePointsFixture servicePointsFixture
     = new ServicePointsFixture(servicePointsClient);
@@ -148,13 +148,13 @@ public abstract class APITests {
     servicePointsFixture);
 
   protected final LoanTypesFixture loanTypesFixture = new LoanTypesFixture(
-    ResourceClient.forLoanTypes(client));
+    ResourceClient.forLoanTypes());
 
   protected final MaterialTypesFixture materialTypesFixture
-    = new MaterialTypesFixture(ResourceClient.forMaterialTypes(client));
+    = new MaterialTypesFixture(ResourceClient.forMaterialTypes());
 
   protected final UserManualBlocksFixture userManualBlocksFixture
-    = new UserManualBlocksFixture(ResourceClient.forUserManualBlocks(client));
+    = new UserManualBlocksFixture(ResourceClient.forUserManualBlocks());
 
   protected final LoanPoliciesFixture loanPoliciesFixture
     = new LoanPoliciesFixture(loanPolicyClient, fixedDueDateScheduleClient);
@@ -174,12 +174,12 @@ public abstract class APITests {
   protected final CirculationRulesFixture circulationRulesFixture
     = new CirculationRulesFixture(client);
 
-  protected final ItemsFixture itemsFixture = new ItemsFixture(client,
+  protected final ItemsFixture itemsFixture = new ItemsFixture(
     materialTypesFixture, loanTypesFixture, locationsFixture,
     instanceTypesClient, contributorNameTypesClient);
 
   protected final AddressTypesFixture addressTypesFixture
-    = new AddressTypesFixture(ResourceClient.forAddressTypes(client));
+    = new AddressTypesFixture(ResourceClient.forAddressTypes());
 
   protected final PatronGroupsFixture patronGroupsFixture
     = new PatronGroupsFixture(patronGroupsClient);
@@ -194,16 +194,16 @@ public abstract class APITests {
           usersFixture, servicePointsFixture);
 
   protected final CancellationReasonsFixture cancellationReasonsFixture
-    = new CancellationReasonsFixture(ResourceClient.forCancellationReasons(client));
+    = new CancellationReasonsFixture(ResourceClient.forCancellationReasons());
 
   protected final RequestsFixture requestsFixture = new RequestsFixture(
     requestsClient, cancellationReasonsFixture, servicePointsFixture);
 
   protected final InstancesFixture instancesFixture
-    = new InstancesFixture(instanceTypesClient, contributorNameTypesClient, client);
+    = new InstancesFixture(instanceTypesClient, contributorNameTypesClient);
 
   protected final HoldingsFixture holdingsFixture
-    = new HoldingsFixture(client);
+    = new HoldingsFixture();
 
   protected final ScheduledNoticeProcessingClient scheduledNoticeProcessingClient =
     new ScheduledNoticeProcessingClient();
@@ -505,16 +505,16 @@ public abstract class APITests {
     OkapiHttpClient cleanupClient = createClient(exception ->
       log.error("Requests to delete all for clean up failed:", exception));
 
-    ResourceClient.forRequests(cleanupClient).deleteAll();
-    ResourceClient.forLoans(cleanupClient).deleteAll();
+    ResourceClient.forRequests().deleteAll();
+    ResourceClient.forLoans().deleteAll();
 
-    ResourceClient.forItems(cleanupClient).deleteAll();
-    ResourceClient.forHoldings(cleanupClient).deleteAll();
-    ResourceClient.forInstances(cleanupClient).deleteAll();
+    ResourceClient.forItems().deleteAll();
+    ResourceClient.forHoldings().deleteAll();
+    ResourceClient.forInstances().deleteAll();
 
-    ResourceClient.forUsers(cleanupClient).deleteAllIndividually();
+    ResourceClient.forUsers().deleteAllIndividually();
 
-    ResourceClient.forAccounts(cleanupClient).deleteAll();
+    ResourceClient.forAccounts().deleteAll();
   }
 
   private static void deleteAllRecords()
@@ -526,31 +526,31 @@ public abstract class APITests {
     OkapiHttpClient client = APITestContext.createClient(exception ->
       log.error("Requests to delete all for clean up failed:", exception));
 
-    ResourceClient.forRequests(client).deleteAll();
-    ResourceClient.forLoans(client).deleteAll();
+    ResourceClient.forRequests().deleteAll();
+    ResourceClient.forLoans().deleteAll();
 
-    ResourceClient.forItems(client).deleteAll();
-    ResourceClient.forHoldings(client).deleteAll();
-    ResourceClient.forInstances(client).deleteAll();
+    ResourceClient.forItems().deleteAll();
+    ResourceClient.forHoldings().deleteAll();
+    ResourceClient.forInstances().deleteAll();
 
-    ResourceClient.forLoanPolicies(client).deleteAllIndividually();
-    ResourceClient.forFixedDueDateSchedules(client).deleteAllIndividually();
+    ResourceClient.forLoanPolicies().deleteAllIndividually();
+    ResourceClient.forFixedDueDateSchedules().deleteAllIndividually();
 
-    ResourceClient.forMaterialTypes(client).deleteAllIndividually();
-    ResourceClient.forLoanTypes(client).deleteAllIndividually();
+    ResourceClient.forMaterialTypes().deleteAllIndividually();
+    ResourceClient.forLoanTypes().deleteAllIndividually();
 
-    ResourceClient.forUsers(client).deleteAllIndividually();
+    ResourceClient.forUsers().deleteAllIndividually();
 
-    ResourceClient.forPatronGroups(client).deleteAllIndividually();
-    ResourceClient.forAddressTypes(client).deleteAllIndividually();
+    ResourceClient.forPatronGroups().deleteAllIndividually();
+    ResourceClient.forAddressTypes().deleteAllIndividually();
 
-    ResourceClient.forMaterialTypes(client).deleteAllIndividually();
-    ResourceClient.forLoanTypes(client).deleteAllIndividually();
-    ResourceClient.forLocations(client).deleteAllIndividually();
-    ResourceClient.forServicePoints(client).deleteAllIndividually();
-    ResourceClient.forContributorNameTypes(client).deleteAllIndividually();
-    ResourceClient.forInstanceTypes(client).deleteAllIndividually();
-    ResourceClient.forCancellationReasons(client).deleteAllIndividually();
+    ResourceClient.forMaterialTypes().deleteAllIndividually();
+    ResourceClient.forLoanTypes().deleteAllIndividually();
+    ResourceClient.forLocations().deleteAllIndividually();
+    ResourceClient.forServicePoints().deleteAllIndividually();
+    ResourceClient.forContributorNameTypes().deleteAllIndividually();
+    ResourceClient.forInstanceTypes().deleteAllIndividually();
+    ResourceClient.forCancellationReasons().deleteAllIndividually();
   }
 
   protected void loanHasFeeFinesProperties(JsonObject loan, double remainingAmount) {

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -8,10 +8,14 @@ import static org.folio.circulation.support.http.OkapiHeader.TENANT;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.folio.circulation.support.http.OkapiHeader;
 import org.folio.circulation.support.http.client.Response;
 
+import api.support.http.CqlQuery;
+import api.support.http.Limit;
+import api.support.http.Offset;
 import api.support.http.OkapiHeaders;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -36,6 +40,18 @@ public class RestAssuredClient {
       .then()
       .log().all()
       .extract().response());
+  }
+
+  public Response get(URL location, CqlQuery query, Limit limit, Offset offset,
+    int expectedStatusCode, String requestId) {
+
+    final HashMap<String, String> queryStringParameters = new HashMap<>();
+
+    Stream.of(query, limit, offset)
+      .forEach(parameter -> parameter.collectInto(queryStringParameters));
+
+    return get(location,
+      queryStringParameters, expectedStatusCode, requestId);
   }
 
   public Response get(URL url, Map<String, String> queryStringParameters,

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -166,7 +166,7 @@ public class RestAssuredClient {
       .extract().response());
   }
 
-  public Response delete(URL location, String requestId) {
+  public Response delete(URL location, int expectedStatusCode, String requestId) {
     return toResponse(given()
       .log().all()
       .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
@@ -174,6 +174,7 @@ public class RestAssuredClient {
       .when().delete(location)
       .then()
       .log().all()
+      .statusCode(expectedStatusCode)
       .extract().response());
   }
 

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -87,7 +87,6 @@ public class RestAssuredClient {
     int expectedStatusCode, String requestId) {
 
     return toResponse(given()
-      .log().all()
       .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
       .spec(timeoutConfig())
       .body(representation.encodePrettily())

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -43,7 +43,7 @@ public class RestAssuredClient {
   }
 
   public Response get(URL location, CqlQuery query, Limit limit, Offset offset,
-    int expectedStatusCode, String requestId) {
+      int expectedStatusCode, String requestId) {
 
     final HashMap<String, String> queryStringParameters = new HashMap<>();
 

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -166,6 +166,17 @@ public class RestAssuredClient {
       .extract().response());
   }
 
+  public Response delete(URL location, String requestId) {
+    return toResponse(given()
+      .log().all()
+      .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
+      .spec(timeoutConfig())
+      .when().delete(location)
+      .then()
+      .log().all()
+      .extract().response());
+  }
+
   private static RequestSpecification standardHeaders(OkapiHeaders okapiHeaders) {
     final HashMap<String, String> headers = new HashMap<>();
 

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -27,6 +27,17 @@ public class RestAssuredClient {
     this.defaultHeaders = defaultHeaders;
   }
 
+  public Response get(URL location, String requestId) {
+    return toResponse(given()
+      .log().all()
+      .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
+      .spec(timeoutConfig())
+      .when().get(location)
+      .then()
+      .log().all()
+      .extract().response());
+  }
+
   public Response get(URL url, Map<String, String> queryStringParameters,
       int expectedStatusCode, String requestId) {
 
@@ -106,6 +117,33 @@ public class RestAssuredClient {
       .spec(timeoutConfig())
       .body(representation.encodePrettily())
       .when().post(location)
+      .then()
+      .log().all()
+      .statusCode(expectedStatusCode)
+      .extract().response());
+  }
+
+  public Response put(JsonObject representation, URL location, String requestId) {
+    return toResponse(given()
+      .log().all()
+      .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
+      .spec(timeoutConfig())
+      .body(representation.encodePrettily())
+      .when().put(location)
+      .then()
+      .log().all()
+      .extract().response());
+  }
+
+  public Response put(JsonObject representation, URL location,
+    int expectedStatusCode, String requestId) {
+
+    return toResponse(given()
+      .log().all()
+      .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
+      .spec(timeoutConfig())
+      .body(representation.encodePrettily())
+      .when().put(location)
       .then()
       .log().all()
       .statusCode(expectedStatusCode)

--- a/src/test/java/api/support/fixtures/HoldingsFixture.java
+++ b/src/test/java/api/support/fixtures/HoldingsFixture.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeoutException;
 
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.support.http.client.IndividualResource;
-import org.folio.circulation.support.http.client.OkapiHttpClient;
 
 import api.support.builders.HoldingBuilder;
 import api.support.http.ResourceClient;
@@ -17,8 +16,8 @@ import io.vertx.core.json.JsonArray;
 public class HoldingsFixture {
   private final ResourceClient holdingsClient;
 
-  public HoldingsFixture(OkapiHttpClient client) {
-    holdingsClient =  ResourceClient.forHoldings(client);
+  public HoldingsFixture() {
+    holdingsClient =  ResourceClient.forHoldings();
   }
 
   public IndividualResource defaultWithHoldings(UUID instanceId)

--- a/src/test/java/api/support/fixtures/InstancesFixture.java
+++ b/src/test/java/api/support/fixtures/InstancesFixture.java
@@ -9,7 +9,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.circulation.support.http.client.IndividualResource;
-import org.folio.circulation.support.http.client.OkapiHttpClient;
 
 import api.support.builders.InstanceBuilder;
 import api.support.http.ResourceClient;
@@ -21,9 +20,8 @@ public class InstancesFixture {
   private final ResourceClient instancesClient;
 
   public InstancesFixture(
-    ResourceClient instanceTypesClient,
-    ResourceClient contributorNameTypesClient,
-    OkapiHttpClient client) {
+      ResourceClient instanceTypesClient,
+      ResourceClient contributorNameTypesClient) {
 
     instanceTypeRecordCreator = new RecordCreator(instanceTypesClient,
       instanceType -> getProperty(instanceType, "name"));
@@ -31,7 +29,7 @@ public class InstancesFixture {
     contributorNameTypeRecordCreator = new RecordCreator(
       contributorNameTypesClient, nameType -> getProperty(nameType, "name"));
 
-    instancesClient =  ResourceClient.forInstances(client);
+    instancesClient =  ResourceClient.forInstances();
   }
 
   public void cleanUp()

--- a/src/test/java/api/support/fixtures/ItemsFixture.java
+++ b/src/test/java/api/support/fixtures/ItemsFixture.java
@@ -15,7 +15,6 @@ import java.util.function.Function;
 
 import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.support.http.client.IndividualResource;
-import org.folio.circulation.support.http.client.OkapiHttpClient;
 
 import api.support.builders.HoldingBuilder;
 import api.support.builders.InstanceBuilder;
@@ -35,16 +34,15 @@ public class ItemsFixture {
   private final RecordCreator contributorNameTypeRecordCreator;
 
   public ItemsFixture(
-    OkapiHttpClient client,
     MaterialTypesFixture materialTypesFixture,
     LoanTypesFixture loanTypesFixture,
     LocationsFixture locationsFixture,
     ResourceClient instanceTypesClient,
     ResourceClient contributorNameTypesClient) {
 
-    itemsClient = ResourceClient.forItems(client);
-    holdingsClient = ResourceClient.forHoldings(client);
-    instancesClient = ResourceClient.forInstances(client);
+    itemsClient = ResourceClient.forItems();
+    holdingsClient = ResourceClient.forHoldings();
+    instancesClient = ResourceClient.forInstances();
     this.materialTypesFixture = materialTypesFixture;
     this.loanTypesFixture = loanTypesFixture;
     this.locationsFixture = locationsFixture;

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -27,6 +27,7 @@ import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.mvel2.util.Make;
 
 import api.support.CheckInByBarcodeResponse;
 import api.support.MultipleJsonRecords;
@@ -398,7 +399,8 @@ public class LoansFixture {
     Stream.of(query, limit, offset)
       .forEach(parameter -> parameter.collectInto(queryStringParameters));
 
-    return restAssuredClient.get(loansUrl(), queryStringParameters, 200, "get-loans");
+    return restAssuredClient.get(loansUrl(),
+      queryStringParameters, 200, "get-loans");
   }
 
   public MultipleJsonRecords getAllLoans() {

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -17,17 +17,14 @@ import static api.support.http.Offset.noOffset;
 import static org.folio.circulation.support.JsonArrayHelper.mapToList;
 
 import java.net.MalformedURLException;
-import java.util.HashMap;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Stream;
 
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.mvel2.util.Make;
 
 import api.support.CheckInByBarcodeResponse;
 import api.support.MultipleJsonRecords;
@@ -394,17 +391,12 @@ public class LoansFixture {
   }
 
   public Response getLoans(CqlQuery query, Limit limit, Offset offset) {
-    final HashMap<String, String> queryStringParameters = new HashMap<>();
-
-    Stream.of(query, limit, offset)
-      .forEach(parameter -> parameter.collectInto(queryStringParameters));
-
-    return restAssuredClient.get(loansUrl(),
-      queryStringParameters, 200, "get-loans");
+    return restAssuredClient.get(loansUrl(), query, limit, offset, 200,
+        "get-loans");
   }
 
   public MultipleJsonRecords getAllLoans() {
     return new MultipleJsonRecords(
-      mapToList(getLoans(maximumLimit()).getJson(), "loans"));
+        mapToList(getLoans(maximumLimit()).getJson(), "loans"));
   }
 }

--- a/src/test/java/api/support/fixtures/RequestsFixture.java
+++ b/src/test/java/api/support/fixtures/RequestsFixture.java
@@ -145,15 +145,18 @@ public class RequestsFixture {
     final JsonObject representation = requestToBuild.create();
 
     return new IndividualResource(restAssuredClient.post(representation,
-        requestsUrl(String.format("/%s/move", representation.getString("id"))),
-        200, "move-request"));
+        requestsUrl(pathToMoveRequest(representation)), 200, "move-request"));
   }
 
-  public Response attemptMove(MoveRequestBuilder requestToBuild)
-      throws InterruptedException, MalformedURLException, TimeoutException,
-      ExecutionException {
+  public Response attemptMove(MoveRequestBuilder requestToBuild) {
+    final JsonObject representation = requestToBuild.create();
 
-    return requestsClient.attemptMove(requestToBuild);
+    return restAssuredClient.post(representation,
+      requestsUrl(pathToMoveRequest(representation)), "move-request");
+  }
+
+  private String pathToMoveRequest(JsonObject representation) {
+    return String.format("/%s/move", representation.getString("id"));
   }
 
   //TODO: Replace return type with MultipleJsonRecords

--- a/src/test/java/api/support/fixtures/RequestsFixture.java
+++ b/src/test/java/api/support/fixtures/RequestsFixture.java
@@ -1,12 +1,14 @@
 package api.support.fixtures;
 
 import static api.support.APITestContext.getOkapiHeadersFromContext;
+import static api.support.http.InterfaceUrls.requestQueueUrl;
+import static api.support.http.InterfaceUrls.requestsUrl;
+import static java.util.function.Function.identity;
 
 import java.net.MalformedURLException;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
 
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.support.http.client.IndividualResource;
@@ -16,7 +18,6 @@ import org.joda.time.DateTime;
 import api.support.RestAssuredClient;
 import api.support.builders.MoveRequestBuilder;
 import api.support.builders.RequestBuilder;
-import api.support.http.InterfaceUrls;
 import api.support.http.ResourceClient;
 import io.vertx.core.json.JsonObject;
 
@@ -26,10 +27,9 @@ public class RequestsFixture {
   private final ServicePointsFixture servicePointsFixture;
   private final RestAssuredClient restAssuredClient;
 
-  public RequestsFixture(
-    ResourceClient requestsClient,
-    CancellationReasonsFixture cancellationReasonsFixture,
-    ServicePointsFixture servicePointsFixture) {
+  public RequestsFixture(ResourceClient requestsClient,
+      CancellationReasonsFixture cancellationReasonsFixture,
+      ServicePointsFixture servicePointsFixture) {
 
     this.requestsClient = requestsClient;
     this.cancellationReasonsFixture = cancellationReasonsFixture;
@@ -38,31 +38,21 @@ public class RequestsFixture {
   }
 
   public IndividualResource place(RequestBuilder requestToBuild)
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+      throws MalformedURLException {
 
     return requestsClient.create(requestToBuild);
   }
 
   public Response attemptPlace(RequestBuilder requestToBuild)
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+      throws MalformedURLException {
 
     return requestsClient.attemptCreate(requestToBuild);
   }
 
-  public IndividualResource placeHoldShelfRequest(
-    IndividualResource item,
-    IndividualResource by,
-    DateTime on)
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+  public IndividualResource placeHoldShelfRequest(IndividualResource item,
+      IndividualResource by, DateTime on)
+      throws InterruptedException, MalformedURLException, TimeoutException,
+      ExecutionException {
 
     return place(new RequestBuilder()
       .hold()
@@ -73,14 +63,8 @@ public class RequestsFixture {
       .withPickupServicePointId(servicePointsFixture.cd1().getId()));
   }
 
-  public IndividualResource placeDeliveryRequest(
-    IndividualResource item,
-    IndividualResource by,
-    DateTime on)
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+  public IndividualResource placeDeliveryRequest(IndividualResource item,
+      IndividualResource by, DateTime on) throws MalformedURLException {
 
     return place(new RequestBuilder()
       .hold()
@@ -90,15 +74,9 @@ public class RequestsFixture {
       .withRequesterId(by.getId()));
   }
 
-  public IndividualResource placeHoldShelfRequest(
-      IndividualResource item,
-      IndividualResource by,
-      DateTime on,
-      UUID pickupServicePointId)
-          throws InterruptedException,
-          MalformedURLException,
-          TimeoutException,
-          ExecutionException {
+  public IndividualResource placeHoldShelfRequest(IndividualResource item,
+      IndividualResource by, DateTime on, UUID pickupServicePointId)
+      throws MalformedURLException {
 
     return place(new RequestBuilder()
         .hold()
@@ -109,17 +87,9 @@ public class RequestsFixture {
         .withPickupServicePointId(pickupServicePointId));
   }
 
-
-  public IndividualResource placeHoldShelfRequest(
-      IndividualResource item,
-      IndividualResource by,
-      DateTime on,
-      UUID pickupServicePointId,
-      String type)
-          throws InterruptedException,
-          MalformedURLException,
-          TimeoutException,
-          ExecutionException {
+  public IndividualResource placeHoldShelfRequest(IndividualResource item,
+      IndividualResource by, DateTime on, UUID pickupServicePointId, String type)
+      throws MalformedURLException {
 
     return place(new RequestBuilder()
         .hold()
@@ -131,15 +101,9 @@ public class RequestsFixture {
         .withPickupServicePointId(pickupServicePointId));
   }
 
-  public IndividualResource placeHoldShelfRequest(
-    IndividualResource item,
-    IndividualResource by,
-    DateTime on,
-    String type)
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+  public IndividualResource placeHoldShelfRequest(IndividualResource item,
+      IndividualResource by, DateTime on, String type)
+      throws MalformedURLException {
 
     return place(new RequestBuilder()
       .withRequestType(type)
@@ -149,16 +113,9 @@ public class RequestsFixture {
       .withRequesterId(by.getId()));
   }
 
-  public Response attemptPlaceHoldShelfRequest(
-      IndividualResource item,
-      IndividualResource by,
-      DateTime on,
-      UUID pickupServicePointId,
-      String type)
-          throws InterruptedException,
-          MalformedURLException,
-          TimeoutException,
-          ExecutionException {
+  public Response attemptPlaceHoldShelfRequest(IndividualResource item,
+      IndividualResource by, DateTime on, UUID pickupServicePointId, String type)
+      throws MalformedURLException {
 
     return attemptPlace(new RequestBuilder()
         .hold()
@@ -171,10 +128,8 @@ public class RequestsFixture {
   }
 
   public void cancelRequest(IndividualResource request)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+      throws MalformedURLException, InterruptedException, ExecutionException,
+      TimeoutException {
 
     final IndividualResource courseReservesCancellationReason
       = cancellationReasonsFixture.courseReserves();
@@ -186,28 +141,25 @@ public class RequestsFixture {
     requestsClient.replace(request.getId(), cancelledRequestBySteve);
   }
 
-  public IndividualResource move(MoveRequestBuilder requestToBuild)
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+  public IndividualResource move(MoveRequestBuilder requestToBuild) {
+    final JsonObject representation = requestToBuild.create();
 
-    return requestsClient.move(requestToBuild);
+    return new IndividualResource(restAssuredClient.post(representation,
+        requestsUrl(String.format("/%s/move", representation.getString("id"))),
+        200, "move-request"));
   }
 
   public Response attemptMove(MoveRequestBuilder requestToBuild)
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+      throws InterruptedException, MalformedURLException, TimeoutException,
+      ExecutionException {
+
     return requestsClient.attemptMove(requestToBuild);
   }
 
   //TODO: Replace return type with MultipleJsonRecords
   public MultipleRecords<JsonObject> getQueueFor(IndividualResource item) {
-    return MultipleRecords.from(
-        restAssuredClient.get(InterfaceUrls.requestQueueUrl(item.getId()),
-      200, "request-queue-request"),
-      Function.identity() ,"requests").value();
+    return MultipleRecords.from(restAssuredClient.get(
+        requestQueueUrl(item.getId()), 200, "request-queue-request"),
+        identity() ,"requests").value();
   }
 }

--- a/src/test/java/api/support/fixtures/RequestsFixture.java
+++ b/src/test/java/api/support/fixtures/RequestsFixture.java
@@ -191,6 +191,7 @@ public class RequestsFixture {
     MalformedURLException,
     TimeoutException,
     ExecutionException {
+
     return requestsClient.move(requestToBuild);
   }
 

--- a/src/test/java/api/support/http/InterfaceUrls.java
+++ b/src/test/java/api/support/http/InterfaceUrls.java
@@ -84,7 +84,7 @@ public class InterfaceUrls {
     return APITestContext.viaOkapiModuleUrl("/fixed-due-date-schedule-storage/fixed-due-date-schedules" + subPath);
   }
 
-  static URL circulationRulesStorageUrl(String subPath) {
+  public static URL circulationRulesStorageUrl(String subPath) {
     return APITestContext.viaOkapiModuleUrl("/circulation-rules-storage" + subPath);
   }
 
@@ -116,8 +116,9 @@ public class InterfaceUrls {
     return circulationModuleUrl("/circulation/requests" + subPath);
   }
 
-  public static URL requestReportUrl(String servicePointId) {
-    return circulationModuleUrl("/circulation/requests-reports/hold-shelf-clearance/" + servicePointId);
+  public static URL requestReportUrl(String subPath) {
+    return circulationModuleUrl(
+      "/circulation/requests-reports/hold-shelf-clearance" + subPath);
   }
 
   public static URL itemsInTransitReportUrl() {

--- a/src/test/java/api/support/http/InterfaceUrls.java
+++ b/src/test/java/api/support/http/InterfaceUrls.java
@@ -121,8 +121,8 @@ public class InterfaceUrls {
       "/circulation/requests-reports/hold-shelf-clearance" + subPath);
   }
 
-  public static URL itemsInTransitReportUrl() {
-    return circulationModuleUrl("/inventory-reports/items-in-transit");
+  public static URL itemsInTransitReportUrl(String subPath) {
+    return circulationModuleUrl("/inventory-reports/items-in-transit" + subPath);
   }
 
    static URL pickSlipsUrl(String servicePointId) {

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -5,7 +5,7 @@ import static api.support.http.CqlQuery.noQuery;
 import static api.support.http.Limit.limit;
 import static api.support.http.Offset.noOffset;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
-import static org.folio.circulation.support.JsonArrayHelper.toList;
+import static org.folio.circulation.support.JsonArrayHelper.mapToList;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -431,27 +431,13 @@ public class ResourceClient {
     });
   }
 
-  //TODO: Replace return value with MultipleJsonRecords
+  //TODO: Replace return valu[e with MultipleJsonRecords
   public List<JsonObject> getAll() throws MalformedURLException {
     final URL location = rootUrl();
 
-    final Response response = restAssuredClient.get(location,
-      noQuery(), limit(1000), noOffset(), 200, "get-all");
-
-    JsonObject json = response.getJson();
-
-    if (json == null) {
-      throw new RuntimeException(String.format(
-        "Response from \"%s\" does not include any JSON", location));
-    }
-
-    if (!json.containsKey(collectionArrayPropertyName)) {
-      throw new RuntimeException(String.format(
-        "Collection array property \"%s\" is not present in: %s",
-        collectionArrayPropertyName, json.encodePrettily()));
-    }
-
-    return toList(json.getJsonArray(collectionArrayPropertyName));
+    return mapToList(restAssuredClient
+      .get(location, noQuery(), limit(1000), noOffset(), 200, "get-all")
+      .getJson(), collectionArrayPropertyName);
   }
 
   private URL recordUrl(Object id) throws MalformedURLException {

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.folio.circulation.support.http.client.IndividualResource;
-import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.client.Response;
 
 import api.support.RestAssuredClient;
@@ -21,242 +20,191 @@ import api.support.builders.Builder;
 import io.vertx.core.json.JsonObject;
 
 public class ResourceClient {
-  private final OkapiHttpClient client;
   private final RestAssuredClient restAssuredClient;
   private final UrlMaker urlMaker;
-  private final String resourceName;
   private final String collectionArrayPropertyName;
 
-  public static ResourceClient forItems(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::itemsStorageUrl,
-      "items");
+  public static ResourceClient forItems() {
+    return new ResourceClient(InterfaceUrls::itemsStorageUrl, "items");
   }
 
-  public static ResourceClient forHoldings(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::holdingsStorageUrl,
-      "holdingsRecords");
+  public static ResourceClient forHoldings() {
+    return new ResourceClient(InterfaceUrls::holdingsStorageUrl, "holdingsRecords");
   }
 
-  public static ResourceClient forInstances(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::instancesStorageUrl,
-      "instances");
+  public static ResourceClient forInstances() {
+    return new ResourceClient(InterfaceUrls::instancesStorageUrl, "instances");
   }
 
-  public static ResourceClient forRequests(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::requestsUrl,
-      "requests");
+  public static ResourceClient forRequests() {
+    return new ResourceClient(InterfaceUrls::requestsUrl, "requests");
   }
 
-  public static ResourceClient forRequestReport(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::requestReportUrl,
-      "requestReport");
+  public static ResourceClient forRequestReport() {
+    return new ResourceClient(InterfaceUrls::requestReportUrl, "requestReport");
   }
 
-  public static ResourceClient forItemsInTransitReport(OkapiHttpClient client) {
-    return new ResourceClient(client,
-      subPath -> InterfaceUrls.itemsInTransitReportUrl(), "items");
+  public static ResourceClient forItemsInTransitReport() {
+    return new ResourceClient(InterfaceUrls::itemsInTransitReportUrl, "items");
   }
 
-  public static ResourceClient forPickSlips(OkapiHttpClient client) {
-    return new ResourceClient(client,
-        InterfaceUrls::pickSlipsUrl, "pickSlips");
+  public static ResourceClient forPickSlips() {
+    return new ResourceClient(InterfaceUrls::pickSlipsUrl, "pickSlips");
   }
 
-  public static ResourceClient forLoans(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::loansUrl,
-      "loans");
+  public static ResourceClient forLoans() {
+    return new ResourceClient(InterfaceUrls::loansUrl, "loans");
   }
 
-  public static ResourceClient forAccounts(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::accountsUrl,
-      "accounts");
+  public static ResourceClient forAccounts() {
+    return new ResourceClient(InterfaceUrls::accountsUrl, "accounts");
   }
 
-  public static ResourceClient forFeeFineActions(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::feeFineActionsUrl, "feefineactions");
+  public static ResourceClient forFeeFineActions() {
+    return new ResourceClient(InterfaceUrls::feeFineActionsUrl, "feefineactions");
   }
 
-  public static ResourceClient forLoanPolicies(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::loanPoliciesStorageUrl,
-      "loan policies", "loanPolicies");
+  public static ResourceClient forLoanPolicies() {
+    return new ResourceClient(InterfaceUrls::loanPoliciesStorageUrl,
+      "loanPolicies");
   }
 
-  public static ResourceClient forRequestPolicies(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::requestPoliciesStorageUrl,
-      "request policies", "requestPolicies");
+  public static ResourceClient forRequestPolicies() {
+    return new ResourceClient(InterfaceUrls::requestPoliciesStorageUrl,
+      "requestPolicies");
   }
 
-  public static ResourceClient forNoticePolicies(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::noticePoliciesStorageUrl,
-      "notice policies", "noticePolicies");
+  public static ResourceClient forNoticePolicies() {
+    return new ResourceClient(InterfaceUrls::noticePoliciesStorageUrl,
+      "noticePolicies");
   }
 
-  public static ResourceClient forOverdueFinePolicies(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::overdueFinesPoliciesStorageUrl,
-      "overdue fines policies", "overdueFinePolicies");
+  public static ResourceClient forOverdueFinePolicies() {
+    return new ResourceClient(InterfaceUrls::overdueFinesPoliciesStorageUrl,
+      "overdueFinePolicies");
   }
 
-  public static ResourceClient forLostItemFeePolicies(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::lostItemFeesPoliciesStorageUrl,
-      "lost item fee policies", "lostItemFeePolicies");
+  public static ResourceClient forLostItemFeePolicies() {
+    return new ResourceClient(InterfaceUrls::lostItemFeesPoliciesStorageUrl,
+      "lostItemFeePolicies");
   }
 
-  public static ResourceClient forFixedDueDateSchedules(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::fixedDueDateSchedulesStorageUrl,
-      "fixed due date schedules", "fixedDueDateSchedules");
+  public static ResourceClient forFixedDueDateSchedules() {
+    return new ResourceClient(InterfaceUrls::fixedDueDateSchedulesStorageUrl,
+      "fixedDueDateSchedules");
   }
 
-  public static ResourceClient forCirculationRules(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::circulationRulesStorageUrl,
-      "circulation rules", "circulationRules");
-  }
-
-  public static ResourceClient forUsers(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::usersUrl,
+  public static ResourceClient forUsers() {
+    return new ResourceClient(InterfaceUrls::usersUrl,
       "users");
   }
 
-  public static ResourceClient forCalendar(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::calendarUrl,
-      "calendar", "calendars");
+  public static ResourceClient forProxyRelationships() {
+    return new ResourceClient(InterfaceUrls::proxyRelationshipsUrl,
+        "proxiesFor");
   }
 
-  public static ResourceClient forProxyRelationships(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::proxyRelationshipsUrl,
-      "proxiesFor");
+  public static ResourceClient forPatronGroups() {
+    return new ResourceClient(InterfaceUrls::patronGroupsStorageUrl,
+        "usergroups");
   }
 
-  public static ResourceClient forPatronGroups(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::patronGroupsStorageUrl,
-      "patron groups", "usergroups");
+  public static ResourceClient forAddressTypes() {
+    return new ResourceClient(InterfaceUrls::addressTypesUrl,
+        "addressTypes");
   }
 
-  public static ResourceClient forAddressTypes(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::addressTypesUrl,
-      "address types", "addressTypes");
+  public static ResourceClient forLoansStorage() {
+    return new ResourceClient(InterfaceUrls::loansStorageUrl,
+        "loans");
   }
 
-  public static ResourceClient forLoansStorage(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::loansStorageUrl,
-      "storage loans", "loans");
+  public static ResourceClient forRequestsStorage() {
+    return new ResourceClient(InterfaceUrls::requestStorageUrl,
+        "requests");
   }
 
-  public static ResourceClient forRequestsStorage(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::requestStorageUrl,
-      "storage requests", "requests");
+  public static ResourceClient forMaterialTypes() {
+    return new ResourceClient(InterfaceUrls::materialTypesStorageUrl,
+      "mtypes");
   }
 
-  public static ResourceClient forMaterialTypes(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::materialTypesStorageUrl,
-      "material types", "mtypes");
+  public static ResourceClient forUserManualBlocks() {
+    return new ResourceClient(subPath ->
+      InterfaceUrls.userManualBlocksStorageUrl(), "manualblocks");
   }
 
-  public static ResourceClient forUserManualBlocks(OkapiHttpClient client) {
-    return new ResourceClient(client, subPath ->
-      InterfaceUrls.userManualBlocksStorageUrl(), "manualblocks", "manualblocks");
+  public static ResourceClient forLoanTypes() {
+    return new ResourceClient(InterfaceUrls::loanTypesStorageUrl,
+        "loantypes");
   }
 
-  public static ResourceClient forLoanTypes(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::loanTypesStorageUrl,
-      "loan types", "loantypes");
+  public static ResourceClient forInstanceTypes() {
+    return new ResourceClient(InterfaceUrls::instanceTypesStorageUrl,
+        "instanceTypes");
   }
 
-  public static ResourceClient forInstanceTypes(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::instanceTypesStorageUrl,
-      "instance types", "instanceTypes");
+  public static ResourceClient forContributorNameTypes() {
+    return new ResourceClient(InterfaceUrls::contributorNameTypesStorageUrl,
+      "contributorNameTypes");
   }
 
-  public static ResourceClient forContributorNameTypes(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::contributorNameTypesStorageUrl,
-      "contributor name types", "contributorNameTypes");
+  public static ResourceClient forInstitutions() {
+    return new ResourceClient(InterfaceUrls::institutionsStorageUrl,
+        "locinsts");
   }
 
-  public static ResourceClient forInstitutions(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::institutionsStorageUrl,
-      "institutions", "locinsts");
+  public static ResourceClient forCampuses() {
+    return new ResourceClient(InterfaceUrls::campusesStorageUrl,
+        "loccamps");
   }
 
-  public static ResourceClient forCampuses(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::campusesStorageUrl,
-      "campuses", "loccamps");
+  public static ResourceClient forLibraries() {
+    return new ResourceClient(InterfaceUrls::librariesStorageUrl, "loclibs");
   }
 
-  public static ResourceClient forLibraries(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::librariesStorageUrl,
-      "libraries", "loclibs");
+  public static ResourceClient forLocations() {
+    return new ResourceClient(InterfaceUrls::locationsStorageUrl, "locations");
   }
 
-  public static ResourceClient forLocations(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::locationsStorageUrl,
-      "locations");
+  public static ResourceClient forCancellationReasons() {
+    return new ResourceClient(InterfaceUrls::cancellationReasonsStorageUrl,
+        "cancellationReasons");
   }
 
-  public static ResourceClient forCancellationReasons(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::cancellationReasonsStorageUrl,
-      "cancellationReasons");
+  public static ResourceClient forServicePoints() {
+    return new ResourceClient(InterfaceUrls::servicePointsStorageUrl,
+        "servicepoints");
   }
 
-  public static ResourceClient forServicePoints(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::servicePointsStorageUrl,
-      "service points", "servicepoints");
+  public static ResourceClient forPatronNotices() {
+    return new ResourceClient(InterfaceUrls::patronNoticesUrl,
+        "patronnotices");
   }
 
-  public static ResourceClient forPatronNotices(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::patronNoticesUrl,
-      "patron notice", "patronnotices");
+  public static ResourceClient forScheduledNotices() {
+    return new ResourceClient(InterfaceUrls::scheduledNoticesUrl,
+        "scheduledNotices");
   }
 
-  public static ResourceClient forScheduledNotices(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::scheduledNoticesUrl,
-      "scheduled notice", "scheduledNotices");
+  public static ResourceClient forPatronSessionRecords() {
+    return new ResourceClient(InterfaceUrls::patronActionSessionsUrl,
+        "patronActionSessions");
   }
 
-  public static ResourceClient forPatronSessionRecords(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::patronActionSessionsUrl,
-      "patron session records", "patronActionSessions");
+  public static ResourceClient forExpiredSessions() {
+    return new ResourceClient(InterfaceUrls::patronExpiredSessionsUrl,
+        "expired session records");
   }
 
-  public static ResourceClient forExpiredSessions(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::patronExpiredSessionsUrl,
-      "expired session records");
+  public static ResourceClient forConfiguration() {
+    return new ResourceClient(InterfaceUrls::configurationUrl, "configs");
   }
 
-  public static ResourceClient forConfiguration(OkapiHttpClient client) {
-    return new ResourceClient(client, InterfaceUrls::configurationUrl,
-      "configuration entries", "configs");
-  }
-
-  public static ResourceClient forRenewByBarcode(OkapiHttpClient client) {
-    return new ResourceClient(client, subPath -> InterfaceUrls.renewByBarcodeUrl(),
-      "renew by barcode");
-  }
-
-  public static ResourceClient forRenewById(OkapiHttpClient client) {
-    return new ResourceClient(client, subPath -> InterfaceUrls.renewByIdUrl(),
-      "renew by id");
-  }
-
-  public static ResourceClient forOverrideRenewalByBarcode(OkapiHttpClient client) {
-    return new ResourceClient(
-      client, subPath -> InterfaceUrls.overrideRenewalByBarcodeUrl(),
-      "override renewal by barcode"
-    );
-  }
-
-  private ResourceClient(OkapiHttpClient client, UrlMaker urlMaker,
-      String resourceName, String collectionArrayPropertyName) {
-
-    this.client = client;
+  private ResourceClient(UrlMaker urlMaker, String collectionArrayPropertyName) {
     this.urlMaker = urlMaker;
-    this.resourceName = resourceName;
     this.collectionArrayPropertyName = collectionArrayPropertyName;
     restAssuredClient = new RestAssuredClient(getOkapiHeadersFromContext());
-  }
-
-  private ResourceClient(OkapiHttpClient client, UrlMaker urlMaker,
-    String resourceName) {
-
-    this(client, urlMaker, resourceName, resourceName);
   }
 
   public Response attemptCreate(Builder builder) throws MalformedURLException {
@@ -371,10 +319,8 @@ public class ResourceClient {
 
   //TODO: Replace return valu[e with MultipleJsonRecords
   public List<JsonObject> getAll() throws MalformedURLException {
-    final URL location = rootUrl();
-
     return mapToList(restAssuredClient
-      .get(location, noQuery(), limit(1000), noOffset(), 200, "get-all")
+      .get(rootUrl(), noQuery(), limit(1000), noOffset(), 200, "get-all")
       .getJson(), collectionArrayPropertyName);
   }
 

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -481,24 +481,6 @@ public class ResourceClient {
     return JsonArrayHelper.toList(json
       .getJsonArray(collectionArrayPropertyName));
   }
-  
-  public Response attemptMove(Builder builder)
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
-
-    CompletableFuture<Response> moveCompleted = new CompletableFuture<>();
-
-    JsonObject request = builder.create();
-
-    String path = String.format("/%s/move", request.getString("id"));
-
-    client.post(urlMaker.combine(path), request,
-      ResponseHandler.any(moveCompleted));
-
-    return moveCompleted.get(15, TimeUnit.SECONDS);
-  }
 
   @FunctionalInterface
   public interface UrlMaker {

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -327,7 +327,7 @@ public class ResourceClient {
   public Response attemptReplace(UUID id, JsonObject representation)
       throws MalformedURLException {
 
-    final URL location = urlMaker.combine(String.format("/%s", id));
+    final URL location = urlForRecordById(id);
 
     return restAssuredClient.put(representation, location,
       "attempt-replace-record");
@@ -340,7 +340,7 @@ public class ResourceClient {
   public void replace(UUID id, JsonObject representation)
       throws MalformedURLException {
 
-    final URL location = urlMaker.combine(String.format("/%s", id));
+    final URL location = urlForRecordById(id);
 
     restAssuredClient.put(representation, location, HTTP_NO_CONTENT,
       "create-record-at-specific-location");
@@ -349,7 +349,7 @@ public class ResourceClient {
   public Response getById(UUID id)
       throws MalformedURLException {
 
-    final URL location = urlMaker.combine(String.format("/%s", id));
+    final URL location = urlForRecordById(id);
 
     return restAssuredClient.get(location, "get-record");
   }
@@ -362,7 +362,7 @@ public class ResourceClient {
 
   public IndividualResource get(UUID id) throws MalformedURLException {
     return new IndividualResource(restAssuredClient.get(
-      urlMaker.combine(String.format("/%s", id)), 200, "get-record"));
+      urlForRecordById(id), 200, "get-record"));
   }
 
   public Response attemptGet(IndividualResource resource)
@@ -379,7 +379,7 @@ public class ResourceClient {
 
     CompletableFuture<Response> deleteFinished = new CompletableFuture<>();
 
-    client.delete(urlMaker.combine(String.format("/%s", id)),
+    client.delete(urlForRecordById(id),
       ResponseHandler.any(deleteFinished));
 
     Response response = deleteFinished.get(5, TimeUnit.SECONDS);
@@ -481,6 +481,10 @@ public class ResourceClient {
     return toList(json.getJsonArray(collectionArrayPropertyName));
   }
 
+  private URL urlForRecordById(UUID id) throws MalformedURLException {
+    return urlMaker.combine(String.format("/%s", id));
+  }
+  
   @FunctionalInterface
   public interface UrlMaker {
     URL combine(String subPath) throws MalformedURLException;

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -484,7 +484,7 @@ public class ResourceClient {
   private URL urlForRecordById(UUID id) throws MalformedURLException {
     return urlMaker.combine(String.format("/%s", id));
   }
-  
+
   @FunctionalInterface
   public interface UrlMaker {
     URL combine(String subPath) throws MalformedURLException;

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -4,12 +4,8 @@ import static api.support.APITestContext.getOkapiHeadersFromContext;
 import static api.support.http.CqlQuery.noQuery;
 import static api.support.http.Limit.limit;
 import static api.support.http.Offset.noOffset;
-import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static org.folio.circulation.support.JsonArrayHelper.mapToList;
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -356,12 +352,7 @@ public class ResourceClient {
   }
 
   public void delete(UUID id) throws MalformedURLException {
-    final Response response = restAssuredClient.delete(recordUrl(id),
-        "delete-record");
-
-    assertThat(String.format(
-        "Failed to delete %s %s: %s", resourceName, id, response.getBody()),
-        response.getStatusCode(), anyOf(is(HTTP_NO_CONTENT), is(HTTP_NOT_FOUND)));
+    restAssuredClient.delete(recordUrl(id), HTTP_NO_CONTENT, "delete-record");
   }
 
   public void delete(IndividualResource resource) throws MalformedURLException {
@@ -369,12 +360,7 @@ public class ResourceClient {
   }
 
   public void deleteAll() throws MalformedURLException {
-    final Response response = restAssuredClient.delete(rootUrl(),
-        "delete-all-records");
-
-    assertThat(String.format(
-        "Failed to delete %s: %s", resourceName, response.getBody()),
-        response.getStatusCode(), is(HTTP_NO_CONTENT));
+    restAssuredClient.delete(rootUrl(), HTTP_NO_CONTENT, "delete-all-records");
   }
 
   public void deleteAllIndividually() throws MalformedURLException {

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -2,6 +2,7 @@ package api.support.http;
 
 import static api.support.APITestContext.getOkapiHeadersFromContext;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+import static org.folio.circulation.support.JsonArrayHelper.toList;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -16,7 +17,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.folio.circulation.support.JsonArrayHelper;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.client.Response;
@@ -478,8 +478,7 @@ public class ResourceClient {
         collectionArrayPropertyName, json.encodePrettily()));
     }
 
-    return JsonArrayHelper.toList(json
-      .getJsonArray(collectionArrayPropertyName));
+    return toList(json.getJsonArray(collectionArrayPropertyName));
   }
 
   @FunctionalInterface

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -2,7 +2,6 @@ package api.support.http;
 
 import static api.support.APITestContext.getOkapiHeadersFromContext;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
-import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -482,16 +481,7 @@ public class ResourceClient {
     return JsonArrayHelper.toList(json
       .getJsonArray(collectionArrayPropertyName));
   }
-
-  public IndividualResource move(Builder builder)
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
-
-    return move(builder.create());
-  }
-
+  
   public Response attemptMove(Builder builder)
     throws InterruptedException,
     MalformedURLException,
@@ -508,32 +498,6 @@ public class ResourceClient {
       ResponseHandler.any(moveCompleted));
 
     return moveCompleted.get(15, TimeUnit.SECONDS);
-  }
-
-  public IndividualResource move(JsonObject request)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
-    CompletableFuture<Response> moveCompleted = new CompletableFuture<>();
-
-    log.debug("Attempting to move {} record: {}", resourceName,
-      request.encodePrettily());
-
-    client.post(urlMaker.combine(String.format("/%s/move", request.getString("id"))), request,
-      ResponseHandler.any(moveCompleted));
-
-    Response response = moveCompleted.get(5, TimeUnit.SECONDS);
-
-    assertThat(
-      String.format("Failed to move %s: %s", resourceName,
-        response.getBody()), response.getStatusCode(), is(HTTP_OK));
-
-    log.debug("Moved resource {}: {}", resourceName,
-      response.getJson().encodePrettily());
-
-    return new IndividualResource(response);
   }
 
   @FunctionalInterface


### PR DESCRIPTION
## Purpose
In order to reduce the coupling and reuse between the API tests and the main code, we can start to replace the use of OkapiHttpClient with RestAssured.

This reduces the chances that tests are affected by unintentional changes in the production code. Hopefully it also reduces the amount of code and improves the readability of the tests.

This also reduces the dependency upon vert.x 3.x HttpClient (some of the methods used in mod-circulation are deprecated), which helps with the eventual migration to vert.x 4.0. Eventually, the remaining production usage will be replaced with the WebClient.

## Approach

This is the third in a series of pull requests. It replaces the use of the OkapiClient with Rest Assured in the `ResourceClient` used in tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
