### PR TITLE
CIRC-820 Can't renew through override

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1592,7 +1592,8 @@
         "circulation-storage.patron-notice-policies.item.get",
         "scheduled-notice-storage.scheduled-notices.collection.delete",
         "scheduled-notice-storage.scheduled-notices.item.post",
-        "patron-notice.post"
+        "patron-notice.post",
+        "automated-patron-blocks.collection.get"
       ],
       "visible": false
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -676,6 +676,7 @@
             "circulation-storage.loans.item.get",
             "circulation-storage.loan-policies.item.get",
             "circulation-storage.loan-policies.collection.get",
+            "circulation-storage.fixed-due-date-schedules.collection.get",
             "inventory-storage.items.item.get",
             "inventory-storage.locations.item.get",
             "inventory-storage.location-units.institutions.item.get",
@@ -689,7 +690,8 @@
             "circulation.rules.loan-policy.get",
             "configuration.entries.collection.get",
             "patron-notice.post",
-            "users.item.get"
+            "users.item.get",
+            "templates.item.get"
           ],
           "unit": "minute",
           "delay": "2"

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1546,7 +1546,9 @@
         "owners.collection.get",
         "accounts.item.post",
         "pubsub.publish.post",
-        "automated-patron-blocks.collection.get"
+        "automated-patron-blocks.collection.get",
+        "overdue-fines-policies.item.get",
+        "lost-item-fees-policies.item.get"
       ],
       "visible": false
 },
@@ -1593,7 +1595,9 @@
         "scheduled-notice-storage.scheduled-notices.collection.delete",
         "scheduled-notice-storage.scheduled-notices.item.post",
         "patron-notice.post",
-        "automated-patron-blocks.collection.get"
+        "automated-patron-blocks.collection.get",
+        "overdue-fines-policies.item.get",
+        "lost-item-fees-policies.item.get"
       ],
       "visible": false
     },


### PR DESCRIPTION
Resolves [CIRC-820](https://issues.folio.org/browse/CIRC-820), [CIRC-802](https://issues.folio.org/browse/CIRC-802), [CIRC-804](https://issues.folio.org/browse/CIRC-804)

## Purpose
During override-renewal-by-barcode we're checking whether automated patron blocks for a patron exist. This call fails due to missing permission.

Additionally, permissions related to policies also added according to Zak's comment in CIRC-820.

Also, permissions mentioned in CIRC-802 and CIRC-804 have been added.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
