### PR TITLE
CIRC-604 Multiple assertThat dependencies

### DIFF
--- a/doc/automated-testing.md
+++ b/doc/automated-testing.md
@@ -33,3 +33,13 @@ tests should also be updated, other the tests might produce false results.
 
 As the names include the interface version, the file should also be renamed. 
 And the paths in the `StorageSchema` class need to be changed.
+
+##### Test standards
+
+* assertThat import used is org.hamcrest.MatcherAssert.assertThat
+
+###### The reason behind why org.hamcrest.MatcherAssert.assertThat was chosen:
+
+* org.junit.Assert.assertThat() is deprecated as of JUnit 4.13.
+* custom hamcrest matchers may include more detailed information about what exactly was wrong
+* control version of Hamcrest

--- a/src/test/java/api/item/EffectiveLocationApiTests.java
+++ b/src/test/java/api/item/EffectiveLocationApiTests.java
@@ -1,7 +1,7 @@
 package api.item;
 
 import static api.support.matchers.UUIDMatcher.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 

--- a/src/test/java/api/item/ItemLastCheckInTests.java
+++ b/src/test/java/api/item/ItemLastCheckInTests.java
@@ -4,7 +4,7 @@ import static api.support.APITestContext.getOkapiHeadersFromContext;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.joda.time.DateTimeZone.UTC;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 

--- a/src/test/java/api/item/ItemStatusApiTests.java
+++ b/src/test/java/api/item/ItemStatusApiTests.java
@@ -4,7 +4,7 @@ import static api.support.matchers.TextDateTimeMatcher.withinSecondsAfter;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.joda.time.Seconds.seconds;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.joda.time.DateTime;

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -14,7 +14,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/api/loans/CheckInByReplacingLoanTests.java
+++ b/src/test/java/api/loans/CheckInByReplacingLoanTests.java
@@ -6,7 +6,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasUUIDParameter;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.UUID;

--- a/src/test/java/api/loans/DeclareLostAPITests.java
+++ b/src/test/java/api/loans/DeclareLostAPITests.java
@@ -5,7 +5,7 @@ import static api.support.matchers.LoanMatchers.hasOpenStatus;
 import static api.support.matchers.LoanMatchers.hasStatus;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.UUID;

--- a/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
@@ -7,7 +7,7 @@ import static api.support.matchers.PatronNoticeMatcher.hasEmailNoticeProperties;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;

--- a/src/test/java/api/loans/DueDateScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/DueDateScheduledNoticesProcessingTests.java
@@ -7,7 +7,7 @@ import static java.util.Comparator.comparing;
 import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimeProperty;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/api/loans/DueDateScheduledNoticesTests.java
+++ b/src/test/java/api/loans/DueDateScheduledNoticesTests.java
@@ -5,7 +5,7 @@ import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimePrope
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.Arrays;

--- a/src/test/java/api/loans/InHouseUseCheckInTest.java
+++ b/src/test/java/api/loans/InHouseUseCheckInTest.java
@@ -4,7 +4,7 @@ import static api.support.http.CqlQuery.queryFromTemplate;
 import static api.support.http.Limit.noLimit;
 import static api.support.http.Offset.noOffset;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 

--- a/src/test/java/api/loans/LoanAPILocationTests.java
+++ b/src/test/java/api/loans/LoanAPILocationTests.java
@@ -2,7 +2,7 @@ package api.loans;
 
 import static api.support.JsonCollectionAssistant.getRecordById;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.List;

--- a/src/test/java/api/loans/LoanAPIPolicyTests.java
+++ b/src/test/java/api/loans/LoanAPIPolicyTests.java
@@ -3,7 +3,7 @@ package api.loans;
 import static api.support.http.InterfaceUrls.circulationRulesUrl;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 

--- a/src/test/java/api/loans/LoanAPIProxyTests.java
+++ b/src/test/java/api/loans/LoanAPIProxyTests.java
@@ -5,7 +5,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
 
 import java.util.UUID;

--- a/src/test/java/api/loans/LoanAPIRelatedRecordsTests.java
+++ b/src/test/java/api/loans/LoanAPIRelatedRecordsTests.java
@@ -3,7 +3,7 @@ package api.loans;
 import static api.support.JsonCollectionAssistant.getRecordById;
 import static api.support.matchers.UUIDMatcher.is;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.List;

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/api/loans/LoanAPITitleTests.java
+++ b/src/test/java/api/loans/LoanAPITitleTests.java
@@ -2,7 +2,7 @@ package api.loans;
 
 import static api.support.JsonCollectionAssistant.getRecordById;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.List;

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansAfterXIntervalTests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansAfterXIntervalTests.java
@@ -3,7 +3,7 @@ package api.loans.anonymization;
 import static api.support.matchers.LoanMatchers.hasOpenStatus;
 import static api.support.matchers.LoanMatchers.isAnonymized;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTime.now;
 import static org.joda.time.DateTimeZone.UTC;
 

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansByUserIdAPITests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansByUserIdAPITests.java
@@ -3,7 +3,7 @@ package api.loans.anonymization;
 import static api.support.matchers.LoanMatchers.hasOpenStatus;
 import static api.support.matchers.LoanMatchers.isAnonymized;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.UUID;

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansImmediatelyAPITests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansImmediatelyAPITests.java
@@ -2,7 +2,7 @@ package api.loans.anonymization;
 
 import static api.support.matchers.LoanMatchers.isAnonymized;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansNeverTests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansNeverTests.java
@@ -2,7 +2,7 @@ package api.loans.anonymization;
 
 import static api.support.matchers.LoanMatchers.isAnonymized;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 

--- a/src/test/java/api/loans/scenarios/ChangeDueDateTests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateTests.java
@@ -11,7 +11,7 @@ import static org.folio.circulation.support.JsonPropertyWriter.write;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
+++ b/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
@@ -5,7 +5,7 @@ import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static org.folio.circulation.domain.policy.DueDateManagement.KEEP_THE_CURRENT_DUE_DATE;
 import static org.folio.circulation.domain.policy.Period.weeks;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeConstants.SEPTEMBER;
 
 import java.net.MalformedURLException;

--- a/src/test/java/api/queue/RequestQueueResourceTest.java
+++ b/src/test/java/api/queue/RequestQueueResourceTest.java
@@ -2,7 +2,7 @@ package api.queue;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Comparator;

--- a/src/test/java/api/requests/HoldShelfClearanceReportTests.java
+++ b/src/test/java/api/requests/HoldShelfClearanceReportTests.java
@@ -3,7 +3,7 @@ package api.requests;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.folio.circulation.support.JsonArrayHelper.toList;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.List;

--- a/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
+++ b/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
@@ -8,7 +8,7 @@ import static org.folio.HttpStatus.HTTP_CREATED;
 import static org.folio.circulation.support.JsonPropertyWriter.write;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTime.now;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.joda.time.format.ISODateTimeFormat.dateTime;

--- a/src/test/java/api/requests/ItemsInTransitReportTests.java
+++ b/src/test/java/api/requests/ItemsInTransitReportTests.java
@@ -5,7 +5,7 @@ import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static org.folio.circulation.support.JsonStringArrayHelper.toList;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -2,7 +2,7 @@ package api.requests;
 
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/src/test/java/api/requests/RequestScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/requests/RequestScheduledNoticesProcessingTests.java
@@ -8,7 +8,7 @@ import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimePrope
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
 
 import java.util.HashMap;

--- a/src/test/java/api/requests/RequestScheduledNoticesTests.java
+++ b/src/test/java/api/requests/RequestScheduledNoticesTests.java
@@ -6,7 +6,7 @@ import static org.folio.circulation.domain.representations.RequestProperties.HOL
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.Arrays;

--- a/src/test/java/api/requests/RequestsAPICreateMultipleRequestsTests.java
+++ b/src/test/java/api/requests/RequestsAPICreateMultipleRequestsTests.java
@@ -1,7 +1,7 @@
 package api.requests;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.UUID;

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import static org.folio.HttpStatus.HTTP_BAD_REQUEST;

--- a/src/test/java/api/requests/RequestsAPIDeletionTests.java
+++ b/src/test/java/api/requests/RequestsAPIDeletionTests.java
@@ -4,7 +4,7 @@ import static api.support.http.InterfaceUrls.requestsUrl;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;

--- a/src/test/java/api/requests/RequestsAPILoanHistoryTests.java
+++ b/src/test/java/api/requests/RequestsAPILoanHistoryTests.java
@@ -2,7 +2,7 @@ package api.requests;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.UUID;

--- a/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
+++ b/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
@@ -8,7 +8,7 @@ import static org.folio.circulation.resources.RenewalValidator.CAN_NOT_RENEW_ITE
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeConstants.APRIL;
 
 import java.time.LocalDate;

--- a/src/test/java/api/requests/RequestsAPILocationTests.java
+++ b/src/test/java/api/requests/RequestsAPILocationTests.java
@@ -19,7 +19,7 @@ import static api.support.JsonCollectionAssistant.getRecordById;
 import static api.support.matchers.RequestItemMatcher.*;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RequestsAPILocationTests extends APITests {
   @Test

--- a/src/test/java/api/requests/RequestsAPIProxyTests.java
+++ b/src/test/java/api/requests/RequestsAPIProxyTests.java
@@ -6,7 +6,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static org.folio.HttpStatus.HTTP_CREATED;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 

--- a/src/test/java/api/requests/RequestsAPIRelatedRecordsTests.java
+++ b/src/test/java/api/requests/RequestsAPIRelatedRecordsTests.java
@@ -3,7 +3,7 @@ package api.requests;
 import static api.support.JsonCollectionAssistant.getRecordById;
 import static api.support.matchers.UUIDMatcher.is;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/test/java/api/requests/RequestsAPIRetrievalTests.java
+++ b/src/test/java/api/requests/RequestsAPIRetrievalTests.java
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/api/requests/RequestsAPITitleTests.java
+++ b/src/test/java/api/requests/RequestsAPITitleTests.java
@@ -2,7 +2,7 @@ package api.requests;
 
 import static api.support.JsonCollectionAssistant.getRecordById;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.List;

--- a/src/test/java/api/requests/RequestsAPIUpdatingTests.java
+++ b/src/test/java/api/requests/RequestsAPIUpdatingTests.java
@@ -16,7 +16,7 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;

--- a/src/test/java/api/requests/scenarios/CancelRequestTests.java
+++ b/src/test/java/api/requests/scenarios/CancelRequestTests.java
@@ -5,7 +5,7 @@ import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
 import static org.folio.circulation.domain.RequestStatus.CLOSED_CANCELLED;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
 
 import java.util.Collection;

--- a/src/test/java/api/requests/scenarios/ClosedRequestTests.java
+++ b/src/test/java/api/requests/scenarios/ClosedRequestTests.java
@@ -10,7 +10,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasUUIDParameter;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.concurrent.ExecutionException;

--- a/src/test/java/api/requests/scenarios/MoveRequestPolicyTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestPolicyTests.java
@@ -4,7 +4,7 @@ import static java.util.Collections.singletonList;
 import static org.folio.circulation.domain.representations.RequestProperties.REQUEST_TYPE;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.time.Clock;

--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -13,7 +13,7 @@ import static org.folio.circulation.domain.representations.RequestProperties.REQ
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.net.MalformedURLException;

--- a/src/test/java/api/requests/scenarios/MultipleHoldShelfRequestsTests.java
+++ b/src/test/java/api/requests/scenarios/MultipleHoldShelfRequestsTests.java
@@ -10,7 +10,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.concurrent.ExecutionException;

--- a/src/test/java/api/requests/scenarios/MultipleMixedFulfilmentRequestsTests.java
+++ b/src/test/java/api/requests/scenarios/MultipleMixedFulfilmentRequestsTests.java
@@ -13,7 +13,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.concurrent.ExecutionException;

--- a/src/test/java/api/requests/scenarios/MultipleOutOfOrderRequestsTests.java
+++ b/src/test/java/api/requests/scenarios/MultipleOutOfOrderRequestsTests.java
@@ -5,7 +5,7 @@ import static api.support.builders.RequestBuilder.OPEN_AWAITING_PICKUP;
 import static api.support.builders.RequestBuilder.OPEN_NOT_YET_FILLED;
 import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.concurrent.ExecutionException;

--- a/src/test/java/api/requests/scenarios/PageRequestWorkflowTests.java
+++ b/src/test/java/api/requests/scenarios/PageRequestWorkflowTests.java
@@ -12,7 +12,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static org.folio.HttpStatus.HTTP_OK;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.concurrent.ExecutionException;

--- a/src/test/java/api/requests/scenarios/RequestPolicyTests.java
+++ b/src/test/java/api/requests/scenarios/RequestPolicyTests.java
@@ -7,7 +7,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static org.folio.HttpStatus.HTTP_INTERNAL_SERVER_ERROR;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.net.MalformedURLException;

--- a/src/test/java/api/requests/scenarios/RequestQueueTests.java
+++ b/src/test/java/api/requests/scenarios/RequestQueueTests.java
@@ -2,7 +2,7 @@ package api.requests.scenarios;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;

--- a/src/test/java/api/requests/scenarios/RequestsForDifferentItemsTests.java
+++ b/src/test/java/api/requests/scenarios/RequestsForDifferentItemsTests.java
@@ -1,7 +1,7 @@
 package api.requests.scenarios;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.UUID;

--- a/src/test/java/api/requests/scenarios/RequestsServicePointsTests.java
+++ b/src/test/java/api/requests/scenarios/RequestsServicePointsTests.java
@@ -1,7 +1,7 @@
 package api.requests.scenarios;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;

--- a/src/test/java/api/requests/scenarios/SingleClosedRequestTests.java
+++ b/src/test/java/api/requests/scenarios/SingleClosedRequestTests.java
@@ -6,7 +6,7 @@ import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
 import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static org.folio.HttpStatus.HTTP_OK;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.UUID;

--- a/src/test/java/api/requests/scenarios/SingleOpenDeliveryRequestTests.java
+++ b/src/test/java/api/requests/scenarios/SingleOpenDeliveryRequestTests.java
@@ -10,7 +10,7 @@ import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.concurrent.ExecutionException;

--- a/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
+++ b/src/test/java/api/requests/scenarios/SingleOpenHoldShelfRequestTests.java
@@ -14,7 +14,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static org.folio.HttpStatus.HTTP_OK;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.UUID;

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -8,7 +8,7 @@ import static api.support.http.api.support.NamedQueryStringParameter.namedParame
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static org.folio.circulation.domain.representations.LoanProperties.PATRON_GROUP_AT_CHECKOUT;
 

--- a/src/test/java/api/support/fixtures/CirculationRulesFixture.java
+++ b/src/test/java/api/support/fixtures/CirculationRulesFixture.java
@@ -8,7 +8,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/test/java/api/support/fixtures/ItemsFixture.java
+++ b/src/test/java/api/support/fixtures/ItemsFixture.java
@@ -4,7 +4,7 @@ import static java.util.function.Function.identity;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.JsonPropertyWriter.write;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.List;

--- a/src/test/java/api/support/fixtures/RequestQueueFixture.java
+++ b/src/test/java/api/support/fixtures/RequestQueueFixture.java
@@ -3,7 +3,7 @@ package api.support.fixtures;
 import static api.support.http.InterfaceUrls.reorderQueueUrl;
 import static api.support.http.InterfaceUrls.requestQueueUrl;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.folio.circulation.support.http.client.Response;
 

--- a/src/test/java/org/folio/circulation/FakeCQLToJSONInterpreterSearchingTests.java
+++ b/src/test/java/org/folio/circulation/FakeCQLToJSONInterpreterSearchingTests.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FakeCQLToJSONInterpreterSearchingTests {
 

--- a/src/test/java/org/folio/circulation/FakeCQLToJSONInterpreterSortingTests.java
+++ b/src/test/java/org/folio/circulation/FakeCQLToJSONInterpreterSortingTests.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FakeCQLToJSONInterpreterSortingTests {
 

--- a/src/test/java/org/folio/circulation/domain/EffectiveLocationTests.java
+++ b/src/test/java/org/folio/circulation/domain/EffectiveLocationTests.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.domain;
 
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 

--- a/src/test/java/org/folio/circulation/domain/ProxyRelationshipTests.java
+++ b/src/test/java/org/folio/circulation/domain/ProxyRelationshipTests.java
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(JUnitParamsRunner.class)
 public class ProxyRelationshipTests {

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -10,7 +10,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RequestQueueTests {
 

--- a/src/test/java/org/folio/circulation/domain/RequestRepresentationTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestRepresentationTests.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.domain;
 
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 

--- a/src/test/java/org/folio/circulation/domain/UpdateRequestQueueTest.java
+++ b/src/test/java/org/folio/circulation/domain/UpdateRequestQueueTest.java
@@ -4,7 +4,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.support.Result.of;
 import static org.folio.circulation.support.Result.succeeded;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/org/folio/circulation/domain/policy/FixedDueDateSchedulesTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/FixedDueDateSchedulesTests.java
@@ -4,7 +4,7 @@ import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FixedDueDateSchedulesTests {
   @Test

--- a/src/test/java/org/folio/circulation/domain/policy/FixedLoanPolicyCheckOutDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/FixedLoanPolicyCheckOutDueDateCalculationTests.java
@@ -2,7 +2,7 @@ package org.folio.circulation.domain.policy;
 
 import static api.support.matchers.FailureMatcher.hasValidationFailure;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 

--- a/src/test/java/org/folio/circulation/domain/policy/FixedLoanPolicyRenewalDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/FixedLoanPolicyRenewalDueDateCalculationTests.java
@@ -5,7 +5,7 @@ import static api.support.matchers.FailureMatcher.hasValidationFailure;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/test/java/org/folio/circulation/domain/policy/InvalidLoanPolicyTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/InvalidLoanPolicyTests.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.domain.policy;
 
 import static api.support.matchers.FailureMatcher.hasValidationFailure;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.RequestQueue;

--- a/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyCheckOutDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyCheckOutDueDateCalculationTests.java
@@ -4,7 +4,7 @@ import static api.support.matchers.FailureMatcher.hasValidationFailure;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyRenewalDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyRenewalDueDateCalculationTests.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 import static api.support.matchers.FailureMatcher.hasNumberOfFailureMessages;
 import static api.support.matchers.FailureMatcher.hasValidationFailure;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(JUnitParamsRunner.class)
 public class RollingLoanPolicyRenewalDueDateCalculationTests {

--- a/src/test/java/org/folio/circulation/domain/policy/UnknownLoanPolicyProfileTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/UnknownLoanPolicyProfileTests.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.domain.policy;
 
 import static api.support.matchers.FailureMatcher.hasValidationFailure;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.RequestQueue;

--- a/src/test/java/org/folio/circulation/domain/validation/InactiveUserValidatorTests.java
+++ b/src/test/java/org/folio/circulation/domain/validation/InactiveUserValidatorTests.java
@@ -6,7 +6,7 @@ import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;

--- a/src/test/java/org/folio/circulation/domain/validation/MoreThanOneLoanValidatorTests.java
+++ b/src/test/java/org/folio/circulation/domain/validation/MoreThanOneLoanValidatorTests.java
@@ -3,7 +3,7 @@ package org.folio.circulation.domain.validation;
 import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static org.folio.circulation.support.Result.of;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/org/folio/circulation/domain/validation/NoLoanValidatorTests.java
+++ b/src/test/java/org/folio/circulation/domain/validation/NoLoanValidatorTests.java
@@ -3,7 +3,7 @@ package org.folio.circulation.domain.validation;
 import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static org.folio.circulation.support.Result.of;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Optional;
 

--- a/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
@@ -9,7 +9,7 @@ import static org.folio.circulation.support.JsonPropertyWriter.write;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.UUID;

--- a/src/test/java/org/folio/circulation/resources/RenewByBarcodeRequestTests.java
+++ b/src/test/java/org/folio/circulation/resources/RenewByBarcodeRequestTests.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static api.support.matchers.FailureMatchers.errorResultFor;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RenewByBarcodeRequestTests {
   @Test

--- a/src/test/java/org/folio/circulation/resources/RenewByIdRequestTests.java
+++ b/src/test/java/org/folio/circulation/resources/RenewByIdRequestTests.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 import static api.support.matchers.FailureMatchers.errorResultFor;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RenewByIdRequestTests {
   @Test

--- a/src/test/java/org/folio/circulation/support/StringUtilTests.java
+++ b/src/test/java/org/folio/circulation/support/StringUtilTests.java
@@ -2,7 +2,7 @@ package org.folio.circulation.support;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.charset.StandardCharsets;
 

--- a/src/test/java/org/folio/circulation/support/http/client/CqlQueryTests.java
+++ b/src/test/java/org/folio/circulation/support/http/client/CqlQueryTests.java
@@ -11,7 +11,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.joda.time.DateTime.now;
 import static org.joda.time.DateTimeZone.UTC;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 

--- a/src/test/java/org/folio/circulation/support/http/client/ResponseInterpretationTests.java
+++ b/src/test/java/org/folio/circulation/support/http/client/ResponseInterpretationTests.java
@@ -8,7 +8,7 @@ import static org.folio.circulation.support.Result.of;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.folio.circulation.support.Result;
 import org.folio.circulation.support.ServerErrorFailure;

--- a/src/test/java/org/folio/circulation/support/results/ResultAfterTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultAfterTests.java
@@ -8,7 +8,7 @@ import static org.folio.circulation.support.results.ResultExamples.alreadyFailed
 import static org.folio.circulation.support.results.ResultExamples.shouldNotExecute;
 import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.ExecutionException;
 
@@ -33,7 +33,7 @@ public class ResultAfterTests {
   public void shouldFailWhenAlreadyFailed()
     throws ExecutionException,
     InterruptedException {
-    
+
     final Result<Integer> result = alreadyFailed()
       .<Integer>after(value -> { throw shouldNotExecute(); })
       .get();

--- a/src/test/java/org/folio/circulation/support/results/ResultAfterWhenTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultAfterWhenTests.java
@@ -9,7 +9,7 @@ import static org.folio.circulation.support.results.ResultExamples.conditionFail
 import static org.folio.circulation.support.results.ResultExamples.shouldNotExecute;
 import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.ExecutionException;
 

--- a/src/test/java/org/folio/circulation/support/results/ResultApplySideEffectTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultApplySideEffectTests.java
@@ -5,7 +5,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/src/test/java/org/folio/circulation/support/results/ResultCombineAfterTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultCombineAfterTests.java
@@ -8,7 +8,7 @@ import static org.folio.circulation.support.results.ResultExamples.alreadyFailed
 import static org.folio.circulation.support.results.ResultExamples.shouldNotExecute;
 import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.ExecutionException;
 

--- a/src/test/java/org/folio/circulation/support/results/ResultFailAfterTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultFailAfterTests.java
@@ -9,7 +9,7 @@ import static org.folio.circulation.support.results.ResultExamples.conditionFail
 import static org.folio.circulation.support.results.ResultExamples.exampleFailure;
 import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.ExecutionException;
 

--- a/src/test/java/org/folio/circulation/support/results/ResultFailWhenTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultFailWhenTests.java
@@ -7,7 +7,7 @@ import static org.folio.circulation.support.results.ResultExamples.conditionFail
 import static org.folio.circulation.support.results.ResultExamples.exampleFailure;
 import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.folio.circulation.support.Result;
 import org.junit.Test;

--- a/src/test/java/org/folio/circulation/support/results/ResultFailureMappingTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultFailureMappingTests.java
@@ -6,7 +6,7 @@ import static org.folio.circulation.support.results.ResultExamples.actionFailed;
 import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
 import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.folio.circulation.support.Result;
 import org.junit.Test;

--- a/src/test/java/org/folio/circulation/support/results/ResultGetValueTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultGetValueTests.java
@@ -3,7 +3,7 @@ package org.folio.circulation.support.results;
 import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/org/folio/circulation/support/results/ResultInitialisationTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultInitialisationTests.java
@@ -5,7 +5,7 @@ import static org.folio.circulation.support.Result.of;
 import static org.folio.circulation.support.Result.ofAsync;
 import static org.folio.circulation.support.results.ResultExamples.*;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;

--- a/src/test/java/org/folio/circulation/support/results/ResultMappingTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultMappingTests.java
@@ -5,7 +5,7 @@ import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
 import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.folio.circulation.support.Result;
 import org.junit.Test;

--- a/src/test/java/org/folio/circulation/support/results/ResultNextTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultNextTests.java
@@ -5,7 +5,7 @@ import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.results.ResultExamples.alreadyFailed;
 import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.folio.circulation.support.Result;
 import org.junit.Test;

--- a/src/test/java/org/folio/circulation/support/results/ResultNextWhenTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultNextWhenTests.java
@@ -7,7 +7,7 @@ import static org.folio.circulation.support.results.ResultExamples.conditionFail
 import static org.folio.circulation.support.results.ResultExamples.throwOnExecution;
 import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.folio.circulation.support.Result;
 import org.junit.Test;


### PR DESCRIPTION
## Purpose
Remove multiple assertThat dependencies

Resolves: [CIRC-604](https://issues.folio.org/browse/CIRC-604)

## Approach 
- change org.junit.Assert.assertThat and org.hamcrest.junit.MatcherAssert.assertThat to org.hamcrest.MatcherAssert.assertThat;

Reason: 

- org.junit.Assert.assertThat() is deprecated as of JUnit 4.13.

- custom hamcrest matchers may include more detailed information about what exactly was wrong

- control version of Hamcrest


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
