### PR TITLE
CIRC-717 use after when whilst deciding whether to charge an overdue fee

### DIFF
--- a/src/main/java/org/folio/circulation/domain/OverdueFineCalculatorService.java
+++ b/src/main/java/org/folio/circulation/domain/OverdueFineCalculatorService.java
@@ -3,14 +3,12 @@ package org.folio.circulation.domain;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.commons.lang3.BooleanUtils.isFalse;
 import static org.folio.circulation.domain.OverdueFineCalculatorService.Scenario.CHECKIN;
-import static org.folio.circulation.support.Result.ofAsync;
 import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.ResultBinding.mapResult;
 
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -74,13 +72,9 @@ public class OverdueFineCalculatorService {
     CheckInProcessRecords records, String userId) {
 
     return shouldChargeOverdueFineOnCheckIn(records)
-      .thenCompose(r -> r.afterWhen(liftToFutureResult(),
+      .thenCompose(r -> r.afterWhen(ResultBinding.toFutureResult(),
           b -> createOverdueFineIfNecessary(records.getLoan(), CHECKIN, userId),
           b -> completedFuture(succeeded(null))));
-  }
-
-  private <T> Function<T, CompletableFuture<Result<T>>> liftToFutureResult() {
-    return b -> ofAsync(() -> b);
   }
 
   private CompletableFuture<Result<Boolean>> shouldChargeOverdueFineOnCheckIn(

--- a/src/main/java/org/folio/circulation/domain/OverdueFineCalculatorService.java
+++ b/src/main/java/org/folio/circulation/domain/OverdueFineCalculatorService.java
@@ -2,12 +2,15 @@ package org.folio.circulation.domain;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.commons.lang3.BooleanUtils.isFalse;
+import static org.folio.circulation.domain.OverdueFineCalculatorService.Scenario.CHECKIN;
+import static org.folio.circulation.support.Result.ofAsync;
 import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.ResultBinding.mapResult;
 
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -71,12 +74,13 @@ public class OverdueFineCalculatorService {
     CheckInProcessRecords records, String userId) {
 
     return shouldChargeOverdueFineOnCheckIn(records)
-      .thenCompose(r -> r.after(shouldChargeOverdueFine -> {
-        if (!shouldChargeOverdueFine) {
-          return completedFuture(succeeded(null));
-        }
-        return createOverdueFineIfNecessary(records.getLoan(), Scenario.CHECKIN, userId);
-      }));
+      .thenCompose(r -> r.afterWhen(liftToFutureResult(),
+          b -> createOverdueFineIfNecessary(records.getLoan(), CHECKIN, userId),
+          b -> completedFuture(succeeded(null))));
+  }
+
+  private <T> Function<T, CompletableFuture<Result<T>>> liftToFutureResult() {
+    return b -> ofAsync(() -> b);
   }
 
   private CompletableFuture<Result<Boolean>> shouldChargeOverdueFineOnCheckIn(
@@ -280,7 +284,7 @@ public class OverdueFineCalculatorService {
     CHECKIN(policy -> !policy.isUnknown()),
     RENEWAL(policy -> !policy.isUnknown() && isFalse(policy.getForgiveFineForRenewals()));
 
-    private Predicate<OverdueFinePolicy> shouldCreateFine;
+    private final Predicate<OverdueFinePolicy> shouldCreateFine;
 
     Scenario(Predicate<OverdueFinePolicy> shouldCreateFine) {
       this.shouldCreateFine = shouldCreateFine;

--- a/src/main/java/org/folio/circulation/support/Result.java
+++ b/src/main/java/org/folio/circulation/support/Result.java
@@ -1,6 +1,7 @@
 package org.folio.circulation.support;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.commons.lang3.BooleanUtils.isTrue;
 import static org.folio.circulation.support.results.CommonFailures.failedDueToServerError;
 
 import java.util.Collection;
@@ -191,7 +192,7 @@ public interface Result<T> {
 
     return after(value ->
       conditionFunction.apply(value)
-        .thenComposeAsync(r -> r.after(condition -> condition
+        .thenComposeAsync(r -> r.after(condition -> isTrue(condition)
           ? whenTrue.apply(value)
           : whenFalse.apply(value))));
   }
@@ -259,7 +260,7 @@ public interface Result<T> {
     Supplier<Result<R>> whenTrue,
     Supplier<Result<R>> whenFalse) {
 
-    return condition.next(result -> result
+    return condition.next(result -> isTrue(result)
       ? whenTrue.get()
       : whenFalse.get());
   }

--- a/src/main/java/org/folio/circulation/support/Result.java
+++ b/src/main/java/org/folio/circulation/support/Result.java
@@ -184,10 +184,10 @@ public interface Result<T> {
    * @param whenFalse executed when condition evaluates to false
    * @return Result of whenTrue or whenFalse, unless previous result failed
    */
-  default CompletableFuture<Result<T>> afterWhen(
+  default <R> CompletableFuture<Result<R>> afterWhen(
     Function<T, CompletableFuture<Result<Boolean>>> conditionFunction,
-    Function<T, CompletableFuture<Result<T>>> whenTrue,
-    Function<T, CompletableFuture<Result<T>>> whenFalse) {
+    Function<T, CompletableFuture<Result<R>>> whenTrue,
+    Function<T, CompletableFuture<Result<R>>> whenFalse) {
 
     return after(value ->
       conditionFunction.apply(value)

--- a/src/main/java/org/folio/circulation/support/ResultBinding.java
+++ b/src/main/java/org/folio/circulation/support/ResultBinding.java
@@ -1,5 +1,8 @@
 package org.folio.circulation.support;
 
+import static org.folio.circulation.support.Result.ofAsync;
+
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 public class ResultBinding {
@@ -15,5 +18,9 @@ public class ResultBinding {
     Function<T, Result<R>> mapper) {
 
     return result -> result.next(mapper);
+  }
+
+  public static <T> Function<T, CompletableFuture<Result<T>>> toFutureResult() {
+    return value -> ofAsync(() -> value);
   }
 }

--- a/src/test/java/api/support/fixtures/ServicePointExamples.java
+++ b/src/test/java/api/support/fixtures/ServicePointExamples.java
@@ -1,40 +1,43 @@
 package api.support.fixtures;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
 import api.support.builders.ServicePointBuilder;
 
 class ServicePointExamples {
   static ServicePointBuilder basedUponCircDesk1() {
     return new ServicePointBuilder("Circ Desk 1", "cd1",
-        "Circulation Desk -- Hallway").withPickupLocation(Boolean.TRUE)
+        "Circulation Desk -- Hallway").withPickupLocation(TRUE)
         .withHoldShelfExpriyPeriod(30, "Days");
   }
 
   static ServicePointBuilder basedUponCircDesk2() {
     return new ServicePointBuilder("Circ Desk 2", "cd2",
-        "Circulation Desk -- Back Entrance").withPickupLocation(Boolean.TRUE)
+        "Circulation Desk -- Back Entrance").withPickupLocation(TRUE)
         .withHoldShelfExpriyPeriod(6, "Months");
   }
 
   static ServicePointBuilder basedUponCircDesk3() {
     return new ServicePointBuilder("Circ Desk 3", "cd3",
-        "Circulation Desk -- Dumpster").withPickupLocation(Boolean.FALSE);
+        "Circulation Desk -- Dumpster").withPickupLocation(FALSE);
   }
 
   static ServicePointBuilder basedUponCircDesk4() {
     return new ServicePointBuilder("Circ Desk 4", "cd4",
-        "Circulation Desk -- Basement").withPickupLocation(Boolean.TRUE)
+        "Circulation Desk -- Basement").withPickupLocation(TRUE)
         .withHoldShelfExpriyPeriod(2, "Weeks");
   }
 
   static ServicePointBuilder basedUponCircDesk5() {
     return new ServicePointBuilder("Circ Desk 5", "cd5",
-        "Circulation Desk -- Rooftop").withPickupLocation(Boolean.TRUE)
+        "Circulation Desk -- Rooftop").withPickupLocation(TRUE)
         .withHoldShelfExpriyPeriod(42, "Minutes");
   }
 
   static ServicePointBuilder basedUponCircDesk6() {
     return new ServicePointBuilder("Circ Desk 6", "cd6",
-        "Circulation Desk -- Igloo").withPickupLocation(Boolean.TRUE)
+        "Circulation Desk -- Igloo").withPickupLocation(TRUE)
         .withHoldShelfExpriyPeriod(9, "Hours");
   }
 }

--- a/src/test/java/org/folio/circulation/domain/RequestRepresentationTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestRepresentationTests.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain;
 
+import static java.lang.Boolean.TRUE;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -80,7 +81,7 @@ public class RequestRepresentationTests {
 
     final ServicePointBuilder servicePointBuilder = new ServicePointBuilder("Circ Desk", "cd1", "Circulation Desk")
       .withId(SERVICE_POINT_ID)
-      .withPickupLocation(Boolean.TRUE);
+      .withPickupLocation(TRUE);
 
     final ServicePoint servicePoint = new ServicePoint(servicePointBuilder.create());
 

--- a/src/test/java/org/folio/circulation/support/results/ResultAfterWhenTests.java
+++ b/src/test/java/org/folio/circulation/support/results/ResultAfterWhenTests.java
@@ -53,7 +53,7 @@ public class ResultAfterWhenTests {
     InterruptedException {
 
     final Result<Integer> result = alreadyFailed()
-      .afterWhen(value -> completedFuture(succeeded(true)),
+      .<Integer>afterWhen(value -> completedFuture(succeeded(true)),
         value -> { throw shouldNotExecute(); },
         value -> { throw shouldNotExecute(); })
       .get();
@@ -67,7 +67,7 @@ public class ResultAfterWhenTests {
     InterruptedException {
 
     final Result<Integer> result = succeeded(10)
-      .afterWhen(value -> completedFuture(conditionFailed()),
+      .<Integer>afterWhen(value -> completedFuture(conditionFailed()),
         value -> { throw shouldNotExecute(); },
         value -> { throw shouldNotExecute(); })
       .get();
@@ -81,7 +81,7 @@ public class ResultAfterWhenTests {
     InterruptedException {
 
     final Result<Integer> result = succeeded(10)
-      .afterWhen(value -> completedFuture(succeeded(true)),
+      .<Integer>afterWhen(value -> completedFuture(succeeded(true)),
         value -> supplyAsync(() -> { throw somethingWentWrong(); }),
         value -> { throw shouldNotExecute(); })
       .get();
@@ -95,7 +95,7 @@ public class ResultAfterWhenTests {
     InterruptedException {
 
     final Result<Integer> result = succeeded(10)
-      .afterWhen(value -> completedFuture(succeeded(false)),
+      .<Integer>afterWhen(value -> completedFuture(succeeded(false)),
         value -> { throw shouldNotExecute(); },
         value -> supplyAsync(() -> { throw somethingWentWrong(); }))
       .get();
@@ -109,7 +109,7 @@ public class ResultAfterWhenTests {
     InterruptedException {
 
     final Result<Integer> result = succeeded(10)
-      .afterWhen(value -> supplyAsync(() -> { throw somethingWentWrong(); }),
+      .<Integer>afterWhen(value -> supplyAsync(() -> { throw somethingWentWrong(); }),
         value -> { throw shouldNotExecute(); },
         value -> { throw shouldNotExecute(); })
       .get();
@@ -123,7 +123,7 @@ public class ResultAfterWhenTests {
     InterruptedException {
 
     final Result<Integer> result = succeeded(10)
-      .afterWhen(value -> completedFuture(succeeded(true)),
+      .<Integer>afterWhen(value -> completedFuture(succeeded(true)),
         value -> { throw somethingWentWrong(); },
         value -> {throw shouldNotExecute(); })
       .get();
@@ -137,7 +137,7 @@ public class ResultAfterWhenTests {
     InterruptedException {
 
     final Result<Integer> result = succeeded(10)
-      .afterWhen(value -> completedFuture(succeeded(false)),
+      .<Integer>afterWhen(value -> completedFuture(succeeded(false)),
         value -> { throw shouldNotExecute(); },
         value -> {throw somethingWentWrong(); })
       .get();


### PR DESCRIPTION
## Purpose

Resolves multiple code smells (some longstanding) for evaluating a Boolean in a way that could cause a `NullPointerException`.

## Approach
* Allow the `afterWhen` method for a `Result` to change the type of result
* Use `afterWhen` whilst deciding whether to charge an overdue fee
* Extract method to express making a future result from a value clearer

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
