### PR TITLE
CIRC-698 Overdue fine location name instead of id

### DIFF
--- a/src/main/java/org/folio/circulation/domain/representations/AccountStorageRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/AccountStorageRepresentation.java
@@ -25,7 +25,7 @@ public class AccountStorageRepresentation extends JsonObject {
     this.put("title", item.getTitle());
     this.put("barcode", item.getBarcode());
     this.put("callNumber", item.getCallNumber());
-    this.put("location", item.getLocation().getPrimaryServicePointId().toString());
+    this.put("location", item.getLocation().getName());
     this.put("materialType", item.getMaterialTypeName());
     this.put("materialTypeId", item.getMaterialTypeId());
     this.put("loanId", loan.getId());

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -649,7 +649,7 @@ public class CheckInByBarcodeTests extends APITests {
     JsonObject account = createdAccounts.get(0);
 
     assertThat(account, OverdueFineMatcher.isValidOverdueFine(loan, nod,
-      servicePointsFixture.cd1().getId(), ownerId, feeFineId, 5.0));
+      homeLocation.getJson().getString("name"), ownerId, feeFineId, 5.0));
 
     Awaitility.await()
       .atMost(1, TimeUnit.SECONDS)
@@ -743,7 +743,7 @@ public class CheckInByBarcodeTests extends APITests {
     JsonObject account = createdAccounts.get(0);
 
     assertThat(account, OverdueFineMatcher.isValidOverdueFine(loan, nod,
-      servicePointsFixture.cd1().getId(), ownerId, feeFineId, 10.0));
+      homeLocation.getJson().getString("name"), ownerId, feeFineId, 10.0));
   }
 
   @Test

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -1361,7 +1361,7 @@ abstract class RenewalAPITests extends APITests {
     JsonObject account = createdAccounts.get(0);
 
     assertThat(account, OverdueFineMatcher.isValidOverdueFine(loan, nod,
-      servicePointsFixture.cd1().getId(), ownerId, feeFineId, 5.0));
+      homeLocation.getJson().getString("name"), ownerId, feeFineId, 5.0));
 
     Awaitility.await()
       .atMost(1, TimeUnit.SECONDS)

--- a/src/test/java/api/support/matchers/OverdueFineMatcher.java
+++ b/src/test/java/api/support/matchers/OverdueFineMatcher.java
@@ -14,7 +14,7 @@ import io.vertx.core.json.JsonObject;
 public class OverdueFineMatcher {
 
   public static Matcher<JsonObject> isValidOverdueFine(IndividualResource loan,
-    IndividualResource item, UUID servicePointId, UUID ownerId, UUID feeFineId, Double amount) {
+    IndividualResource item, String location, UUID ownerId, UUID feeFineId, Double amount) {
     return JsonObjectMatcher.allOfPaths(
       hasJsonPath("ownerId", is(ownerId.toString())),
       hasJsonPath("feeFineId", is(feeFineId.toString())),
@@ -26,7 +26,7 @@ public class OverdueFineMatcher {
       hasJsonPath("barcode", is(item.getJson().getString("barcode"))),
       hasJsonPath("callNumber", is(item.getJson().getJsonObject("effectiveCallNumberComponents")
         .getString("callNumber"))),
-      hasJsonPath("location", UUIDMatcher.is(servicePointId)),
+      hasJsonPath("location", is(location)),
       hasJsonPath("materialTypeId", is(item.getJson().getString(ItemProperties.MATERIAL_TYPE_ID))),
       hasJsonPath("materialType", is(loan.getJson().getJsonObject("item")
         .getJsonObject("materialType").getString("name"))),

--- a/src/test/java/org/folio/circulation/domain/OverdueFineCalculatorServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverdueFineCalculatorServiceTest.java
@@ -53,6 +53,7 @@ public class OverdueFineCalculatorServiceTest {
   private static final UUID ITEM_MATERIAL_TYPE_ID = UUID.randomUUID();
   private static final UUID FEE_FINE_OWNER_ID = UUID.randomUUID();
   private static final String FEE_FINE_OWNER = "fee-fine-owner";
+  private static final String LOCATION_NAME = "location-name";
   private static final UUID SERVICE_POINT_ID = UUID.randomUUID();
   private static final UUID FEE_FINE_ID = UUID.randomUUID();
   private static final UUID ACCOUNT_ID = UUID.randomUUID();
@@ -227,7 +228,7 @@ public class OverdueFineCalculatorServiceTest {
     assertEquals(TITLE, account.getValue().getString("title"));
     assertEquals(BARCODE, account.getValue().getString("barcode"));
     assertEquals(CALL_NUMBER, account.getValue().getString("callNumber"));
-    assertEquals(SERVICE_POINT_ID.toString(), account.getValue().getString("location"));
+    assertEquals(LOCATION_NAME, account.getValue().getString("location"));
     assertEquals(ITEM_MATERIAL_TYPE_NAME, account.getValue().getString("materialType"));
     assertEquals(ITEM_MATERIAL_TYPE_ID.toString(), account.getValue().getString("materialTypeId"));
     assertEquals(LOAN_ID.toString(), account.getValue().getString("loanId"));
@@ -516,7 +517,10 @@ public class OverdueFineCalculatorServiceTest {
 
     return Item.from(item)
       .withLocation(
-        Location.from(new LocationBuilder().withPrimaryServicePoint(SERVICE_POINT_ID).create()))
+        Location.from(new LocationBuilder()
+          .withName(LOCATION_NAME)
+          .withPrimaryServicePoint(SERVICE_POINT_ID)
+          .create()))
       .withInstance(new InstanceBuilder(TITLE, UUID.randomUUID()).create())
       .withMaterialType(materialType);
   }
@@ -570,7 +574,7 @@ public class OverdueFineCalculatorServiceTest {
         new AccountFeeFineTypeInfo(FEE_FINE_ID.toString(), FEE_FINE_TYPE),
         new AccountLoanInfo(LOAN_ID.toString(), LOAN_USER_ID.toString()),
         new AccountItemInfo(ITEM_ID.toString(), TITLE, BARCODE, CALL_NUMBER,
-          SERVICE_POINT_ID.toString(), ITEM_MATERIAL_TYPE_ID.toString())
+          LOCATION_NAME, ITEM_MATERIAL_TYPE_ID.toString())
       ),
       correctOverdueFine, correctOverdueFine, "Open", "Outstanding"
       );


### PR DESCRIPTION
Resolves [CIRC-698](https://issues.folio.org/browse/CIRC-698)

## Purpose
Currently, when overdue fine is created, location ID is passed as `account.location` instead of location name.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
