### PR TITLE
CIRC-638 Claimed returned: prevent renewal

### DIFF
--- a/src/main/java/org/folio/circulation/resources/RegularRenewalStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/RegularRenewalStrategy.java
@@ -108,11 +108,13 @@ public class RegularRenewalStrategy implements RenewalStrategy {
           loan.getItemId()));
         return failedValidation(errors);
       }
+
       if (loan.hasItemWithStatus(ItemStatus.CLAIMED_RETURNED)) {
         errors.add(itemByIdValidationError(CLAIMED_RETURNED_RENEWED_ERROR,
           loan.getItemId()));
         return failedValidation(errors);
       }
+
       final Result<DateTime> proposedDueDateResult =
         loanPolicy.determineStrategy(null, true, isRenewalWithHoldRequest, systemDate)
           .calculateDueDate(loan);

--- a/src/main/java/org/folio/circulation/resources/RegularRenewalStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/RegularRenewalStrategy.java
@@ -4,6 +4,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.domain.RequestType.HOLD;
 import static org.folio.circulation.domain.RequestType.RECALL;
 import static org.folio.circulation.resources.RenewalValidator.CAN_NOT_RENEW_ITEM_ERROR;
+import static org.folio.circulation.resources.RenewalValidator.CLAIMED_RETURNED_RENEWED_ERROR;
 import static org.folio.circulation.resources.RenewalValidator.DECLARED_LOST_ITEM_RENEWED_ERROR;
 import static org.folio.circulation.resources.RenewalValidator.FIXED_POLICY_HAS_ALTERNATE_RENEWAL_PERIOD;
 import static org.folio.circulation.resources.RenewalValidator.FIXED_POLICY_HAS_ALTERNATE_RENEWAL_PERIOD_FOR_HOLDS;
@@ -104,6 +105,11 @@ public class RegularRenewalStrategy implements RenewalStrategy {
       }
       if (loan.hasItemWithStatus(ItemStatus.DECLARED_LOST)) {
         errors.add(itemByIdValidationError(DECLARED_LOST_ITEM_RENEWED_ERROR,
+          loan.getItemId()));
+        return failedValidation(errors);
+      }
+      if (loan.hasItemWithStatus(ItemStatus.CLAIMED_RETURNED)) {
+        errors.add(itemByIdValidationError(CLAIMED_RETURNED_RENEWED_ERROR,
           loan.getItemId()));
         return failedValidation(errors);
       }

--- a/src/main/java/org/folio/circulation/resources/RenewalValidator.java
+++ b/src/main/java/org/folio/circulation/resources/RenewalValidator.java
@@ -26,6 +26,7 @@ public final class RenewalValidator {
     "Item's loan policy has fixed profile but renewal period is specified";
 
   public static final String DECLARED_LOST_ITEM_RENEWED_ERROR = "item is Declared lost";
+  public static final String CLAIMED_RETURNED_RENEWED_ERROR = "item is Claimed returned";
 
   private RenewalValidator() {
 


### PR DESCRIPTION
## Purpose
Prevent users from renewing an item that is claim returned.

Resolves: [CIRC-638](https://issues.folio.org/browse/CIRC-638)

## Approach 
- add validation if an item is  claim returned;

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.