### PR TITLE
Change domain of created note to users CIRC-742

### DIFF
--- a/src/main/java/org/folio/circulation/domain/notes/NoteCreator.java
+++ b/src/main/java/org/folio/circulation/domain/notes/NoteCreator.java
@@ -22,7 +22,9 @@ public class NoteCreator {
         .title(message)
         .typeId(noteType.getId())
         .content(message)
-        .domain("loans")
+        // The domain must be users otherwise it won't be found by the reference UI
+        // which uses a query like /note-links/domain/users/type/user/id/{userId}
+        .domain("users")
         .link(new NoteLink(userId, NoteLinkType.USER.getValue()))
         .build())));
   }

--- a/src/test/java/api/loans/DeclareClaimedReturnedItemAsMissingApiTests.java
+++ b/src/test/java/api/loans/DeclareClaimedReturnedItemAsMissingApiTests.java
@@ -130,6 +130,6 @@ public class DeclareClaimedReturnedItemAsMissingApiTests extends APITests {
     List<JsonObject> notes = notesClient.getAll();
     assertThat(notes.size(), is(1));
     assertThat(notes.get(0).getString("title"), is("Claimed returned item marked missing"));
-    assertThat(notes.get(0).getString("domain"), is("loans"));
+    assertThat(notes.get(0).getString("domain"), is("users"));
   }
 }

--- a/src/test/java/api/loans/DeclareLostAPITests.java
+++ b/src/test/java/api/loans/DeclareLostAPITests.java
@@ -572,6 +572,6 @@ public class DeclareLostAPITests extends APITests {
     List<JsonObject> notes = notesClient.getAll();
     assertThat(notes.size(), is(1));
     assertThat(notes.get(0).getString("title"), is("Claimed returned item marked declared lost"));
-    assertThat(notes.get(0).getString("domain"), is("loans"));
+    assertThat(notes.get(0).getString("domain"), is("users"));
   }
 }


### PR DESCRIPTION
## Purpose

The reference UI relies upon the domain of all notes for users being
`user` - https://github.com/folio-org/stripes-smart-components/blob/30de4ba6a4f7d71bb37210631b053a17b403bc6a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js#L36

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
