### PR TITLE
CIRC-706 add tests to cover fix with default limit of existing policies

### DIFF
--- a/src/test/java/api/CirculationRulesAPITests.java
+++ b/src/test/java/api/CirculationRulesAPITests.java
@@ -85,11 +85,11 @@ public class CirculationRulesAPITests extends APITests {
   public void cannotUpdateCirculationRulesWithInvalidLoanPolicyId() {
 
     String rule = circulationRulesFixture.soleFallbackPolicyRule(
-      UUID.randomUUID().toString(),
-      requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
-      noticePoliciesFixture.activeNotice().getId().toString(),
-      overdueFinePoliciesFixture.facultyStandard().getId().toString(),
-      lostItemFeePoliciesFixture.facultyStandard().getId().toString());
+      UUID.randomUUID(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.activeNotice().getId(),
+      overdueFinePoliciesFixture.facultyStandard().getId(),
+      lostItemFeePoliciesFixture.facultyStandard().getId());
 
     Response response = circulationRulesFixture
       .attemptUpdateCirculationRules(rule);
@@ -103,11 +103,11 @@ public class CirculationRulesAPITests extends APITests {
   public void cannotUpdateCirculationRulesWithInvalidNoticePolicyId() {
 
     String rule = circulationRulesFixture.soleFallbackPolicyRule(
-      loanPoliciesFixture.canCirculateFixed().getId().toString(),
-      requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
-      UUID.randomUUID().toString(),
-      overdueFinePoliciesFixture.facultyStandard().getId().toString(),
-      lostItemFeePoliciesFixture.facultyStandard().getId().toString());
+      loanPoliciesFixture.canCirculateFixed().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      UUID.randomUUID(),
+      overdueFinePoliciesFixture.facultyStandard().getId(),
+      lostItemFeePoliciesFixture.facultyStandard().getId());
 
     Response response = circulationRulesFixture
       .attemptUpdateCirculationRules(rule);
@@ -121,11 +121,11 @@ public class CirculationRulesAPITests extends APITests {
   public void cannotUpdateCirculationRulesWithInvalidRequestPolicyId() {
 
     String rule = circulationRulesFixture.soleFallbackPolicyRule(
-      loanPoliciesFixture.canCirculateFixed().getId().toString(),
-      UUID.randomUUID().toString(),
-      noticePoliciesFixture.activeNotice().getId().toString(),
-      overdueFinePoliciesFixture.facultyStandard().getId().toString(),
-      lostItemFeePoliciesFixture.facultyStandard().getId().toString());
+      loanPoliciesFixture.canCirculateFixed().getId(),
+      UUID.randomUUID(),
+      noticePoliciesFixture.activeNotice().getId(),
+      overdueFinePoliciesFixture.facultyStandard().getId(),
+      lostItemFeePoliciesFixture.facultyStandard().getId());
 
     Response response = circulationRulesFixture
       .attemptUpdateCirculationRules(rule);
@@ -139,11 +139,11 @@ public class CirculationRulesAPITests extends APITests {
   public void cannotUpdateCirculationRulesWithOverdueFinePolicyId() {
 
     String rule = circulationRulesFixture.soleFallbackPolicyRule(
-      loanPoliciesFixture.canCirculateFixed().getId().toString(),
-      requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
-      noticePoliciesFixture.activeNotice().getId().toString(),
-      UUID.randomUUID().toString(),
-      lostItemFeePoliciesFixture.facultyStandard().getId().toString());
+      loanPoliciesFixture.canCirculateFixed().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.activeNotice().getId(),
+      UUID.randomUUID(),
+      lostItemFeePoliciesFixture.facultyStandard().getId());
 
     Response response = circulationRulesFixture
       .attemptUpdateCirculationRules(rule);
@@ -157,11 +157,11 @@ public class CirculationRulesAPITests extends APITests {
   public void cannotUpdateCirculationRulesWithLostItemPolicyId() {
 
     String rule = circulationRulesFixture.soleFallbackPolicyRule(
-      loanPoliciesFixture.canCirculateFixed().getId().toString(),
-      requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
-      noticePoliciesFixture.activeNotice().getId().toString(),
-      overdueFinePoliciesFixture.facultyStandard().getId().toString(),
-      UUID.randomUUID().toString());
+      loanPoliciesFixture.canCirculateFixed().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.activeNotice().getId(),
+      overdueFinePoliciesFixture.facultyStandard().getId(),
+      UUID.randomUUID());
 
     Response response = circulationRulesFixture.attemptUpdateCirculationRules(rule);
 
@@ -178,11 +178,14 @@ public class CirculationRulesAPITests extends APITests {
 
     loanPolicyIds.forEach(loanPolicyId -> {
       String rule = circulationRulesFixture.soleFallbackPolicyRule(
-        loanPolicyId.toString(), requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
-        noticePoliciesFixture.activeNotice().getId().toString(),
-        overdueFinePoliciesFixture.facultyStandard().getId().toString(),
-        lostItemFeePoliciesFixture.facultyStandard().getId().toString());
-      circulationRulesFixture.updateCirculationRules(rule);
+        loanPolicyId, requestPoliciesFixture.allowAllRequestPolicy().getId(),
+        noticePoliciesFixture.activeNotice().getId(),
+        overdueFinePoliciesFixture.facultyStandard().getId(),
+        lostItemFeePoliciesFixture.facultyStandard().getId());
+      Response response = circulationRulesFixture.attemptUpdateCirculationRules(rule);
+      assertThat(String.format(
+        "Failed to set circulation rules: %s", response.getBody()),
+        response.getStatusCode(), is(204));
     });
   }
 
@@ -194,12 +197,15 @@ public class CirculationRulesAPITests extends APITests {
 
     noticePolicyIds.forEach(noticePolicyId -> {
       String rule = circulationRulesFixture.soleFallbackPolicyRule(
-        loanPoliciesFixture.canCirculateFixed().getId().toString(),
-        requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
-        noticePolicyId.toString(),
-        overdueFinePoliciesFixture.facultyStandard().getId().toString(),
-        lostItemFeePoliciesFixture.facultyStandard().getId().toString());
-      circulationRulesFixture.updateCirculationRules(rule);
+        loanPoliciesFixture.canCirculateFixed().getId(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId(),
+        noticePolicyId,
+        overdueFinePoliciesFixture.facultyStandard().getId(),
+        lostItemFeePoliciesFixture.facultyStandard().getId());
+      Response response = circulationRulesFixture.attemptUpdateCirculationRules(rule);
+      assertThat(String.format(
+        "Failed to set circulation rules: %s", response.getBody()),
+        response.getStatusCode(), is(204));
     });
   }
 
@@ -210,13 +216,18 @@ public class CirculationRulesAPITests extends APITests {
     requestPolicyIds.forEach(requestPoliciesFixture::allowAllRequestPolicy);
 
     requestPolicyIds.forEach(requestPolicyId -> {
+      UUID allowAllRequestPolicyId = requestPoliciesFixture.allowAllRequestPolicy(
+        requestPolicyId).getId();
       String rule = circulationRulesFixture.soleFallbackPolicyRule(
-        loanPoliciesFixture.canCirculateFixed().getId().toString(),
-        requestPoliciesFixture.allowAllRequestPolicy(requestPolicyId).getId().toString(),
-        noticePoliciesFixture.activeNotice().getId().toString(),
-        overdueFinePoliciesFixture.facultyStandard().getId().toString(),
-        lostItemFeePoliciesFixture.facultyStandard().getId().toString());
-      circulationRulesFixture.updateCirculationRules(rule);
+        loanPoliciesFixture.canCirculateFixed().getId(),
+        allowAllRequestPolicyId,
+        noticePoliciesFixture.activeNotice().getId(),
+        overdueFinePoliciesFixture.facultyStandard().getId(),
+        lostItemFeePoliciesFixture.facultyStandard().getId());
+      Response response = circulationRulesFixture.attemptUpdateCirculationRules(rule);
+      assertThat(String.format(
+        "Failed to set circulation rules: %s", response.getBody()),
+        response.getStatusCode(), is(204));
     });
   }
 
@@ -228,12 +239,15 @@ public class CirculationRulesAPITests extends APITests {
 
     overdueFinePolicyIds.forEach(overdueFinePolicyId -> {
       String rule = circulationRulesFixture.soleFallbackPolicyRule(
-        loanPoliciesFixture.canCirculateFixed().getId().toString(),
-        requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
-        noticePoliciesFixture.activeNotice().getId().toString(),
-        overdueFinePolicyId.toString(),
-        lostItemFeePoliciesFixture.facultyStandard().getId().toString());
-      circulationRulesFixture.updateCirculationRules(rule);
+        loanPoliciesFixture.canCirculateFixed().getId(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId(),
+        noticePoliciesFixture.activeNotice().getId(),
+        overdueFinePolicyId,
+        lostItemFeePoliciesFixture.facultyStandard().getId());
+      Response response = circulationRulesFixture.attemptUpdateCirculationRules(rule);
+      assertThat(String.format(
+        "Failed to set circulation rules: %s", response.getBody()),
+        response.getStatusCode(), is(204));
     });
   }
 
@@ -245,12 +259,15 @@ public class CirculationRulesAPITests extends APITests {
 
     lostItemFeePolicyIds.forEach(lostItemFeePolicyId -> {
       String rule = circulationRulesFixture.soleFallbackPolicyRule(
-        loanPoliciesFixture.canCirculateFixed().getId().toString(),
-        requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
-        noticePoliciesFixture.activeNotice().getId().toString(),
-        overdueFinePoliciesFixture.facultyStandard().getId().toString(),
-        lostItemFeePolicyId.toString());
-      circulationRulesFixture.updateCirculationRules(rule);
+        loanPoliciesFixture.canCirculateFixed().getId(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId(),
+        noticePoliciesFixture.activeNotice().getId(),
+        overdueFinePoliciesFixture.facultyStandard().getId(),
+        lostItemFeePolicyId);
+      Response response = circulationRulesFixture.attemptUpdateCirculationRules(rule);
+      assertThat(String.format(
+        "Failed to set circulation rules: %s", response.getBody()),
+        response.getStatusCode(), is(204));
     });
   }
 
@@ -294,11 +311,11 @@ public class CirculationRulesAPITests extends APITests {
   }
 
   private Set<UUID> getSetOfPolicyIds(int numberOfPolicies) {
-    Set<UUID> ofpIds = new HashSet<>();
+    Set<UUID> ids = new HashSet<>();
     for (int i = 0; i < numberOfPolicies; i++) {
-      ofpIds.add(UUID.randomUUID());
+      ids.add(UUID.randomUUID());
     }
-    return ofpIds;
+    return ids;
   }
 
   private void addPoliciesToLoanPolicyFixture(Set<UUID> lpIds) {

--- a/src/test/java/api/CirculationRulesAPITests.java
+++ b/src/test/java/api/CirculationRulesAPITests.java
@@ -174,7 +174,7 @@ public class CirculationRulesAPITests extends APITests {
   public void canUpdateCirculationRulesWithTwentyExistingLoanPolicies() {
 
     Set<UUID> loanPolicyIds = getSetOfPolicyIds(20);
-    addPoliciesToLoanPolicyFixture(loanPolicyIds);
+    createLoanPolicies(loanPolicyIds);
 
     loanPolicyIds.forEach(loanPolicyId -> {
       String rule = circulationRulesFixture.soleFallbackPolicyRule(
@@ -193,7 +193,7 @@ public class CirculationRulesAPITests extends APITests {
   public void canUpdateCirculationRulesWithTwentyExistingNoticePolicies() {
 
     Set<UUID> noticePolicyIds = getSetOfPolicyIds(20);
-    addPoliciesToNoticePolicyFixture(noticePolicyIds);
+    createNoticePolicies(noticePolicyIds);
 
     noticePolicyIds.forEach(noticePolicyId -> {
       String rule = circulationRulesFixture.soleFallbackPolicyRule(
@@ -235,7 +235,7 @@ public class CirculationRulesAPITests extends APITests {
   public void canUpdateCirculationRulesWithTwentyExistingOverdueFinePolicies() {
 
     Set<UUID> overdueFinePolicyIds = getSetOfPolicyIds(20);
-    addPoliciesToOverdueFinePolicyFixture(overdueFinePolicyIds);
+    createOverdueFinePolicies(overdueFinePolicyIds);
 
     overdueFinePolicyIds.forEach(overdueFinePolicyId -> {
       String rule = circulationRulesFixture.soleFallbackPolicyRule(
@@ -255,7 +255,7 @@ public class CirculationRulesAPITests extends APITests {
   public void canUpdateCirculationRulesWithTwentyExistingLostItemFeePolicies() {
 
     Set<UUID> lostItemFeePolicyIds = getSetOfPolicyIds(20);
-    addPoliciesToLostItemFeePolicyFixture(lostItemFeePolicyIds);
+    createLostItemFeePolicies(lostItemFeePolicyIds);
 
     lostItemFeePolicyIds.forEach(lostItemFeePolicyId -> {
       String rule = circulationRulesFixture.soleFallbackPolicyRule(
@@ -318,28 +318,28 @@ public class CirculationRulesAPITests extends APITests {
     return ids;
   }
 
-  private void addPoliciesToLoanPolicyFixture(Set<UUID> lpIds) {
+  private void createLoanPolicies(Set<UUID> lpIds) {
     lpIds.forEach(id -> loanPoliciesFixture.create(
       new LoanPolicyBuilder()
         .withId(id)
         .withName("Example LoanPolicy " + id)));
   }
 
-  private void addPoliciesToNoticePolicyFixture(Set<UUID> lpIds) {
+  private void createNoticePolicies(Set<UUID> lpIds) {
     lpIds.forEach(id -> noticePoliciesFixture.create(
       new NoticePolicyBuilder()
         .withId(id)
         .withName("Example NoticePolicy " + id)));
   }
 
-  private void addPoliciesToOverdueFinePolicyFixture(Set<UUID> ofpIds) {
+  private void createOverdueFinePolicies(Set<UUID> ofpIds) {
     ofpIds.forEach(id -> overdueFinePoliciesFixture.create(
       new OverdueFinePolicyBuilder()
         .withId(id)
         .withName("Example OverdueFinePolicy " + id)));
   }
 
-  private void addPoliciesToLostItemFeePolicyFixture(Set<UUID> ofpIds) {
+  private void createLostItemFeePolicies(Set<UUID> ofpIds) {
     ofpIds.forEach(id -> lostItemFeePoliciesFixture.create(
       new LostItemFeePolicyBuilder()
         .withId(id)

--- a/src/test/java/api/CirculationRulesAPITests.java
+++ b/src/test/java/api/CirculationRulesAPITests.java
@@ -5,6 +5,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import org.folio.circulation.support.http.client.Response;
@@ -90,7 +92,7 @@ public class CirculationRulesAPITests extends APITests {
       lostItemFeePoliciesFixture.facultyStandard().getId().toString());
 
     Response response = circulationRulesFixture
-      .attemptUpdateCirculationRules(rule, "l");
+      .attemptUpdateCirculationRules(rule);
 
     assertThat(response.getStatusCode(), is(422));
     assertThat(response.getJson().getString("message"),
@@ -108,7 +110,7 @@ public class CirculationRulesAPITests extends APITests {
       lostItemFeePoliciesFixture.facultyStandard().getId().toString());
 
     Response response = circulationRulesFixture
-      .attemptUpdateCirculationRules(rule, "n");
+      .attemptUpdateCirculationRules(rule);
 
     assertThat(response.getStatusCode(), is(422));
     assertThat(response.getJson().getString("message"),
@@ -126,7 +128,7 @@ public class CirculationRulesAPITests extends APITests {
       lostItemFeePoliciesFixture.facultyStandard().getId().toString());
 
     Response response = circulationRulesFixture
-      .attemptUpdateCirculationRules(rule, "r");
+      .attemptUpdateCirculationRules(rule);
 
     assertThat(response.getStatusCode(), is(422));
     assertThat(response.getJson().getString("message"),
@@ -144,7 +146,7 @@ public class CirculationRulesAPITests extends APITests {
       lostItemFeePoliciesFixture.facultyStandard().getId().toString());
 
     Response response = circulationRulesFixture
-      .attemptUpdateCirculationRules(rule, "o");
+      .attemptUpdateCirculationRules(rule);
 
     assertThat(response.getStatusCode(), is(422));
     assertThat(response.getJson().getString("message"),
@@ -161,12 +163,95 @@ public class CirculationRulesAPITests extends APITests {
       overdueFinePoliciesFixture.facultyStandard().getId().toString(),
       UUID.randomUUID().toString());
 
-    Response response = circulationRulesFixture
-      .attemptUpdateCirculationRules(rule, "i");
+    Response response = circulationRulesFixture.attemptUpdateCirculationRules(rule);
 
     assertThat(response.getStatusCode(), is(422));
     assertThat(response.getJson().getString("message"),
       is("The policy i does not exist"));
+  }
+
+  @Test
+  public void canUpdateCirculationRulesWithTwentyExistingLoanPolicies() {
+
+    Set<UUID> loanPolicyIds = getSetOfPolicyIds(20);
+    addPoliciesToLoanPolicyFixture(loanPolicyIds);
+
+    loanPolicyIds.forEach(loanPolicyId -> {
+      String rule = circulationRulesFixture.soleFallbackPolicyRule(
+        loanPolicyId.toString(), requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
+        noticePoliciesFixture.activeNotice().getId().toString(),
+        overdueFinePoliciesFixture.facultyStandard().getId().toString(),
+        lostItemFeePoliciesFixture.facultyStandard().getId().toString());
+      circulationRulesFixture.updateCirculationRules(rule);
+    });
+  }
+
+  @Test
+  public void canUpdateCirculationRulesWithTwentyExistingNoticePolicies() {
+
+    Set<UUID> noticePolicyIds = getSetOfPolicyIds(20);
+    addPoliciesToNoticePolicyFixture(noticePolicyIds);
+
+    noticePolicyIds.forEach(noticePolicyId -> {
+      String rule = circulationRulesFixture.soleFallbackPolicyRule(
+        loanPoliciesFixture.canCirculateFixed().getId().toString(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
+        noticePolicyId.toString(),
+        overdueFinePoliciesFixture.facultyStandard().getId().toString(),
+        lostItemFeePoliciesFixture.facultyStandard().getId().toString());
+      circulationRulesFixture.updateCirculationRules(rule);
+    });
+  }
+
+  @Test
+  public void canUpdateCirculationRulesWithTwentyExistingRequestPolicies() {
+
+    Set<UUID> requestPolicyIds = getSetOfPolicyIds(20);
+    requestPolicyIds.forEach(requestPoliciesFixture::allowAllRequestPolicy);
+
+    requestPolicyIds.forEach(requestPolicyId -> {
+      String rule = circulationRulesFixture.soleFallbackPolicyRule(
+        loanPoliciesFixture.canCirculateFixed().getId().toString(),
+        requestPoliciesFixture.allowAllRequestPolicy(requestPolicyId).getId().toString(),
+        noticePoliciesFixture.activeNotice().getId().toString(),
+        overdueFinePoliciesFixture.facultyStandard().getId().toString(),
+        lostItemFeePoliciesFixture.facultyStandard().getId().toString());
+      circulationRulesFixture.updateCirculationRules(rule);
+    });
+  }
+
+  @Test
+  public void canUpdateCirculationRulesWithTwentyExistingOverdueFinePolicies() {
+
+    Set<UUID> overdueFinePolicyIds = getSetOfPolicyIds(20);
+    addPoliciesToOverdueFinePolicyFixture(overdueFinePolicyIds);
+
+    overdueFinePolicyIds.forEach(overdueFinePolicyId -> {
+      String rule = circulationRulesFixture.soleFallbackPolicyRule(
+        loanPoliciesFixture.canCirculateFixed().getId().toString(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
+        noticePoliciesFixture.activeNotice().getId().toString(),
+        overdueFinePolicyId.toString(),
+        lostItemFeePoliciesFixture.facultyStandard().getId().toString());
+      circulationRulesFixture.updateCirculationRules(rule);
+    });
+  }
+
+  @Test
+  public void canUpdateCirculationRulesWithTwentyExistingLostItemFeePolicies() {
+
+    Set<UUID> lostItemFeePolicyIds = getSetOfPolicyIds(20);
+    addPoliciesToLostItemFeePolicyFixture(lostItemFeePolicyIds);
+
+    lostItemFeePolicyIds.forEach(lostItemFeePolicyId -> {
+      String rule = circulationRulesFixture.soleFallbackPolicyRule(
+        loanPoliciesFixture.canCirculateFixed().getId().toString(),
+        requestPoliciesFixture.allowAllRequestPolicy().getId().toString(),
+        noticePoliciesFixture.activeNotice().getId().toString(),
+        overdueFinePoliciesFixture.facultyStandard().getId().toString(),
+        lostItemFeePolicyId.toString());
+      circulationRulesFixture.updateCirculationRules(rule);
+    });
   }
 
   @Test
@@ -206,5 +291,41 @@ public class CirculationRulesAPITests extends APITests {
 
   private void setRules(String rules) {
     circulationRulesFixture.updateCirculationRules(rules);
+  }
+
+  private Set<UUID> getSetOfPolicyIds(int numberOfPolicies) {
+    Set<UUID> ofpIds = new HashSet<>();
+    for (int i = 0; i < numberOfPolicies; i++) {
+      ofpIds.add(UUID.randomUUID());
+    }
+    return ofpIds;
+  }
+
+  private void addPoliciesToLoanPolicyFixture(Set<UUID> lpIds) {
+    lpIds.forEach(id -> loanPoliciesFixture.create(
+      new LoanPolicyBuilder()
+        .withId(id)
+        .withName("Example LoanPolicy " + id)));
+  }
+
+  private void addPoliciesToNoticePolicyFixture(Set<UUID> lpIds) {
+    lpIds.forEach(id -> noticePoliciesFixture.create(
+      new NoticePolicyBuilder()
+        .withId(id)
+        .withName("Example NoticePolicy " + id)));
+  }
+
+  private void addPoliciesToOverdueFinePolicyFixture(Set<UUID> ofpIds) {
+    ofpIds.forEach(id -> overdueFinePoliciesFixture.create(
+      new OverdueFinePolicyBuilder()
+        .withId(id)
+        .withName("Example OverdueFinePolicy " + id)));
+  }
+
+  private void addPoliciesToLostItemFeePolicyFixture(Set<UUID> ofpIds) {
+    ofpIds.forEach(id -> lostItemFeePoliciesFixture.create(
+      new LostItemFeePolicyBuilder()
+        .withId(id)
+        .withName("Example LostItemFeePolicy " + id)));
   }
 }

--- a/src/test/java/api/CirculationRulesAPITests.java
+++ b/src/test/java/api/CirculationRulesAPITests.java
@@ -182,7 +182,9 @@ public class CirculationRulesAPITests extends APITests {
         noticePoliciesFixture.activeNotice().getId(),
         overdueFinePoliciesFixture.facultyStandard().getId(),
         lostItemFeePoliciesFixture.facultyStandard().getId());
+
       Response response = circulationRulesFixture.attemptUpdateCirculationRules(rule);
+
       assertThat(String.format(
         "Failed to set circulation rules: %s", response.getBody()),
         response.getStatusCode(), is(204));
@@ -202,7 +204,9 @@ public class CirculationRulesAPITests extends APITests {
         noticePolicyId,
         overdueFinePoliciesFixture.facultyStandard().getId(),
         lostItemFeePoliciesFixture.facultyStandard().getId());
+
       Response response = circulationRulesFixture.attemptUpdateCirculationRules(rule);
+
       assertThat(String.format(
         "Failed to set circulation rules: %s", response.getBody()),
         response.getStatusCode(), is(204));
@@ -224,7 +228,9 @@ public class CirculationRulesAPITests extends APITests {
         noticePoliciesFixture.activeNotice().getId(),
         overdueFinePoliciesFixture.facultyStandard().getId(),
         lostItemFeePoliciesFixture.facultyStandard().getId());
+
       Response response = circulationRulesFixture.attemptUpdateCirculationRules(rule);
+
       assertThat(String.format(
         "Failed to set circulation rules: %s", response.getBody()),
         response.getStatusCode(), is(204));
@@ -244,7 +250,9 @@ public class CirculationRulesAPITests extends APITests {
         noticePoliciesFixture.activeNotice().getId(),
         overdueFinePolicyId,
         lostItemFeePoliciesFixture.facultyStandard().getId());
+
       Response response = circulationRulesFixture.attemptUpdateCirculationRules(rule);
+
       assertThat(String.format(
         "Failed to set circulation rules: %s", response.getBody()),
         response.getStatusCode(), is(204));
@@ -264,7 +272,9 @@ public class CirculationRulesAPITests extends APITests {
         noticePoliciesFixture.activeNotice().getId(),
         overdueFinePoliciesFixture.facultyStandard().getId(),
         lostItemFeePolicyId);
+
       Response response = circulationRulesFixture.attemptUpdateCirculationRules(rule);
+
       assertThat(String.format(
         "Failed to set circulation rules: %s", response.getBody()),
         response.getStatusCode(), is(204));
@@ -318,29 +328,29 @@ public class CirculationRulesAPITests extends APITests {
     return ids;
   }
 
-  private void createLoanPolicies(Set<UUID> lpIds) {
-    lpIds.forEach(id -> loanPoliciesFixture.create(
+  private void createLoanPolicies(Set<UUID> ids) {
+    ids.forEach(id -> loanPoliciesFixture.create(
       new LoanPolicyBuilder()
         .withId(id)
         .withName("Example LoanPolicy " + id)));
   }
 
-  private void createNoticePolicies(Set<UUID> lpIds) {
-    lpIds.forEach(id -> noticePoliciesFixture.create(
+  private void createNoticePolicies(Set<UUID> ids) {
+    ids.forEach(id -> noticePoliciesFixture.create(
       new NoticePolicyBuilder()
         .withId(id)
         .withName("Example NoticePolicy " + id)));
   }
 
-  private void createOverdueFinePolicies(Set<UUID> ofpIds) {
-    ofpIds.forEach(id -> overdueFinePoliciesFixture.create(
+  private void createOverdueFinePolicies(Set<UUID> ids) {
+    ids.forEach(id -> overdueFinePoliciesFixture.create(
       new OverdueFinePolicyBuilder()
         .withId(id)
         .withName("Example OverdueFinePolicy " + id)));
   }
 
-  private void createLostItemFeePolicies(Set<UUID> ofpIds) {
-    ofpIds.forEach(id -> lostItemFeePoliciesFixture.create(
+  private void createLostItemFeePolicies(Set<UUID> ids) {
+    ids.forEach(id -> lostItemFeePoliciesFixture.create(
       new LostItemFeePolicyBuilder()
         .withId(id)
         .withName("Example LostItemFeePolicy " + id)));

--- a/src/test/java/api/support/fixtures/CirculationRulesFixture.java
+++ b/src/test/java/api/support/fixtures/CirculationRulesFixture.java
@@ -74,8 +74,7 @@ public class CirculationRulesFixture {
       response.getStatusCode(), is(204));
   }
 
-  public Response attemptUpdateCirculationRules(
-    String rules, String policyType) {
+  public Response attemptUpdateCirculationRules(String rules) {
 
     JsonObject circulationRulesRequest = new JsonObject()
       .put("rulesAsText", rules);

--- a/src/test/java/api/support/fixtures/CirculationRulesFixture.java
+++ b/src/test/java/api/support/fixtures/CirculationRulesFixture.java
@@ -94,7 +94,7 @@ public class CirculationRulesFixture {
       .statusCode(204);
   }
 
-  private String soleFallbackPolicyRule(UUID loanPolicyId, UUID requestPolicyId,
+  public String soleFallbackPolicyRule(UUID loanPolicyId, UUID requestPolicyId,
       UUID noticePolicyId, UUID overdueFinePolicyId, UUID lostItemFeePolicyId) {
 
     return soleFallbackPolicyRule(loanPolicyId.toString(),

--- a/src/test/java/api/support/fixtures/RequestPoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/RequestPoliciesFixture.java
@@ -32,15 +32,14 @@ public class RequestPoliciesFixture {
     return requestPolicyRecordCreator.createIfAbsent(allowAllPolicy);
   }
 
-  public void allowAllRequestPolicy(UUID id) {
+  public IndividualResource allowAllRequestPolicy(UUID id) {
 
     List<RequestType> types = new ArrayList<>();
     types.add(RequestType.HOLD);
     types.add(RequestType.PAGE);
     types.add(RequestType.RECALL);
 
-    requestPolicyRecordCreator.createIfAbsent(
-      new RequestPolicyBuilder(types, id));
+    return requestPolicyRecordCreator.createIfAbsent(new RequestPolicyBuilder(types, id));
   }
 
   public IndividualResource customRequestPolicy(ArrayList<RequestType> types) {


### PR DESCRIPTION
## Purpose
Create test to cover logic that was implemented in scope of CIRC-705.
The issue (CIRC-705) is caused by not setting the limit in the calls that retrieve policies from other modules, so the default limit of 10 is applied. As a consequence, only first 10 policies of each type are recognized as existing.
Considering it's crucial to deliver this fix ASAP, the fix was merged. This PR was created to cover this functionality with tests.

Resolves: [CIRC-706](https://issues.folio.org/browse/CIRC-706)

## Links
https://issues.folio.org/browse/CIRC-706

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.