### PR TITLE
[CIRC-556] In transit report: remaining call number fields

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -22,7 +22,7 @@
     },
     {
       "id": "inventory-reports",
-      "version": "0.3",
+      "version": "0.4",
       "handlers": [
         {
           "methods": [

--- a/ramls/examples/items-in-transit.json
+++ b/ramls/examples/items-in-transit.json
@@ -58,6 +58,12 @@
           "id": "c4c90014-c8c9-4ade-8f24-b5e313319f4b",
           "name": "Circ Desk 2"
         }
+      },
+      "copyNumber": "cp.1",
+      "effectiveCallNumberComponents": {
+        "callNumber": "TK5105.88815 . A58 2004 FT MEADE",
+        "prefix": "0001",
+        "suffix": "124"
       }
     }
   ],

--- a/ramls/inventory-reports.raml
+++ b/ramls/inventory-reports.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Circulation
-version: v0.3
+version: v0.4
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/items-in-transit.json
+++ b/ramls/items-in-transit.json
@@ -217,8 +217,7 @@
           },
           "effectiveCallNumberComponents": {
             "description": "Elements of a full call number",
-            "$ref": "schema/call-number-components.json",
-            "readonly": true
+            "$ref": "schema/call-number-components.json"
           }
         },
         "additionalProperties": false

--- a/ramls/items-in-transit.json
+++ b/ramls/items-in-transit.json
@@ -16,7 +16,7 @@
           "id": {
             "description": "UUID of the item",
             "type": "string",
-            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+            "$ref": "uuid.json"
           },
           "title": {
             "description": "title of the item (stored)",
@@ -81,7 +81,7 @@
               "id": {
                 "description": "UUID of the service point",
                 "type": "string",
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+                "$ref": "uuid.json"
               },
               "name": {
                 "description": "Name of the service point",
@@ -201,7 +201,7 @@
                   "id": {
                     "description": "UUID of the service point",
                     "type": "string",
-                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+                    "$ref": "uuid.json"
                   },
                   "name": {
                     "type": "string",
@@ -210,6 +210,15 @@
                 }
               }
             }
+          },
+          "copyNumber": {
+            "type": "string",
+            "description": "Copy number is the piece identifier. The copy number reflects if the library has a copy of a single-volume monograph; one copy of a multi-volume, (e.g. Copy 1, or C.7.)"
+          },
+          "effectiveCallNumberComponents": {
+            "description": "Elements of a full call number",
+            "$ref": "schema/call-number-components.json",
+            "readonly": true
           }
         },
         "additionalProperties": false

--- a/src/main/java/org/folio/circulation/domain/representations/ItemReportRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemReportRepresentation.java
@@ -70,7 +70,6 @@ public class ItemReportRepresentation {
     if (lastCheckIn != null) {
       writeLastCheckIn(itemReport, lastCheckIn);
     }
-
     return itemReport;
   }
 

--- a/src/main/java/org/folio/circulation/domain/representations/ItemReportRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemReportRepresentation.java
@@ -5,6 +5,7 @@ import static org.folio.circulation.support.JsonPropertyWriter.writeNamedObject;
 
 import java.util.Optional;
 
+import org.folio.circulation.domain.CallNumberComponents;
 import org.folio.circulation.domain.InTransitReportEntry;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.ItemStatus;
@@ -43,6 +44,7 @@ public class ItemReportRepresentation {
     writeNamedObject(itemReport, "status", Optional.ofNullable(item.getStatus())
       .map(ItemStatus::getValue).orElse(null));
     write(itemReport, "inTransitDestinationServicePointId", item.getInTransitDestinationServicePointId());
+    write(itemReport, "copyNumber", item.getCopyNumber());
 
     final ServicePoint inTransitDestinationServicePoint = item.getInTransitDestinationServicePoint();
     if (inTransitDestinationServicePoint != null) {
@@ -66,7 +68,23 @@ public class ItemReportRepresentation {
     if (lastCheckIn != null) {
       writeLastCheckIn(itemReport, lastCheckIn);
     }
+
+    final CallNumberComponents callNumberComponents = item.getCallNumberComponents();
+    if (callNumberComponents != null) {
+      writeCallNumberComponents(itemReport, callNumberComponents);
+    }
+
     return itemReport;
+  }
+
+  private void writeCallNumberComponents(JsonObject itemReport, CallNumberComponents components) {
+    final JsonObject componentsJson = new JsonObject();
+    write(componentsJson, "callNumber", components.getCallNumber());
+    write(componentsJson, "prefix", components.getPrefix());
+    write(componentsJson, "suffix", components.getSuffix());
+    if (!componentsJson.isEmpty()) {
+      write(itemReport, "effectiveCallNumberComponents", componentsJson);
+    }
   }
 
   private void writeLastCheckIn(JsonObject itemReport, LastCheckIn lastCheckIn) {

--- a/src/main/java/org/folio/circulation/domain/representations/ItemReportRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemReportRepresentation.java
@@ -1,11 +1,11 @@
 package org.folio.circulation.domain.representations;
 
+import static org.folio.circulation.domain.representations.CallNumberComponentsRepresentation.createCallNumberComponents;
 import static org.folio.circulation.support.JsonPropertyWriter.write;
 import static org.folio.circulation.support.JsonPropertyWriter.writeNamedObject;
 
 import java.util.Optional;
 
-import org.folio.circulation.domain.CallNumberComponents;
 import org.folio.circulation.domain.InTransitReportEntry;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.ItemStatus;
@@ -45,6 +45,8 @@ public class ItemReportRepresentation {
       .map(ItemStatus::getValue).orElse(null));
     write(itemReport, "inTransitDestinationServicePointId", item.getInTransitDestinationServicePointId());
     write(itemReport, "copyNumber", item.getCopyNumber());
+    write(itemReport, "effectiveCallNumberComponents",
+      createCallNumberComponents(item.getCallNumberComponents()));
 
     final ServicePoint inTransitDestinationServicePoint = item.getInTransitDestinationServicePoint();
     if (inTransitDestinationServicePoint != null) {
@@ -69,22 +71,7 @@ public class ItemReportRepresentation {
       writeLastCheckIn(itemReport, lastCheckIn);
     }
 
-    final CallNumberComponents callNumberComponents = item.getCallNumberComponents();
-    if (callNumberComponents != null) {
-      writeCallNumberComponents(itemReport, callNumberComponents);
-    }
-
     return itemReport;
-  }
-
-  private void writeCallNumberComponents(JsonObject itemReport, CallNumberComponents components) {
-    final JsonObject componentsJson = new JsonObject();
-    write(componentsJson, "callNumber", components.getCallNumber());
-    write(componentsJson, "prefix", components.getPrefix());
-    write(componentsJson, "suffix", components.getSuffix());
-    if (!componentsJson.isEmpty()) {
-      write(itemReport, "effectiveCallNumberComponents", componentsJson);
-    }
   }
 
   private void writeLastCheckIn(JsonObject itemReport, LastCheckIn lastCheckIn) {

--- a/src/test/java/api/requests/ItemsInTransitReportTests.java
+++ b/src/test/java/api/requests/ItemsInTransitReportTests.java
@@ -587,10 +587,7 @@ public class ItemsInTransitReportTests extends APITests {
     return ItemExamples.basedUponSmallAngryPlanet(
       materialTypesFixture.book().getId(),
       loanTypesFixture.canCirculate().getId(),
-      "55555",
-      "PREFIX",
-      "SUFFIX",
-      "Copy 1")
+      "55555", "PREFIX", "SUFFIX", "Copy 1")
       .withEnumeration("smallAngryPlanetEnumeration")
       .withVolume("smallAngryPlanetVolume")
       .withYearCaption(Collections.singletonList("2019"));

--- a/src/test/java/api/requests/ItemsInTransitReportTests.java
+++ b/src/test/java/api/requests/ItemsInTransitReportTests.java
@@ -64,6 +64,8 @@ public class ItemsInTransitReportTests extends APITests {
   private static final String SERVICE_POINT_NAME_2 = "Circ Desk 2";
   private static final String REQUEST_PATRON_GROUP_DESCRIPTION = "Regular group";
   private static final String SERVICE_POINT_CODE_2 = "cd2";
+  private static final String COPY_NUMBER = "copyNumber";
+  private static final String EFFECTIVE_CALL_NUMBER_COMPONENTS = "effectiveCallNumberComponents";
 
   @Override
   public void afterEach() {
@@ -491,6 +493,12 @@ public class ItemsInTransitReportTests extends APITests {
 
     assertThat(itemJson.getJsonArray(YEAR_CAPTION),
       is(smallAngryPlanetResponse.getJsonArray(YEAR_CAPTION)));
+
+    assertThat(itemJson.getString(COPY_NUMBER),
+      is(smallAngryPlanetResponse.getString(COPY_NUMBER)));
+
+    assertThat(smallAngryPlanetResponse.getJsonObject(EFFECTIVE_CALL_NUMBER_COMPONENTS),
+      is(itemJson.getJsonObject(EFFECTIVE_CALL_NUMBER_COMPONENTS)));
   }
 
   private void verifyLocation(JsonObject itemJson) {
@@ -563,7 +571,7 @@ public class ItemsInTransitReportTests extends APITests {
       .withEnumeration("nodeEnumeration")
       .withVolume("nodeVolume")
       .withYearCaption(Collections.singletonList("2017"))
-      .withCallNumber("222245", null, null);
+      .withCallNumber("222245", "PREFIX", "SUFFIX");
     return itemsFixture.basedUponNod(builder -> nodItemBuilder);
   }
 
@@ -580,13 +588,12 @@ public class ItemsInTransitReportTests extends APITests {
     return ItemExamples.basedUponSmallAngryPlanet(
       materialTypesFixture.book().getId(),
       loanTypesFixture.canCirculate().getId(),
-      StringUtils.EMPTY,
-      "ItemPrefix",
-      "ItemSuffix",
-      "")
+      "55555",
+      "PREFIX",
+      "SUFFIX",
+      "Copy 1")
       .withEnumeration("smallAngryPlanetEnumeration")
       .withVolume("smallAngryPlanetVolume")
-      .withYearCaption(Collections.singletonList("2019"))
-      .withCallNumber("55555", null, null);
+      .withYearCaption(Collections.singletonList("2019"));
   }
 }

--- a/src/test/java/api/requests/ItemsInTransitReportTests.java
+++ b/src/test/java/api/requests/ItemsInTransitReportTests.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.support.JsonPropertyFetcher;
 import org.folio.circulation.support.http.client.IndividualResource;


### PR DESCRIPTION
## Purpose
Add call number components and copy number to items in transit report.

Resolves [CIRC-556](https://issues.folio.org/browse/CIRC-556).