### PR TITLE
CIRC-801: Do not change due date when overdue loan is recalled.

### DIFF
--- a/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
+++ b/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
@@ -804,7 +804,7 @@ public class LoanDueDatesAfterRecallTests extends APITests {
   }
 
   @Test
-  public void shouldNotRenewOverdueLoan() {
+  public void shouldNotExtendLoanDueDateIfOverdueLoanIsRecalled() {
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
 
     final Period loanPeriod = Period.weeks(3);


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-801 - Recall of overdue item extends loan

## Purpose
Per Cate:
> Hi Bohdan Suprun, once an item is already overdue, a recall should not change the loan period at all since the due date is already in the past (the patron just needs to get the item returned.) It should still add a row to the Loan actions table indicating that the item was recalled.
>
> In terms of notices, which are out of scope for this bug fix, ideally there would be a special notice triggered to the patron saying "Your overdue item has now been recalled. Please get it to the library ASAP. Elevated fees will apply" or something along those lines. We don't have the ability to trigger a special notice for that case yet (it's part of UXPROD-2112) so I assume it will probably just trigger a standard recall notice which might be a bit confusing, if the standard noticed has test that says "the new due date is yyyy-mm-dd" and the new due date is the same as the original one. I suppose we could consider not sending standard recall notices when an item that is already overdue is recalled. I'll leave it to Darcy Branchini to decide what she wants to do there.

## Approach
Return the previous due date of loan when the loan is overdue.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
