### PR TITLE
CIRC-865 fix issue with 414 status during ending expired sessions

### DIFF
--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionProperties.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionProperties.java
@@ -1,7 +1,6 @@
 package org.folio.circulation.domain.notice.session;
 
 public class PatronActionSessionProperties {
-
   private PatronActionSessionProperties() { }
 
   public static final String ID = "id";

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionProperties.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionProperties.java
@@ -1,0 +1,12 @@
+package org.folio.circulation.domain.notice.session;
+
+public class PatronActionSessionProperties {
+
+  private PatronActionSessionProperties() { }
+
+  public static final String ID = "id";
+  public static final String PATRON_ID = "patronId";
+  public static final String LOAN_ID = "loanId";
+  public static final String ACTION_TYPE = "actionType";
+  public static final String PATRON_ACTION_SESSIONS = "patronActionSessions";
+}

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionService.java
@@ -90,8 +90,7 @@ public class PatronActionSessionService {
 
   public CompletableFuture<Result<Void>> endSession(List<ExpiredSession> expiredSessions) {
 
-    return patronActionSessionRepository.findPatronActionSessions(expiredSessions,
-      DEFAULT_SESSION_SIZE_PAGE_LIMIT)
+    return patronActionSessionRepository.findPatronActionSessions(expiredSessions)
       .thenCompose(r -> r.after(this::endSessionsForRecords));
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronSessionRecord.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronSessionRecord.java
@@ -1,10 +1,18 @@
 package org.folio.circulation.domain.notice.session;
 
 import static java.util.Objects.requireNonNull;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ID;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ACTION_TYPE;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.LOAN_ID;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.PATRON_ID;
+import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.JsonPropertyFetcher.getUUIDProperty;
 
 import java.util.UUID;
 
 import org.folio.circulation.domain.Loan;
+
+import io.vertx.core.json.JsonObject;
 
 public class PatronSessionRecord {
 
@@ -53,5 +61,16 @@ public class PatronSessionRecord {
 
   public PatronSessionRecord withLoan(Loan newLoan) {
     return new PatronSessionRecord(id, patronId, loanId, actionType, newLoan);
+  }
+
+  public static PatronSessionRecord from(JsonObject representation) {
+    UUID id = getUUIDProperty(representation, ID);
+    UUID patronId = getUUIDProperty(representation, PATRON_ID);
+    UUID loanId = getUUIDProperty(representation, LOAN_ID);
+    String actionTypeValue = getProperty(representation, ACTION_TYPE);
+
+    return PatronActionType.from(actionTypeValue)
+      .map(patronActionType -> new PatronSessionRecord(id, patronId, loanId, patronActionType))
+      .orElse(null);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/representations/EndPatronSessionRequest.java
+++ b/src/main/java/org/folio/circulation/domain/representations/EndPatronSessionRequest.java
@@ -1,5 +1,7 @@
 package org.folio.circulation.domain.representations;
 
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ACTION_TYPE;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.PATRON_ID;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
@@ -7,18 +9,16 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
-
 import org.folio.circulation.domain.notice.session.PatronActionType;
 import org.folio.circulation.support.Result;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 public class EndPatronSessionRequest {
 
   private final PatronActionType actionType;
-  private static final String PATRON_ID = "patronId";
-  private static final String ACTION_TYPE = "actionType";
   private static final String END_SESSIONS = "endSessions";
   private final String patronId;
 

--- a/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
@@ -1,16 +1,22 @@
 package org.folio.circulation.infrastructure.storage.sessions;
 
 import static java.util.function.Function.identity;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ACTION_TYPE;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ID;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.LOAN_ID;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.PATRON_ACTION_SESSIONS;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.PATRON_ID;
 import static org.folio.circulation.support.JsonPropertyFetcher.getProperty;
-import static org.folio.circulation.support.JsonPropertyFetcher.getUUIDProperty;
 import static org.folio.circulation.support.JsonPropertyWriter.write;
 import static org.folio.circulation.support.Result.of;
+import static org.folio.circulation.support.Result.succeeded;
 import static org.folio.circulation.support.ResultBinding.flatMapResult;
 import static org.folio.circulation.support.ResultBinding.mapResult;
+import static org.folio.circulation.support.fetching.RecordFetching.findWithMultipleCqlIndexValues;
 import static org.folio.circulation.support.http.ResponseMapping.flatMapUsingJson;
 import static org.folio.circulation.support.http.ResponseMapping.forwardOnFailure;
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
-import static org.folio.circulation.support.http.client.CqlQuery.exactMatchAny;
+import static org.folio.circulation.support.http.client.CqlQuery.noQuery;
 import static org.folio.circulation.support.results.CommonFailures.failedDueToServerError;
 
 import java.util.HashSet;
@@ -109,15 +115,13 @@ public class PatronActionSessionRepository {
   }
 
   private Result<PatronSessionRecord> mapFromJson(JsonObject json) {
-    UUID id = getUUIDProperty(json, ID);
-    UUID patronId = getUUIDProperty(json, PATRON_ID);
-    UUID loanId = getUUIDProperty(json, LOAN_ID);
-    String actionTypeValue = getProperty(json, ACTION_TYPE);
 
-    return PatronActionType.from(actionTypeValue)
-      .map(patronActionType -> new PatronSessionRecord(id, patronId, loanId, patronActionType))
-      .map(Result::succeeded)
-      .orElse(failedDueToServerError("Invalid patron action type value: " + actionTypeValue));
+    PatronSessionRecord patronSessionRecord = PatronSessionRecord.from(json);
+    if (patronSessionRecord == null) {
+      return failedDueToServerError("Invalid patron action type value: "
+        + getProperty(json, ACTION_TYPE));
+    }
+    return succeeded(patronSessionRecord);
   }
 
   public CompletableFuture<Result<MultipleRecords<PatronSessionRecord>>> findPatronActionSessions(
@@ -134,7 +138,7 @@ public class PatronActionSessionRepository {
   }
 
   public CompletableFuture<Result<MultipleRecords<PatronSessionRecord>>> findPatronActionSessions(
-    List<ExpiredSession> expiredSessions, PageLimit pageLimit) {
+    List<ExpiredSession> expiredSessions) {
 
     Set<String> patronIds = expiredSessions.stream()
       .filter(expiredSession -> StringUtils.isNotBlank(expiredSession.getPatronId()) )
@@ -142,14 +146,15 @@ public class PatronActionSessionRepository {
       .collect(Collectors.toCollection(HashSet::new));
 
     if (patronIds.isEmpty()) {
-      return CompletableFuture.completedFuture(Result.succeeded(null));
+      return CompletableFuture.completedFuture(succeeded(null));
     }
-    Result<CqlQuery> sessionsQuery = exactMatchAny(PATRON_ID, patronIds);
-    sessionsQuery = addActionTypeToCqlQuery(sessionsQuery,
+
+    Result<CqlQuery> actionTypeQuery = createActionTypeCqlQuery(
       expiredSessions.get(0).getActionType());
 
-    return sessionsQuery
-      .after(query -> findBy(query, pageLimit))
+    return findWithMultipleCqlIndexValues(patronActionSessionsStorageClient,
+      PATRON_ACTION_SESSIONS, PatronSessionRecord::from)
+      .findByIdIndexAndQuery(patronIds, PATRON_ID, actionTypeQuery)
       .thenCompose(r -> r.combineAfter(
         () -> userRepository.getUsersForUserIds(patronIds), this::setUsersForLoans));
   }
@@ -163,6 +168,14 @@ public class PatronActionSessionRepository {
       sessionsQuery = sessionsQuery.combine(actionTypeQuery, CqlQuery::and);
     }
     return sessionsQuery;
+  }
+
+  private Result<CqlQuery> createActionTypeCqlQuery(PatronActionType actionType) {
+
+    if (isPatronActionTypeSpecified(actionType)) {
+      return exactMatch(ACTION_TYPE, actionType.getRepresentation());
+    }
+    return noQuery();
   }
 
   private boolean isPatronActionTypeSpecified(PatronActionType actionType) {
@@ -194,7 +207,7 @@ public class PatronActionSessionRepository {
 
     return patronActionSessionsStorageClient.getMany(query, pageLimit)
       .thenApply(r -> r.next(response ->
-        MultipleRecords.from(response, identity(), "patronActionSessions")))
+        MultipleRecords.from(response, identity(), PATRON_ACTION_SESSIONS)))
       .thenApply(r -> r.next(records -> records.flatMapRecords(this::mapFromJson)))
       .thenCompose(r -> r.after(this::fetchLoans));
   }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
@@ -50,10 +50,6 @@ import org.folio.circulation.support.http.client.ResponseInterpreter;
 import io.vertx.core.json.JsonObject;
 
 public class PatronActionSessionRepository {
-  private static final String ID = "id";
-  private static final String PATRON_ID = "patronId";
-  private static final String LOAN_ID = "loanId";
-  private static final String ACTION_TYPE = "actionType";
 
   private final CollectionResourceClient patronActionSessionsStorageClient;
   private final LoanRepository loanRepository;

--- a/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronExpiredSessionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronExpiredSessionRepository.java
@@ -1,11 +1,13 @@
 package org.folio.circulation.infrastructure.storage.sessions;
 
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ACTION_TYPE;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.PATRON_ACTION_SESSIONS;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.PATRON_ID;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.notice.session.ExpiredSession;
 import org.folio.circulation.domain.notice.session.PatronActionType;
@@ -13,6 +15,9 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FetchSingleRecord;
 import org.folio.circulation.support.Result;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 public class PatronExpiredSessionRepository {
   private static final int EXPIRED_SESSIONS_LIMIT = 100;
@@ -40,7 +45,7 @@ public class PatronExpiredSessionRepository {
 
     String path = String.format(PATH_PARAM_WITH_QUERY, actionType, inactivityTimeLimit, EXPIRED_SESSIONS_LIMIT);
 
-    return FetchSingleRecord.<List<ExpiredSession>>forRecord("patronActionSessions")
+    return FetchSingleRecord.<List<ExpiredSession>>forRecord(PATRON_ACTION_SESSIONS)
       .using(patronExpiredSessionsStorageClient)
       .mapTo(this::mapFromJson)
       .fetch(path);
@@ -55,9 +60,9 @@ public class PatronExpiredSessionRepository {
     JsonArray expiredSessionsArray = json.getJsonArray(EXPIRED_SESSIONS);
     for (int i = 0; i < expiredSessionsArray.size(); i++) {
       String patronId = expiredSessionsArray.getJsonObject(i)
-        .getString("patronId", StringUtils.EMPTY);
+        .getString(PATRON_ID, StringUtils.EMPTY);
       String actionType = expiredSessionsArray.getJsonObject(i)
-        .getString("actionType", StringUtils.EMPTY);
+        .getString(ACTION_TYPE, StringUtils.EMPTY);
 
       PatronActionType.from(actionType)
         .ifPresent(patronActionType -> expiredSessions.add(

--- a/src/test/java/api/loans/EndExpiredPatronActionSessionTests.java
+++ b/src/test/java/api/loans/EndExpiredPatronActionSessionTests.java
@@ -308,6 +308,20 @@ public class EndExpiredPatronActionSessionTests extends APITests {
       .until(patronSessionRecordsClient::getAll, empty());
   }
 
+  @Test
+  public void sessionsWithNotSpecifiedActionTypeShouldBeEnded() {
+
+    createOneHundredPatronActionCheckOutSessions("");
+    List<JsonObject> sessions = patronSessionRecordsClient.getAll();
+    assertThat(sessions, Matchers.hasSize(100));
+
+    expiredSessionProcessingClient.runRequestExpiredSessionsProcessing(204);
+
+    Awaitility.await()
+      .atMost(1, TimeUnit.SECONDS)
+      .until(patronSessionRecordsClient::getAll, empty());
+  }
+
   private void createOneHundredPatronActionCheckOutSessions(String actionType) {
     IntStream.range(0, 100).forEach(
       notUsed -> {

--- a/src/test/java/api/loans/EndExpiredPatronActionSessionTests.java
+++ b/src/test/java/api/loans/EndExpiredPatronActionSessionTests.java
@@ -281,9 +281,9 @@ public class EndExpiredPatronActionSessionTests extends APITests {
   }
 
   @Test
-  public void shouldNotFailWithUriTooLargeErrorDuringEndingExpiredSessions() {
+  public void shouldNotFailWithUriTooLargeErrorDuringEndingExpiredCheckOutSessions() {
 
-    createOneHundredPatronActionCheckOutSessions();
+    createOneHundredPatronActionCheckOutSessions("Check-out");
     List<JsonObject> sessions = patronSessionRecordsClient.getAll();
     assertThat(sessions, Matchers.hasSize(100));
 
@@ -294,7 +294,21 @@ public class EndExpiredPatronActionSessionTests extends APITests {
       .until(patronSessionRecordsClient::getAll, empty());
   }
 
-  private void createOneHundredPatronActionCheckOutSessions() {
+  @Test
+  public void shouldNotFailWithUriTooLargeErrorDuringEndingExpiredCheckInSessions() {
+
+    createOneHundredPatronActionCheckOutSessions("Check-in");
+    List<JsonObject> sessions = patronSessionRecordsClient.getAll();
+    assertThat(sessions, Matchers.hasSize(100));
+
+    expiredSessionProcessingClient.runRequestExpiredSessionsProcessing(204);
+
+    Awaitility.await()
+      .atMost(1, TimeUnit.SECONDS)
+      .until(patronSessionRecordsClient::getAll, empty());
+  }
+
+  private void createOneHundredPatronActionCheckOutSessions(String actionType) {
     IntStream.range(0, 100).forEach(
       notUsed -> {
         String patronId = UUID.randomUUID().toString();
@@ -303,11 +317,11 @@ public class EndExpiredPatronActionSessionTests extends APITests {
             .put(ID, UUID.randomUUID().toString())
             .put(PATRON_ID, patronId)
             .put(LOAN_ID, UUID.randomUUID().toString())
-            .put(ACTION_TYPE, "Check-out"));
+            .put(ACTION_TYPE, actionType));
         expiredEndSessionClient.create(
           new JsonObject()
             .put(PATRON_ID, patronId)
-            .put(ACTION_TYPE, "Check-out"));
+            .put(ACTION_TYPE, actionType));
       });
   }
 }

--- a/src/test/java/api/loans/PatronActionSessionTests.java
+++ b/src/test/java/api/loans/PatronActionSessionTests.java
@@ -8,6 +8,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ACTION_TYPE;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ID;
 import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.LOAN_ID;
 import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.PATRON_ID;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -26,6 +27,8 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.awaitility.Awaitility;
+import org.folio.circulation.domain.notice.session.PatronActionType;
+import org.folio.circulation.domain.notice.session.PatronSessionRecord;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.hamcrest.Matcher;
@@ -229,6 +232,26 @@ public class PatronActionSessionTests extends APITests {
       .until(this::getCheckInSessions, empty());
 
     assertThat(patronNoticesClient.getAll(), hasSize(1));
+  }
+
+  @Test
+  public void shouldMapJsonRepresentationToPatronSessionRecord() {
+    String id = UUID.randomUUID().toString();
+    String patronId = UUID.randomUUID().toString();
+    String loanId = UUID.randomUUID().toString();
+
+    JsonObject representation = new JsonObject()
+      .put(ID, id)
+      .put(PATRON_ID, patronId)
+      .put(LOAN_ID, loanId)
+      .put(ACTION_TYPE, "Check-in");
+
+    PatronSessionRecord sessionRecord = PatronSessionRecord.from(representation);
+
+    assertThat(sessionRecord.getId().toString(), is(id));
+    assertThat(sessionRecord.getPatronId().toString(), is(patronId));
+    assertThat(sessionRecord.getLoanId().toString(), is(loanId));
+    assertThat(sessionRecord.getActionType(), is(PatronActionType.CHECK_IN));
   }
 
   private List<JsonObject> getCheckInSessions() {

--- a/src/test/java/api/loans/PatronActionSessionTests.java
+++ b/src/test/java/api/loans/PatronActionSessionTests.java
@@ -7,6 +7,9 @@ import static api.support.matchers.PatronNoticeMatcher.hasEmailNoticeProperties;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ACTION_TYPE;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.LOAN_ID;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.PATRON_ID;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -71,7 +74,7 @@ public class PatronActionSessionTests extends APITests {
   @Test
   public void cannotEndSessionWhenPatronIdIsNotSpecified() {
     JsonObject body = new JsonObject()
-      .put("actionType", "Check-out");
+      .put(ACTION_TYPE, "Check-out");
     Response response = endPatronSessionClient.attemptEndPatronSession(wrapInObjectWithArray(body));
 
     assertThat(response.getJson(), hasErrorWith(allOf(
@@ -81,7 +84,7 @@ public class PatronActionSessionTests extends APITests {
   @Test
   public void cannotEndSessionWhenActionTypeIsNotSpecified() {
     JsonObject body = new JsonObject()
-      .put("patronId", UUID.randomUUID().toString());
+      .put(PATRON_ID, UUID.randomUUID().toString());
     Response response = endPatronSessionClient.attemptEndPatronSession(wrapInObjectWithArray(body));
 
     assertThat(response.getJson(), hasErrorWith(allOf(
@@ -93,8 +96,8 @@ public class PatronActionSessionTests extends APITests {
     String invalidActionType = "invalidActionType";
 
     JsonObject body = new JsonObject()
-      .put("patronId", UUID.randomUUID().toString())
-      .put("actionType", invalidActionType);
+      .put(PATRON_ID, UUID.randomUUID().toString())
+      .put(ACTION_TYPE, invalidActionType);
     Response response = endPatronSessionClient.attemptEndPatronSession(wrapInObjectWithArray(body));
 
     assertThat(response.getJson(), hasErrorWith(allOf(
@@ -183,8 +186,8 @@ public class PatronActionSessionTests extends APITests {
     assertThat(checkInSessions, Matchers.hasSize(1));
 
     JsonObject checkInSession = checkInSessions.get(0);
-    assertThat(checkInSession.getString("patronId"), is(james.getId().toString()));
-    assertThat(checkInSession.getString("loanId"), is(loan.getId().toString()));
+    assertThat(checkInSession.getString(PATRON_ID), is(james.getId().toString()));
+    assertThat(checkInSession.getString(LOAN_ID), is(loan.getId().toString()));
   }
 
   @Test
@@ -230,7 +233,7 @@ public class PatronActionSessionTests extends APITests {
 
   private List<JsonObject> getCheckInSessions() {
 
-    Predicate<JsonObject> isCheckInSession = json -> json.getString("actionType").equals("Check-in");
+    Predicate<JsonObject> isCheckInSession = json -> json.getString(ACTION_TYPE).equals("Check-in");
 
     return patronSessionRecordsClient.getAll().stream()
       .filter(isCheckInSession)

--- a/src/test/java/api/loans/PatronActionSessionTests.java
+++ b/src/test/java/api/loans/PatronActionSessionTests.java
@@ -234,26 +234,6 @@ public class PatronActionSessionTests extends APITests {
     assertThat(patronNoticesClient.getAll(), hasSize(1));
   }
 
-  @Test
-  public void shouldMapJsonRepresentationToPatronSessionRecord() {
-    String id = UUID.randomUUID().toString();
-    String patronId = UUID.randomUUID().toString();
-    String loanId = UUID.randomUUID().toString();
-
-    JsonObject representation = new JsonObject()
-      .put(ID, id)
-      .put(PATRON_ID, patronId)
-      .put(LOAN_ID, loanId)
-      .put(ACTION_TYPE, "Check-in");
-
-    PatronSessionRecord sessionRecord = PatronSessionRecord.from(representation);
-
-    assertThat(sessionRecord.getId().toString(), is(id));
-    assertThat(sessionRecord.getPatronId().toString(), is(patronId));
-    assertThat(sessionRecord.getLoanId().toString(), is(loanId));
-    assertThat(sessionRecord.getActionType(), is(PatronActionType.CHECK_IN));
-  }
-
   private List<JsonObject> getCheckInSessions() {
 
     Predicate<JsonObject> isCheckInSession = json -> json.getString(ACTION_TYPE).equals("Check-in");

--- a/src/test/java/api/support/builders/EndSessionBuilder.java
+++ b/src/test/java/api/support/builders/EndSessionBuilder.java
@@ -1,5 +1,8 @@
 package api.support.builders;
 
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ACTION_TYPE;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.PATRON_ID;
+
 import io.vertx.core.json.JsonObject;
 
 public class EndSessionBuilder extends JsonBuilder implements Builder {
@@ -25,8 +28,8 @@ public class EndSessionBuilder extends JsonBuilder implements Builder {
     }
 
     return jsonObject
-      .put("patronId", this.patronId)
-      .put("actionType", this.actionType);
+      .put(PATRON_ID, this.patronId)
+      .put(ACTION_TYPE, this.actionType);
   }
 
   public EndSessionBuilder withPatronId(String patronId) {

--- a/src/test/java/api/support/fixtures/EndPatronSessionClient.java
+++ b/src/test/java/api/support/fixtures/EndPatronSessionClient.java
@@ -2,6 +2,8 @@ package api.support.fixtures;
 
 import static api.support.APITestContext.getOkapiHeadersFromContext;
 import static api.support.http.InterfaceUrls.endSessionUrl;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ACTION_TYPE;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.PATRON_ID;
 
 import java.util.UUID;
 
@@ -26,8 +28,8 @@ public class EndPatronSessionClient {
 
   private void endPatronSession(UUID patronId, String actionType) {
     JsonObject body = new JsonObject()
-      .put("patronId", patronId.toString())
-      .put("actionType", actionType);
+      .put(PATRON_ID, patronId.toString())
+      .put(ACTION_TYPE, actionType);
     JsonArray jsonArray = new JsonArray().add(body);
     endPatronSession(new JsonObject().put("endSessions", jsonArray));
   }

--- a/src/test/java/org/folio/circulation/domain/notice/session/PatronSessionRecordTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/session/PatronSessionRecordTest.java
@@ -1,0 +1,37 @@
+package org.folio.circulation.domain.notice.session;
+
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ACTION_TYPE;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.ID;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.LOAN_ID;
+import static org.folio.circulation.domain.notice.session.PatronActionSessionProperties.PATRON_ID;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.UUID;
+
+import org.junit.Test;
+
+import io.vertx.core.json.JsonObject;
+
+public class PatronSessionRecordTest {
+
+  @Test
+  public void shouldMapJsonRepresentationToPatronSessionRecord() {
+    String id = UUID.randomUUID().toString();
+    String patronId = UUID.randomUUID().toString();
+    String loanId = UUID.randomUUID().toString();
+
+    JsonObject representation = new JsonObject()
+      .put(ID, id)
+      .put(PATRON_ID, patronId)
+      .put(LOAN_ID, loanId)
+      .put(ACTION_TYPE, "Check-in");
+
+    PatronSessionRecord sessionRecord = PatronSessionRecord.from(representation);
+
+    assertThat(sessionRecord.getId().toString(), is(id));
+    assertThat(sessionRecord.getPatronId().toString(), is(patronId));
+    assertThat(sessionRecord.getLoanId().toString(), is(loanId));
+    assertThat(sessionRecord.getActionType(), is(PatronActionType.CHECK_IN));
+  }
+}


### PR DESCRIPTION
## Approach
- Use FindWithMultipleCqlIndexValues to get expired for items to avoid 414 Uri too long error;
- Cover this scenario by test;

Resolves: [CIRC-865](https://issues.folio.org/browse/CIRC-865)

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
