### PR TITLE
CIRC-699: Use partition to fetch loans for requests.

### DIFF
--- a/src/test/java/api/support/http/CqlQuery.java
+++ b/src/test/java/api/support/http/CqlQuery.java
@@ -13,6 +13,10 @@ public class CqlQuery implements QueryStringParameter {
     return new CqlQuery(String.format(queryTemplate, parameters));
   }
 
+  public static CqlQuery exactMatch(String indexName, String value) {
+    return queryFromTemplate("%s==\"%s\"", indexName, value);
+  }
+
   public static CqlQuery noQuery() {
     return new CqlQuery(null);
   }


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-699 - Bugfest: 500 Error when filtering Requests by Type = Page

## Approach
Use `FindWithMultipleCqlIndexValues` to fetch open loans for items, when fetching multiple requests in order to omit `414 Uri too long` error.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
