### PR TITLE
Change notice processing test dependent upon fixed date to use relative date

### DIFF
--- a/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
@@ -23,6 +23,7 @@ import org.folio.circulation.support.http.client.IndividualResource;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -213,8 +214,6 @@ public class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests 
 
     use(noticePolicy);
 
-    DateTime loanDate = new DateTime(2019, 8, 23, 10, 30);
-
     IndividualResource james = usersFixture.james();
     IndividualResource steve = usersFixture.steve();
     IndividualResource rebecca = usersFixture.rebecca();
@@ -239,7 +238,8 @@ public class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests 
 
     //Should fetch 10 notices, when total records is 12
     //So that notices for one of the users should not be processed
-    scheduledNoticeProcessingClient.runDueDateNotRealTimeNoticesProcessing(loanDate.plusYears(1));
+    final DateTime runTime = DateTime.now(DateTimeZone.UTC).plusDays(15);
+    scheduledNoticeProcessingClient.runDueDateNotRealTimeNoticesProcessing(runTime);
 
     List<JsonObject> scheduledNotices = scheduledNoticesClient.getAll();
     assertThat(scheduledNotices, hasSize(4));


### PR DESCRIPTION
## Purpose

Yesterday, a single notice sending test [started failing|https://jenkins-aws.indexdata.com/job/folio-org/job/mod-circulation/job/master/626/].

This was caused by 

## Approach
@bohdan-suprun identified, during another pull request, that it was caused by a date being fixed rather than relative and resolved it.

This pull request cherry picks that change to the mainline.

## Learning
* Use fixed dates with caution as they can cause fragility if any processing is relative to the current date.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
