### PR TITLE
CIRC-653 Use safe methods to get JSON properties

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicy.java
@@ -1,5 +1,8 @@
 package org.folio.circulation.domain.policy;
 
+import static org.folio.circulation.support.JsonPropertyFetcher.getBooleanProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getDoubleProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getObjectProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 
 import io.vertx.core.json.JsonObject;
@@ -26,12 +29,13 @@ public class OverdueFinePolicy extends Policy {
     return new OverdueFinePolicy(
       getProperty(json, "id"),
       getProperty(json, "name"),
-      json.getJsonObject("overdueFine").getDouble("quantity"),
-      OverdueFineInterval.fromValue(json.getJsonObject("overdueFine").getString("intervalId")),
-      new OverdueFinePolicyLimitInfo(json.getDouble("maxOverdueFine"),
-        json.getDouble("maxOverdueRecallFine")),
-      json.getBoolean("gracePeriodRecall"),
-      json.getBoolean("countClosed"));
+      getDoubleProperty(getObjectProperty(json, "overdueFine"), "quantity", null),
+      OverdueFineInterval.fromValue(
+        getProperty(getObjectProperty(json, "overdueFine"), "intervalId")),
+      new OverdueFinePolicyLimitInfo(getDoubleProperty(json, "maxOverdueFine", null),
+        getDoubleProperty(json, "maxOverdueRecallFine", null)),
+      getBooleanProperty(json, "gracePeriodRecall"),
+      getBooleanProperty(json, "countClosed"));
   }
 
   public Double getOverdueFine() {

--- a/src/main/java/org/folio/circulation/support/JsonPropertyFetcher.java
+++ b/src/main/java/org/folio/circulation/support/JsonPropertyFetcher.java
@@ -154,6 +154,18 @@ public class JsonPropertyFetcher {
     }
   }
 
+  public static Double getDoubleProperty(
+    JsonObject representation,
+    String propertyName,
+    Double defaultValue) {
+
+    if (representation != null) {
+      return representation.getDouble(propertyName, defaultValue);
+    } else {
+      return defaultValue;
+    }
+  }
+
   public static void copyProperty(
     JsonObject from,
     JsonObject to,


### PR DESCRIPTION
Resolves [CIRC-653](https://issues.folio.org/browse/CIRC-653).

NullPointerException was being thrown for overdue fine policies without `overdueFine` property. This PR fixes this issue and other similar potential issues in OverdueFinePolicy by using safer methods for getting JSON properties.