### PR TITLE
Ensure timer tasks respond CIRC-850

### DIFF
--- a/src/main/java/org/folio/circulation/domain/anonymization/LoanAnonymizationService.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/LoanAnonymizationService.java
@@ -5,6 +5,5 @@ import java.util.concurrent.CompletableFuture;
 import org.folio.circulation.support.Result;
 
 public interface LoanAnonymizationService {
-
   CompletableFuture<Result<LoanAnonymizationRecords>> anonymizeLoans();
 }

--- a/src/main/java/org/folio/circulation/resources/ExpiredSessionProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ExpiredSessionProcessingResource.java
@@ -18,6 +18,7 @@ import org.folio.circulation.support.Result;
 import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.server.NoContentResponse;
 import org.folio.circulation.support.http.server.WebContext;
+import org.folio.circulation.support.results.CommonFailures;
 import org.joda.time.DateTime;
 
 import io.vertx.core.http.HttpClient;
@@ -58,6 +59,7 @@ public class ExpiredSessionProcessingResource extends Resource {
       .thenCompose(r -> r.after(expiredSessions -> attemptEndSession(
         patronSessionService, expiredSessions)))
       .thenApply(r -> r.toFixedValue(NoContentResponse::noContent))
+      .exceptionally(CommonFailures::failedDueToServerError)
       .thenAccept(context::writeResultToHttpResponse);
   }
 

--- a/src/main/java/org/folio/circulation/resources/ExpiredSessionProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ExpiredSessionProcessingResource.java
@@ -1,16 +1,16 @@
 package org.folio.circulation.resources;
 
 import static org.folio.circulation.domain.notice.session.PatronActionType.ALL;
+import static org.folio.circulation.support.results.AsynchronousResultBindings.safelyInitialise;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.domain.notice.session.ExpiredSession;
 import org.folio.circulation.domain.notice.session.PatronActionSessionService;
-import org.folio.circulation.domain.notice.session.PatronActionType;
+import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.sessions.PatronExpiredSessionRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.ClockManager;
@@ -51,7 +51,7 @@ public class ExpiredSessionProcessingResource extends Resource {
     final PatronExpiredSessionRepository patronExpiredSessionRepository
       = PatronExpiredSessionRepository.using(clients);
 
-    configurationRepository.lookupSessionTimeout()
+    safelyInitialise(configurationRepository::lookupSessionTimeout)
       .thenCompose(r -> r.after(this::defineExpiredTime))
       .thenCompose(r -> r.after(inactivityTime ->
         patronExpiredSessionRepository.findPatronExpiredSessions(ALL, inactivityTime.toString())))

--- a/src/main/java/org/folio/circulation/resources/ExpiredSessionProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ExpiredSessionProcessingResource.java
@@ -1,5 +1,7 @@
 package org.folio.circulation.resources;
 
+import static org.folio.circulation.domain.notice.session.PatronActionType.ALL;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -51,8 +53,8 @@ public class ExpiredSessionProcessingResource extends Resource {
 
     configurationRepository.lookupSessionTimeout()
       .thenCompose(r -> r.after(this::defineExpiredTime))
-      .thenCompose(r -> patronExpiredSessionRepository.findPatronExpiredSessions(
-        PatronActionType.ALL, r.value().toString()))
+      .thenCompose(r -> r.after(inactivityTime ->
+        patronExpiredSessionRepository.findPatronExpiredSessions(ALL, inactivityTime.toString())))
       .thenCompose(r -> r.after(expiredSessions -> attemptEndSession(
         patronSessionService, expiredSessions)))
       .thenApply(r -> r.toFixedValue(NoContentResponse::noContent))

--- a/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
@@ -1,8 +1,10 @@
 package org.folio.circulation.resources;
 
-import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import static org.folio.circulation.support.results.AsynchronousResultBindings.safelyInitialise;
+
 import org.folio.circulation.domain.anonymization.LoanAnonymization;
 import org.folio.circulation.domain.representations.anonymization.AnonymizeLoansRepresentation;
+import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.server.JsonHttpResponse;
@@ -36,7 +38,7 @@ public class ScheduledAnonymizationProcessingResource extends Resource {
     ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
     LoanAnonymization loanAnonymization = new LoanAnonymization(clients);
 
-    configurationRepository.loanHistoryConfiguration()
+    safelyInitialise(configurationRepository::loanHistoryConfiguration)
       .thenCompose(r -> r.after(config -> loanAnonymization
           .byCurrentTenant(config).anonymizeLoans()))
       .thenApply(AnonymizeLoansRepresentation::from)

--- a/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
@@ -9,6 +9,7 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.server.JsonHttpResponse;
 import org.folio.circulation.support.http.server.WebContext;
+import org.folio.circulation.support.results.CommonFailures;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.ext.web.Router;
@@ -43,6 +44,7 @@ public class ScheduledAnonymizationProcessingResource extends Resource {
           .byCurrentTenant(config).anonymizeLoans()))
       .thenApply(AnonymizeLoansRepresentation::from)
       .thenApply(r -> r.map(JsonHttpResponse::ok))
+      .exceptionally(CommonFailures::failedDueToServerError)
       .thenAccept(context::writeResultToHttpResponse);
   }
 }

--- a/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
@@ -34,12 +34,13 @@ public class ScheduledAnonymizationProcessingResource extends Resource {
     final Clients clients = Clients.create(context, client);
 
     ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
+    LoanAnonymization loanAnonymization = new LoanAnonymization(clients);
 
-    configurationRepository.loanHistoryConfiguration().thenCompose(c -> c.after(config ->
-        new LoanAnonymization(clients).byCurrentTenant(config).anonymizeLoans())
-        .thenApply(AnonymizeLoansRepresentation::from)
-        .thenApply(r -> r.map(JsonHttpResponse::ok))
-        .thenAccept(context::writeResultToHttpResponse));
-
+    configurationRepository.loanHistoryConfiguration()
+      .thenCompose(r -> r.after(config -> loanAnonymization
+          .byCurrentTenant(config).anonymizeLoans()))
+      .thenApply(AnonymizeLoansRepresentation::from)
+      .thenApply(r -> r.map(JsonHttpResponse::ok))
+      .thenAccept(context::writeResultToHttpResponse);
   }
 }

--- a/src/main/java/org/folio/circulation/resources/ScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledNoticeProcessingResource.java
@@ -1,5 +1,7 @@
 package org.folio.circulation.resources;
 
+import static org.folio.circulation.support.results.AsynchronousResultBindings.safelyInitialise;
+
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
@@ -12,6 +14,7 @@ import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.server.NoContentResponse;
 import org.folio.circulation.support.http.server.WebContext;
+import org.folio.circulation.support.results.AsynchronousResultBindings;
 import org.folio.circulation.support.results.CommonFailures;
 
 import io.vertx.core.http.HttpClient;
@@ -42,7 +45,7 @@ public abstract class ScheduledNoticeProcessingResource extends Resource {
     final ConfigurationRepository configurationRepository =
       new ConfigurationRepository(clients);
 
-    configurationRepository.lookupSchedulerNoticesProcessingLimit()
+    safelyInitialise(configurationRepository::lookupSchedulerNoticesProcessingLimit)
       .thenCompose(r -> r.after(limit -> findNoticesToSend(scheduledNoticesRepository,
         limit)))
       .thenCompose(r -> r.after(notices -> handleNotices(clients, notices)))

--- a/src/main/java/org/folio/circulation/resources/ScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledNoticeProcessingResource.java
@@ -12,6 +12,7 @@ import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.server.NoContentResponse;
 import org.folio.circulation.support.http.server.WebContext;
+import org.folio.circulation.support.results.CommonFailures;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.ext.web.Router;
@@ -46,6 +47,7 @@ public abstract class ScheduledNoticeProcessingResource extends Resource {
         limit)))
       .thenCompose(r -> r.after(notices -> handleNotices(clients, notices)))
       .thenApply(r -> r.toFixedValue(NoContentResponse::noContent))
+      .exceptionally(CommonFailures::failedDueToServerError)
       .thenAccept(context::writeResultToHttpResponse);
   }
 

--- a/src/main/java/org/folio/circulation/support/results/AsynchronousResultBindings.java
+++ b/src/main/java/org/folio/circulation/support/results/AsynchronousResultBindings.java
@@ -1,0 +1,29 @@
+package org.folio.circulation.support.results;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.support.results.CommonFailures.failedDueToServerError;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import org.folio.circulation.support.Result;
+
+public class AsynchronousResultBindings {
+  private AsynchronousResultBindings() { }
+
+  public static <T> CompletableFuture<Result<T>> safelyInitialise(
+    Supplier<CompletableFuture<Result<T>>> supplier) {
+
+    if (supplier == null) {
+      return completedFuture(failedDueToServerError(new NullPointerException(
+        "The asynchronous result supplier should not be null")));
+    }
+
+    try {
+      return supplier.get();
+    }
+    catch(Exception e) {
+      return completedFuture(failedDueToServerError(e));
+    }
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/SafelyInitialiseAsynchronousResultTests.java
+++ b/src/test/java/org/folio/circulation/support/results/SafelyInitialiseAsynchronousResultTests.java
@@ -1,0 +1,61 @@
+package org.folio.circulation.support.results;
+
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.folio.circulation.support.Result.of;
+import static org.folio.circulation.support.results.AsynchronousResultBindings.safelyInitialise;
+import static org.folio.circulation.support.results.ResultExamples.actionFailed;
+import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Test;
+
+import lombok.val;
+
+public class SafelyInitialiseAsynchronousResultTests {
+  @Test
+  public void shouldSucceedWhenSupplierSucceeds() throws ExecutionException,
+    InterruptedException, TimeoutException {
+
+    val result = safelyInitialise(() -> completedFuture(of(() -> 10)))
+      .get(1, SECONDS);
+
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(10));
+  }
+
+  @Test
+  public void shouldFailWhenSupplierFails() throws ExecutionException,
+    InterruptedException, TimeoutException {
+
+    val result = safelyInitialise(() -> completedFuture(actionFailed()))
+      .get(1, SECONDS);
+
+    assertThat(result, isErrorFailureContaining("Action failed"));
+  }
+
+  @Test
+  public void shouldFailWhenSupplierIsNull() throws ExecutionException,
+    InterruptedException, TimeoutException {
+
+    val result = safelyInitialise(null)
+      .get(1, SECONDS);
+
+    assertThat(result, isErrorFailureContaining("The asynchronous result supplier should not be null"));
+  }
+
+  @Test
+  public void shouldFailWhenSupplierThrowsException() throws ExecutionException,
+    InterruptedException, TimeoutException {
+
+    val result = safelyInitialise(() -> { throw somethingWentWrong(); })
+      .get(1, SECONDS);
+
+    assertThat(result, isErrorFailureContaining("Something went wrong"));
+  }
+}


### PR DESCRIPTION
## Purpose

It was reported in [CIRC-850](https://issues.folio.org/browse/CIRC-850) that mod-circulation and Okapi were consuming a large number of HTTP connections even when idle, meaning that only timer initiated tasks were executed.

A hypothesis for the high number of open connections from Okapi -> mod-circulation was that mod-circulation was failing to respond (for an unknown reason) and that was keeping the connection open.

This pull request intends to reduce the possibility of that happening.

## Approach
* Introduce a new method for initialising a future result in a safe manner (to avoid having to have a try-catch around every future chain)
* Safely initialise the initial future result in each timed task
* Check that each step in the chain used the appropriate result method for handling exceptions and prior failures
* Use `exceptionally` at the latest point in the chain prior to conversion to a HTTP response, in order to compensate for failures not handled by result processing

#### TODOS and Open Questions
* Use the safe initialisation method for any future chains that start with a method that could fail

## Learning
* The failure model for CompletableFuture is unstable if the chain could start with a null object

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
