### PR TITLE
CIRC-581: Fix "No content to map due to end-of-input"

### DIFF
--- a/src/main/java/org/folio/circulation/infrastructure/storage/ConfigurationRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/ConfigurationRepository.java
@@ -67,7 +67,7 @@ public class ConfigurationRepository {
     final String period = configurations.stream()
       .map(Configuration::getValue)
       .findFirst()
-      .orElse("");
+      .orElse("{}");
 
     return LoanAnonymizationConfiguration.from(new JsonObject(period));
   }


### PR DESCRIPTION
Fix "No content to map due to end-of-input"

Cause:
POST request for mod-circulation-19.1.0
/circulation/scheduled-anonymize-processing failed with 500:
Failed to decode:No content to map due to end-of-input
  at [Source: (String)""; line: 1, column: 0]
io.vertx.core.json.DecodeException:
Failed to decode:No content to map due to end-of-input
  at [Source: (String)""; line: 1, column: 0]
	at io.vertx.core.json.jackson.JacksonCodec.fromParser(JacksonCodec.java:100)
