### PR TITLE
CIRC-678 Handle overdue recall correctly

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/OverdueFineCalculationParameters.java
+++ b/src/main/java/org/folio/circulation/domain/policy/OverdueFineCalculationParameters.java
@@ -1,0 +1,26 @@
+package org.folio.circulation.domain.policy;
+
+public class OverdueFineCalculationParameters {
+  private final Double finePerInterval;
+  private final OverdueFineInterval interval;
+  private final Double maxFine;
+
+  public OverdueFineCalculationParameters(Double finePerInterval, OverdueFineInterval interval,
+    Double maxFine) {
+    this.finePerInterval = finePerInterval;
+    this.interval = interval;
+    this.maxFine = maxFine;
+  }
+
+  public Double getFinePerInterval() {
+    return finePerInterval;
+  }
+
+  public OverdueFineInterval getInterval() {
+    return interval;
+  }
+
+  public Double getMaxFine() {
+    return maxFine;
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicy.java
@@ -2,9 +2,11 @@ package org.folio.circulation.domain.policy;
 
 import static org.folio.circulation.support.JsonPropertyFetcher.getBooleanProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getDoubleProperty;
-import static org.folio.circulation.support.JsonPropertyFetcher.getObjectProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getNestedStringProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getObjectProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
+
+import org.apache.commons.lang3.ObjectUtils;
 
 import io.vertx.core.json.JsonObject;
 
@@ -41,6 +43,26 @@ public class OverdueFinePolicy extends Policy {
         getDoubleProperty(json, "maxOverdueRecallFine", null)),
       getBooleanProperty(json, "gracePeriodRecall"),
       getBooleanProperty(json, "countClosed"));
+  }
+
+  public OverdueFineCalculationParameters getCalculationParameters(boolean dueDateChangedByRecall) {
+    if (dueDateChangedByRecall) {
+      if (ObjectUtils.allNotNull(fineInfo.getOverdueRecallFine(),
+        fineInfo.getOverdueRecallFineInterval(), limitInfo.getMaxOverdueRecallFine())) {
+
+        return new OverdueFineCalculationParameters(fineInfo.getOverdueRecallFine(),
+          fineInfo.getOverdueRecallFineInterval(), limitInfo.getMaxOverdueRecallFine());
+      }
+    }
+    else {
+      if (ObjectUtils.allNotNull(fineInfo.getOverdueFine(), fineInfo.getOverdueFineInterval(),
+        limitInfo.getMaxOverdueFine())) {
+
+        return new OverdueFineCalculationParameters(fineInfo.getOverdueFine(),
+          fineInfo.getOverdueFineInterval(), limitInfo.getMaxOverdueFine());
+      }
+    }
+    return null;
   }
 
   public OverdueFinePolicyFineInfo getFineInfo() {

--- a/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicyFineInfo.java
+++ b/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicyFineInfo.java
@@ -1,0 +1,32 @@
+package org.folio.circulation.domain.policy;
+
+public class OverdueFinePolicyFineInfo {
+  private final Double overdueFine;
+  private final OverdueFineInterval overdueFineInterval;
+  private final Double overdueRecallFine;
+  private final OverdueFineInterval overdueRecallFineInterval;
+
+  public OverdueFinePolicyFineInfo(Double overdueFine, OverdueFineInterval overdueFineInterval,
+    Double overdueRecallFine, OverdueFineInterval overdueRecallFineInterval) {
+    this.overdueFine = overdueFine;
+    this.overdueFineInterval = overdueFineInterval;
+    this.overdueRecallFine = overdueRecallFine;
+    this.overdueRecallFineInterval = overdueRecallFineInterval;
+  }
+
+  public Double getOverdueFine() {
+    return overdueFine;
+  }
+
+  public OverdueFineInterval getOverdueFineInterval() {
+    return overdueFineInterval;
+  }
+
+  public Double getOverdueRecallFine() {
+    return overdueRecallFine;
+  }
+
+  public OverdueFineInterval getOverdueRecallFineInterval() {
+    return overdueRecallFineInterval;
+  }
+}

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
 import org.folio.circulation.domain.User;
-import org.folio.circulation.domain.representations.ItemProperties;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.hamcrest.Matcher;
@@ -53,6 +52,7 @@ import api.support.builders.RequestBuilder;
 import api.support.fixtures.TemplateContextMatchers;
 import api.support.http.CqlQuery;
 import api.support.http.InventoryItemResource;
+import api.support.matchers.OverdueFineMatcher;
 import io.vertx.core.json.JsonObject;
 
 public class CheckInByBarcodeTests extends APITests {
@@ -646,34 +646,9 @@ public class CheckInByBarcodeTests extends APITests {
     assertThat("Fee/fine record should be created", createdAccounts, hasSize(1));
 
     JsonObject account = createdAccounts.get(0);
-    assertThat("owner ID is included",
-      account.getString("ownerId"), is(ownerId.toString()));
-    assertThat("fee/fine ID is included",
-      account.getString("feeFineId"), is(feeFineId.toString()));
-    assertThat("amount is correct", account.getDouble("amount"), is(5.0));
-    assertThat("remaining is the same as amount",
-      account.getDouble("remaining"), is(5.0));
-    assertThat("correct fee/fine type is included",
-      account.getString("feeFineType"), is("Overdue fine"));
-    assertThat("fee/fine owner is included",
-      account.getString("feeFineOwner"), is("fee-fine-owner"));
-    assertThat("item's title is included",
-      account.getString("title"), is(loan.getJson().getJsonObject("item").getString("title")));
-    assertThat("item's barcode is included",
-      account.getString("barcode"), is(nod.getJson().getString("barcode")));
-    assertThat("call number from the item is included",
-      account.getString("callNumber"),
-      is(nod.getJson().getJsonObject("effectiveCallNumberComponents").getString("callNumber")));
-    assertThat("effective location ID is included",
-      account.getString("location"),
-      is(servicePointsFixture.cd1().getId()));
-    assertThat("item's material type is included",
-      account.getString("materialTypeId"),
-      is(nod.getJson().getString(ItemProperties.MATERIAL_TYPE_ID)));
-    assertThat("loan ID is included", account.getString("loanId"), is(loan.getId()));
-    assertThat("user ID is included",
-      account.getString("userId"), is(loan.getJson().getString("userId")));
-    assertThat("item ID is included", account.getString("itemId"), is(nod.getId()));
+
+    assertThat(account, OverdueFineMatcher.isValidOverdueFine(loan, nod,
+      servicePointsFixture.cd1().getId(), ownerId, feeFineId, 5.0));
   }
 
   @Test
@@ -742,34 +717,9 @@ public class CheckInByBarcodeTests extends APITests {
     assertThat("Fee/fine record should be created", createdAccounts, hasSize(1));
 
     JsonObject account = createdAccounts.get(0);
-    assertThat("owner ID is included",
-      account.getString("ownerId"), is(ownerId.toString()));
-    assertThat("fee/fine ID is included",
-      account.getString("feeFineId"), is(feeFineId.toString()));
-    assertThat("amount is correct", account.getDouble("amount"), is(10.0));
-    assertThat("remaining is the same as amount",
-      account.getDouble("remaining"), is(10.0));
-    assertThat("correct fee/fine type is included",
-      account.getString("feeFineType"), is("Overdue fine"));
-    assertThat("fee/fine owner is included",
-      account.getString("feeFineOwner"), is("fee-fine-owner"));
-    assertThat("item's title is included",
-      account.getString("title"), is(loan.getJson().getJsonObject("item").getString("title")));
-    assertThat("item's barcode is included",
-      account.getString("barcode"), is(nod.getJson().getString("barcode")));
-    assertThat("call number from the item is included",
-      account.getString("callNumber"),
-      is(nod.getJson().getJsonObject("effectiveCallNumberComponents").getString("callNumber")));
-    assertThat("effective location ID is included",
-      account.getString("location"),
-      is(servicePointsFixture.cd1().getId()));
-    assertThat("item's material type is included",
-      account.getString("materialTypeId"),
-      is(nod.getJson().getString(ItemProperties.MATERIAL_TYPE_ID)));
-    assertThat("loan ID is included", account.getString("loanId"), is(loan.getId()));
-    assertThat("user ID is included",
-      account.getString("userId"), is(loan.getJson().getString("userId")));
-    assertThat("item ID is included", account.getString("itemId"), is(nod.getId()));
+
+    assertThat(account, OverdueFineMatcher.isValidOverdueFine(loan, nod,
+      servicePointsFixture.cd1().getId(), ownerId, feeFineId, 10.0));
   }
 
   @Test

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -42,14 +42,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.awaitility.Awaitility;
 import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.Period;
-import org.folio.circulation.domain.representations.ItemProperties;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.hamcrest.core.Is;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeConstants;
 import org.joda.time.DateTimeUtils;
@@ -59,9 +57,9 @@ import org.junit.Test;
 
 import api.support.APITests;
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
+import api.support.builders.ClaimItemReturnedRequestBuilder;
 import api.support.builders.FeeFineBuilder;
 import api.support.builders.FeeFineOwnerBuilder;
-import api.support.builders.ClaimItemReturnedRequestBuilder;
 import api.support.builders.FixedDueDateSchedule;
 import api.support.builders.FixedDueDateSchedulesBuilder;
 import api.support.builders.ItemBuilder;
@@ -73,7 +71,7 @@ import api.support.fixtures.ConfigurationExample;
 import api.support.fixtures.ItemExamples;
 import api.support.fixtures.TemplateContextMatchers;
 import api.support.http.InventoryItemResource;
-import api.support.matchers.UUIDMatcher;
+import api.support.matchers.OverdueFineMatcher;
 import io.vertx.core.json.JsonObject;
 
 abstract class RenewalAPITests extends APITests {
@@ -1355,33 +1353,9 @@ abstract class RenewalAPITests extends APITests {
     org.hamcrest.junit.MatcherAssert.assertThat("Fee/fine record should be created", createdAccounts, hasSize(1));
 
     JsonObject account = createdAccounts.get(0);
-    assertThat("owner ID is included",
-      account.getString("ownerId"), is(ownerId.toString()));
-    assertThat("fee/fine ID is included",
-      account.getString("feeFineId"), is(feeFineId.toString()));
-    assertThat("amount is correct", account.getDouble("amount"), is(5.0));
-    assertThat("remaining is the same as amount",
-      account.getDouble("remaining"), is(5.0));
-    assertThat("correct fee/fine type is included",
-      account.getString("feeFineType"), is("Overdue fine"));
-    assertThat("fee/fine owner is included",
-      account.getString("feeFineOwner"), is("fee-fine-owner"));
-    assertThat("item's title is included",
-      account.getString("title"), is(loan.getJson().getJsonObject("item").getString("title")));
-    assertThat("item's barcode is included",
-      account.getString("barcode"), is(nod.getJson().getString("barcode")));
-    assertThat("call number from the item is included",
-      account.getString("callNumber"),
-      is(nod.getJson().getJsonObject("effectiveCallNumberComponents").getString("callNumber")));
-    assertThat("effective location ID is included",
-      account.getString("location"), UUIDMatcher.is(servicePointsFixture.cd1().getId()));
-    assertThat("item's material type is included",
-      account.getString("materialTypeId"),
-      is(nod.getJson().getString(ItemProperties.MATERIAL_TYPE_ID)));
-    assertThat("loan ID is included", account.getString("loanId"), UUIDMatcher.is(loan.getId()));
-    assertThat("user ID is included",
-      account.getString("userId"), is(loan.getJson().getString("userId")));
-    assertThat("item ID is included", account.getString("itemId"), UUIDMatcher.is(nod.getId()));
+
+    assertThat(account, OverdueFineMatcher.isValidOverdueFine(loan, nod,
+      servicePointsFixture.cd1().getId(), ownerId, feeFineId, 5.0));
   }
 
   private void checkRenewalAttempt(DateTime expectedDueDate, UUID dueDateLimitedPolicyId) {

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -258,6 +258,7 @@ public abstract class APITests {
     holdingsClient.deleteAll();
     instancesClient.deleteAll();
     configClient.deleteAll();
+    accountsClient.deleteAll();
 
     //TODO: Only cleans up reference records, move items, holdings records
     // and instances into here too

--- a/src/test/java/api/support/matchers/OverdueFineMatcher.java
+++ b/src/test/java/api/support/matchers/OverdueFineMatcher.java
@@ -1,0 +1,37 @@
+package api.support.matchers;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.core.Is.is;
+
+import java.util.UUID;
+
+import org.folio.circulation.domain.representations.ItemProperties;
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.hamcrest.Matcher;
+
+import io.vertx.core.json.JsonObject;
+
+public class OverdueFineMatcher {
+
+  public static Matcher<JsonObject> isValidOverdueFine(IndividualResource loan,
+    IndividualResource item, UUID servicePointId, UUID ownerId, UUID feeFineId, Double amount) {
+    return JsonObjectMatcher.allOfPaths(
+      hasJsonPath("ownerId", is(ownerId.toString())),
+      hasJsonPath("feeFineId", is(feeFineId.toString())),
+      hasJsonPath("amount", is(amount)),
+      hasJsonPath("remaining", is(amount)),
+      hasJsonPath("feeFineType", is("Overdue fine")),
+      hasJsonPath("feeFineOwner", is("fee-fine-owner")),
+      hasJsonPath("title", is(loan.getJson().getJsonObject("item").getString("title"))),
+      hasJsonPath("barcode", is(item.getJson().getString("barcode"))),
+      hasJsonPath("callNumber", is(item.getJson().getJsonObject("effectiveCallNumberComponents")
+        .getString("callNumber"))),
+      hasJsonPath("location", UUIDMatcher.is(servicePointId)),
+      hasJsonPath("materialTypeId", is(item.getJson().getString(ItemProperties.MATERIAL_TYPE_ID))),
+      hasJsonPath("loanId", UUIDMatcher.is(loan.getId())),
+      hasJsonPath("userId", is(loan.getJson().getString("userId"))),
+      hasJsonPath("itemId", UUIDMatcher.is(item.getId()))
+    );
+  }
+
+}

--- a/src/test/java/org/folio/circulation/domain/OverdueFineCalculatorServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverdueFineCalculatorServiceTest.java
@@ -112,9 +112,9 @@ public class OverdueFineCalculatorServiceTest {
         parameters.add(new Object[]
           {false, 1.0, interval, 10.0, 1.0, interval, 10.0, 15 * minutesInInterval, 10.0});
         parameters.add(new Object[]
-          {true, 1.0, interval, 10.0, 1.0, interval, 10.0, 5 * minutesInInterval, 5.0});
+          {true, 1.0, interval, 10.0, 3.0, interval, 30.0, 5 * minutesInInterval, 15.0});
         parameters.add(new Object[]
-          {true, 1.0, interval, 10.0, 1.0, interval, 10.0, 15 * minutesInInterval, 10.0});
+          {true, 1.0, interval, 10.0, 3.0, interval, 30.0, 15 * minutesInInterval, 30.0});
       });
     return parameters;
   }

--- a/src/test/java/org/folio/circulation/domain/policy/OverdueFinePolicyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/OverdueFinePolicyTest.java
@@ -173,6 +173,30 @@ public class OverdueFinePolicyTest {
     assertThatAllFieldsHaveDefaultValuesExceptId();
   }
 
+  @Test
+  public void calculationParametersAreCorrectForValidJsonRepresentation() {
+    overdueFinePolicy = OverdueFinePolicy.from(overdueFinePolicyJsonObject);
+
+    OverdueFineCalculationParameters calculationParameters =
+      overdueFinePolicy.getCalculationParameters(false);
+    assertThat(calculationParameters.getFinePerInterval(), is(5.0));
+    assertThat(calculationParameters.getInterval(), is(OverdueFineInterval.MINUTE));
+    assertThat(calculationParameters.getMaxFine(), is(10.0));
+
+    OverdueFineCalculationParameters recallCalculationParameters =
+      overdueFinePolicy.getCalculationParameters(true);
+    assertThat(recallCalculationParameters.getFinePerInterval(), is(6.0));
+    assertThat(recallCalculationParameters.getInterval(), is(OverdueFineInterval.HOUR));
+    assertThat(recallCalculationParameters.getMaxFine(), is(12.0));
+  }
+
+  @Test
+  public void calculationParametersIsNullForUnknownPolicy() {
+    overdueFinePolicy = OverdueFinePolicy.unknown(overdueFinePolicyJsonObject.getString("id"));
+    assertThat(overdueFinePolicy.getCalculationParameters(false), nullValue());
+    assertThat(overdueFinePolicy.getCalculationParameters(true), nullValue());
+  }
+
   private void checkAllFieldsAndAssertThatQuantityIsNull() {
     checkId();
     checkName();

--- a/src/test/java/org/folio/circulation/domain/policy/OverdueFinePolicyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/OverdueFinePolicyTest.java
@@ -15,6 +15,8 @@ public class OverdueFinePolicyTest {
 
   private static JsonObject overdueFinePolicyJsonObject;
 
+  private OverdueFinePolicy overdueFinePolicy;
+
   @Before
   public void setUp() {
     overdueFinePolicyJsonObject = new JsonObject()
@@ -23,30 +25,29 @@ public class OverdueFinePolicyTest {
       .put("overdueFine", new JsonObject()
         .put("intervalId", "minute")
         .put("quantity", 5.0))
+      .put("overdueRecallFine", new JsonObject()
+        .put("intervalId", "hour")
+        .put("quantity", 6.0))
       .put("maxOverdueFine", 10.0)
-      .put("maxOverdueRecallFine", 10.0)
+      .put("maxOverdueRecallFine", 12.0)
       .put("gracePeriodRecall", true)
       .put("countClosed", true);
   }
 
   @Test
   public void shouldAcceptValidJsonRepresentation() {
-    OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(overdueFinePolicyJsonObject);
+    overdueFinePolicy = OverdueFinePolicy.from(overdueFinePolicyJsonObject);
 
-    assertThat(overdueFinePolicy.getId(), is(overdueFinePolicyJsonObject.getString("id")));
-    assertThat(overdueFinePolicy.getName(), is(overdueFinePolicyJsonObject.getString("name")));
-    assertThat(overdueFinePolicy.getOverdueFineInterval(), is(OverdueFineInterval.fromValue(
-      overdueFinePolicyJsonObject.getJsonObject("overdueFine").getString("intervalId"))));
-    assertThat(overdueFinePolicy.getOverdueFine(),
-      is(overdueFinePolicyJsonObject.getJsonObject("overdueFine").getDouble("quantity")));
-    assertThat(overdueFinePolicy.getMaxOverdueFine(),
-      is(overdueFinePolicyJsonObject.getDouble("maxOverdueFine")));
-    assertThat(overdueFinePolicy.getMaxOverdueRecallFine(),
-      is(overdueFinePolicyJsonObject.getDouble("maxOverdueRecallFine")));
-    assertThat(overdueFinePolicy.getIgnoreGracePeriodForRecalls(),
-      is(overdueFinePolicyJsonObject.getBoolean("gracePeriodRecall")));
-    assertThat(overdueFinePolicy.getCountPeriodsWhenServicePointIsClosed(),
-      is(overdueFinePolicyJsonObject.getBoolean("countClosed")));
+    checkId();
+    checkName();
+    checkOverdueFineInterval();
+    checkOverdueFineQuantity();
+    checkOverdueRecallFineInterval();
+    checkOverdueRecallFineQuantity();
+    checkMaxOverdueFine();
+    checkMaxOverdueRecallFine();
+    checkIgnoreGracePeriodForRecalls();
+    checkCountPeriodsWhenServicePointIsClosed();
   }
 
   @Test
@@ -54,9 +55,9 @@ public class OverdueFinePolicyTest {
     JsonObject jsonObject = overdueFinePolicyJsonObject.copy();
     jsonObject.getJsonObject("overdueFine").remove("quantity");
 
-    OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
+    overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
 
-    checkAllFieldsAndAssertThatQuantityIsNull(overdueFinePolicy);
+    checkAllFieldsAndAssertThatQuantityIsNull();
   }
 
   @Test
@@ -64,9 +65,9 @@ public class OverdueFinePolicyTest {
     JsonObject jsonObject = overdueFinePolicyJsonObject.copy();
     jsonObject.getJsonObject("overdueFine").put("quantity", (Double) null);
 
-    OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
+    overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
 
-    checkAllFieldsAndAssertThatQuantityIsNull(overdueFinePolicy);
+    checkAllFieldsAndAssertThatQuantityIsNull();
   }
 
   @Test
@@ -74,9 +75,9 @@ public class OverdueFinePolicyTest {
     JsonObject jsonObject = overdueFinePolicyJsonObject.copy();
     jsonObject.getJsonObject("overdueFine").remove("intervalId");
 
-    OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
+    overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
 
-    checkAllFieldsAndAssertThatIntervalIsNull(overdueFinePolicy);
+    checkAllFieldsAndAssertThatIntervalIsNull();
   }
 
   @Test
@@ -84,9 +85,9 @@ public class OverdueFinePolicyTest {
     JsonObject jsonObject = overdueFinePolicyJsonObject.copy();
     jsonObject.getJsonObject("overdueFine").put("intervalId", (String) null);
 
-    OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
+    overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
 
-    checkAllFieldsAndAssertThatIntervalIsNull(overdueFinePolicy);
+    checkAllFieldsAndAssertThatIntervalIsNull();
   }
 
   @Test
@@ -94,101 +95,234 @@ public class OverdueFinePolicyTest {
     JsonObject jsonObject = overdueFinePolicyJsonObject.copy();
     jsonObject.remove("overdueFine");
 
-    OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
+    overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
 
-    checkAllFieldsAndAssertThatQuantityAndIntervalAreNull(overdueFinePolicy);
+    checkAllFieldsAndAssertThatQuantityAndIntervalAreNull();
+  }
+
+  @Test
+  public void shouldAcceptOverdueFinePolicyWithMissingOverdueRecallFineQuantity() {
+    JsonObject jsonObject = overdueFinePolicyJsonObject.copy();
+    jsonObject.getJsonObject("overdueRecallFine").remove("quantity");
+
+    overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
+
+    checkAllFieldsAndAssertThatRecallQuantityIsNull();
+  }
+
+  @Test
+  public void shouldAcceptOverdueFinePolicyWithNullOverdueRecallFineQuantity() {
+    JsonObject jsonObject = overdueFinePolicyJsonObject.copy();
+    jsonObject.getJsonObject("overdueRecallFine").put("quantity", (Double) null);
+
+    overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
+
+    checkAllFieldsAndAssertThatRecallQuantityIsNull();
+  }
+
+  @Test
+  public void shouldAcceptOverdueFinePolicyWithMissingOverdueRecallFineInterval() {
+    JsonObject jsonObject = overdueFinePolicyJsonObject.copy();
+    jsonObject.getJsonObject("overdueRecallFine").remove("intervalId");
+
+    overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
+
+    checkAllFieldsAndAssertThatRecallIntervalIsNull();
+  }
+
+  @Test
+  public void shouldAcceptOverdueFinePolicyWithNullOverdueRecallFineInterval() {
+    JsonObject jsonObject = overdueFinePolicyJsonObject.copy();
+    jsonObject.getJsonObject("overdueRecallFine").put("intervalId", (String) null);
+
+    overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
+
+    checkAllFieldsAndAssertThatRecallIntervalIsNull();
+  }
+
+  @Test
+  public void shouldAcceptOverdueFinePolicyWithOverdueRecallFineMissing() {
+    JsonObject jsonObject = overdueFinePolicyJsonObject.copy();
+    jsonObject.remove("overdueRecallFine");
+
+    overdueFinePolicy = OverdueFinePolicy.from(jsonObject);
+
+    checkAllFieldsAndAssertThatRecallQuantityAndIntervalAreNull();
   }
 
   @Test
   public void shouldAcceptOverdueFinePolicyWithOnlyIdAndName() {
-    OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(new JsonObject()
+    overdueFinePolicy = OverdueFinePolicy.from(new JsonObject()
       .put("id", overdueFinePolicyJsonObject.getString("id"))
       .put("name", "Overdue Fine Policy"));
 
-    assertThatAllFieldsHaveDefaultValuesExceptIdAndName(overdueFinePolicy);
+    assertThatAllFieldsHaveDefaultValuesExceptIdAndName();
   }
 
   @Test
   public void shouldAcceptOverdueFinePolicyWithOnlyId() {
-    OverdueFinePolicy overdueFinePolicy = OverdueFinePolicy.from(new JsonObject()
+    overdueFinePolicy = OverdueFinePolicy.from(new JsonObject()
       .put("id", overdueFinePolicyJsonObject.getString("id")));
 
-    assertThatAllFieldsHaveDefaultValuesExceptId(overdueFinePolicy);
+    assertThatAllFieldsHaveDefaultValuesExceptId();
   }
 
   @Test
   public void unknownPolicyShouldBeInitializedWithDefaultValues() {
-    assertThatAllFieldsHaveDefaultValuesExceptId(OverdueFinePolicy.unknown(
-      overdueFinePolicyJsonObject.getString("id")));
+    overdueFinePolicy = OverdueFinePolicy.unknown(overdueFinePolicyJsonObject.getString("id"));
+    assertThatAllFieldsHaveDefaultValuesExceptId();
   }
 
-  private void checkAllFieldsAndAssertThatQuantityIsNull(OverdueFinePolicy overdueFinePolicy) {
-    assertThat(overdueFinePolicy.getId(), is(overdueFinePolicyJsonObject.getString("id")));
-    assertThat(overdueFinePolicy.getName(), is(overdueFinePolicyJsonObject.getString("name")));
-    assertThat(overdueFinePolicy.getOverdueFineInterval(), is(OverdueFineInterval.fromValue(
-      overdueFinePolicyJsonObject.getJsonObject("overdueFine").getString("intervalId"))));
-    assertThat(overdueFinePolicy.getOverdueFine(), nullValue());
-    assertThat(overdueFinePolicy.getMaxOverdueFine(),
-      is(overdueFinePolicyJsonObject.getDouble("maxOverdueFine")));
-    assertThat(overdueFinePolicy.getMaxOverdueRecallFine(),
-      is(overdueFinePolicyJsonObject.getDouble("maxOverdueRecallFine")));
-    assertThat(overdueFinePolicy.getIgnoreGracePeriodForRecalls(),
-      is(overdueFinePolicyJsonObject.getBoolean("gracePeriodRecall")));
-    assertThat(overdueFinePolicy.getCountPeriodsWhenServicePointIsClosed(),
-      is(overdueFinePolicyJsonObject.getBoolean("countClosed")));
+  private void checkAllFieldsAndAssertThatQuantityIsNull() {
+    checkId();
+    checkName();
+    checkOverdueFineInterval();
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueFine(), nullValue());
+    checkOverdueRecallFineInterval();
+    checkOverdueRecallFineQuantity();
+    checkMaxOverdueFine();
+    checkMaxOverdueRecallFine();
+    checkIgnoreGracePeriodForRecalls();
+    checkCountPeriodsWhenServicePointIsClosed();
   }
 
-  private void checkAllFieldsAndAssertThatIntervalIsNull(OverdueFinePolicy overdueFinePolicy) {
-    assertThat(overdueFinePolicy.getId(), is(overdueFinePolicyJsonObject.getString("id")));
-    assertThat(overdueFinePolicy.getName(), is(overdueFinePolicyJsonObject.getString("name")));
-    assertThat(overdueFinePolicy.getOverdueFineInterval(), nullValue());
-    assertThat(overdueFinePolicy.getOverdueFine(),
-      is(overdueFinePolicyJsonObject.getJsonObject("overdueFine").getDouble("quantity")));
-    assertThat(overdueFinePolicy.getMaxOverdueFine(),
-      is(overdueFinePolicyJsonObject.getDouble("maxOverdueFine")));
-    assertThat(overdueFinePolicy.getMaxOverdueRecallFine(),
-      is(overdueFinePolicyJsonObject.getDouble("maxOverdueRecallFine")));
-    assertThat(overdueFinePolicy.getIgnoreGracePeriodForRecalls(),
-      is(overdueFinePolicyJsonObject.getBoolean("gracePeriodRecall")));
-    assertThat(overdueFinePolicy.getCountPeriodsWhenServicePointIsClosed(),
-      is(overdueFinePolicyJsonObject.getBoolean("countClosed")));
+  private void checkAllFieldsAndAssertThatRecallQuantityIsNull() {
+    checkId();
+    checkName();
+    checkOverdueFineInterval();
+    checkOverdueFineQuantity();
+    checkOverdueRecallFineInterval();
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueRecallFine(), nullValue());
+    checkMaxOverdueFine();
+    checkMaxOverdueRecallFine();
+    checkIgnoreGracePeriodForRecalls();
+    checkCountPeriodsWhenServicePointIsClosed();
   }
 
-  private void checkAllFieldsAndAssertThatQuantityAndIntervalAreNull(
-    OverdueFinePolicy overdueFinePolicy) {
-    assertThat(overdueFinePolicy.getId(), is(overdueFinePolicyJsonObject.getString("id")));
-    assertThat(overdueFinePolicy.getName(), is(overdueFinePolicyJsonObject.getString("name")));
-    assertThat(overdueFinePolicy.getOverdueFineInterval(), nullValue());
-    assertThat(overdueFinePolicy.getOverdueFine(), nullValue());
-    assertThat(overdueFinePolicy.getMaxOverdueFine(),
-      is(overdueFinePolicyJsonObject.getDouble("maxOverdueFine")));
-    assertThat(overdueFinePolicy.getMaxOverdueRecallFine(),
-      is(overdueFinePolicyJsonObject.getDouble("maxOverdueRecallFine")));
-    assertThat(overdueFinePolicy.getIgnoreGracePeriodForRecalls(),
-      is(overdueFinePolicyJsonObject.getBoolean("gracePeriodRecall")));
-    assertThat(overdueFinePolicy.getCountPeriodsWhenServicePointIsClosed(),
-      is(overdueFinePolicyJsonObject.getBoolean("countClosed")));
+  private void checkAllFieldsAndAssertThatIntervalIsNull() {
+    checkId();
+    checkName();
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueFineInterval(), nullValue());
+    checkOverdueFineQuantity();
+    checkOverdueRecallFineInterval();
+    checkOverdueRecallFineQuantity();
+    checkMaxOverdueFine();
+    checkMaxOverdueRecallFine();
+    checkIgnoreGracePeriodForRecalls();
+    checkCountPeriodsWhenServicePointIsClosed();
   }
 
-  private void assertThatAllFieldsHaveDefaultValuesExceptIdAndName(OverdueFinePolicy overdueFinePolicy) {
-    assertThat(overdueFinePolicy.getId(), is(overdueFinePolicyJsonObject.getString("id")));
-    assertThat(overdueFinePolicy.getName(), is(overdueFinePolicyJsonObject.getString("name")));
-    assertThat(overdueFinePolicy.getOverdueFineInterval(), nullValue());
-    assertThat(overdueFinePolicy.getOverdueFine(), nullValue());
-    assertThat(overdueFinePolicy.getMaxOverdueFine(), nullValue());
-    assertThat(overdueFinePolicy.getMaxOverdueRecallFine(), nullValue());
+  private void checkAllFieldsAndAssertThatRecallIntervalIsNull() {
+    checkId();
+    checkName();
+    checkOverdueFineInterval();
+    checkOverdueFineQuantity();
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueRecallFineInterval(), nullValue());
+    checkOverdueRecallFineQuantity();
+    checkMaxOverdueFine();
+    checkMaxOverdueRecallFine();
+    checkIgnoreGracePeriodForRecalls();
+    checkCountPeriodsWhenServicePointIsClosed();
+  }
+
+  private void checkAllFieldsAndAssertThatQuantityAndIntervalAreNull() {
+    checkId();
+    checkName();
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueFineInterval(), nullValue());
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueFine(), nullValue());
+    checkOverdueRecallFineInterval();
+    checkOverdueRecallFineQuantity();
+    checkMaxOverdueFine();
+    checkMaxOverdueRecallFine();
+    checkIgnoreGracePeriodForRecalls();
+    checkCountPeriodsWhenServicePointIsClosed();
+  }
+
+  private void checkAllFieldsAndAssertThatRecallQuantityAndIntervalAreNull() {
+    checkId();
+    checkName();
+    checkOverdueFineInterval();
+    checkOverdueFineQuantity();
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueRecallFineInterval(), nullValue());
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueRecallFine(),nullValue());
+    checkMaxOverdueFine();
+    checkMaxOverdueRecallFine();
+    checkIgnoreGracePeriodForRecalls();
+    checkCountPeriodsWhenServicePointIsClosed();
+  }
+
+  private void assertThatAllFieldsHaveDefaultValuesExceptIdAndName() {
+    checkId();
+    checkName();
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueFineInterval(), nullValue());
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueFine(), nullValue());
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueFineInterval(), nullValue());
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueFine(),nullValue());
+    assertThat(overdueFinePolicy.getLimitInfo().getMaxOverdueFine(), nullValue());
+    assertThat(overdueFinePolicy.getLimitInfo().getMaxOverdueRecallFine(), nullValue());
     assertThat(overdueFinePolicy.getIgnoreGracePeriodForRecalls(), is(false));
     assertThat(overdueFinePolicy.getCountPeriodsWhenServicePointIsClosed(), is(false));
   }
 
-  private void assertThatAllFieldsHaveDefaultValuesExceptId(OverdueFinePolicy overdueFinePolicy) {
-    assertThat(overdueFinePolicy.getId(), is(overdueFinePolicyJsonObject.getString("id")));
+  private void assertThatAllFieldsHaveDefaultValuesExceptId() {
+    checkId();
     assertThat(overdueFinePolicy.getName(), nullValue());
-    assertThat(overdueFinePolicy.getOverdueFineInterval(), nullValue());
-    assertThat(overdueFinePolicy.getOverdueFine(), nullValue());
-    assertThat(overdueFinePolicy.getMaxOverdueFine(), nullValue());
-    assertThat(overdueFinePolicy.getMaxOverdueRecallFine(), nullValue());
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueFineInterval(), nullValue());
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueFine(), nullValue());
+    assertThat(overdueFinePolicy.getLimitInfo().getMaxOverdueFine(), nullValue());
+    assertThat(overdueFinePolicy.getLimitInfo().getMaxOverdueRecallFine(), nullValue());
     assertThat(overdueFinePolicy.getIgnoreGracePeriodForRecalls(), is(false));
     assertThat(overdueFinePolicy.getCountPeriodsWhenServicePointIsClosed(), is(false));
   }
+
+  private void checkId() {
+    assertThat(overdueFinePolicy.getId(), is(overdueFinePolicyJsonObject.getString("id")));
+  }
+
+  private void checkName() {
+    assertThat(overdueFinePolicy.getName(), is(overdueFinePolicyJsonObject.getString("name")));
+  }
+
+  private void checkOverdueFineInterval() {
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueFineInterval(),
+      is(OverdueFineInterval.fromValue(overdueFinePolicyJsonObject.getJsonObject("overdueFine")
+        .getString("intervalId"))));
+  }
+
+  private void checkOverdueFineQuantity() {
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueFine(),
+      is(overdueFinePolicyJsonObject.getJsonObject("overdueFine").getDouble("quantity")));
+  }
+
+  private void checkOverdueRecallFineInterval() {
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueRecallFineInterval(),
+      is(OverdueFineInterval.fromValue(
+        overdueFinePolicyJsonObject.getJsonObject("overdueRecallFine").getString("intervalId"))));
+  }
+
+  private void checkOverdueRecallFineQuantity() {
+    assertThat(overdueFinePolicy.getFineInfo().getOverdueRecallFine(),
+      is(overdueFinePolicyJsonObject.getJsonObject("overdueRecallFine").getDouble("quantity")));
+  }
+
+  private void checkMaxOverdueFine() {
+    assertThat(overdueFinePolicy.getLimitInfo().getMaxOverdueFine(),
+      is(overdueFinePolicyJsonObject.getDouble("maxOverdueFine")));
+  }
+
+  private void checkMaxOverdueRecallFine() {
+    assertThat(overdueFinePolicy.getLimitInfo().getMaxOverdueRecallFine(),
+      is(overdueFinePolicyJsonObject.getDouble("maxOverdueRecallFine")));
+  }
+
+  private void checkIgnoreGracePeriodForRecalls() {
+    assertThat(overdueFinePolicy.getIgnoreGracePeriodForRecalls(),
+      is(overdueFinePolicyJsonObject.getBoolean("gracePeriodRecall")));
+  }
+
+  private void checkCountPeriodsWhenServicePointIsClosed() {
+    assertThat(overdueFinePolicy.getCountPeriodsWhenServicePointIsClosed(),
+      is(overdueFinePolicyJsonObject.getBoolean("countClosed")));
+  }
+
 }


### PR DESCRIPTION
Fixes [CIRC-678](https://issues.folio.org/browse/CIRC-678)
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Currently, when loan's due date is changed by a recall request, `Overdue fine` (`quantity` and `interval`) field of the Overdue fine policy is being used for overdue fine calculation. We should use `Overdue recall fine` value instead.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
- Extend Overdue fine policy class to include "Overdue recall fine"
(quantity and interval).
- Use "Overdue recall fine" value for overdue fine calculation if
loan's due date was changed by a recall (instead of "Overdue fine"
value).
- Extend unit and API tests to cover a "recall" scenario.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
