### PR TITLE
[CIRC-768] Increased page limit for fetching locations during pick slips generation

### DIFF
--- a/src/main/java/org/folio/circulation/resources/PickSlipsResource.java
+++ b/src/main/java/org/folio/circulation/resources/PickSlipsResource.java
@@ -38,6 +38,7 @@ import org.folio.circulation.support.ItemRepository;
 import org.folio.circulation.support.Result;
 import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.client.CqlQuery;
+import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.server.JsonHttpResponse;
 import org.folio.circulation.support.http.server.WebContext;
 
@@ -58,6 +59,8 @@ public class PickSlipsResource extends Resource {
   private static final String SERVICE_POINT_ID_PARAM = "servicePointId";
   private static final String EFFECTIVE_LOCATION_ID_KEY = "effectiveLocationId";
   private static final String PRIMARY_SERVICE_POINT_KEY = "primaryServicePoint";
+
+  private static final PageLimit LOCATIONS_LIMIT = PageLimit.oneThousand();
 
   private final String rootPath;
 
@@ -98,7 +101,7 @@ public class PickSlipsResource extends Resource {
     UUID servicePointId, Clients clients) {
 
     return findWithCqlQuery(clients.locationsStorage(), LOCATIONS_KEY, Location::from)
-      .findByQuery(exactMatch(PRIMARY_SERVICE_POINT_KEY, servicePointId.toString()));
+      .findByQuery(exactMatch(PRIMARY_SERVICE_POINT_KEY, servicePointId.toString()), LOCATIONS_LIMIT);
   }
 
   private CompletableFuture<Result<Collection<Item>>> fetchPagedItemsForLocations(

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -394,7 +394,6 @@ public class PickSlipsTests extends APITests {
       .forItem(item)
       .by(james);
 
-
     IndividualResource pageRequest = requestsClient.create(pageRequestBuilder);
 
     Response response = ResourceClient.forPickSlips().getById(servicePointId);

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -365,6 +365,46 @@ public class PickSlipsTests extends APITests {
     assertResponseContains(responseForCd4, planetSecondFloorCd4, requestForSecondFloorCd4, jessica);
   }
 
+  @Test
+  public void responseContainsPickSlipsWhenServicePointHasManyLocations() {
+    final UUID servicePointId = servicePointsFixture.cd1().getId();
+    final int numberOfLocations = 100;
+
+    IndividualResource location = null;
+    for (int i = 0; i < numberOfLocations; i++) {
+      final int currentIndex = i;
+      location = locationsFixture.basedUponExampleLocation(
+        builder -> builder
+          .withName("Test location " + currentIndex)
+          .withCode("LOC_" + currentIndex)
+          .withPrimaryServicePoint(servicePointId));
+    }
+
+    final IndividualResource lastLocation = location;
+    InventoryItemResource item = itemsFixture.basedUponSmallAngryPlanet(builder -> builder
+      .withPermanentLocation(lastLocation.getId())
+      .withNoTemporaryLocation());
+
+    IndividualResource james = usersFixture.james();
+
+    RequestBuilder pageRequestBuilder = new RequestBuilder()
+      .withStatus(RequestStatus.OPEN_NOT_YET_FILLED.getValue())
+      .page()
+      .withPickupServicePointId(servicePointId)
+      .forItem(item)
+      .by(james);
+
+
+    IndividualResource pageRequest = requestsClient.create(pageRequestBuilder);
+
+    Response response = ResourceClient.forPickSlips().getById(servicePointId);
+
+    assertThat(response.getStatusCode(), is(HTTP_OK));
+    assertResponseHasItems(response, 1);
+    assertResponseContains(response, item, pageRequest, james);
+  }
+
+
   private void assertResponseHasItems(Response response, int itemsCount) {
     JsonObject responseJson = response.getJson();
     assertThat(responseJson.getJsonArray(PICK_SLIPS_KEY).size(), is(itemsCount));


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
When more than 10 locations are assigned to a single service point, picks slips for items located in some of those location may not be created.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
Increase page limit for fetching locations during pick slips generation from default 10 to 1000.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
