### PR TITLE
Double docker memory allocation CIRC-762

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2250,7 +2250,7 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 357913941,
+        "Memory": 715827882,
         "PortBindings": { "9801/tcp": [ { "HostPort": "%p" } ] }
       }
     },


### PR DESCRIPTION
## Purpose

Recently, mod-circulation has repeatedly run out of memory in the hosted reference environments.

It is possible that this is caused by recent changes to integrate with pub-sub, which likely requires a higher baseline memory due to additional libraries and heavy use when processing messages.

Given that it is close to the end of the quarter and it is hard to diagnose these kinds of issues, an initial workaround is to increase the memory allocated to the module.

## Approach
* Doubled the memory allocation for Docker container in module descriptor