### PR TITLE
Revert JDK 11 upgrade CIRC-883

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/alpine-jre-openjdk11:latest
+FROM folioci/alpine-jre-openjdk8:latest
 
 ENV VERTICLE_FILE mod-circulation.jar
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,6 @@ buildMvn {
   runLintRamlCop = true
   doKubeDeploy = true
   publishPreview = false
-  buildNode = 'jenkins-agent-java11'
 
   doDocker = {
     buildJavaDocker {

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <release>11</release>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Purpose

Mod-circulation cannot use JDK 11 at this point because the pub-sub client depends upon a RAML Module Builder version that is not compatible with JDK 11, see [FOLIO-2734](https://issues.folio.org/browse/FOLIO-2734) for more details.

Thanks to @bohdan-suprun for identifying the issue.

Until there a JDK 11 compatible version of the pub-sub client, mod-circulation cannot use JDK 11

## Learning
* This could not be caught by automated tests because the code that fails is not executed when running in a test context rather than as a jar

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
