### PR TITLE
CIRC-716: Refund lost item fees on override renewal.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -150,7 +150,7 @@
     },
     {
       "id": "circulation",
-      "version": "9.3",
+      "version": "9.4",
       "handlers": [
         {
           "methods": [
@@ -1404,7 +1404,11 @@
         "scheduled-notice-storage.scheduled-notices.item.post",
         "usergroups.collection.get",
         "usergroups.item.get",
-        "automated-patron-blocks.collection.get"
+        "automated-patron-blocks.collection.get",
+        "accounts.collection.get",
+        "feefineactions.collection.get",
+        "feefineactions.item.post",
+        "accounts.item.put"
       ],
       "visible": false
     },

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <lombok.version>1.18.12</lombok.version>
+    <spring.version>5.2.7.RELEASE</spring.version>
   </properties>
 
   <dependencies>
@@ -194,6 +195,24 @@
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
       <version>2.25.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${spring.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>${spring.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>${spring.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- Reinstate if we figure out a way to refer to schema that are compatible

--- a/ramls/circulation.raml
+++ b/ramls/circulation.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Circulation
-version: v9.3
+version: v9.4
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost:9130
 

--- a/ramls/examples/override-renewal-by-barcode-request.json
+++ b/ramls/examples/override-renewal-by-barcode-request.json
@@ -3,5 +3,5 @@
   "itemBarcode": "2887532577331",
   "comment": "Renewal override",
   "dueDate": "2018-12-21T13:30:00Z",
-  "overrideServicePointId": "f0e919e7-1f91-4d9f-920f-9ea2d9c7451c"
+  "servicePointId": "f0e919e7-1f91-4d9f-920f-9ea2d9c7451c"
 }

--- a/ramls/examples/override-renewal-by-barcode-request.json
+++ b/ramls/examples/override-renewal-by-barcode-request.json
@@ -2,5 +2,6 @@
   "userBarcode": "466983136459401",
   "itemBarcode": "2887532577331",
   "comment": "Renewal override",
-  "dueDate": "2018-12-21T13:30:00Z"
+  "dueDate": "2018-12-21T13:30:00Z",
+  "overrideServicePointId": "f0e919e7-1f91-4d9f-920f-9ea2d9c7451c"
 }

--- a/ramls/override-renewal-by-barcode-request.json
+++ b/ramls/override-renewal-by-barcode-request.json
@@ -19,6 +19,11 @@
     "comment": {
       "description": "Comment to override action stored in loan history",
       "type": "string"
+    },
+    "overrideServicePointId": {
+      "description": "Service point id where override happens",
+      "type": "string",
+      "$ref": "raml-util/schemas/uuid.schema"
     }
   },
   "additionalProperties": false,

--- a/ramls/override-renewal-by-barcode-request.json
+++ b/ramls/override-renewal-by-barcode-request.json
@@ -20,7 +20,7 @@
       "description": "Comment to override action stored in loan history",
       "type": "string"
     },
-    "overrideServicePointId": {
+    "servicePointId": {
       "description": "Service point id where override happens",
       "type": "string",
       "$ref": "raml-util/schemas/uuid.schema"

--- a/src/main/java/org/folio/circulation/domain/OverdueFineCalculatorService.java
+++ b/src/main/java/org/folio/circulation/domain/OverdueFineCalculatorService.java
@@ -3,8 +3,10 @@ package org.folio.circulation.domain;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.commons.lang3.BooleanUtils.isFalse;
 import static org.folio.circulation.domain.OverdueFineCalculatorService.Scenario.CHECKIN;
+import static org.folio.circulation.domain.OverdueFineCalculatorService.Scenario.RENEWAL;
 import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.ResultBinding.mapResult;
+import static org.folio.circulation.support.ResultBinding.toFutureResult;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -64,8 +66,8 @@ public class OverdueFineCalculatorService {
     final Loan loanBeforeRenewal = context.getLoanBeforeRenewal();
 
     return shouldChargeOverdueFineOnRenewal(context)
-      .thenCompose(r -> r.afterWhen(ResultBinding.toFutureResult(),
-        b -> createOverdueFineIfNecessary(loanBeforeRenewal, Scenario.RENEWAL, loggedInUserId),
+      .thenCompose(r -> r.afterWhen(toFutureResult(),
+        b -> createOverdueFineIfNecessary(loanBeforeRenewal, RENEWAL, loggedInUserId),
         b -> completedFuture(succeeded(null))))
       .thenApply(mapResult(context::withOverdueFeeFineAction));
   }
@@ -91,7 +93,7 @@ public class OverdueFineCalculatorService {
     CheckInContext context, String userId) {
 
     return shouldChargeOverdueFineOnCheckIn(context)
-      .thenCompose(r -> r.afterWhen(ResultBinding.toFutureResult(),
+      .thenCompose(r -> r.afterWhen(toFutureResult(),
           b -> createOverdueFineIfNecessary(context.getLoan(), CHECKIN, userId),
           b -> completedFuture(succeeded(null))));
   }

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeService.java
@@ -49,10 +49,8 @@ public class FeeFineScheduledNoticeService {
     return succeeded(records);
   }
 
-  public Result<RenewalContext> scheduleNotices(
-    RenewalContext records, FeeFineAction action) {
-
-    scheduleNotices(records.getLoan(), action, OVERDUE_FINE_RENEWED);
+  public Result<RenewalContext> scheduleOverdueFineNotices(RenewalContext records) {
+    scheduleNotices(records.getLoan(), records.getOverdueFeeFineAction(), OVERDUE_FINE_RENEWED);
 
     return succeeded(records);
   }

--- a/src/main/java/org/folio/circulation/resources/context/RenewalContext.java
+++ b/src/main/java/org/folio/circulation/resources/context/RenewalContext.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.resources.context;
 
+import org.folio.circulation.domain.FeeFineAction;
 import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.RequestQueue;
@@ -21,6 +22,7 @@ public class RenewalContext {
   boolean lostItemFeesRefundedOrCancelled;
   String loggedInUserId;
   JsonObject renewalRequest;
+  FeeFineAction overdueFeeFineAction;
 
   public static RenewalContext newRenewalContext(Loan loan, JsonObject renewalRequest,
     String loggedInUserId) {
@@ -30,6 +32,6 @@ public class RenewalContext {
       ? loan.getItem().getStatus() : null;
 
     return new RenewalContext(loan, null, null, loanBeforeRenewal, itemStatusBeforeRenew,
-      false, loggedInUserId, renewalRequest);
+      false, loggedInUserId, renewalRequest, null);
   }
 }

--- a/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalByBarcodeResource.java
@@ -17,7 +17,8 @@ import io.vertx.core.json.JsonObject;
 public class OverrideRenewalByBarcodeResource extends RenewalResource {
 
   public OverrideRenewalByBarcodeResource(HttpClient client) {
-    super("/circulation/override-renewal-by-barcode", new OverrideRenewalStrategy(), client);
+    super("/circulation/override-renewal-by-barcode", new OverrideRenewalStrategy(),
+      new OverrideRenewalFeeProcessingStrategy(), client);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalFeeProcessingStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalFeeProcessingStrategy.java
@@ -7,6 +7,9 @@ import org.folio.circulation.services.LostItemFeeRefundService;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.Result;
 
+/**
+ * Fee processing strategy that used to process fees/fines for override renewal.
+ */
 public class OverrideRenewalFeeProcessingStrategy implements RenewalFeeProcessingStrategy {
   private final RegularRenewalFeeProcessingStrategy regularFeeProcessing =
     new RegularRenewalFeeProcessingStrategy();

--- a/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalFeeProcessingStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalFeeProcessingStrategy.java
@@ -7,9 +7,6 @@ import org.folio.circulation.services.LostItemFeeRefundService;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.Result;
 
-/**
- * Fee processing strategy that used to process fees/fines for override renewal.
- */
 public class OverrideRenewalFeeProcessingStrategy implements RenewalFeeProcessingStrategy {
   private final RegularRenewalFeeProcessingStrategy regularFeeProcessing =
     new RegularRenewalFeeProcessingStrategy();

--- a/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalFeeProcessingStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalFeeProcessingStrategy.java
@@ -1,0 +1,27 @@
+package org.folio.circulation.resources.renewal;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.circulation.resources.context.RenewalContext;
+import org.folio.circulation.services.LostItemFeeRefundService;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.Result;
+
+public class OverrideRenewalFeeProcessingStrategy implements RenewalFeeProcessingStrategy {
+  private final RegularRenewalFeeProcessingStrategy regularFeeProcessing =
+    new RegularRenewalFeeProcessingStrategy();
+
+  @Override
+  public CompletableFuture<Result<RenewalContext>> processFeesFines(
+    RenewalContext renewalContext, Clients clients) {
+
+    final LostItemFeeRefundService lostFeeRefundService = new LostItemFeeRefundService(clients);
+
+    return lostFeeRefundService.refundLostItemFees(renewalContext, overrideServicePointId(renewalContext))
+      .thenCompose(r -> r.after(context -> regularFeeProcessing.processFeesFines(context, clients)));
+  }
+
+  private String overrideServicePointId(RenewalContext renewalContext) {
+    return renewalContext.getRenewalRequest().getString("overrideServicePointId");
+  }
+}

--- a/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalFeeProcessingStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalFeeProcessingStrategy.java
@@ -20,11 +20,11 @@ public class OverrideRenewalFeeProcessingStrategy implements RenewalFeeProcessin
 
     final LostItemFeeRefundService lostFeeRefundService = new LostItemFeeRefundService(clients);
 
-    return lostFeeRefundService.refundLostItemFees(renewalContext, overrideServicePointId(renewalContext))
+    return lostFeeRefundService.refundLostItemFees(renewalContext, servicePointId(renewalContext))
       .thenCompose(r -> r.after(context -> regularFeeProcessing.processFeesFines(context, clients)));
   }
 
-  private String overrideServicePointId(RenewalContext renewalContext) {
-    return renewalContext.getRenewalRequest().getString("overrideServicePointId");
+  private String servicePointId(RenewalContext renewalContext) {
+    return renewalContext.getRenewalRequest().getString("servicePointId");
   }
 }

--- a/src/main/java/org/folio/circulation/resources/renewal/RegularRenewalFeeProcessingStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RegularRenewalFeeProcessingStrategy.java
@@ -9,9 +9,6 @@ import org.folio.circulation.resources.context.RenewalContext;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.Result;
 
-/**
- * Fee processing strategy that used to process fees/fines for regular renew.
- */
 public class RegularRenewalFeeProcessingStrategy implements RenewalFeeProcessingStrategy {
   @Override
   public CompletableFuture<Result<RenewalContext>> processFeesFines(

--- a/src/main/java/org/folio/circulation/resources/renewal/RegularRenewalFeeProcessingStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RegularRenewalFeeProcessingStrategy.java
@@ -9,6 +9,9 @@ import org.folio.circulation.resources.context.RenewalContext;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.Result;
 
+/**
+ * Fee processing strategy that used to process fees/fines for regular renew.
+ */
 public class RegularRenewalFeeProcessingStrategy implements RenewalFeeProcessingStrategy {
   @Override
   public CompletableFuture<Result<RenewalContext>> processFeesFines(

--- a/src/main/java/org/folio/circulation/resources/renewal/RegularRenewalFeeProcessingStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RegularRenewalFeeProcessingStrategy.java
@@ -1,0 +1,20 @@
+package org.folio.circulation.resources.renewal;
+
+import static org.folio.circulation.domain.OverdueFineCalculatorService.using;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.circulation.domain.OverdueFineCalculatorService;
+import org.folio.circulation.resources.context.RenewalContext;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.Result;
+
+public class RegularRenewalFeeProcessingStrategy implements RenewalFeeProcessingStrategy {
+  @Override
+  public CompletableFuture<Result<RenewalContext>> processFeesFines(
+    RenewalContext renewalContext, Clients clients) {
+
+    final OverdueFineCalculatorService overdueFineService = using(clients);
+    return overdueFineService.createOverdueFineIfNecessary(renewalContext);
+  }
+}

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewByBarcodeResource.java
@@ -16,7 +16,8 @@ import io.vertx.core.json.JsonObject;
 
 public class RenewByBarcodeResource extends RenewalResource {
   public RenewByBarcodeResource(HttpClient client) {
-    super("/circulation/renew-by-barcode", new RegularRenewalStrategy(), client);
+    super("/circulation/renew-by-barcode", new RegularRenewalStrategy(),
+      new RegularRenewalFeeProcessingStrategy(), client);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewByIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewByIdResource.java
@@ -21,7 +21,8 @@ import io.vertx.core.json.JsonObject;
 
 public class RenewByIdResource extends RenewalResource {
   public RenewByIdResource(HttpClient client) {
-    super("/circulation/renew-by-id", new RegularRenewalStrategy(), client);
+    super("/circulation/renew-by-id", new RegularRenewalStrategy(),
+      new RegularRenewalFeeProcessingStrategy(), client);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalFeeProcessingStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalFeeProcessingStrategy.java
@@ -1,0 +1,13 @@
+package org.folio.circulation.resources.renewal;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.circulation.resources.context.RenewalContext;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.Result;
+
+public interface RenewalFeeProcessingStrategy {
+
+  CompletableFuture<Result<RenewalContext>> processFeesFines(
+    RenewalContext renewalContext, Clients clients);
+}

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalFeeProcessingStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalFeeProcessingStrategy.java
@@ -7,7 +7,6 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.Result;
 
 public interface RenewalFeeProcessingStrategy {
-
   CompletableFuture<Result<RenewalContext>> processFeesFines(
     RenewalContext renewalContext, Clients clients);
 }

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -12,7 +12,6 @@ import org.folio.circulation.domain.ConfigurationRepository;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanRepository;
 import org.folio.circulation.domain.LoanRepresentation;
-import org.folio.circulation.domain.OverdueFineCalculatorService;
 import org.folio.circulation.domain.RequestQueueRepository;
 import org.folio.circulation.domain.UserRepository;
 import org.folio.circulation.domain.notice.schedule.DueDateScheduledNoticeService;
@@ -41,11 +40,15 @@ import io.vertx.ext.web.RoutingContext;
 public abstract class RenewalResource extends Resource {
   private final String rootPath;
   private final RenewalStrategy renewalStrategy;
+  private final RenewalFeeProcessingStrategy feeProcessing;
 
-  RenewalResource(String rootPath, RenewalStrategy renewalStrategy, HttpClient client) {
+  RenewalResource(String rootPath, RenewalStrategy renewalStrategy,
+    RenewalFeeProcessingStrategy feeProcessing, HttpClient client) {
+
     super(client);
     this.rootPath = rootPath;
     this.renewalStrategy = renewalStrategy;
+    this.feeProcessing = feeProcessing;
   }
 
   @Override
@@ -82,6 +85,8 @@ public abstract class RenewalResource extends Resource {
         messages -> new ValidationErrorFailure(messages.stream()
           .map(message -> new ValidationError(message, new HashMap<>()))
           .collect(Collectors.toList())));
+    final FeeFineScheduledNoticeService feeFineNoticesService =
+      FeeFineScheduledNoticeService.using(clients);
 
     //TODO: Validation check for same user should be in the domain service
     JsonObject bodyAsJson = routingContext.getBodyAsJson();
@@ -98,22 +103,14 @@ public abstract class RenewalResource extends Resource {
         RenewalContext::withTimeZone))
       .thenComposeAsync(r -> r.after(records -> renewalStrategy.renew(records, clients)))
       .thenComposeAsync(r -> r.after(storeLoanAndItem::updateLoanAndItemInStorage))
-      .thenComposeAsync(r -> r.after(records -> createOverdueFine(records, clients)))
+      .thenComposeAsync(r -> r.after(records -> feeProcessing.processFeesFines(records, clients)))
+      .thenApplyAsync(r -> r.next(feeFineNoticesService::scheduleOverdueFineNotices))
       .thenComposeAsync(r -> r.after(eventPublisher::publishDueDateChangedEvent))
       .thenApply(r -> r.next(scheduledNoticeService::rescheduleDueDateNotices))
       .thenApply(r -> r.next(loanNoticeSender::sendRenewalPatronNotice))
       .thenApply(r -> r.map(loanRepresentation::extendedLoan))
       .thenApply(r -> r.map(this::toResponse))
       .thenAccept(context::writeResultToHttpResponse);
-  }
-
-  private CompletableFuture<Result<RenewalContext>> createOverdueFine(
-    RenewalContext records, Clients clients) {
-
-    return OverdueFineCalculatorService.using(clients)
-      .createOverdueFineIfNecessary(records)
-      .thenApply(r -> r.next(action -> FeeFineScheduledNoticeService.using(clients)
-        .scheduleNotices(records, action)));
   }
 
   private HttpResponse toResponse(JsonObject body) {

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
@@ -24,6 +24,7 @@ import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanRepository;
 import org.folio.circulation.domain.policy.LostItemPolicyRepository;
 import org.folio.circulation.domain.policy.lostitem.LostItemPolicy;
+import org.folio.circulation.resources.context.RenewalContext;
 import org.folio.circulation.services.support.RefundAccountCommand;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.Result;
@@ -57,6 +58,17 @@ public class LostItemFeeRefundService {
 
     return refundLostItemFees(referenceDataContext)
       .thenApply(r -> r.map(checkInRecords::withLostItemFeesRefundedOrCancelled));
+  }
+
+  public CompletableFuture<Result<RenewalContext>> refundLostItemFees(
+    RenewalContext renewalContext, String currentServicePointId) {
+
+    final ReferenceDataContext referenceDataContext = new ReferenceDataContext(
+      renewalContext.getItemStatusBeforeRenewal(), renewalContext.getLoan().getItemId(),
+      renewalContext.getLoan(), renewalContext.getLoggedInUserId(), currentServicePointId);
+
+    return refundLostItemFees(referenceDataContext)
+      .thenApply(r -> r.map(renewalContext::withLostItemFeesRefundedOrCancelled));
   }
 
   private CompletableFuture<Result<Boolean>> refundLostItemFees(ReferenceDataContext referenceData) {

--- a/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import api.support.builders.CheckInByBarcodeRequestBuilder;
 import io.vertx.core.json.JsonObject;
 
-public class CheckInDeclaredLostItemTest extends RefundLostItemFeesBaseTest {
+public class CheckInDeclaredLostItemTest extends RefundLostItemFeesTestBase {
 
   @Override
   protected void performActionThatRequiresRefund() {

--- a/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
@@ -1,361 +1,42 @@
 package api.loans.scenarios;
 
-import static api.support.http.CqlQuery.queryFromTemplate;
-import static api.support.matchers.AccountActionsMatchers.CANCELLED_ITEM_RETURNED;
-import static api.support.matchers.AccountActionsMatchers.CREDITED_FULLY;
-import static api.support.matchers.AccountActionsMatchers.REFUNDED_FULLY;
-import static api.support.matchers.AccountActionsMatchers.REFUND_TO_BURSAR;
-import static api.support.matchers.AccountActionsMatchers.REFUND_TO_PATRON;
 import static api.support.matchers.AccountActionsMatchers.arePaymentRefundActionsCreated;
-import static api.support.matchers.AccountActionsMatchers.areTransferRefundActionsCreated;
 import static api.support.matchers.AccountActionsMatchers.isCancelledItemReturnedActionCreated;
-import static api.support.matchers.AccountMatchers.isClosedCancelledItemReturned;
 import static api.support.matchers.AccountMatchers.isOpen;
-import static api.support.matchers.AccountMatchers.isPaidFully;
 import static api.support.matchers.AccountMatchers.isRefundedFully;
-import static api.support.matchers.AccountMatchers.isTransferredFully;
 import static api.support.matchers.ItemMatchers.isAvailable;
-import static api.support.matchers.ItemMatchers.isLostAndPaid;
-import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
 import static api.support.matchers.LoanAccountActionsMatcher.hasLostItemFeeActions;
-import static api.support.matchers.LoanAccountActionsMatcher.hasLostItemProcessingFeeActions;
 import static api.support.matchers.LoanAccountMatcher.hasLostItemFee;
-import static api.support.matchers.LoanAccountMatcher.hasLostItemProcessingFee;
-import static api.support.matchers.LoanAccountMatcher.hasNoOverdueFine;
-import static api.support.matchers.LoanAccountMatcher.hasOverdueFine;
-import static api.support.matchers.LoanMatchers.isClosed;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInRelativeOrder;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTime.parse;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Before;
 import org.junit.Test;
 
-import api.support.APITests;
-import api.support.MultipleJsonRecords;
 import api.support.builders.CheckInByBarcodeRequestBuilder;
-import api.support.builders.DeclareItemLostRequestBuilder;
 import io.vertx.core.json.JsonObject;
 
-public class CheckInDeclaredLostItemTest extends APITests {
-  private static final String DATE_ACTION_PROPERTY = "dateAction";
+public class CheckInDeclaredLostItemTest extends RefundLostItemFeesBaseTest {
 
-  private final IndividualResource item = itemsFixture.basedUponNod();
-  private IndividualResource loan;
-
-  @Before
-  public void activateChargeableLostItemFeePolicy() {
-    useLostItemPolicy(lostItemFeePoliciesFixture.chargeFee().getId());
-  }
-
-  @Test
-  public void shouldCancelItemFeeOnlyWhenNoOtherFeesCharged() {
-    final double itemFee = 15.00;
-
-    useLostItemPolicy(lostItemFeePoliciesFixture.create(
-      lostItemFeePoliciesFixture.facultyStandardPolicy()
-        .withName("Test check in")
-        .doNotChargeProcessingFee()
-        .withSetCost(itemFee)).getId());
-
-    declareItemLost();
-
+  @Override
+  protected void performActionThatRequiresRefund() {
     checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemFee(isClosedCancelledItemReturned(itemFee)));
-    assertThat(loan, hasLostItemFeeActions(isCancelledItemReturnedActionCreated(itemFee)));
   }
 
-  @Test
-  public void shouldCancelItemProcessingFeeOnlyWhenNoOtherFeesChargedAndNoPaymentsMade() {
-    final double processingFee = 12.99;
-
-    useLostItemPolicy(lostItemFeePoliciesFixture.create(
-      lostItemFeePoliciesFixture.facultyStandardPolicy()
-        .withName("Test check in")
-        .chargeProcessingFee(processingFee)
-        .withNoChargeAmountItem()).getId());
-
-    declareItemLost();
-
-    checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      isCancelledItemReturnedActionCreated(processingFee)));
-  }
-
-  @Test
-  public void shouldNotRefundProcessingFeeWhenPolicyStatesNotTo() {
-    final double processingFee = 12.99;
-
-    useLostItemPolicy(lostItemFeePoliciesFixture.create(
-      lostItemFeePoliciesFixture.facultyStandardPolicy()
-        .withName("Test check in")
-        .chargeProcessingFee(processingFee)
-        .doNotRefundProcessingFeeWhenReturned()
-        .withNoChargeAmountItem()).getId());
-
-    declareItemLost();
-
-    feeFineAccountFixture.payLostItemProcessingFee(loan.getId());
-
-    checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemProcessingFee(isPaidFully(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      not(arePaymentRefundActionsCreated(processingFee))));
-  }
-
-  @Test
-  public void shouldNotRefundFeesWhenReturnedAfterRefundPeriod() {
-    final double setCostFee = 10.55;
-    final double processingFee = 12.99;
-
-    useChargeableRefundableLostItemFee(setCostFee, processingFee);
-
-    declareItemLost();
-
-    feeFineAccountFixture.transferLostItemFee(loan.getId());
-    feeFineAccountFixture.payLostItemProcessingFee(loan.getId());
-
-    mockClockManagerToReturnFixedDateTime(now(DateTimeZone.UTC).plusMinutes(2));
-
-    checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemFee(isTransferredFully(setCostFee)));
-    assertThat(loan, hasLostItemFeeActions(
-      not(areTransferRefundActionsCreated(setCostFee))));
-
-    assertThat(loan, hasLostItemProcessingFee(isPaidFully(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      not(arePaymentRefundActionsCreated(processingFee))));
-  }
-
-  @Test
-  public void shouldRefundFeesAtAnyPointWhenNoMaximumRefundPeriod() {
-    final double setCostFee = 10.55;
-    final double processingFee = 12.99;
-
-    useLostItemPolicy(lostItemFeePoliciesFixture.create(
-      lostItemFeePoliciesFixture.facultyStandardPolicy()
-        .withName("Test check in")
-        .chargeProcessingFee(processingFee)
-        .withSetCost(setCostFee)
-        .withNoFeeRefundInterval()).getId());
-
-    declareItemLost();
-
-    feeFineAccountFixture.transferLostItemFee(loan.getId());
-    feeFineAccountFixture.payLostItemProcessingFee(loan.getId());
-
-    checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
-    assertThat(loan, hasLostItemFeeActions(areTransferRefundActionsCreated(setCostFee)));
-
-    assertThat(loan, hasLostItemProcessingFee(isRefundedFully(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      arePaymentRefundActionsCreated(processingFee)));
-  }
-
-  @Test
-  public void shouldCancelBothItemAndProcessingFeesWhenNeitherHaveBeenPaid() {
-    final double processingFee = 5.0;
-    final double itemFee = 10.0;
-
-    declareItemLost();
-
-    checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemFee(isClosedCancelledItemReturned(itemFee)));
-    assertThat(loan, hasLostItemFeeActions(isCancelledItemReturnedActionCreated(itemFee)));
-
-    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      isCancelledItemReturnedActionCreated(processingFee)));
-  }
-
-  @Test
-  public void shouldRefundTransferredFee() {
-    final double setCostFee = 10.89;
-    final double processingFee = 5.00;
-
-    useChargeableRefundableLostItemFee(setCostFee, processingFee);
-
-    declareItemLost();
-
-    feeFineAccountFixture.transferLostItemFee(loan.getId());
-
-    checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
-    assertThat(loan, hasLostItemFeeActions(areTransferRefundActionsCreated(setCostFee)));
-
-    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      isCancelledItemReturnedActionCreated(processingFee)));
-  }
-
-  @Test
-  public void shouldRefundPaidFee() {
-    final double setCostFee = 9.99;
-    final double processingFee = 5.00;
-
-    useChargeableRefundableLostItemFee(setCostFee, processingFee);
-
-    declareItemLost();
-
-    feeFineAccountFixture.payLostItemFee(loan.getId());
-
-    checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
-    assertThat(loan, hasLostItemFeeActions(arePaymentRefundActionsCreated(setCostFee)));
-
-    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      isCancelledItemReturnedActionCreated(processingFee)));
-  }
-
-  @Test
-  public void shouldRefundPaidAndTransferredFee() {
-    final double transferAmount = 6.0;
-    final double paymentAmount = 4.0;
-    final double setCostFee = transferAmount + paymentAmount;
-    final double processingFee = 5.00;
-
-    useChargeableRefundableLostItemFee(setCostFee, processingFee);
-
-    declareItemLost();
-
-    feeFineAccountFixture.transferLostItemFee(loan.getId(), transferAmount);
-    feeFineAccountFixture.payLostItemFee(loan.getId(), paymentAmount);
-
-    checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
-    assertThat(loan, hasLostItemFeeActions(allOf(
-      areTransferRefundActionsCreated(transferAmount),
-      arePaymentRefundActionsCreated(paymentAmount)
-    )));
-
-    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      isCancelledItemReturnedActionCreated(processingFee)));
-  }
-
-  @Test
-  public void shouldRefundPartiallyPaidAndTransferredFeeAndCancelRemainingAmount() {
-    final double transferAmount = 6.0;
-    final double paymentAmount = 4.0;
-    final double remainingAmount = 5.99;
-    final double setCostFee = transferAmount + paymentAmount + remainingAmount;
-    final double processingFee = 5.00;
-
-    useChargeableRefundableLostItemFee(setCostFee, processingFee);
-
-    declareItemLost();
-
-    feeFineAccountFixture.transferLostItemFee(loan.getId(), transferAmount);
-    feeFineAccountFixture.payLostItemFee(loan.getId(), paymentAmount);
-
-    checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemFee(isClosedCancelledItemReturned(setCostFee)));
-    assertThat(loan, hasLostItemFeeActions(allOf(
-      isCancelledItemReturnedActionCreated(remainingAmount),
-      areTransferRefundActionsCreated(remainingAmount, transferAmount),
-      arePaymentRefundActionsCreated(remainingAmount, paymentAmount)
-    )));
-    lostItemFeeActionsOrderedHistorically();
-
-    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      isCancelledItemReturnedActionCreated(processingFee)));
-  }
-
-  @Test
-  public void shouldChargeOverdueFineWhenStatedByPolicyAndLostFeesCanceled() {
-    final double processingFee = 12.99;
-
-    // Create overdue fine type
-    feeFineTypeFixture.overdueFine();
-
-    useLostItemPolicy(lostItemFeePoliciesFixture.create(
-      lostItemFeePoliciesFixture.facultyStandardPolicy()
-        .withName("Test check in")
-        .chargeProcessingFee(processingFee)
-        .withNoChargeAmountItem()
-        .chargeOverdueFineWhenReturned()).getId());
-
-    declareItemLost();
-
+  @Override
+  protected void performActionThatRequiresRefund(DateTime actionDate) {
     checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
       .forItem(item)
       .at(servicePointsFixture.cd1())
-      .on(now().plusMonths(2)));
-
-    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      isCancelledItemReturnedActionCreated(processingFee)));
-
-    assertThat(loan, hasOverdueFine());
-  }
-
-  @Test
-  public void shouldNotChargeOverdueFineWhenNotStatedByPolicy() {
-    final double processingFee = 12.99;
-
-    // Create overdue fine type
-    feeFineTypeFixture.overdueFine();
-
-    useLostItemPolicy(lostItemFeePoliciesFixture.create(
-      lostItemFeePoliciesFixture.facultyStandardPolicy()
-        .withName("Test check in")
-        .chargeProcessingFee(processingFee)
-        .withNoChargeAmountItem()
-        .doNotChargeOverdueFineWhenReturned()).getId());
-
-    declareItemLost();
-
-    checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
-      .forItem(item)
-      .at(servicePointsFixture.cd1())
-      .on(now().plusMonths(2)));
-
-    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      isCancelledItemReturnedActionCreated(processingFee)));
-
-    assertThat(loan, hasNoOverdueFine());
-  }
-
-  @Test
-  public void shouldRefundPaidAmountForLostAndPaidItem() {
-    final double setCostFee = 10.00;
-
-    declareItemLost(setCostFee);
-    resolveLostItemFee();
-
-    checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
-    assertThat(loan, hasLostItemFeeActions(arePaymentRefundActionsCreated(setCostFee)));
+      .on(actionDate));
   }
 
   @Test
@@ -424,129 +105,27 @@ public class CheckInDeclaredLostItemTest extends APITests {
   }
 
   @Test
-  public void shouldNotChargeOverdueFineWhenLostFeeIsNotCancelled() {
-    final double itemFee = 11.55;
+  public void shouldRefundPaidAmountForLostAndPaidItem() {
+    final double setCostFee = 10.00;
 
-    feeFineTypeFixture.overdueFine();
+    declareItemLost(setCostFee);
+    resolveLostItemFee();
 
-    useLostItemPolicy(lostItemFeePoliciesFixture.create(
-      lostItemFeePoliciesFixture.facultyStandardPolicy()
-        .withName("Test check in")
-        .doNotChargeProcessingFee()
-        .withSetCost(itemFee)
-        .refundFeesWithinMinutes(1)
-        .chargeOverdueFineWhenReturned()).getId());
+    performActionThatRequiresRefund();
 
-    declareItemLost();
-
-    mockClockManagerToReturnFixedDateTime(DateTime.now(DateTimeZone.UTC).plusMinutes(2));
-
-    checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemFee(isOpen(itemFee)));
-    assertThat(loan, hasNoOverdueFine());
+    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
+    assertThat(loan, hasLostItemFeeActions(arePaymentRefundActionsCreated(setCostFee)));
   }
 
   @Test
-  public void shouldNotChargeOverdueFineWhenProcessingFeeIsNotRefundable() {
-    final double processingFee = 14.37;
-
-    feeFineTypeFixture.overdueFine();
-
-    useLostItemPolicy(lostItemFeePoliciesFixture.create(
-      lostItemFeePoliciesFixture.facultyStandardPolicy()
-        .withName("Test check in")
-        .chargeProcessingFee(processingFee)
-        .withNoChargeAmountItem()
-        .doNotRefundProcessingFeeWhenReturned()
-        .chargeOverdueFineWhenReturned()).getId());
+  public void lostFeeCancellationDoesNotTriggerMarkingItemAsLostAndPaaid() {
+    useChargeableRefundableLostItemFee(15.00, 0.0);
 
     declareItemLost();
 
-    checkInFixture.checkInByBarcode(item);
-
-    assertThat(loan, hasLostItemProcessingFee(isOpen(processingFee)));
-    assertThat(loan, hasNoOverdueFine());
-  }
-
-  private void resolveLostItemFee() {
-    feeFineAccountFixture.payLostItemFee(loan.getId());
+    performActionThatRequiresRefund();
     eventSubscribersFixture.publishLoanRelatedFeeFineClosedEvent(loan.getId());
 
-    assertThat(itemsClient.getById(item.getId()).getJson(), isLostAndPaid());
-    assertThat(loansFixture.getLoanById(loan.getId()).getJson(), isClosed());
-  }
-
-  private IndividualResource declareItemLost() {
-    loan = checkOutFixture.checkOutByBarcode(item, usersFixture.charlotte());
-
-    declareLostFixtures.declareItemLost(new DeclareItemLostRequestBuilder()
-      .withServicePointId(servicePointsFixture.cd1().getId())
-      .forLoanId(loan.getId()));
-
-    loan = loansFixture.getLoanById(loan.getId());
-    return loan;
-  }
-
-  private void declareItemLost(double setCostFee) {
-    useChargeableRefundableLostItemFee(setCostFee, 0.0);
-
-    declareItemLost();
-  }
-
-  private void useChargeableRefundableLostItemFee(double itemFee, double processingFee) {
-    useLostItemPolicy(lostItemFeePoliciesFixture.create(
-      lostItemFeePoliciesFixture.facultyStandardPolicy()
-        .withName(String.format("Test lost policy processing fee %s, item fee %s",
-          itemFee, processingFee))
-        .chargeProcessingFee(processingFee)
-        .withSetCost(itemFee)
-        .refundFeesWithinMinutes(1)).getId());
-  }
-
-  private JsonObject getLostItemFeeAccountForLoan() {
-    return accountsClient.getMany(queryFromTemplate(
-      "loanId==%s and feeFineType==\"Lost item fee\"", loan.getId())).getFirst();
-  }
-
-  private MultipleJsonRecords getAccountActions(String accountId) {
-    return feeFineActionsClient.getMany(queryFromTemplate("accountId==%s", accountId));
-  }
-
-  @SuppressWarnings("unchecked")
-  private void lostItemFeeActionsOrderedHistorically() {
-    final JsonObject fee = getLostItemFeeAccountForLoan();
-    final List<JsonObject> accountsOrdered = getAccountActions(fee.getString("id"))
-      .stream()
-      .sorted((first, second) -> parse(second.getString(DATE_ACTION_PROPERTY))
-        .compareTo(parse(first.getString(DATE_ACTION_PROPERTY))))
-      .collect(Collectors.toList());
-
-    assertThat(accountsOrdered, containsInRelativeOrder(
-      allOf(
-        hasJsonPath("typeAction", CANCELLED_ITEM_RETURNED),
-        hasJsonPath("transactionInformation", "-")),
-      allOf(
-        hasJsonPath("typeAction", REFUNDED_FULLY),
-        hasJsonPath("transactionInformation", REFUND_TO_PATRON)),
-      allOf(
-        hasJsonPath("typeAction", CREDITED_FULLY),
-        hasJsonPath("transactionInformation", REFUND_TO_PATRON)),
-      allOf(
-        hasJsonPath("typeAction", REFUNDED_FULLY),
-        hasJsonPath("transactionInformation", REFUND_TO_BURSAR)),
-      allOf(
-        hasJsonPath("typeAction", CREDITED_FULLY),
-        hasJsonPath("transactionInformation", REFUND_TO_BURSAR))
-    ));
-
-    final int numberOfRefundCancelActions = 5;
-    for (int index = 1; index < numberOfRefundCancelActions; index++) {
-      final JsonObject previousAction = accountsOrdered.get(index - 1);
-      final JsonObject currentAction = accountsOrdered.get(index);
-
-      assertThat(parse(previousAction.getString(DATE_ACTION_PROPERTY)),
-        greaterThan(parse(currentAction.getString(DATE_ACTION_PROPERTY))));
-    }
+    assertThat(itemsClient.getById(item.getId()).getJson(), isAvailable());
   }
 }

--- a/src/test/java/api/loans/scenarios/OverrideRenewDeclaredLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/OverrideRenewDeclaredLostItemTest.java
@@ -1,0 +1,44 @@
+package api.loans.scenarios;
+
+import static api.support.matchers.ItemMatchers.isCheckedOut;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import api.support.fixtures.OverrideRenewalFixture;
+import api.support.spring.TestSpringConfiguration;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestSpringConfiguration.class)
+public class OverrideRenewDeclaredLostItemTest extends RefundLostItemFeesBaseTest {
+  @Autowired
+  private OverrideRenewalFixture overrideRenewalFixture;
+
+  @Override
+  protected void performActionThatRequiresRefund() {
+    overrideRenewalFixture.overrideRenewalByBarcode(loan, servicePointsFixture.cd1().getId());
+  }
+
+  @Override
+  protected void performActionThatRequiresRefund(DateTime actionDate) {
+    mockClockManagerToReturnFixedDateTime(actionDate);
+    performActionThatRequiresRefund();
+  }
+
+  @Test
+  public void lostFeeCancellationDoesNotTriggerMarkingItemAsLostAndPaid() {
+    useChargeableRefundableLostItemFee(15.00, 0.0);
+
+    declareItemLost();
+
+    performActionThatRequiresRefund();
+    eventSubscribersFixture.publishLoanRelatedFeeFineClosedEvent(loan.getId());
+
+    assertThat(itemsClient.getById(item.getId()).getJson(), isCheckedOut());
+  }
+}

--- a/src/test/java/api/loans/scenarios/OverrideRenewDeclaredLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/OverrideRenewDeclaredLostItemTest.java
@@ -15,7 +15,7 @@ import api.support.spring.TestSpringConfiguration;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = TestSpringConfiguration.class)
-public class OverrideRenewDeclaredLostItemTest extends RefundLostItemFeesBaseTest {
+public class OverrideRenewDeclaredLostItemTest extends RefundLostItemFeesTestBase {
   @Autowired
   private OverrideRenewalFixture overrideRenewalFixture;
 

--- a/src/test/java/api/loans/scenarios/RefundLostItemFeesBaseTest.java
+++ b/src/test/java/api/loans/scenarios/RefundLostItemFeesBaseTest.java
@@ -1,0 +1,474 @@
+package api.loans.scenarios;
+
+import static api.support.http.CqlQuery.queryFromTemplate;
+import static api.support.matchers.AccountActionsMatchers.CANCELLED_ITEM_RETURNED;
+import static api.support.matchers.AccountActionsMatchers.CREDITED_FULLY;
+import static api.support.matchers.AccountActionsMatchers.REFUNDED_FULLY;
+import static api.support.matchers.AccountActionsMatchers.REFUND_TO_BURSAR;
+import static api.support.matchers.AccountActionsMatchers.REFUND_TO_PATRON;
+import static api.support.matchers.AccountActionsMatchers.arePaymentRefundActionsCreated;
+import static api.support.matchers.AccountActionsMatchers.areTransferRefundActionsCreated;
+import static api.support.matchers.AccountActionsMatchers.isCancelledItemReturnedActionCreated;
+import static api.support.matchers.AccountMatchers.isClosedCancelledItemReturned;
+import static api.support.matchers.AccountMatchers.isOpen;
+import static api.support.matchers.AccountMatchers.isPaidFully;
+import static api.support.matchers.AccountMatchers.isRefundedFully;
+import static api.support.matchers.AccountMatchers.isTransferredFully;
+import static api.support.matchers.ItemMatchers.isLostAndPaid;
+import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
+import static api.support.matchers.LoanAccountActionsMatcher.hasLostItemFeeActions;
+import static api.support.matchers.LoanAccountActionsMatcher.hasLostItemProcessingFeeActions;
+import static api.support.matchers.LoanAccountMatcher.hasLostItemFee;
+import static api.support.matchers.LoanAccountMatcher.hasLostItemProcessingFee;
+import static api.support.matchers.LoanAccountMatcher.hasNoOverdueFine;
+import static api.support.matchers.LoanAccountMatcher.hasOverdueFine;
+import static api.support.matchers.LoanMatchers.isClosed;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInRelativeOrder;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.joda.time.DateTime.now;
+import static org.joda.time.DateTime.parse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.Test;
+
+import api.support.APITests;
+import api.support.MultipleJsonRecords;
+import api.support.builders.CheckInByBarcodeRequestBuilder;
+import api.support.builders.DeclareItemLostRequestBuilder;
+import io.vertx.core.json.JsonObject;
+
+public abstract class RefundLostItemFeesBaseTest extends APITests {
+  private static final String DATE_ACTION_PROPERTY = "dateAction";
+
+  protected final IndividualResource item = itemsFixture.basedUponNod();
+  protected IndividualResource loan;
+
+  protected abstract void performActionThatRequiresRefund();
+
+  protected abstract void performActionThatRequiresRefund(DateTime actionDate);
+
+  @Before
+  public void activateChargeableLostItemFeePolicy() {
+    useLostItemPolicy(lostItemFeePoliciesFixture.chargeFee().getId());
+  }
+
+  @Test
+  public void shouldCancelItemFeeOnlyWhenNoOtherFeesCharged() {
+    final double itemFee = 15.00;
+
+    useLostItemPolicy(lostItemFeePoliciesFixture.create(
+      lostItemFeePoliciesFixture.facultyStandardPolicy()
+        .withName("Test check in")
+        .doNotChargeProcessingFee()
+        .withSetCost(itemFee)).getId());
+
+    declareItemLost();
+
+    performActionThatRequiresRefund();
+
+    assertThat(loan, hasLostItemFee(isClosedCancelledItemReturned(itemFee)));
+    assertThat(loan, hasLostItemFeeActions(isCancelledItemReturnedActionCreated(itemFee)));
+  }
+
+  @Test
+  public void shouldCancelItemProcessingFeeOnlyWhenNoOtherFeesChargedAndNoPaymentsMade() {
+    final double processingFee = 12.99;
+
+    useLostItemPolicy(lostItemFeePoliciesFixture.create(
+      lostItemFeePoliciesFixture.facultyStandardPolicy()
+        .withName("Test check in")
+        .chargeProcessingFee(processingFee)
+        .withNoChargeAmountItem()).getId());
+
+    declareItemLost();
+
+    performActionThatRequiresRefund();
+
+    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      isCancelledItemReturnedActionCreated(processingFee)));
+  }
+
+  @Test
+  public void shouldNotRefundProcessingFeeWhenPolicyStatesNotTo() {
+    final double processingFee = 12.99;
+
+    useLostItemPolicy(lostItemFeePoliciesFixture.create(
+      lostItemFeePoliciesFixture.facultyStandardPolicy()
+        .withName("Test check in")
+        .chargeProcessingFee(processingFee)
+        .doNotRefundProcessingFeeWhenReturned()
+        .withNoChargeAmountItem()).getId());
+
+    declareItemLost();
+
+    feeFineAccountFixture.payLostItemProcessingFee(loan.getId());
+
+    performActionThatRequiresRefund();
+
+    assertThat(loan, hasLostItemProcessingFee(isPaidFully(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      not(arePaymentRefundActionsCreated(processingFee))));
+  }
+
+  @Test
+  public void shouldNotRefundFeesWhenReturnedAfterRefundPeriod() {
+    final double setCostFee = 10.55;
+    final double processingFee = 12.99;
+
+    useChargeableRefundableLostItemFee(setCostFee, processingFee);
+
+    declareItemLost();
+
+    feeFineAccountFixture.transferLostItemFee(loan.getId());
+    feeFineAccountFixture.payLostItemProcessingFee(loan.getId());
+
+    mockClockManagerToReturnFixedDateTime(now(DateTimeZone.UTC).plusMinutes(2));
+
+    performActionThatRequiresRefund();
+
+    assertThat(loan, hasLostItemFee(isTransferredFully(setCostFee)));
+    assertThat(loan, hasLostItemFeeActions(
+      not(areTransferRefundActionsCreated(setCostFee))));
+
+    assertThat(loan, hasLostItemProcessingFee(isPaidFully(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      not(arePaymentRefundActionsCreated(processingFee))));
+  }
+
+  @Test
+  public void shouldRefundFeesAtAnyPointWhenNoMaximumRefundPeriod() {
+    final double setCostFee = 10.55;
+    final double processingFee = 12.99;
+
+    useLostItemPolicy(lostItemFeePoliciesFixture.create(
+      lostItemFeePoliciesFixture.facultyStandardPolicy()
+        .withName("Test check in")
+        .chargeProcessingFee(processingFee)
+        .withSetCost(setCostFee)
+        .withNoFeeRefundInterval()).getId());
+
+    declareItemLost();
+
+    feeFineAccountFixture.transferLostItemFee(loan.getId());
+    feeFineAccountFixture.payLostItemProcessingFee(loan.getId());
+
+    performActionThatRequiresRefund();
+
+    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
+    assertThat(loan, hasLostItemFeeActions(areTransferRefundActionsCreated(setCostFee)));
+
+    assertThat(loan, hasLostItemProcessingFee(isRefundedFully(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      arePaymentRefundActionsCreated(processingFee)));
+  }
+
+  @Test
+  public void shouldCancelBothItemAndProcessingFeesWhenNeitherHaveBeenPaid() {
+    final double processingFee = 5.0;
+    final double itemFee = 10.0;
+
+    declareItemLost();
+
+    performActionThatRequiresRefund();
+
+    assertThat(loan, hasLostItemFee(isClosedCancelledItemReturned(itemFee)));
+    assertThat(loan, hasLostItemFeeActions(isCancelledItemReturnedActionCreated(itemFee)));
+
+    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      isCancelledItemReturnedActionCreated(processingFee)));
+  }
+
+  @Test
+  public void shouldRefundTransferredFee() {
+    final double setCostFee = 10.89;
+    final double processingFee = 5.00;
+
+    useChargeableRefundableLostItemFee(setCostFee, processingFee);
+
+    declareItemLost();
+
+    feeFineAccountFixture.transferLostItemFee(loan.getId());
+
+    performActionThatRequiresRefund();
+
+    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
+    assertThat(loan, hasLostItemFeeActions(areTransferRefundActionsCreated(setCostFee)));
+
+    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      isCancelledItemReturnedActionCreated(processingFee)));
+  }
+
+  @Test
+  public void shouldRefundPaidFee() {
+    final double setCostFee = 9.99;
+    final double processingFee = 5.00;
+
+    useChargeableRefundableLostItemFee(setCostFee, processingFee);
+
+    declareItemLost();
+
+    feeFineAccountFixture.payLostItemFee(loan.getId());
+
+    performActionThatRequiresRefund();
+
+    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
+    assertThat(loan, hasLostItemFeeActions(arePaymentRefundActionsCreated(setCostFee)));
+
+    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      isCancelledItemReturnedActionCreated(processingFee)));
+  }
+
+  @Test
+  public void shouldRefundPaidAndTransferredFee() {
+    final double transferAmount = 6.0;
+    final double paymentAmount = 4.0;
+    final double setCostFee = transferAmount + paymentAmount;
+    final double processingFee = 5.00;
+
+    useChargeableRefundableLostItemFee(setCostFee, processingFee);
+
+    declareItemLost();
+
+    feeFineAccountFixture.transferLostItemFee(loan.getId(), transferAmount);
+    feeFineAccountFixture.payLostItemFee(loan.getId(), paymentAmount);
+
+    performActionThatRequiresRefund();
+
+    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
+    assertThat(loan, hasLostItemFeeActions(allOf(
+      areTransferRefundActionsCreated(transferAmount),
+      arePaymentRefundActionsCreated(paymentAmount)
+    )));
+
+    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      isCancelledItemReturnedActionCreated(processingFee)));
+  }
+
+  @Test
+  public void shouldRefundPartiallyPaidAndTransferredFeeAndCancelRemainingAmount() {
+    final double transferAmount = 6.0;
+    final double paymentAmount = 4.0;
+    final double remainingAmount = 5.99;
+    final double setCostFee = transferAmount + paymentAmount + remainingAmount;
+    final double processingFee = 5.00;
+
+    useChargeableRefundableLostItemFee(setCostFee, processingFee);
+
+    declareItemLost();
+
+    feeFineAccountFixture.transferLostItemFee(loan.getId(), transferAmount);
+    feeFineAccountFixture.payLostItemFee(loan.getId(), paymentAmount);
+
+    performActionThatRequiresRefund();
+
+    assertThat(loan, hasLostItemFee(isClosedCancelledItemReturned(setCostFee)));
+    assertThat(loan, hasLostItemFeeActions(allOf(
+      isCancelledItemReturnedActionCreated(remainingAmount),
+      areTransferRefundActionsCreated(remainingAmount, transferAmount),
+      arePaymentRefundActionsCreated(remainingAmount, paymentAmount)
+    )));
+    lostItemFeeActionsOrderedHistorically();
+
+    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      isCancelledItemReturnedActionCreated(processingFee)));
+  }
+
+  @Test
+  public void shouldChargeOverdueFineWhenStatedByPolicyAndLostFeesCanceled() {
+    final double processingFee = 12.99;
+
+    // Create overdue fine type
+    feeFineTypeFixture.overdueFine();
+
+    useLostItemPolicy(lostItemFeePoliciesFixture.create(
+      lostItemFeePoliciesFixture.facultyStandardPolicy()
+        .withName("Test check in")
+        .chargeProcessingFee(processingFee)
+        .withNoChargeAmountItem()
+        .chargeOverdueFineWhenReturned()).getId());
+
+    declareItemLost();
+
+    checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
+      .forItem(item)
+      .at(servicePointsFixture.cd1())
+      .on(now().plusMonths(2)));
+
+    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      isCancelledItemReturnedActionCreated(processingFee)));
+
+    assertThat(loan, hasOverdueFine());
+  }
+
+  @Test
+  public void shouldNotChargeOverdueFineWhenNotStatedByPolicy() {
+    final double processingFee = 12.99;
+
+    // Create overdue fine type
+    feeFineTypeFixture.overdueFine();
+
+    useLostItemPolicy(lostItemFeePoliciesFixture.create(
+      lostItemFeePoliciesFixture.facultyStandardPolicy()
+        .withName("Test check in")
+        .chargeProcessingFee(processingFee)
+        .withNoChargeAmountItem()
+        .doNotChargeOverdueFineWhenReturned()).getId());
+
+    declareItemLost();
+
+    performActionThatRequiresRefund(now().plusMonths(2));
+//    checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
+//      .forItem(item)
+//      .at(servicePointsFixture.cd1())
+//      .on(now().plusMonths(2)));
+
+    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      isCancelledItemReturnedActionCreated(processingFee)));
+
+    assertThat(loan, hasNoOverdueFine());
+  }
+
+  @Test
+  public void shouldNotChargeOverdueFineWhenLostFeeIsNotCancelled() {
+    final double itemFee = 11.55;
+
+    feeFineTypeFixture.overdueFine();
+
+    useLostItemPolicy(lostItemFeePoliciesFixture.create(
+      lostItemFeePoliciesFixture.facultyStandardPolicy()
+        .withName("Test check in")
+        .doNotChargeProcessingFee()
+        .withSetCost(itemFee)
+        .refundFeesWithinMinutes(1)
+        .chargeOverdueFineWhenReturned()).getId());
+
+    declareItemLost();
+
+    mockClockManagerToReturnFixedDateTime(DateTime.now(DateTimeZone.UTC).plusMinutes(2));
+
+    performActionThatRequiresRefund();
+
+    assertThat(loan, hasLostItemFee(isOpen(itemFee)));
+    assertThat(loan, hasNoOverdueFine());
+  }
+
+  @Test
+  public void shouldNotChargeOverdueFineWhenProcessingFeeIsNotRefundable() {
+    final double processingFee = 14.37;
+
+    feeFineTypeFixture.overdueFine();
+
+    useLostItemPolicy(lostItemFeePoliciesFixture.create(
+      lostItemFeePoliciesFixture.facultyStandardPolicy()
+        .withName("Test check in")
+        .chargeProcessingFee(processingFee)
+        .withNoChargeAmountItem()
+        .doNotRefundProcessingFeeWhenReturned()
+        .chargeOverdueFineWhenReturned()).getId());
+
+    declareItemLost();
+
+    performActionThatRequiresRefund();
+
+    assertThat(loan, hasLostItemProcessingFee(isOpen(processingFee)));
+    assertThat(loan, hasNoOverdueFine());
+  }
+
+  protected void resolveLostItemFee() {
+    feeFineAccountFixture.payLostItemFee(loan.getId());
+    eventSubscribersFixture.publishLoanRelatedFeeFineClosedEvent(loan.getId());
+
+    assertThat(itemsClient.getById(item.getId()).getJson(), isLostAndPaid());
+    assertThat(loansFixture.getLoanById(loan.getId()).getJson(), isClosed());
+  }
+
+  protected IndividualResource declareItemLost() {
+    loan = checkOutFixture.checkOutByBarcode(item, usersFixture.charlotte());
+
+    declareLostFixtures.declareItemLost(new DeclareItemLostRequestBuilder()
+      .withServicePointId(servicePointsFixture.cd1().getId())
+      .forLoanId(loan.getId()));
+
+    loan = loansFixture.getLoanById(loan.getId());
+    return loan;
+  }
+
+  protected void declareItemLost(double setCostFee) {
+    useChargeableRefundableLostItemFee(setCostFee, 0.0);
+
+    declareItemLost();
+  }
+
+  protected void useChargeableRefundableLostItemFee(double itemFee, double processingFee) {
+    useLostItemPolicy(lostItemFeePoliciesFixture.create(
+      lostItemFeePoliciesFixture.facultyStandardPolicy()
+        .withName(String.format("Test lost policy processing fee %s, item fee %s",
+          itemFee, processingFee))
+        .chargeProcessingFee(processingFee)
+        .withSetCost(itemFee)
+        .refundFeesWithinMinutes(1)).getId());
+  }
+
+  private JsonObject getLostItemFeeAccountForLoan() {
+    return accountsClient.getMany(queryFromTemplate(
+      "loanId==%s and feeFineType==\"Lost item fee\"", loan.getId())).getFirst();
+  }
+
+  private MultipleJsonRecords getAccountActions(String accountId) {
+    return feeFineActionsClient.getMany(queryFromTemplate("accountId==%s", accountId));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void lostItemFeeActionsOrderedHistorically() {
+    final JsonObject fee = getLostItemFeeAccountForLoan();
+    final List<JsonObject> accountsOrdered = getAccountActions(fee.getString("id"))
+      .stream()
+      .sorted((first, second) -> parse(second.getString(DATE_ACTION_PROPERTY))
+        .compareTo(parse(first.getString(DATE_ACTION_PROPERTY))))
+      .collect(Collectors.toList());
+
+    assertThat(accountsOrdered, containsInRelativeOrder(
+      allOf(
+        hasJsonPath("typeAction", CANCELLED_ITEM_RETURNED),
+        hasJsonPath("transactionInformation", "-")),
+      allOf(
+        hasJsonPath("typeAction", REFUNDED_FULLY),
+        hasJsonPath("transactionInformation", REFUND_TO_PATRON)),
+      allOf(
+        hasJsonPath("typeAction", CREDITED_FULLY),
+        hasJsonPath("transactionInformation", REFUND_TO_PATRON)),
+      allOf(
+        hasJsonPath("typeAction", REFUNDED_FULLY),
+        hasJsonPath("transactionInformation", REFUND_TO_BURSAR)),
+      allOf(
+        hasJsonPath("typeAction", CREDITED_FULLY),
+        hasJsonPath("transactionInformation", REFUND_TO_BURSAR))
+    ));
+
+    final int numberOfRefundCancelActions = 5;
+    for (int index = 1; index < numberOfRefundCancelActions; index++) {
+      final JsonObject previousAction = accountsOrdered.get(index - 1);
+      final JsonObject currentAction = accountsOrdered.get(index);
+
+      assertThat(parse(previousAction.getString(DATE_ACTION_PROPERTY)),
+        greaterThan(parse(currentAction.getString(DATE_ACTION_PROPERTY))));
+    }
+  }
+}

--- a/src/test/java/api/loans/scenarios/RefundLostItemFeesBaseTest.java
+++ b/src/test/java/api/loans/scenarios/RefundLostItemFeesBaseTest.java
@@ -333,10 +333,6 @@ public abstract class RefundLostItemFeesBaseTest extends APITests {
     declareItemLost();
 
     performActionThatRequiresRefund(now().plusMonths(2));
-//    checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
-//      .forItem(item)
-//      .at(servicePointsFixture.cd1())
-//      .on(now().plusMonths(2)));
 
     assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
     assertThat(loan, hasLostItemProcessingFeeActions(

--- a/src/test/java/api/loans/scenarios/RefundLostItemFeesTestBase.java
+++ b/src/test/java/api/loans/scenarios/RefundLostItemFeesTestBase.java
@@ -46,7 +46,7 @@ import api.support.builders.CheckInByBarcodeRequestBuilder;
 import api.support.builders.DeclareItemLostRequestBuilder;
 import io.vertx.core.json.JsonObject;
 
-public abstract class RefundLostItemFeesBaseTest extends APITests {
+public abstract class RefundLostItemFeesTestBase extends APITests {
   private static final String DATE_ACTION_PROPERTY = "dateAction";
 
   protected final IndividualResource item = itemsFixture.basedUponNod();

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -79,7 +79,7 @@ public class RestAssuredClient {
       .config(config)
       .log().all()
       .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
-      .queryParams(params(parameters))
+      .queryParams(toMap(parameters))
       .spec(timeoutConfig())
       .when().get(url)
       .then()
@@ -93,7 +93,7 @@ public class RestAssuredClient {
       .config(config)
       .log().all()
       .spec(standardHeaders(defaultHeaders.withRequestId("get-many-" + collectionName)))
-      .queryParams(params(asList(parameters)))
+      .queryParams(toMap(asList(parameters)))
       .spec(timeoutConfig())
       .when().get(url)
       .then()
@@ -218,7 +218,7 @@ public class RestAssuredClient {
       .extract().response());
   }
 
-  private Map<String, String> params(Iterable<QueryStringParameter> params) {
+  private Map<String, String> toMap(Iterable<QueryStringParameter> params) {
     final Map<String, String> paramsMap = new HashMap<>();
     params.forEach(param -> param.collectInto(paramsMap));
     return paramsMap;

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -1,6 +1,7 @@
 package api.support;
 
 import static api.support.APITestContext.getOkapiHeadersFromContext;
+import static api.support.RestAssuredConfiguration.defaultRestAssuredConfig;
 import static api.support.RestAssuredConfiguration.standardHeaders;
 import static api.support.RestAssuredConfiguration.timeoutConfig;
 import static api.support.RestAssuredResponseConversion.toResponse;
@@ -10,6 +11,8 @@ import static java.util.Arrays.asList;
 import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.folio.circulation.support.http.client.Response;
 
@@ -18,14 +21,20 @@ import api.support.http.Limit;
 import api.support.http.Offset;
 import api.support.http.OkapiHeaders;
 import api.support.http.QueryStringParameter;
+import io.restassured.config.RestAssuredConfig;
 import io.restassured.specification.RequestSpecification;
-import io.vertx.core.json.JsonObject;
 
 public class RestAssuredClient {
   private final OkapiHeaders defaultHeaders;
+  private final RestAssuredConfig config;
 
   public RestAssuredClient(OkapiHeaders defaultHeaders) {
+    this(defaultHeaders, defaultRestAssuredConfig());
+  }
+
+  public RestAssuredClient(OkapiHeaders defaultHeaders, RestAssuredConfig config) {
     this.defaultHeaders = defaultHeaders;
+    this.config = config;
   }
 
   public static RestAssuredClient defaultRestAssuredClient() {
@@ -35,6 +44,7 @@ public class RestAssuredClient {
   public RequestSpecification beginRequest(String requestId) {
     return given()
       .log().all()
+      .config(config)
       .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
       .spec(timeoutConfig());
   }
@@ -47,6 +57,14 @@ public class RestAssuredClient {
       .extract().response());
   }
 
+  public <T> T get(URL location, String requestId, Class<T> type) {
+    return beginRequest(requestId)
+      .when().get(location)
+      .then()
+      .log().all()
+      .extract().body().as(type);
+  }
+
   public Response get(URL location, CqlQuery query, Limit limit, Offset offset,
       int expectedStatusCode, String requestId) {
 
@@ -57,21 +75,31 @@ public class RestAssuredClient {
   public Response get(URL url, Collection<QueryStringParameter> parameters,
       int expectedStatusCode, String requestId) {
 
-    final HashMap<String, String> queryStringParametersMap = new HashMap<>();
-
-    parameters
-      .forEach(parameter -> parameter.collectInto(queryStringParametersMap));
-
     return toResponse(given()
+      .config(config)
       .log().all()
       .spec(standardHeaders(defaultHeaders.withRequestId(requestId)))
-      .queryParams(queryStringParametersMap)
+      .queryParams(params(parameters))
       .spec(timeoutConfig())
       .when().get(url)
       .then()
       .log().all()
       .statusCode(expectedStatusCode)
       .extract().response());
+  }
+
+  public <T> List<T> getMany(URL url, Class<T> type, String collectionName, QueryStringParameter... parameters) {
+    return given()
+      .config(config)
+      .log().all()
+      .spec(standardHeaders(defaultHeaders.withRequestId("get-many-" + collectionName)))
+      .queryParams(params(asList(parameters)))
+      .spec(timeoutConfig())
+      .when().get(url)
+      .then()
+      .log().all()
+      .statusCode(200)
+      .extract().jsonPath().getList(collectionName, type);
   }
 
   public Response get(URL url, int expectedStatusCode, String requestId) {
@@ -91,6 +119,7 @@ public class RestAssuredClient {
       : timeoutConfig();
 
     return toResponse(given()
+      .config(config)
       .log().all()
       .spec(standardHeaders(getOkapiHeadersFromContext().withRequestId(requestId)))
       .spec(timeoutConfig)
@@ -101,20 +130,20 @@ public class RestAssuredClient {
       .extract().response());
   }
 
-  public Response post(JsonObject representation, URL url, String requestId) {
+  public Response post(Object representation, URL url, String requestId) {
     return toResponse(beginRequest(requestId)
-      .body(representation.encodePrettily())
+      .body(representation)
       .when().post(url)
       .then()
       .log().all()
       .extract().response());
   }
 
-  public Response post(JsonObject representation, URL url,
+  public Response post(Object representation, URL url,
     int expectedStatusCode, String requestId) {
 
     return toResponse(beginRequest(requestId)
-      .body(representation.encodePrettily())
+      .body(representation)
       .when().post(url)
       .then()
       .log().all()
@@ -122,14 +151,15 @@ public class RestAssuredClient {
       .extract().response());
   }
 
-  public Response post(JsonObject representation, URL location,
+  public Response post(Object representation, URL location,
     int expectedStatusCode, OkapiHeaders okapiHeaders) {
 
     return toResponse(given()
+      .config(config)
       .log().all()
       .spec(standardHeaders(okapiHeaders))
       .spec(timeoutConfig())
-      .body(representation.encodePrettily())
+      .body(representation)
       .when().post(location)
       .then()
       .log().all()
@@ -137,32 +167,33 @@ public class RestAssuredClient {
       .extract().response());
   }
 
-  public Response post(JsonObject representation, URL location, OkapiHeaders okapiHeaders) {
+  public Response post(Object representation, URL location, OkapiHeaders okapiHeaders) {
     return toResponse(given()
+      .config(config)
       .log().all()
       .spec(standardHeaders(okapiHeaders))
       .spec(timeoutConfig())
-      .body(representation.encodePrettily())
+      .body(representation)
       .when().post(location)
       .then()
       .log().all()
       .extract().response());
   }
 
-  public Response put(JsonObject representation, URL location, String requestId) {
+  public Response put(Object representation, URL location, String requestId) {
     return toResponse(beginRequest(requestId)
-      .body(representation.encodePrettily())
+      .body(representation)
       .when().put(location)
       .then()
       .log().all()
       .extract().response());
   }
 
-  public Response put(JsonObject representation, URL location,
+  public Response put(Object representation, URL location,
     int expectedStatusCode, String requestId) {
 
     return toResponse(beginRequest(requestId)
-      .body(representation.encodePrettily())
+      .body(representation)
       .when().put(location)
       .then()
       .log().all()
@@ -185,5 +216,11 @@ public class RestAssuredClient {
       .then()
       .log().all()
       .extract().response());
+  }
+
+  private Map<String, String> params(Iterable<QueryStringParameter> params) {
+    final Map<String, String> paramsMap = new HashMap<>();
+    params.forEach(param -> param.collectInto(paramsMap));
+    return paramsMap;
   }
 }

--- a/src/test/java/api/support/RestAssuredConfiguration.java
+++ b/src/test/java/api/support/RestAssuredConfiguration.java
@@ -7,11 +7,18 @@ import java.util.HashMap;
 
 import org.folio.circulation.support.http.OkapiHeader;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
 import api.support.http.OkapiHeaders;
+import api.support.jackson.serializer.JsonObjectJacksonSerializer;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.config.HttpClientConfig;
+import io.restassured.config.ObjectMapperConfig;
+import io.restassured.config.RestAssuredConfig;
 import io.restassured.specification.RequestSpecification;
+import io.vertx.core.json.JsonObject;
 
 public class RestAssuredConfiguration {
   public static RequestSpecification standardHeaders(OkapiHeaders okapiHeaders) {
@@ -46,5 +53,23 @@ public class RestAssuredConfiguration {
           .setParam("http.connection.timeout", timeOutInMilliseconds)
           .setParam("http.socket.timeout", timeOutInMilliseconds)))
       .build();
+  }
+
+  public static RestAssuredConfig defaultRestAssuredConfig() {
+    final ObjectMapperConfig objectMapperConfig = new ObjectMapperConfig()
+      .jackson2ObjectMapperFactory((type, s) -> defaultObjectMapper());
+
+    return new RestAssuredConfig().objectMapperConfig(objectMapperConfig);
+  }
+
+  /**
+   * Object mapper that allows JsonObject to be correctly serialized.
+   */
+  private static ObjectMapper defaultObjectMapper() {
+    final SimpleModule jsonObjectMapperModule = new SimpleModule();
+    jsonObjectMapperModule.addSerializer(JsonObject.class, new JsonObjectJacksonSerializer());
+
+    return new ObjectMapper().findAndRegisterModules()
+      .registerModule(jsonObjectMapperModule);
   }
 }

--- a/src/test/java/api/support/dto/Item.java
+++ b/src/test/java/api/support/dto/Item.java
@@ -1,0 +1,11 @@
+package api.support.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Item {
+  String id;
+  String barcode;
+}

--- a/src/test/java/api/support/dto/OverrideRenewal.java
+++ b/src/test/java/api/support/dto/OverrideRenewal.java
@@ -12,5 +12,5 @@ public class OverrideRenewal {
   private final String userBarcode;
   private final String comment;
   private Date dueDate;
-  private String overrideServicePointId;
+  private String servicePointId;
 }

--- a/src/test/java/api/support/dto/OverrideRenewal.java
+++ b/src/test/java/api/support/dto/OverrideRenewal.java
@@ -1,0 +1,16 @@
+package api.support.dto;
+
+import java.util.Date;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OverrideRenewal {
+  private final String itemBarcode;
+  private final String userBarcode;
+  private final String comment;
+  private Date dueDate;
+  private String overrideServicePointId;
+}

--- a/src/test/java/api/support/dto/User.java
+++ b/src/test/java/api/support/dto/User.java
@@ -1,0 +1,11 @@
+package api.support.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class User {
+  private String id;
+  private String barcode;
+}

--- a/src/test/java/api/support/fixtures/OverrideRenewalFixture.java
+++ b/src/test/java/api/support/fixtures/OverrideRenewalFixture.java
@@ -35,7 +35,7 @@ public final class OverrideRenewalFixture {
       .itemBarcode(item.getBarcode())
       .userBarcode(user.getBarcode())
       .comment("Override renewal")
-      .overrideServicePointId(servicePointId.toString())
+      .servicePointId(servicePointId.toString())
       .build());
   }
 }

--- a/src/test/java/api/support/fixtures/OverrideRenewalFixture.java
+++ b/src/test/java/api/support/fixtures/OverrideRenewalFixture.java
@@ -1,0 +1,41 @@
+package api.support.fixtures;
+
+import static api.support.http.InterfaceUrls.overrideRenewalByBarcodeUrl;
+
+import java.util.UUID;
+
+import org.folio.circulation.support.http.client.IndividualResource;
+
+import api.support.RestAssuredClient;
+import api.support.dto.Item;
+import api.support.dto.OverrideRenewal;
+import api.support.dto.User;
+import api.support.spring.clients.ResourceClient;
+import lombok.AllArgsConstructor;
+import lombok.val;
+
+@AllArgsConstructor
+public final class OverrideRenewalFixture {
+  private final RestAssuredClient restAssuredClient;
+  private final ResourceClient<Item> itemsFixture;
+  private final ResourceClient<User> usersFixture;
+
+  public void overrideRenewalByBarcode(OverrideRenewal request) {
+    restAssuredClient.post(request, overrideRenewalByBarcodeUrl(), 200, "override-renewal");
+  }
+
+  public void overrideRenewalByBarcode(IndividualResource loan, UUID servicePointId) {
+    val itemId = loan.getJson().getString("itemId");
+    val userId = loan.getJson().getString("userId");
+
+    final Item item = itemsFixture.getById(itemId);
+    final User user = usersFixture.getById(userId);
+
+    overrideRenewalByBarcode(OverrideRenewal.builder()
+      .itemBarcode(item.getBarcode())
+      .userBarcode(user.getBarcode())
+      .comment("Override renewal")
+      .overrideServicePointId(servicePointId.toString())
+      .build());
+  }
+}

--- a/src/test/java/api/support/http/InterfaceUrls.java
+++ b/src/test/java/api/support/http/InterfaceUrls.java
@@ -40,7 +40,7 @@ public class InterfaceUrls {
     return APITestContext.viaOkapiModuleUrl("/contributor-name-types" + subPath);
   }
 
-  static URL itemsStorageUrl(String subPath) {
+  public static URL itemsStorageUrl(String subPath) {
     return APITestContext.viaOkapiModuleUrl("/item-storage/items" + subPath);
   }
 
@@ -92,7 +92,7 @@ public class InterfaceUrls {
     return APITestContext.viaOkapiModuleUrl("/circulation-rules-storage" + subPath);
   }
 
-  static URL usersUrl(String subPath) {
+  public static URL usersUrl(String subPath) {
     return APITestContext.viaOkapiModuleUrl("/users" + subPath);
   }
 

--- a/src/test/java/api/support/jackson/serializer/JsonObjectJacksonSerializer.java
+++ b/src/test/java/api/support/jackson/serializer/JsonObjectJacksonSerializer.java
@@ -1,0 +1,19 @@
+package api.support.jackson.serializer;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Jackson serializer that allows vertx JsonObject to be correctly serialized.
+ */
+public final class JsonObjectJacksonSerializer extends JsonSerializer<JsonObject> {
+  @Override
+  public void serialize(JsonObject value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    gen.writeRaw(value.toString());
+  }
+}

--- a/src/test/java/api/support/jackson/serializer/JsonObjectJacksonSerializer.java
+++ b/src/test/java/api/support/jackson/serializer/JsonObjectJacksonSerializer.java
@@ -14,6 +14,6 @@ import io.vertx.core.json.JsonObject;
 public final class JsonObjectJacksonSerializer extends JsonSerializer<JsonObject> {
   @Override
   public void serialize(JsonObject value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-    gen.writeRaw(value.toString());
+    gen.writeRaw(value.encode());
   }
 }

--- a/src/test/java/api/support/spring/TestSpringConfiguration.java
+++ b/src/test/java/api/support/spring/TestSpringConfiguration.java
@@ -1,0 +1,67 @@
+package api.support.spring;
+
+import static api.support.APITestContext.getOkapiHeadersFromContext;
+import static api.support.http.InterfaceUrls.itemsStorageUrl;
+import static api.support.http.InterfaceUrls.usersUrl;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import api.support.RestAssuredClient;
+import api.support.dto.Item;
+import api.support.dto.User;
+import api.support.fixtures.OverrideRenewalFixture;
+import api.support.jackson.serializer.JsonObjectJacksonSerializer;
+import api.support.spring.clients.ResourceClient;
+import io.restassured.config.ObjectMapperConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.vertx.core.json.JsonObject;
+
+@Configuration
+@SuppressWarnings("unused")
+public class TestSpringConfiguration {
+  @Bean
+  public RestAssuredClient restAssuredClient(RestAssuredConfig config) {
+    return new RestAssuredClient(getOkapiHeadersFromContext(), config);
+  }
+
+  @Bean
+  public ResourceClient<Item> itemClient(RestAssuredClient client) {
+    return new ResourceClient<>(client, itemsStorageUrl(""), Item.class);
+  }
+
+  @Bean
+  public ResourceClient<User> userClient(RestAssuredClient client) {
+    return new ResourceClient<>(client, usersUrl(""), User.class);
+  }
+
+  @Bean
+  public OverrideRenewalFixture overrideRenewalFixture(RestAssuredClient client) {
+    return new OverrideRenewalFixture(client, itemClient(client), userClient(client));
+  }
+
+  @Bean
+  public RestAssuredConfig restAssuredConfig() {
+    final ObjectMapperConfig objectMapperConfig = new ObjectMapperConfig()
+      .jackson2ObjectMapperFactory((type, s) -> objectMapper());
+
+    return new RestAssuredConfig().objectMapperConfig(objectMapperConfig);
+  }
+
+  @Bean
+  public ObjectMapper objectMapper() {
+    final SimpleModule jsonObjectMapper = new SimpleModule();
+    jsonObjectMapper.addSerializer(JsonObject.class, new JsonObjectJacksonSerializer());
+
+    return new ObjectMapper().findAndRegisterModules()
+      .setSerializationInclusion(NON_NULL)
+      .disable(FAIL_ON_UNKNOWN_PROPERTIES)
+      .disable(WRITE_DATES_AS_TIMESTAMPS);
+  }
+}

--- a/src/test/java/api/support/spring/clients/ResourceClient.java
+++ b/src/test/java/api/support/spring/clients/ResourceClient.java
@@ -1,0 +1,42 @@
+package api.support.spring.clients;
+
+import static api.support.http.Limit.noLimit;
+import static api.support.http.Offset.noOffset;
+
+import java.net.URL;
+import java.util.List;
+
+import api.support.RestAssuredClient;
+import api.support.http.CqlQuery;
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+
+@AllArgsConstructor
+public final class ResourceClient<T> {
+  private final RestAssuredClient restAssuredClient;
+  private final URL baseUrl;
+  private final Class<T> type;
+  private final String collectionName;
+
+  public ResourceClient(RestAssuredClient client, URL baseUrl, Class<T> type) {
+    this(client, baseUrl, type, generateCollectionNameFromType(type));
+  }
+
+  public T getById(String id) {
+    return restAssuredClient.get(baseUrl("/" + id), "get-by-id", type);
+  }
+
+  public List<T> getMany(CqlQuery cqlQuery) {
+    return restAssuredClient.getMany(baseUrl, type, collectionName,
+      cqlQuery, noLimit(), noOffset());
+  }
+
+  @SneakyThrows
+  private URL baseUrl(String subPath) {
+    return new URL(baseUrl + subPath);
+  }
+
+  private static <T> String generateCollectionNameFromType(Class<T> type) {
+    return type.getTypeName().toLowerCase() + "s";
+  }
+}


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-716 - BE - Declared lost: renewal (effect on lost item fees) - SET COST

## Purpose
Refund lost item fees when `Declared lost` item is renewed through override. 

## Implementation notes

The main business logic is the same as for check-in (https://issues.folio.org/browse/CIRC-717). The main changes is to integrate the refund logic with override renewal. For this, new  [`RenewalFeeProcessingStrategy`](https://github.com/folio-org/mod-circulation/pull/579/files#diff-f9787b2ed191b119232110fc10e35d2f) class has been introduced with two implementations:
* [`RegularRenewalFeeProcessingStrategy`](https://github.com/folio-org/mod-circulation/pull/579/files#diff-c03a04597161f4b24604313d8bab425a) - charges overdue fines only, if any. Applies to renewal by barcode/by id operations;
*  [`OverrideRenewalFeeProcessingStrategy`](https://github.com/folio-org/mod-circulation/pull/579/files#diff-ec88929ebe68a4f1265910900aa0a793) - refunds lost item fees, if any and then executes the `RegularRenewalFeeProcessingStrategy` to do the usual fee processing staff. Applies only to override renewal operation;

## Approach
### Production code:
* Add new optional [`overrideServicePointId`](https://github.com/folio-org/mod-circulation/pull/579/files#diff-da6e4435f06c2a4f0886defa03e5b77d) property for `override-renewal-by-barcode-request` request. Bump up circulation interface version;
* Add the new fee processing strategies for renew and override - [renew](https://github.com/folio-org/mod-circulation/pull/579/files#diff-c03a04597161f4b24604313d8bab425a), [override](https://github.com/folio-org/mod-circulation/pull/579/files#diff-ec88929ebe68a4f1265910900aa0a793);
* Assign overdue fines for lost items when returned - [OverdueFineCalculatorService.java](https://github.com/folio-org/mod-circulation/pull/579/files#diff-f30d04d1dcd201545e5c2adfce52f4a9);
* Add small adapter method to refund lost fees on renewal - [LostItemFeeRefundService.java](https://github.com/folio-org/mod-circulation/pull/579/files#diff-2403ad4ea13245175169b2f8de582d52)

### Test code:
* Reuse all existing tests for refund lost item fees on check-in by moving them into an [abstract ](https://github.com/folio-org/mod-circulation/pull/579/files#diff-88d86c58f33eee5a890956333e5c5f97) class and extending by [OverrideRenewDeclaredLostItemTest.class](https://github.com/folio-org/mod-circulation/pull/579/files#diff-f54339b62c01186cd0bc05ff0590e60a) and [CheckInDeclaredLostItemTest.class](https://github.com/folio-org/mod-circulation/pull/579/files#diff-0a790d253e0c77c940e37b7c33983de1) (the existing one);
* Introduce spring testing/context/bean test dependencies;
* Refactor [RestAssuredClient.java](https://github.com/folio-org/mod-circulation/pull/579/files#diff-a91fbb2b080873d7a51699aacbf989b8) to allow accepting an object as body representation and add [JsonObjectJacksonSerializer.class](https://github.com/folio-org/mod-circulation/pull/579/files#diff-412312e74bcb98c07537ad51b4483379) to allow proper jackson serialization of `JsonObject` class.
* Introduce new parameterized [ResourceClient](https://github.com/folio-org/mod-circulation/pull/579/files#diff-f1987ccf077915692c860fd96ca5271d);
* Add [OverrideRenewalFixture.class](https://github.com/folio-org/mod-circulation/pull/579/files#diff-69ac5f987c36736b84e18d3af6aeffb5);
* Add [spring context configuration for tests](https://github.com/folio-org/mod-circulation/pull/579/files#diff-99e156d9d8e8e6689b8e53a6019b2923)


#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
