### PR TITLE
CIRC-722 Add new stop sending event for overdue notices

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1493,7 +1493,8 @@
         "feefineactions.collection.get",
         "feefineactions.item.post",
         "accounts.item.put",
-        "pubsub.publish.post"
+        "pubsub.publish.post",
+        "scheduled-notice-storage.scheduled-notices.item.delete"
       ],
       "visible": false
     },
@@ -1546,7 +1547,8 @@
         "owners.collection.get",
         "accounts.item.post",
         "pubsub.publish.post",
-        "automated-patron-blocks.collection.get"
+        "automated-patron-blocks.collection.get",
+        "scheduled-notice-storage.scheduled-notices.item.delete"
       ],
       "visible": false
 },
@@ -1692,7 +1694,8 @@
         "feefines.item.post",
         "owners.collection.get",
         "accounts.item.post",
-        "pubsub.publish.post"
+        "pubsub.publish.post",
+        "scheduled-notice-storage.scheduled-notices.item.delete"
       ],
       "visible": false
     },

--- a/src/main/java/org/folio/circulation/domain/OverdueFineCalculatorService.java
+++ b/src/main/java/org/folio/circulation/domain/OverdueFineCalculatorService.java
@@ -220,9 +220,9 @@ public class OverdueFineCalculatorService {
       .thenCompose(r -> r.after(this::lookupFeeFineOwner))
       .thenCompose(r -> r.after(params -> this.lookupLoggedInUser(params, loggedInUserId)))
       .thenCompose(r -> r.after(params -> createAccount(fineAmount, params)))
-      .thenCompose(r -> r.after(feeFineAction ->
-        repos.scheduledNoticesRepository.deleteOverdueNotices(loan.getId())
-          .thenApply(rs -> succeeded(feeFineAction))));
+      .thenCompose(r -> r.after(feeFineAction -> repos.scheduledNoticesRepository
+          .deleteOverdueNotices(loan.getId())
+          .thenApply(rs -> r)));
   }
 
   private CompletableFuture<Result<FeeFineAction>> createAccount(Double fineAmount,

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/JsonScheduledNoticeMapper.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/JsonScheduledNoticeMapper.java
@@ -21,14 +21,14 @@ import io.vertx.core.json.JsonObject;
 public class JsonScheduledNoticeMapper {
 
   private static final String ID = "id";
-  private static final String LOAN_ID = "loanId";
+  static final String LOAN_ID = "loanId";
   private static final String REQUEST_ID = "requestId";
   private static final String FEE_FINE_ACTION_ID = "feeFineActionId";
   private static final String RECIPIENT_USER_ID = "recipientUserId";
   private static final String NEXT_RUN_TIME = "nextRunTime";
-  private static final String TRIGGERING_EVENT = "triggeringEvent";
-  private static final String NOTICE_CONFIG = "noticeConfig";
-  private static final String TIMING = "timing";
+  static final String TRIGGERING_EVENT = "triggeringEvent";
+  static final String NOTICE_CONFIG = "noticeConfig";
+  static final String TIMING = "timing";
   private static final String RECURRING_PERIOD = "recurringPeriod";
   private static final String TEMPLATE_ID = "templateId";
   private static final String FORMAT = "format";

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticesRepository.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticesRepository.java
@@ -1,7 +1,9 @@
 package org.folio.circulation.domain.notice.schedule;
 
 import static java.util.function.Function.identity;
+import static org.folio.circulation.domain.notice.NoticeTiming.AFTER;
 import static org.folio.circulation.domain.notice.schedule.JsonScheduledNoticeMapper.mapToJson;
+import static org.folio.circulation.domain.notice.schedule.TriggeringEvent.DUE_DATE;
 import static org.folio.circulation.support.ResultBinding.flatMapResult;
 import static org.folio.circulation.support.http.CommonResponseInterpreters.noContentRecordInterpreter;
 import static org.folio.circulation.support.http.ResponseMapping.flatMapUsingJson;
@@ -100,6 +102,14 @@ public class ScheduledNoticesRepository {
 
     return exactMatch("loanId", loanId)
       .combine(exactMatch("triggeringEvent", triggeringEvent.getRepresentation()), CqlQuery::and)
+      .after(this::deleteMany);
+  }
+
+  public CompletableFuture<Result<Response>> deleteOverdueNotices(String loanId) {
+
+    return exactMatch("loanId", loanId)
+      .combine(exactMatch("triggeringEvent", DUE_DATE.getRepresentation()), CqlQuery::and)
+      .combine(exactMatch("noticeConfig.timing", AFTER.getRepresentation()), CqlQuery::and)
       .after(this::deleteMany);
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticesRepository.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticesRepository.java
@@ -36,6 +36,10 @@ import org.joda.time.DateTimeZone;
 import io.vertx.core.json.JsonObject;
 
 public class ScheduledNoticesRepository {
+
+  private static final List<String> UPON_AT_AND_AFTER_TIMING =
+    Arrays.asList(UPON_AT.getRepresentation(), AFTER.getRepresentation());
+
   public static ScheduledNoticesRepository using(Clients clients) {
     return new ScheduledNoticesRepository(
       clients.scheduledNoticesStorageClient());
@@ -115,8 +119,7 @@ public class ScheduledNoticesRepository {
 
     return exactMatch(LOAN_ID, loanId)
       .combine(exactMatch(TRIGGERING_EVENT, DUE_DATE.getRepresentation()), CqlQuery::and)
-      .combine(exactMatchAny(NOTICE_CONFIG + "." + TIMING,
-        Arrays.asList(UPON_AT.getRepresentation(), AFTER.getRepresentation())), CqlQuery::and)
+      .combine(exactMatchAny(NOTICE_CONFIG + "." + TIMING, UPON_AT_AND_AFTER_TIMING), CqlQuery::and)
       .after(this::deleteMany);
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticesRepository.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticesRepository.java
@@ -2,6 +2,11 @@ package org.folio.circulation.domain.notice.schedule;
 
 import static java.util.function.Function.identity;
 import static org.folio.circulation.domain.notice.NoticeTiming.AFTER;
+import static org.folio.circulation.domain.notice.NoticeTiming.UPON_AT;
+import static org.folio.circulation.domain.notice.schedule.JsonScheduledNoticeMapper.LOAN_ID;
+import static org.folio.circulation.domain.notice.schedule.JsonScheduledNoticeMapper.NOTICE_CONFIG;
+import static org.folio.circulation.domain.notice.schedule.JsonScheduledNoticeMapper.TIMING;
+import static org.folio.circulation.domain.notice.schedule.JsonScheduledNoticeMapper.TRIGGERING_EVENT;
 import static org.folio.circulation.domain.notice.schedule.JsonScheduledNoticeMapper.mapToJson;
 import static org.folio.circulation.domain.notice.schedule.TriggeringEvent.DUE_DATE;
 import static org.folio.circulation.support.ResultBinding.flatMapResult;
@@ -11,6 +16,7 @@ import static org.folio.circulation.support.http.ResponseMapping.forwardOnFailur
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatchAny;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -107,9 +113,10 @@ public class ScheduledNoticesRepository {
 
   public CompletableFuture<Result<Response>> deleteOverdueNotices(String loanId) {
 
-    return exactMatch("loanId", loanId)
-      .combine(exactMatch("triggeringEvent", DUE_DATE.getRepresentation()), CqlQuery::and)
-      .combine(exactMatch("noticeConfig.timing", AFTER.getRepresentation()), CqlQuery::and)
+    return exactMatch(LOAN_ID, loanId)
+      .combine(exactMatch(TRIGGERING_EVENT, DUE_DATE.getRepresentation()), CqlQuery::and)
+      .combine(exactMatchAny(NOTICE_CONFIG + "." + TIMING,
+        Arrays.asList(UPON_AT.getRepresentation(), AFTER.getRepresentation())), CqlQuery::and)
       .after(this::deleteMany);
   }
 

--- a/src/test/java/api/support/fixtures/FeeFineOwnerFixture.java
+++ b/src/test/java/api/support/fixtures/FeeFineOwnerFixture.java
@@ -3,6 +3,8 @@ package api.support.fixtures;
 import static api.support.http.ResourceClient.forFeeFineOwners;
 import static api.support.http.ResourceClient.forServicePoints;
 
+import java.util.UUID;
+
 import org.folio.circulation.support.http.client.IndividualResource;
 
 import api.support.builders.FeeFineOwnerBuilder;
@@ -19,5 +21,11 @@ public final class FeeFineOwnerFixture extends RecordCreator {
     return createIfAbsent(new FeeFineOwnerBuilder()
       .withOwner("Test owner for cd1")
       .withServicePointOwner(servicePointsFixture.cd1().getId()));
+  }
+
+  public IndividualResource ownerForServicePoint(UUID servicePointId) {
+    return createIfAbsent(new FeeFineOwnerBuilder()
+      .withOwner("Test owner for service point" + servicePointId.toString())
+      .withServicePointOwner(servicePointId));
   }
 }

--- a/src/test/java/api/support/fixtures/FeeFineTypeFixture.java
+++ b/src/test/java/api/support/fixtures/FeeFineTypeFixture.java
@@ -1,5 +1,7 @@
 package api.support.fixtures;
 
+import java.util.UUID;
+
 import org.folio.circulation.support.http.client.IndividualResource;
 
 import api.support.builders.FeeFineBuilder;
@@ -25,6 +27,13 @@ public final class FeeFineTypeFixture extends RecordCreator {
   public IndividualResource overdueFine() {
     return createIfAbsent(new FeeFineBuilder()
       .withFeeFineType("Overdue fine")
+      .withAutomatic(true));
+  }
+
+  public IndividualResource overdueFine(UUID ownerId) {
+    return createIfAbsent(new FeeFineBuilder()
+      .withFeeFineType("Overdue fine")
+      .withOwnerId(ownerId)
       .withAutomatic(true));
   }
 }

--- a/src/test/java/org/folio/circulation/domain/OverdueFineCalculatorServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverdueFineCalculatorServiceTest.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
+import org.folio.circulation.domain.notice.schedule.ScheduledNoticesRepository;
 import org.folio.circulation.domain.policy.LostItemPolicyRepository;
 import org.folio.circulation.domain.policy.OverdueFinePolicy;
 import org.folio.circulation.domain.policy.OverdueFinePolicyRepository;
@@ -42,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 import api.support.builders.CheckInByBarcodeRequestBuilder;
 import api.support.builders.FeeFineBuilder;
 import api.support.builders.FeeFineOwnerBuilder;
+import api.support.builders.FeefineActionsBuilder;
 import api.support.builders.InstanceBuilder;
 import api.support.builders.ItemBuilder;
 import api.support.builders.LoanBuilder;
@@ -93,6 +95,7 @@ public class OverdueFineCalculatorServiceTest {
   private UserRepository userRepository;
   private FeeFineActionRepository feeFineActionRepository;
   private LostItemPolicyRepository lostItemPolicyRepository;
+  private ScheduledNoticesRepository scheduledNoticesRepository;
   private Boolean renewal;
   private Boolean dueDateChangedByRecall;
   private Double overdueFine;
@@ -158,12 +161,13 @@ public class OverdueFineCalculatorServiceTest {
     userRepository = mock(UserRepository.class);
     feeFineActionRepository = mock(FeeFineActionRepository.class);
     lostItemPolicyRepository = mock(LostItemPolicyRepository.class);
+    scheduledNoticesRepository = mock(ScheduledNoticesRepository.class);
 
     overdueFineCalculatorService = new OverdueFineCalculatorService(
       new OverdueFineCalculatorService.Repos(
         overdueFinePolicyRepository, accountRepository, itemRepository,
         feeFineOwnerRepository, feeFineRepository, userRepository, feeFineActionRepository,
-        lostItemPolicyRepository),
+        lostItemPolicyRepository, scheduledNoticesRepository),
       overduePeriodCalculatorService);
 
     when(userRepository.getUser(any(String.class))).thenReturn(
@@ -489,6 +493,43 @@ public class OverdueFineCalculatorServiceTest {
     verifyNoInteractions(accountRepository);
   }
 
+  @Test
+  public void shouldDeleteOverdueNoticesWhenFeeFineRecordCreated()
+    throws ExecutionException, InterruptedException {
+    Loan loan = createLoan();
+
+    when(overdueFinePolicyRepository.findOverdueFinePolicyForLoan(any()))
+      .thenReturn(completedFuture(succeeded(loan)));
+    when(overduePeriodCalculatorService.getMinutes(any(), any()))
+      .thenReturn(completedFuture(succeeded(periodCalculatorResult)));
+    when(itemRepository.fetchItemRelatedRecords(any()))
+      .thenReturn(completedFuture(succeeded(createItem())));
+    when(feeFineOwnerRepository.findOwnerForServicePoint(SERVICE_POINT_ID.toString()))
+      .thenReturn(completedFuture(succeeded(createFeeFineOwner())));
+    when(feeFineRepository.getFeeFine(FEE_FINE_TYPE, true))
+      .thenReturn(completedFuture(succeeded(createFeeFine())));
+    when(accountRepository.create(any())).thenReturn(completedFuture(succeeded(createAccount())));
+    when(feeFineActionRepository.create(any()))
+      .thenReturn(completedFuture(succeeded(createFeeFineAction())));
+    when(scheduledNoticesRepository.deleteOverdueNotices(any()))
+      .thenReturn(completedFuture(succeeded(null)));
+
+    if (renewal) {
+      RenewalContext context = createRenewalContext(loan);
+
+      overdueFineCalculatorService.createOverdueFineIfNecessary(context).get();
+    }
+    else {
+      CheckInContext context = new CheckInContext(
+        CheckInByBarcodeRequest.from(createCheckInByBarcodeRequest()).value())
+        .withLoan(loan);
+
+      overdueFineCalculatorService.createOverdueFineIfNecessary(context, LOGGED_IN_USER_ID).get();
+    }
+
+    verify(scheduledNoticesRepository, times(1)).deleteOverdueNotices(any());
+  }
+
   private RenewalContext createRenewalContext(Loan loan) {
     return create(loan, new JsonObject(), LOGGED_IN_USER_ID);
   }
@@ -578,6 +619,11 @@ public class OverdueFineCalculatorServiceTest {
     return FeeFine.from(new FeeFineBuilder()
       .withId(FEE_FINE_ID)
       .withFeeFineType(FEE_FINE_TYPE)
+      .create());
+  }
+
+  private FeeFineAction createFeeFineAction() {
+    return FeeFineAction.from(new FeefineActionsBuilder()
       .create());
   }
 


### PR DESCRIPTION
Resolves [CIRC-722](https://issues.folio.org/browse/CIRC-722).

Once overdue fine is charged, we're cancelling scheduled overdue notices for this loan (all **Upon/At due date** and **After due date** notices).

## Purpose
After overdue fine is charged we start sending overdue fine notices, so there's no sense in sending overdue notices on top of overdue fine notices - existence of overdue fine implies that an item is overdue.

## Approach
Deletion of scheduled patron notices is added to the overdue fine creation chain (OverdueFineCalculatorService) at the very end - after Account and FeeFineAction creation.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
