### PR TITLE
CIRC-614 Declared lost item: prevent all request types

### DIFF
--- a/src/main/java/org/folio/circulation/domain/RequestTypeItemStatusWhiteList.java
+++ b/src/main/java/org/folio/circulation/domain/RequestTypeItemStatusWhiteList.java
@@ -33,6 +33,7 @@ public class RequestTypeItemStatusWhiteList {
     recallRules.put(ItemStatus.PAGED, true);
     recallRules.put(ItemStatus.ON_ORDER, true);
     recallRules.put(ItemStatus.IN_PROCESS, true);
+    recallRules.put(ItemStatus.DECLARED_LOST, false);
     recallRules.put(ItemStatus.NONE, false);
   }
 
@@ -47,6 +48,7 @@ public class RequestTypeItemStatusWhiteList {
     holdRules.put(ItemStatus.PAGED, true);
     holdRules.put(ItemStatus.ON_ORDER, true);
     holdRules.put(ItemStatus.IN_PROCESS, true);
+    holdRules.put(ItemStatus.DECLARED_LOST, false);
     holdRules.put(ItemStatus.NONE, true);
   }
 
@@ -61,6 +63,7 @@ public class RequestTypeItemStatusWhiteList {
     pageRules.put(ItemStatus.PAGED, false);
     pageRules.put(ItemStatus.ON_ORDER, false);
     pageRules.put(ItemStatus.IN_PROCESS, false);
+    pageRules.put(ItemStatus.DECLARED_LOST, false);
     pageRules.put(ItemStatus.NONE, false);
   }
 
@@ -75,6 +78,7 @@ public class RequestTypeItemStatusWhiteList {
     noneRules.put(ItemStatus.PAGED, false);
     noneRules.put(ItemStatus.ON_ORDER, false);
     noneRules.put(ItemStatus.IN_PROCESS, false);
+    noneRules.put(ItemStatus.DECLARED_LOST, false);
     noneRules.put(ItemStatus.NONE, false);
   }
 

--- a/src/test/java/api/requests/RequestTypeItemStatusWhiteListTests.java
+++ b/src/test/java/api/requests/RequestTypeItemStatusWhiteListTests.java
@@ -3,11 +3,15 @@ package api.requests;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.RequestType;
 import org.folio.circulation.domain.RequestTypeItemStatusWhiteList;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(JUnitParamsRunner.class)
 public class RequestTypeItemStatusWhiteListTests {
 
   @Test
@@ -93,5 +97,17 @@ public class RequestTypeItemStatusWhiteListTests {
   @Test
   public void cannotCreateNoneRequestWhenItemStatusAwaitingDelivery() {
     assertFalse(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.AWAITING_DELIVERY, RequestType.NONE));
+  }
+
+  @Test
+  @Parameters({
+    "",
+    "Hold",
+    "Recall",
+    "Page"
+  })
+  public void cannotCreateRequestWhenItemStatusDeclaredLostItem(String requestType) {
+    assertFalse(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.DECLARED_LOST,
+      RequestType.from(requestType)));
   }
 }


### PR DESCRIPTION
## Purpose
Declared lost item: prevent all request types

Resolves: [CIRC-614](https://issues.folio.org/browse/CIRC-614)

## Approach 
- add validation if an item has `declared lost item` status;

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
