### PR TITLE
CIRC-610 Grant move request endpoint permissions to apply circulation rules

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1058,7 +1058,8 @@
         "patron-notice.post",
         "circulation-storage.cancellation-reasons.item.get",
         "inventory-storage.loan-types.item.get",
-        "configuration.entries.collection.get"
+        "configuration.entries.collection.get",
+        "circulation.internal.apply-rules"
       ],
       "visible": false
     },
@@ -1868,7 +1869,26 @@
         "circulation-storage.requests.collection.get"
       ],
       "visible": false
+    },
+    {
+      "permissionName": "circulation.internal.apply-rules",
+      "displayName" : "Apply circulation rules",
+      "description" : "Internal permission set for applying circulation rules",
+      "subPermissions": [
+        "circulation.rules.loan-policy.get",
+        "circulation-storage.loan-policies.collection.get",
+        "circulation-storage.loan-policies.item.get",
+        "circulation.rules.request-policy.get",
+        "circulation-storage.request-policies.item.get",
+        "circulation-storage.request-policies.collection.get",
+        "circulation.rules.notice-policy.get",
+        "circulation-storage.patron-notice-policies.item.get",
+        "circulation-storage.patron-notice-policies.collection.get"
+      ],
+      "visible": false
     }
+
+
   ],
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",


### PR DESCRIPTION
## Purpose

The endpoint to move requests currently does not have enough permissions to complete it's work.

Permissions need to be added to allow the circulation rules to be applied to determine a loan policy.

## Approach

* Introduces a new internal permission set for applying circulation rules. This is intended to try to reduce the duplication between endpoints and start to grant more role or activity based permissions. Hopefully this might make it less likely that a permission is missed when changes are made.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
