### PR TITLE
CIRC-761 Ignore PubSub NO SUBSCRIBERS response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
       <version>${vertx.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
+      <version>${vertx.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.9.10.3</version>

--- a/src/main/java/org/folio/circulation/services/PubSubPublishingService.java
+++ b/src/main/java/org/folio/circulation/services/PubSubPublishingService.java
@@ -23,12 +23,10 @@ import io.vertx.ext.web.RoutingContext;
 public class PubSubPublishingService {
   private static final Logger logger = LoggerFactory.getLogger(PubSubPublishingService.class);
 
-  private final RoutingContext routingContext;
   private final Map<String, String> okapiHeaders;
   private final Context vertxContext;
 
   public PubSubPublishingService(RoutingContext routingContext) {
-    this.routingContext = routingContext;
     okapiHeaders = new WebContext(routingContext).getHeaders();
     vertxContext = routingContext.vertx().getOrCreateContext();
   }

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -1220,6 +1220,23 @@ public class CheckOutByBarcodeTests extends APITests {
     assertThat(event, isValidItemCheckedOutEvent(loan));
   }
 
+  @Test
+  public void checkOutSucceedsWhenEventPublishingFailsWithNoSubscribersError() {
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource steve = usersFixture.steve();
+
+    FakePubSub.setFailPublishingWithNoSubscribersError(true);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(smallAngryPlanet)
+        .to(steve)
+        .on(DateTime.now(UTC))
+        .at(UUID.randomUUID()));
+
+    assertThat(itemsClient.getById(smallAngryPlanet.getId()).getJson(), isCheckedOut());
+  }
+
   private IndividualResource prepareLoanPolicyWithItemLimit(int itemLimit) {
     return loanPoliciesFixture.create(
       new LoanPolicyBuilder()

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -299,6 +299,7 @@ public abstract class APITests {
     usersFixture.defaultAdmin();
 
     FakePubSub.clearPublishedEvents();
+    FakePubSub.setFailPublishingWithNoSubscribersError(false);
   }
 
   @After

--- a/src/test/java/api/support/fakes/FakePubSub.java
+++ b/src/test/java/api/support/fakes/FakePubSub.java
@@ -31,7 +31,6 @@ public class FakePubSub {
 
     router.post("/pubsub/publish")
       .handler(routingContext -> {
-        publishedEvents.add(routingContext.getBodyAsJson());
         if (failPublishingWithNoSubscribersError) {
           Buffer buffer = Buffer.buffer(
             "There is no SUBSCRIBERS registered for event type EVENT_TYPE", "UTF-8");
@@ -43,6 +42,7 @@ public class FakePubSub {
             .end();
         }
         else {
+          publishedEvents.add(routingContext.getBodyAsJson());
           routingContext.response()
             .setStatusCode(HTTP_NO_CONTENT.toInt())
             .end();

--- a/src/test/java/api/support/fakes/FakePubSub.java
+++ b/src/test/java/api/support/fakes/FakePubSub.java
@@ -3,6 +3,7 @@ package api.support.fakes;
 import static org.folio.HttpStatus.HTTP_CREATED;
 import static org.folio.HttpStatus.HTTP_INTERNAL_SERVER_ERROR;
 import static org.folio.HttpStatus.HTTP_NO_CONTENT;
+import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -10,14 +11,11 @@ import java.util.List;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 
 public class FakePubSub {
-  private static final Logger logger = LoggerFactory.getLogger(FakePubSub.class);
   private static final List<JsonObject> publishedEvents = new ArrayList<>();
   private static final List<JsonObject> createdEventTypes = new ArrayList<>();
   private static final List<JsonObject> registeredPublishers = new ArrayList<>();
@@ -26,6 +24,7 @@ public class FakePubSub {
 
   private static boolean failPubSubRegistration;
   private static boolean failPubSubUnregistering;
+  private static boolean failPublishingWithNoSubscribersError;
 
   public static void register(Router router) {
     router.route().handler(BodyHandler.create());
@@ -33,9 +32,21 @@ public class FakePubSub {
     router.post("/pubsub/publish")
       .handler(routingContext -> {
         publishedEvents.add(routingContext.getBodyAsJson());
-        routingContext.response()
-          .setStatusCode(HTTP_NO_CONTENT.toInt())
-          .end();
+        if (failPublishingWithNoSubscribersError) {
+          Buffer buffer = Buffer.buffer(
+            "There is no SUBSCRIBERS registered for event type EVENT_TYPE", "UTF-8");
+          routingContext.response()
+            .setStatusCode(HTTP_UNPROCESSABLE_ENTITY.toInt())
+            .putHeader("content-type", "text/plain; charset=utf-8")
+            .putHeader("content-length", Integer.toString(buffer.length()))
+            .write(buffer)
+            .end();
+        }
+        else {
+          routingContext.response()
+            .setStatusCode(HTTP_NO_CONTENT.toInt())
+            .end();
+        }
       });
 
     router.post("/pubsub/event-types")
@@ -119,5 +130,11 @@ public class FakePubSub {
 
   public static void setFailPubSubUnregistering(boolean failPubSubUnregistering) {
     FakePubSub.failPubSubUnregistering = failPubSubUnregistering;
+  }
+
+  public static void setFailPublishingWithNoSubscribersError(
+    boolean failPublishingWithNoSubscribersError) {
+
+    FakePubSub.failPublishingWithNoSubscribersError = failPublishingWithNoSubscribersError;
   }
 }

--- a/src/test/java/api/support/fakes/FakePubSub.java
+++ b/src/test/java/api/support/fakes/FakePubSub.java
@@ -1,9 +1,9 @@
 package api.support.fakes;
 
+import static org.folio.HttpStatus.HTTP_BAD_REQUEST;
 import static org.folio.HttpStatus.HTTP_CREATED;
 import static org.folio.HttpStatus.HTTP_INTERNAL_SERVER_ERROR;
 import static org.folio.HttpStatus.HTTP_NO_CONTENT;
-import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +36,7 @@ public class FakePubSub {
           Buffer buffer = Buffer.buffer(
             "There is no SUBSCRIBERS registered for event type EVENT_TYPE", "UTF-8");
           routingContext.response()
-            .setStatusCode(HTTP_UNPROCESSABLE_ENTITY.toInt())
+            .setStatusCode(HTTP_BAD_REQUEST.toInt())
             .putHeader("content-type", "text/plain; charset=utf-8")
             .putHeader("content-length", Integer.toString(buffer.length()))
             .write(buffer)

--- a/src/test/java/org/folio/circulation/services/PubSubPublishingServiceTest.java
+++ b/src/test/java/org/folio/circulation/services/PubSubPublishingServiceTest.java
@@ -1,0 +1,54 @@
+package org.folio.circulation.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PubSubPublishingServiceTest {
+  @Mock
+  private RoutingContext routingContext;
+
+  @Mock
+  private HttpServerRequest request;
+
+  private PubSubPublishingService pubSubPublishingService;
+  private Throwable pubSubClientThrowable;
+
+  @Before
+  public void setUp() {
+    when(routingContext.request()).thenReturn(request);
+    when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+    pubSubPublishingService = new PubSubPublishingService(routingContext);
+  }
+
+  @Test
+  public void shouldFailWhenPubSubClientThrowsException() {
+    PubSubPublishingService pubSubPublishingServiceSpy = spy(pubSubPublishingService);
+    when(pubSubPublishingServiceSpy.getPubSubClient()).thenThrow(
+      new IllegalArgumentException("Error message"));
+    CompletableFuture<Boolean> future = pubSubPublishingServiceSpy.publishEvent(
+      "EVENT_TYPE", "EVENT_PAYLOAD").whenComplete(
+        (Boolean result, Throwable throwable) -> pubSubClientThrowable = throwable);
+
+    Awaitility.await()
+      .atMost(1, TimeUnit.SECONDS)
+      .until(future::isCompletedExceptionally);
+
+    assertEquals("Error message", pubSubClientThrowable.getMessage());
+  }
+}


### PR DESCRIPTION
Resolves [CIRC-761](https://issues.folio.org/browse/CIRC-761).

## Purpose
PubSub returns 400 Bad Request response when the event is published and there are no subscribers for its event type. CIRC-734 contained code aimed to ignore this response but it didn't handle the response correctly.

## Approach
New method for publishing was created, because method from PubSubClientUtils doesn't include response body in the exception message.
There's also additional API test to ensure that 400 Bad Request with "no SUBSCRIBERS" message is ignored (only for check out, other actions call the same publishing service).

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
