### PR TITLE
[CIRC-684] No exception handling for notice-session-expiration-by-timeout

### DIFF
--- a/src/main/java/org/folio/circulation/domain/ConfigurationService.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationService.java
@@ -76,7 +76,7 @@ class ConfigurationService {
   }
 
   private Integer findTimeoutDuration(JsonObject configJson) {
-    return configJson.getInteger(CHECKOUT_TIMEOUT_DURATION_KEY, DEFAULT_CHECKOUT_TIMEOUT_DURATION_IN_MINUTES);
+    return Integer.parseInt(configJson.getValue(CHECKOUT_TIMEOUT_DURATION_KEY, DEFAULT_CHECKOUT_TIMEOUT_DURATION_IN_MINUTES).toString());
   }
 
   private Integer applySchedulerNoticesLimit(Configuration config) {

--- a/src/main/java/org/folio/circulation/domain/ConfigurationService.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationService.java
@@ -76,7 +76,15 @@ class ConfigurationService {
   }
 
   private Integer findTimeoutDuration(JsonObject configJson) {
-    return Integer.parseInt(configJson.getValue(CHECKOUT_TIMEOUT_DURATION_KEY, DEFAULT_CHECKOUT_TIMEOUT_DURATION_IN_MINUTES).toString());
+    try {
+      return Integer.parseInt(configJson
+        .getValue(CHECKOUT_TIMEOUT_DURATION_KEY, DEFAULT_CHECKOUT_TIMEOUT_DURATION_IN_MINUTES).toString());
+    } catch (NumberFormatException e) {
+      log.debug("Can't parse property {} {}. Will be returned default value: {}",
+        CHECKOUT_TIMEOUT_DURATION_KEY, e.getMessage(),
+        DEFAULT_CHECKOUT_TIMEOUT_DURATION_IN_MINUTES);
+      return DEFAULT_CHECKOUT_TIMEOUT_DURATION_IN_MINUTES;
+    }
   }
 
   private Integer applySchedulerNoticesLimit(Configuration config) {

--- a/src/main/java/org/folio/circulation/domain/ConfigurationService.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationService.java
@@ -80,7 +80,7 @@ class ConfigurationService {
       return Integer.parseInt(configJson
         .getValue(CHECKOUT_TIMEOUT_DURATION_KEY, DEFAULT_CHECKOUT_TIMEOUT_DURATION_IN_MINUTES).toString());
     } catch (NumberFormatException e) {
-      log.debug("Can't parse property {} {}. Will be returned default value: {}",
+      log.warn("Can't parse property {} {}. Will be returned default value: {}",
         CHECKOUT_TIMEOUT_DURATION_KEY, e.getMessage(),
         DEFAULT_CHECKOUT_TIMEOUT_DURATION_IN_MINUTES);
       return DEFAULT_CHECKOUT_TIMEOUT_DURATION_IN_MINUTES;

--- a/src/test/java/org/folio/circulation/domain/ConfigurationServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/ConfigurationServiceTest.java
@@ -21,6 +21,7 @@ public class ConfigurationServiceTest {
 
   private static ConfigurationService service;
 
+
   @BeforeClass
   public static void before() {
     service = new ConfigurationService();
@@ -66,7 +67,7 @@ public class ConfigurationServiceTest {
   }
 
   @Test
-  public void shouldCorrectParseIfCheckoutTimeoutDurationIsInteger() {
+  public void shouldUseConfiguredCheckoutTimeoutDurationWhenAnInteger() {
     JsonObject jsonConfig = new JsonObject()
       .put(VALUE, getJsonConfigWithCheckoutTimeoutDurationAsInteger());
     List<Configuration> records = Collections.singletonList(new Configuration(jsonConfig));
@@ -77,7 +78,7 @@ public class ConfigurationServiceTest {
   }
 
   @Test
-  public void shouldCorrectParseIfCheckoutTimeoutDurationIsString() {
+  public void shouldUseConfiguredCheckoutTimeoutDurationWhenIsAnIntegerString() {
     JsonObject jsonConfig = new JsonObject()
       .put(VALUE, getJsonConfigWithCheckoutTimeoutDurationAsString("1"));
     List<Configuration> records = Collections.singletonList(new Configuration(jsonConfig));
@@ -95,7 +96,7 @@ public class ConfigurationServiceTest {
 
     Integer actualSessionTimeout = service.findSessionTimeout(records);
 
-    assertEquals(actualSessionTimeout, DEFAULT_TIMEOUT_CONFIGURATION);
+    assertEquals(DEFAULT_TIMEOUT_CONFIGURATION, actualSessionTimeout);
   }
 
   private JsonObject getJsonObject(String timeZoneValue) {

--- a/src/test/java/org/folio/circulation/domain/ConfigurationServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/ConfigurationServiceTest.java
@@ -17,6 +17,7 @@ public class ConfigurationServiceTest {
 
   private static final String US_LOCALE = "en-US";
   private static final String VALUE = "value";
+  private static final Integer DEFAULT_TIMEOUT_CONFIGURATION = 3;
 
   private static ConfigurationService service;
 
@@ -67,34 +68,34 @@ public class ConfigurationServiceTest {
   @Test
   public void shouldCorrectParseIfCheckoutTimeoutDurationIsInteger() {
     JsonObject jsonConfig = new JsonObject()
-      .put("value", getJsonConfigWithCheckoutTimeoutDurationAsInteger());
+      .put(VALUE, getJsonConfigWithCheckoutTimeoutDurationAsInteger());
     List<Configuration> records = Collections.singletonList(new Configuration(jsonConfig));
 
-    Integer expectedSessionTimeout = service.findSessionTimeout(records);
+    Integer actualSessionTimeout = service.findSessionTimeout(records);
 
-    assertEquals(expectedSessionTimeout, new Integer(1));
+    assertEquals(actualSessionTimeout, new Integer(1));
   }
 
   @Test
   public void shouldCorrectParseIfCheckoutTimeoutDurationIsString() {
     JsonObject jsonConfig = new JsonObject()
-      .put(VALUE, getJsonConfigWithCheckoutTimeoutDurationAsString());
+      .put(VALUE, getJsonConfigWithCheckoutTimeoutDurationAsString("1"));
     List<Configuration> records = Collections.singletonList(new Configuration(jsonConfig));
 
-    Integer expectedSessionTimeout = service.findSessionTimeout(records);
+    Integer actualSessionTimeout = service.findSessionTimeout(records);
 
-    assertEquals(expectedSessionTimeout, new Integer(1));
+    assertEquals(actualSessionTimeout, new Integer(1));
   }
 
   @Test
   public void shouldCorrectParseIfCheckoutTimeoutDurationIsWrongString() {
     JsonObject jsonConfig = new JsonObject()
-      .put("value", getJsonConfigWithCheckoutTimeoutDurationAsWrongValue());
+      .put(VALUE, getJsonConfigWithCheckoutTimeoutDurationAsString("test"));
     List<Configuration> records = Collections.singletonList(new Configuration(jsonConfig));
 
-    Integer expectedSessionTimeout = service.findSessionTimeout(records);
+    Integer actualSessionTimeout = service.findSessionTimeout(records);
 
-    assertEquals(expectedSessionTimeout, new Integer(3));
+    assertEquals(actualSessionTimeout, DEFAULT_TIMEOUT_CONFIGURATION);
   }
 
   private JsonObject getJsonObject(String timeZoneValue) {
@@ -109,16 +110,9 @@ public class ConfigurationServiceTest {
     return encodedValue.toString();
   }
 
-  private String getJsonConfigWithCheckoutTimeoutDurationAsString() {
+  private String getJsonConfigWithCheckoutTimeoutDurationAsString(String checkoutTimeoutDuration) {
     final JsonObject encodedValue = new JsonObject();
-    write(encodedValue, "checkoutTimeoutDuration", "1");
-    write(encodedValue, "checkoutTimeout", true);
-    return encodedValue.toString();
-  }
-
-  private String getJsonConfigWithCheckoutTimeoutDurationAsWrongValue() {
-    final JsonObject encodedValue = new JsonObject();
-    write(encodedValue, "checkoutTimeoutDuration", "test");
+    write(encodedValue, "checkoutTimeoutDuration", checkoutTimeoutDuration);
     write(encodedValue, "checkoutTimeout", true);
     return encodedValue.toString();
   }

--- a/src/test/java/org/folio/circulation/domain/ConfigurationServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/ConfigurationServiceTest.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import api.support.builders.ConfigRecordBuilder;
 import api.support.builders.ConfigurationBuilder;
 import io.vertx.core.json.JsonObject;
+import java.util.List;
 import org.joda.time.DateTimeZone;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -15,6 +16,7 @@ import org.junit.Test;
 public class ConfigurationServiceTest {
 
   private static final String US_LOCALE = "en-US";
+  private static final String VALUE = "value";
 
   private static ConfigurationService service;
 
@@ -62,6 +64,39 @@ public class ConfigurationServiceTest {
     assertEquals(DateTimeZone.UTC, service.findDateTimeZone(jsonObject));
   }
 
+  @Test
+  public void shouldCorrectParseIfCheckoutTimeoutDurationIsInteger() {
+    JsonObject jsonConfig = new JsonObject()
+      .put("value", getJsonConfigWithCheckoutTimeoutDurationAsInteger());
+    List<Configuration> records = Collections.singletonList(new Configuration(jsonConfig));
+
+    Integer expectedSessionTimeout = service.findSessionTimeout(records);
+
+    assertEquals(expectedSessionTimeout, new Integer(1));
+  }
+
+  @Test
+  public void shouldCorrectParseIfCheckoutTimeoutDurationIsString() {
+    JsonObject jsonConfig = new JsonObject()
+      .put(VALUE, getJsonConfigWithCheckoutTimeoutDurationAsString());
+    List<Configuration> records = Collections.singletonList(new Configuration(jsonConfig));
+
+    Integer expectedSessionTimeout = service.findSessionTimeout(records);
+
+    assertEquals(expectedSessionTimeout, new Integer(1));
+  }
+
+  @Test
+  public void shouldCorrectParseIfCheckoutTimeoutDurationIsWrongString() {
+    JsonObject jsonConfig = new JsonObject()
+      .put("value", getJsonConfigWithCheckoutTimeoutDurationAsWrongValue());
+    List<Configuration> records = Collections.singletonList(new Configuration(jsonConfig));
+
+    Integer expectedSessionTimeout = service.findSessionTimeout(records);
+
+    assertEquals(expectedSessionTimeout, new Integer(3));
+  }
+
   private JsonObject getJsonObject(String timeZoneValue) {
     ConfigRecordBuilder config = new ConfigRecordBuilder(timeZoneValue);
     return new ConfigurationBuilder(Collections.singletonList(config)).create();
@@ -71,6 +106,27 @@ public class ConfigurationServiceTest {
     final JsonObject encodedValue = new JsonObject();
     write(encodedValue, "locale", US_LOCALE);
     write(encodedValue, "timezone", timezone);
+    return encodedValue.toString();
+  }
+
+  private String getJsonConfigWithCheckoutTimeoutDurationAsString() {
+    final JsonObject encodedValue = new JsonObject();
+    write(encodedValue, "checkoutTimeoutDuration", "1");
+    write(encodedValue, "checkoutTimeout", true);
+    return encodedValue.toString();
+  }
+
+  private String getJsonConfigWithCheckoutTimeoutDurationAsWrongValue() {
+    final JsonObject encodedValue = new JsonObject();
+    write(encodedValue, "checkoutTimeoutDuration", "test");
+    write(encodedValue, "checkoutTimeout", true);
+    return encodedValue.toString();
+  }
+
+  private String getJsonConfigWithCheckoutTimeoutDurationAsInteger() {
+    final JsonObject encodedValue = new JsonObject();
+    write(encodedValue, "checkoutTimeoutDuration", 1);
+    write(encodedValue, "checkoutTimeout", true);
     return encodedValue.toString();
   }
 }

--- a/src/test/java/org/folio/circulation/domain/ConfigurationServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/ConfigurationServiceTest.java
@@ -88,7 +88,7 @@ public class ConfigurationServiceTest {
   }
 
   @Test
-  public void shouldCorrectParseIfCheckoutTimeoutDurationIsWrongString() {
+  public void shouldUseDefaultCheckoutTimeoutDurationWhenConfiguredValueIsNotAnInteger() {
     JsonObject jsonConfig = new JsonObject()
       .put(VALUE, getJsonConfigWithCheckoutTimeoutDurationAsString("test"));
     List<Configuration> records = Collections.singletonList(new Configuration(jsonConfig));


### PR DESCRIPTION
Fixes [CIRC-684](https://issues.folio.org/browse/CIRC-684)

## Purpose
Currently, we have exception, when we retrieve from UI part value as String, but we expect integer. For avoiding this situation we can retrieve object and then parse to integer

## Approach
To get value from json and then parse
