### PR TITLE
CIRC-708 User with Check Out: All permissions cannot override

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1242,7 +1242,8 @@
         "inventory-storage.loan-types.item.get",
         "scheduled-notice-storage.scheduled-notices.item.post",
         "usergroups.collection.get",
-        "usergroups.item.get"
+        "usergroups.item.get",
+        "lost-item-fees-policies.collection.get"
       ],
       "visible": false
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1208,6 +1208,7 @@
         "circulation.rules.loan-policy.get",
         "circulation.rules.request-policy.get",
         "circulation.rules.overdue-fine-policy.get",
+        "lost-item-fees-policies.collection.get",
         "circulation-storage.requests.collection.get",
         "circulation-storage.requests.item.put",
         "circulation-storage.request-batch.item.post",
@@ -1242,8 +1243,7 @@
         "inventory-storage.loan-types.item.get",
         "scheduled-notice-storage.scheduled-notices.item.post",
         "usergroups.collection.get",
-        "usergroups.item.get",
-        "lost-item-fees-policies.collection.get"
+        "usergroups.item.get"
       ],
       "visible": false
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1207,6 +1207,7 @@
         "circulation-storage.loans.collection.get",
         "circulation.rules.loan-policy.get",
         "circulation.rules.request-policy.get",
+        "circulation.rules.overdue-fine-policy.get",
         "circulation-storage.requests.collection.get",
         "circulation-storage.requests.item.put",
         "circulation-storage.request-batch.item.post",


### PR DESCRIPTION

## Purpose
Resolves [CIRC-708](https://issues.folio.org/browse/CIRC-708)

## Approach

This adds a missing sub permission (`circulation.rules.overdue-fine-policy.get`) to `modperms.circulation.override-check-out-by-barcode.post` allowing a user with Check Out: All permissions to conduct a post to override-check-out-by-barcode.post without encountering the current error.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  