### PR TITLE
CIRC-340: Unneeded/wrong dependencies in maven/code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,11 +188,6 @@
       <!--</exclusions>-->
     <!--</dependency>-->
     <dependency>
-      <groupId>org.jacoco</groupId>
-      <artifactId>jacoco-maven-plugin</artifactId>
-      <version>0.8.3</version>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>3.1.0</version>
@@ -394,14 +389,6 @@
           <tagNameFormat>v@{project.version}</tagNameFormat>
           <pushChanges>false</pushChanges>
           <localCheckout>true</localCheckout>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.3</version>
-        <configuration>
-          <excludes>**org.drools**</excludes>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/org/folio/circulation/domain/UpdateLoan.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateLoan.java
@@ -6,7 +6,6 @@ import static org.folio.circulation.support.Result.succeeded;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.commons.lang.StringUtils;
 import org.folio.circulation.domain.notice.schedule.DueDateScheduledNoticeService;
 import org.folio.circulation.domain.policy.LoanPolicy;
 import org.folio.circulation.domain.policy.LoanPolicyRepository;


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/CIRC-340

## Approach
`jacoco-maven-plugin` is no longer needed as described in above link and the `org.apache.commons.lang.StringUtils` import is not even used anymore.

#### TODOS and Open Questions
- [x] Tests appear to be failing independently of this change and seem unrelated, can this be confirmed/denied?