### PR TITLE
CIRC-705 fix limit issue for policies

### DIFF
--- a/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
+++ b/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
@@ -28,6 +28,7 @@ import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.JsonResponseResult;
 import org.folio.circulation.support.OkJsonResponseResult;
 import org.folio.circulation.support.Result;
+import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.server.ForwardResponse;
 import org.folio.circulation.support.http.server.SuccessResponse;
@@ -50,6 +51,7 @@ public class CirculationRulesResource extends Resource {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final int FIRST_ELEMENT_OF_LIST = 0;
   private static final int POLICY_ID_POSITION_NUMBER = 1;
+  private static final PageLimit POLICY_PAGE_LIMIT = PageLimit.limit(1000);
   private final String rootPath;
 
   /**
@@ -213,7 +215,7 @@ public class CirculationRulesResource extends Resource {
   private CompletableFuture<Result<Map<String, Set<String>>>> getPolicyIdsByType(
     CollectionResourceClient client, String entityName, String policyType) {
 
-    return client.get()
+    return client.get(POLICY_PAGE_LIMIT)
       .thenApply(r -> r.next(response -> mapResponseToIds(response, entityName)))
       .thenApply(r -> r.map(MultipleRecords::getRecords))
       .thenApply(r -> r.map(collection -> collection.stream()

--- a/src/main/java/org/folio/circulation/support/CollectionResourceClient.java
+++ b/src/main/java/org/folio/circulation/support/CollectionResourceClient.java
@@ -53,6 +53,10 @@ public class CollectionResourceClient implements GetManyRecordsClient {
     return client.get(collectionRoot.toString());
   }
 
+  public CompletableFuture<Result<Response>> get(PageLimit pageLimit) {
+    return client.get(collectionRoot, pageLimit);
+  }
+
   public CompletableFuture<Result<Response>> get(String id) {
     return client.get(individualRecordUrl(id));
   }


### PR DESCRIPTION
## Purpose
Fix issue with validation error for existing policies.  Set custom limit to retrieve existing policies.

This issue (CIRC-705) is caused by not setting the limit in the calls that retrieve policies from other modules, so the default limit of 10 is applied. As a consequence, only first 10 policies of each type are recognized as existing.

The reason why it's important to deliver this fix to Bugfest ASAP is that in the attempt to reproduce CIRC-705 most of the rules were deleted. We can't revert it because there are more than 10 loan policies on Bugfest and some of them are used in the rules, so this bug prevents rules from being saved. With the current set of rules and 10 policy limit POs are likely won't be able to continue testing.

Resolves: CIRC-705