### PR TITLE
CIRC-827: RMB 30.2.2; update log4j to 2.13.3 fixing CVE-2020-9488

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
   <properties>
     <antlr4.version>4.7.2</antlr4.version>
     <drools.version>7.0.0.Final</drools.version>
-    <rmb.version>30.2.1</rmb.version>
+    <rmb.version>30.2.2</rmb.version>
     <vertx.version>3.9.1</vertx.version>
-    <log4j2.version>2.13.0</log4j2.version>
+    <log4j2.version>2.13.3</log4j2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <lombok.version>1.18.12</lombok.version>


### PR DESCRIPTION
The SmtpAppender did not verify the host name matched the SSL/TLS certificate
of an SMTPS connection which could allow an attacker with
man-in-the-middle access to intercept log messages sent through SMTPS.

This affects log4j < 2.13.2. Fix: Upgrade to log4j >= 2.13.2.

References:
https://nvd.nist.gov/vuln/detail/CVE-2020-9488
https://issues.apache.org/jira/browse/LOG4J2-2819

Also upgrade RMB from 30.2.1 to latest 30.2.2.

mod-circulation is probably not affected by these issues but this upgrade will
silence automated security scanners like GitHub.