### PR TITLE
[CIRC-681] Fix security vulnerability reported in jackson-databind >=2.9.0, <= 2.9.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.1</version>
+      <version>2.9.10.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Fixes [CIRC-681](https://issues.folio.org/browse/CIRC-681)

## Purpose
Currently, com.fasterxml.jackson.core:jackson-databind vulnerabilities found in pom.xml

## Approach
Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.9.10.3 or later
