### PR TITLE
CIRC-664 Fix NPE for pre-configured policies

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicy.java
@@ -49,11 +49,11 @@ public class OverdueFinePolicy extends Policy {
   }
 
   public Double getMaxOverdueFine() {
-    return limitInfo == null ? null : limitInfo.getMaxOverdueFine();
+    return limitInfo.getMaxOverdueFine();
   }
 
   public Double getMaxOverdueRecallFine() {
-    return limitInfo == null ? null : limitInfo.getMaxOverdueRecallFine();
+    return limitInfo.getMaxOverdueRecallFine();
   }
 
   public Boolean getIgnoreGracePeriodForRecalls() {

--- a/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicy.java
@@ -49,11 +49,11 @@ public class OverdueFinePolicy extends Policy {
   }
 
   public Double getMaxOverdueFine() {
-    return limitInfo.getMaxOverdueFine();
+    return limitInfo == null ? null : limitInfo.getMaxOverdueFine();
   }
 
   public Double getMaxOverdueRecallFine() {
-    return limitInfo.getMaxOverdueRecallFine();
+    return limitInfo == null ? null : limitInfo.getMaxOverdueRecallFine();
   }
 
   public Boolean getIgnoreGracePeriodForRecalls() {
@@ -70,7 +70,7 @@ public class OverdueFinePolicy extends Policy {
 
   private static class UnknownOverdueFinePolicy extends OverdueFinePolicy {
     UnknownOverdueFinePolicy(String id) {
-      super(id, null, null, null, null, null, null);
+      super(id, null, null, null, new OverdueFinePolicyLimitInfo(null, null), false, false);
     }
   }
 }

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -598,7 +598,7 @@ public class CheckInByBarcodeTests extends APITests {
   }
 
   @Test
-  public void overdueFineShouldBeChargedWhenItemIsOverdue() throws InterruptedException {
+  public void overdueFineShouldBeChargedWhenItemIsOverdue() {
     useFallbackPolicies(loanPoliciesFixture.canCirculateRolling().getId(),
       requestPoliciesFixture.allowAllRequestPolicy().getId(),
       noticePoliciesFixture.activeNotice().getId(),
@@ -674,6 +674,55 @@ public class CheckInByBarcodeTests extends APITests {
     assertThat("user ID is included",
       account.getString("userId"), is(loan.getJson().getString("userId")));
     assertThat("item ID is included", account.getString("itemId"), is(nod.getId()));
+  }
+
+  @Test
+  public void noOverdueFineShouldBeChargedForOverdueFinePolicyWithNoOverdueFine()
+    throws InterruptedException {
+
+    useFallbackPolicies(loanPoliciesFixture.canCirculateRolling().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.activeNotice().getId(),
+      overdueFinePoliciesFixture.noOverdueFine().getId(),
+      lostItemFeePoliciesFixture.facultyStandard().getId());
+
+    final IndividualResource james = usersFixture.james();
+    final UUID checkInServicePointId = servicePointsFixture.cd1().getId();
+    final IndividualResource homeLocation = locationsFixture.basedUponExampleLocation(
+      item -> item.withPrimaryServicePoint(checkInServicePointId));
+    final IndividualResource nod = itemsFixture.basedUponNod(item ->
+      item.withPermanentLocation(homeLocation.getId()));
+
+    loansFixture.checkOutByBarcode(nod, james,
+      new DateTime(2020, 1, 1, 12, 0, 0, DateTimeZone.UTC));
+
+    JsonObject servicePointOwner = new JsonObject();
+    servicePointOwner.put("value", homeLocation.getJson().getString("primaryServicePoint"));
+    servicePointOwner.put("label", "label");
+    UUID ownerId = UUID.randomUUID();
+    feeFineOwnersClient.create(new FeeFineOwnerBuilder()
+      .withId(ownerId)
+      .withOwner("fee-fine-owner")
+      .withServicePointOwner(Collections.singletonList(servicePointOwner))
+    );
+
+    UUID feeFineId = UUID.randomUUID();
+    feeFinesClient.create(new FeeFineBuilder()
+      .withId(feeFineId)
+      .withFeeFineType("Overdue fine")
+      .withOwnerId(ownerId)
+    );
+
+    loansFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
+      .forItem(nod)
+      .on(new DateTime(2020, 1, 25, 12, 0, 0, DateTimeZone.UTC))
+      .at(checkInServicePointId));
+
+    TimeUnit.SECONDS.sleep(1);
+
+    List<JsonObject> createdAccounts = accountsClient.getAll();
+
+    assertThat("Fee/fine record shouldn't be created", createdAccounts, empty());
   }
 
   private void checkPatronNoticeEvent(

--- a/src/test/java/api/support/fixtures/OverdueFinePoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/OverdueFinePoliciesFixture.java
@@ -2,6 +2,8 @@ package api.support.fixtures;
 
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 
+import java.util.UUID;
+
 import org.folio.circulation.support.http.client.IndividualResource;
 
 import api.support.builders.NoticePolicyBuilder;
@@ -63,6 +65,13 @@ public class OverdueFinePoliciesFixture {
       .withMaxOverdueRecallFine(50.00);
 
     return overdueFinePolicyRecordCreator.createIfAbsent(overdueFinePolicyBuilder);
+  }
+
+  public IndividualResource  noOverdueFine() {
+    JsonObject overdueFinePolicy = new JsonObject();
+    overdueFinePolicy.put("id", UUID.randomUUID().toString());
+    overdueFinePolicy.put("name", "No overdue fine policy");
+    return overdueFinePolicyRecordCreator.createIfAbsent(overdueFinePolicy);
   }
 
   public IndividualResource create(NoticePolicyBuilder noticePolicy) {

--- a/src/test/java/org/folio/circulation/domain/policy/OverdueFinePolicyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/OverdueFinePolicyTest.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.domain.policy;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
@@ -56,7 +56,7 @@ public class OverdueFinePolicyTest {
 
     OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
 
-    assertThat(overdueFinePolicy, notNullValue());
+    checkAllFieldsAndAssertThatQuantityIsNull(overdueFinePolicy);
   }
 
   @Test
@@ -66,7 +66,7 @@ public class OverdueFinePolicyTest {
 
     OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
 
-    assertThat(overdueFinePolicy, notNullValue());
+    checkAllFieldsAndAssertThatQuantityIsNull(overdueFinePolicy);
   }
 
   @Test
@@ -76,7 +76,7 @@ public class OverdueFinePolicyTest {
 
     OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
 
-    assertThat(overdueFinePolicy, notNullValue());
+    checkAllFieldsAndAssertThatIntervalIsNull(overdueFinePolicy);
   }
 
   @Test
@@ -86,7 +86,7 @@ public class OverdueFinePolicyTest {
 
     OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
 
-    assertThat(overdueFinePolicy, notNullValue());
+    checkAllFieldsAndAssertThatIntervalIsNull(overdueFinePolicy);
   }
 
   @Test
@@ -96,6 +96,99 @@ public class OverdueFinePolicyTest {
 
     OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
 
-    assertThat(overdueFinePolicy, notNullValue());
+    checkAllFieldsAndAssertThatQuantityAndIntervalAreNull(overdueFinePolicy);
+  }
+
+  @Test
+  public void shouldAcceptOverdueFinePolicyWithOnlyIdAndName() {
+    OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(new JsonObject()
+      .put("id", overdueFinePolicyJsonObject.getString("id"))
+      .put("name", "Overdue Fine Policy"));
+
+    assertThatAllFieldsHaveDefaultValuesExceptIdAndName(overdueFinePolicy);
+  }
+
+  @Test
+  public void shouldAcceptOverdueFinePolicyWithOnlyId() {
+    OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(new JsonObject()
+      .put("id", overdueFinePolicyJsonObject.getString("id")));
+
+    assertThatAllFieldsHaveDefaultValuesExceptId(overdueFinePolicy);
+  }
+
+  @Test
+  public void unknownPolicyShouldBeInitializedWithDefaultValues() {
+    assertThatAllFieldsHaveDefaultValuesExceptId(OverdueFinePolicy.unknown(
+      overdueFinePolicyJsonObject.getString("id")));
+  }
+
+  private void checkAllFieldsAndAssertThatQuantityIsNull(OverdueFinePolicy overdueFinePolicy) {
+    assertThat(overdueFinePolicy.getId(), is(overdueFinePolicyJsonObject.getString("id")));
+    assertThat(overdueFinePolicy.getName(), is(overdueFinePolicyJsonObject.getString("name")));
+    assertThat(overdueFinePolicy.getOverdueFineInterval(), is(OverdueFineInterval.fromValue(
+      overdueFinePolicyJsonObject.getJsonObject("overdueFine").getString("intervalId"))));
+    assertThat(overdueFinePolicy.getOverdueFine(), nullValue());
+    assertThat(overdueFinePolicy.getMaxOverdueFine(),
+      is(overdueFinePolicyJsonObject.getDouble("maxOverdueFine")));
+    assertThat(overdueFinePolicy.getMaxOverdueRecallFine(),
+      is(overdueFinePolicyJsonObject.getDouble("maxOverdueRecallFine")));
+    assertThat(overdueFinePolicy.getIgnoreGracePeriodForRecalls(),
+      is(overdueFinePolicyJsonObject.getBoolean("gracePeriodRecall")));
+    assertThat(overdueFinePolicy.getCountPeriodsWhenServicePointIsClosed(),
+      is(overdueFinePolicyJsonObject.getBoolean("countClosed")));
+  }
+
+  private void checkAllFieldsAndAssertThatIntervalIsNull(OverdueFinePolicy overdueFinePolicy) {
+    assertThat(overdueFinePolicy.getId(), is(overdueFinePolicyJsonObject.getString("id")));
+    assertThat(overdueFinePolicy.getName(), is(overdueFinePolicyJsonObject.getString("name")));
+    assertThat(overdueFinePolicy.getOverdueFineInterval(), nullValue());
+    assertThat(overdueFinePolicy.getOverdueFine(),
+      is(overdueFinePolicyJsonObject.getJsonObject("overdueFine").getDouble("quantity")));
+    assertThat(overdueFinePolicy.getMaxOverdueFine(),
+      is(overdueFinePolicyJsonObject.getDouble("maxOverdueFine")));
+    assertThat(overdueFinePolicy.getMaxOverdueRecallFine(),
+      is(overdueFinePolicyJsonObject.getDouble("maxOverdueRecallFine")));
+    assertThat(overdueFinePolicy.getIgnoreGracePeriodForRecalls(),
+      is(overdueFinePolicyJsonObject.getBoolean("gracePeriodRecall")));
+    assertThat(overdueFinePolicy.getCountPeriodsWhenServicePointIsClosed(),
+      is(overdueFinePolicyJsonObject.getBoolean("countClosed")));
+  }
+
+  private void checkAllFieldsAndAssertThatQuantityAndIntervalAreNull(
+    OverdueFinePolicy overdueFinePolicy) {
+    assertThat(overdueFinePolicy.getId(), is(overdueFinePolicyJsonObject.getString("id")));
+    assertThat(overdueFinePolicy.getName(), is(overdueFinePolicyJsonObject.getString("name")));
+    assertThat(overdueFinePolicy.getOverdueFineInterval(), nullValue());
+    assertThat(overdueFinePolicy.getOverdueFine(), nullValue());
+    assertThat(overdueFinePolicy.getMaxOverdueFine(),
+      is(overdueFinePolicyJsonObject.getDouble("maxOverdueFine")));
+    assertThat(overdueFinePolicy.getMaxOverdueRecallFine(),
+      is(overdueFinePolicyJsonObject.getDouble("maxOverdueRecallFine")));
+    assertThat(overdueFinePolicy.getIgnoreGracePeriodForRecalls(),
+      is(overdueFinePolicyJsonObject.getBoolean("gracePeriodRecall")));
+    assertThat(overdueFinePolicy.getCountPeriodsWhenServicePointIsClosed(),
+      is(overdueFinePolicyJsonObject.getBoolean("countClosed")));
+  }
+
+  private void assertThatAllFieldsHaveDefaultValuesExceptIdAndName(OverdueFinePolicy overdueFinePolicy) {
+    assertThat(overdueFinePolicy.getId(), is(overdueFinePolicyJsonObject.getString("id")));
+    assertThat(overdueFinePolicy.getName(), is(overdueFinePolicyJsonObject.getString("name")));
+    assertThat(overdueFinePolicy.getOverdueFineInterval(), nullValue());
+    assertThat(overdueFinePolicy.getOverdueFine(), nullValue());
+    assertThat(overdueFinePolicy.getMaxOverdueFine(), nullValue());
+    assertThat(overdueFinePolicy.getMaxOverdueRecallFine(), nullValue());
+    assertThat(overdueFinePolicy.getIgnoreGracePeriodForRecalls(), is(false));
+    assertThat(overdueFinePolicy.getCountPeriodsWhenServicePointIsClosed(), is(false));
+  }
+
+  private void assertThatAllFieldsHaveDefaultValuesExceptId(OverdueFinePolicy overdueFinePolicy) {
+    assertThat(overdueFinePolicy.getId(), is(overdueFinePolicyJsonObject.getString("id")));
+    assertThat(overdueFinePolicy.getName(), nullValue());
+    assertThat(overdueFinePolicy.getOverdueFineInterval(), nullValue());
+    assertThat(overdueFinePolicy.getOverdueFine(), nullValue());
+    assertThat(overdueFinePolicy.getMaxOverdueFine(), nullValue());
+    assertThat(overdueFinePolicy.getMaxOverdueRecallFine(), nullValue());
+    assertThat(overdueFinePolicy.getIgnoreGracePeriodForRecalls(), is(false));
+    assertThat(overdueFinePolicy.getCountPeriodsWhenServicePointIsClosed(), is(false));
   }
 }


### PR DESCRIPTION
[CIRC-664](https://issues.folio.org/browse/CIRC-664) POST requests to /circulation/check-in-by-barcode fail with 500, NPE
## Purpose
Integration tests are failing with NPE. The issue seems to not be reproducible from the UI, but it is possible to create "unknown" overdue fine policies internally that would cause such issue.
## Approach
- Change UnknownOverdueFinePolicy class to set default values
- Add checks for null
- Add unit tests to ensure that reading policy fields is not causing issues in these cases:
  - Policy was created from JSON with `id` field only
  - Policy was created from JSON with `id` and `name` fields only
  - Policy was created with `unknown()` factory method

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
