### PR TITLE
CIRC-813 fix issue with URI Too Large error

### DIFF
--- a/src/main/java/org/folio/circulation/resources/ItemsInTransitResource.java
+++ b/src/main/java/org/folio/circulation/resources/ItemsInTransitResource.java
@@ -207,10 +207,6 @@ public class ItemsInTransitResource extends Resource {
     return inTransitReportEntry;
   }
 
-  private Result<MultipleRecords<Loan>> mapResponseToLoans(Response response) {
-    return MultipleRecords.from(response, Loan::from, "loans");
-  }
-
   private List<String> mapToItemIdList(List<InTransitReportEntry> inTransitReportEntryList) {
     return inTransitReportEntryList.stream()
       .map(InTransitReportEntry::getItem)

--- a/src/main/java/org/folio/circulation/resources/ItemsInTransitResource.java
+++ b/src/main/java/org/folio/circulation/resources/ItemsInTransitResource.java
@@ -39,7 +39,6 @@ import org.folio.circulation.support.GetManyRecordsClient;
 import org.folio.circulation.support.Result;
 import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.client.CqlQuery;
-import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.server.JsonHttpResponse;
 import org.folio.circulation.support.http.server.WebContext;
 

--- a/src/test/java/api/requests/ItemsInTransitReportTests.java
+++ b/src/test/java/api/requests/ItemsInTransitReportTests.java
@@ -450,7 +450,8 @@ public class ItemsInTransitReportTests extends APITests {
     final UUID forthServicePointLocationId = locationsFixture.fourthServicePoint().getId();
 
     for (int i = 0; i < 200; i++) {
-      InventoryItemResource item = createSmallAngryPlanet(forthServicePointLocationId, i);
+      InventoryItemResource item = createSmallAngryPlanetCopy(forthServicePointLocationId,
+        Integer.toString(i));
 
       checkOutFixture.checkOutByBarcode(item);
 
@@ -604,10 +605,14 @@ public class ItemsInTransitReportTests extends APITests {
       itemsFixture.thirdFloorHoldings());
   }
 
-  private InventoryItemResource createSmallAngryPlanet(UUID locationId, int barcode) {
+  private InventoryItemResource createSmallAngryPlanetCopy(UUID locationId, String barcode) {
 
-    final ItemBuilder smallAngryPlanetItemBuilder = createSmallAngryPlanetItemBuilder(
-      locationId, barcode);
+    final ItemBuilder smallAngryPlanetItemBuilder = new ItemBuilder()
+      .withPermanentLoanType(materialTypesFixture.book().getId())
+      .withMaterialType(loanTypesFixture.canCirculate().getId())
+      .withBarcode(barcode)
+      .withPermanentLocation(locationId)
+      .withTemporaryLocation(locationId);
 
     return itemsFixture.basedUponSmallAngryPlanet(smallAngryPlanetItemBuilder,
       itemsFixture.thirdFloorHoldings());
@@ -622,15 +627,5 @@ public class ItemsInTransitReportTests extends APITests {
       .withEnumeration("smallAngryPlanetEnumeration")
       .withVolume("smallAngryPlanetVolume")
       .withYearCaption(Collections.singletonList("2019"));
-  }
-
-  private ItemBuilder createSmallAngryPlanetItemBuilder(UUID locationId, int barcode) {
-
-    return new ItemBuilder()
-      .withPermanentLoanType(materialTypesFixture.book().getId())
-      .withMaterialType(loanTypesFixture.canCirculate().getId())
-      .withBarcode(Integer.toString(barcode))
-      .withPermanentLocation(locationId)
-      .withTemporaryLocation(locationId);
   }
 }


### PR DESCRIPTION
## Approach 
- Use FindWithMultipleCqlIndexValues to fetch open loans for items to avoid 414 Uri too long error;
- Cover this scenario by test;

Resolves: [CIRC-813](https://issues.folio.org/browse/CIRC-813)


- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
 
