### PR TITLE
CIRC-862: Save date and time when loan is aged to lost

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -14,6 +14,7 @@ import static org.folio.circulation.domain.LoanAction.MISSING;
 import static org.folio.circulation.domain.LoanAction.RENEWED;
 import static org.folio.circulation.domain.LoanAction.RENEWED_THROUGH_OVERRIDE;
 import static org.folio.circulation.domain.representations.LoanProperties.ACTION_COMMENT;
+import static org.folio.circulation.domain.representations.LoanProperties.AGED_TO_LOST_DATE;
 import static org.folio.circulation.domain.representations.LoanProperties.CHECKIN_SERVICE_POINT_ID;
 import static org.folio.circulation.domain.representations.LoanProperties.CHECKOUT_SERVICE_POINT_ID;
 import static org.folio.circulation.domain.representations.LoanProperties.CLAIMED_RETURNED_DATE;
@@ -27,6 +28,7 @@ import static org.folio.circulation.domain.representations.LoanProperties.RETURN
 import static org.folio.circulation.domain.representations.LoanProperties.STATUS;
 import static org.folio.circulation.domain.representations.LoanProperties.SYSTEM_RETURN_DATE;
 import static org.folio.circulation.domain.representations.LoanProperties.USER_ID;
+import static org.folio.circulation.support.ClockManager.getClockManager;
 import static org.folio.circulation.support.JsonPropertyFetcher.getBooleanProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimeProperty;
 import static org.folio.circulation.support.JsonPropertyFetcher.getIntegerProperty;
@@ -47,7 +49,6 @@ import org.folio.circulation.domain.policy.LoanPolicy;
 import org.folio.circulation.domain.policy.OverdueFinePolicy;
 import org.folio.circulation.domain.policy.lostitem.LostItemPolicy;
 import org.folio.circulation.domain.representations.LoanProperties;
-import org.folio.circulation.support.ClockManager;
 import org.folio.circulation.support.Result;
 import org.joda.time.DateTime;
 
@@ -511,7 +512,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   public boolean isOverdue() {
-    return isOverdue(ClockManager.getClockManager().getDateTime());
+    return isOverdue(getClockManager().getDateTime());
   }
 
   public boolean isOverdue(DateTime systemTime) {
@@ -588,7 +589,12 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     changeAction(ITEM_AGED_TO_LOST);
     removeActionComment();
     changeItemStatusForItemAndLoan(ItemStatus.AGED_TO_LOST);
+    changeAgedToLostDate(getClockManager().getDateTime());
 
     return this;
+  }
+
+  private void changeAgedToLostDate(DateTime dateTime) {
+    representation.put(AGED_TO_LOST_DATE, dateTime.toString());
   }
 }

--- a/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
@@ -28,4 +28,5 @@ public class LoanProperties {
   public static final String DECLARED_LOST_DATE = "declaredLostDate";
   public static final String CLAIMED_RETURNED_DATE = "claimedReturnedDate";
   public static final String LOAN_DATE = "loanDate";
+  public static final String AGED_TO_LOST_DATE = "agedToLostDate";
 }

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostApiTest.java
@@ -5,12 +5,14 @@ import static api.support.matchers.ItemMatchers.isAgedToLost;
 import static api.support.matchers.ItemMatchers.isCheckedOut;
 import static api.support.matchers.ItemMatchers.isClaimedReturned;
 import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
+import static api.support.matchers.TextDateTimeMatcher.withinSecondsBeforeNow;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.joda.time.DateTime.now;
 import static org.joda.time.DateTimeZone.UTC;
+import static org.joda.time.Seconds.seconds;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -54,6 +56,8 @@ public class ScheduledAgeToLostApiTest extends SpringApiTest {
 
     assertThat(itemsClient.get(overdueItem).getJson(), isAgedToLost());
     assertThat(getLoanActions(), hasAgedToLostAction());
+    assertThat(loansClient.get(overdueLoan).getJson(),
+      hasJsonPath("agedToLostDate", withinSecondsBeforeNow(seconds(1))));
   }
 
   @Test
@@ -68,6 +72,8 @@ public class ScheduledAgeToLostApiTest extends SpringApiTest {
 
       assertThat(itemFromStorage.getJson(), isAgedToLost());
       assertThat(getLoanActions(loanFromStorage), hasAgedToLostAction());
+      assertThat(loansClient.get(overdueLoan).getJson(),
+        hasJsonPath("agedToLostDate", withinSecondsBeforeNow(seconds(1))));
     });
   }
 
@@ -166,7 +172,8 @@ public class ScheduledAgeToLostApiTest extends SpringApiTest {
     return hasItem(allOf(
       hasJsonPath("loan.status.name", "Open"),
       hasJsonPath("loan.action", "itemAgedToLost"),
-      hasJsonPath("loan.itemStatus", "Aged to lost")
+      hasJsonPath("loan.itemStatus", "Aged to lost"),
+      hasJsonPath("loan.agedToLostDate", withinSecondsBeforeNow(seconds(1)))
     ));
   }
 }

--- a/src/test/java/api/support/fakes/StorageSchema.java
+++ b/src/test/java/api/support/fakes/StorageSchema.java
@@ -12,7 +12,7 @@ public class StorageSchema {
   }
 
   public static JsonSchemaValidator validatorForStorageLoanSchema() throws IOException {
-    return JsonSchemaValidator.fromResource("/storage-loan-7-0.json");
+    return JsonSchemaValidator.fromResource("/storage-loan-7-1.json");
   }
 
   public static JsonSchemaValidator validatorForLocationInstSchema() throws IOException {

--- a/src/test/resources/storage-loan-7-1.json
+++ b/src/test/resources/storage-loan-7-1.json
@@ -103,6 +103,11 @@
       "type": "string",
       "format": "date-time"
     },
+    "agedToLostDate": {
+      "description": "Date and time the item was aged to lost for this loan",
+      "type": "string",
+      "format": "date-time"
+    },
     "overdueFinePolicyId": {
       "description": "ID of overdue fines policy at the time the item is check-in or renewed",
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
@@ -121,7 +126,7 @@
     "agedToLostDelayedBilling": {
       "description": "Aged to Lost Delayed Billing processing",
       "type": "object",
-      "properties": {  
+      "properties": {
         "lostItemHasBeenBilled": {
           "description": "Indicates if the aged to lost fee has been billed (for use where delayed billing is set up)",
           "type": "boolean"


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-862 - Backend: Aged to lost action on loan details

## Approach
* Require `loan-storage` of `7.1` version;
* Set `loan.agedToLostDate` when a loan is being aged to lost.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
