### PR TITLE
CIRC-845: Refund lost item fees when it checked in.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -920,7 +920,7 @@
   "requires": [
     {
       "id": "loan-storage",
-      "version": "7.0"
+      "version": "7.1"
     },
     {
       "id": "circulation-rules-storage",

--- a/src/main/java/org/folio/circulation/domain/ItemStatus.java
+++ b/src/main/java/org/folio/circulation/domain/ItemStatus.java
@@ -55,7 +55,7 @@ public enum ItemStatus {
     return equalsIgnoreCase(getValue(), value);
   }
 
-  public boolean isLost() {
+  public boolean isLostNotResolved() {
     return this == DECLARED_LOST || this == AGED_TO_LOST;
   }
 }

--- a/src/main/java/org/folio/circulation/domain/ItemStatus.java
+++ b/src/main/java/org/folio/circulation/domain/ItemStatus.java
@@ -54,4 +54,8 @@ public enum ItemStatus {
   private boolean valueMatches(String value) {
     return equalsIgnoreCase(getValue(), value);
   }
+
+  public boolean isLost() {
+    return this == DECLARED_LOST || this == AGED_TO_LOST;
+  }
 }

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -443,7 +443,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   public boolean isItemLost() {
-    return getItem().getStatus().isLost();
+    return getItem().getStatus().isLostNotResolved();
   }
 
   public boolean isClaimedReturned() {

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -443,7 +443,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   public boolean isItemLost() {
-    return isDeclaredLost() || isAgedToLost();
+    return getItem().getStatus().isLost();
   }
 
   public boolean isClaimedReturned() {

--- a/src/main/java/org/folio/circulation/domain/LoanCheckInService.java
+++ b/src/main/java/org/folio/circulation/domain/LoanCheckInService.java
@@ -26,6 +26,10 @@ public class LoanCheckInService {
           systemDateTime, request.getServicePointId()));
     }
 
+    if (loan.isAgedToLost()) {
+      loan.removeAgedToLostBillingInfo();
+    }
+
     return succeeded(loan.checkIn(request.getCheckInDate(), systemDateTime,
       request.getServicePointId()));
   }

--- a/src/main/java/org/folio/circulation/domain/LoanRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepresentation.java
@@ -79,6 +79,8 @@ public class LoanRepresentation {
         .createItemSummary(item));
     }
 
+    loan.remove(LoanProperties.AGED_TO_LOST_DELAYED_BILLING);
+
     return loan;
   }
 

--- a/src/main/java/org/folio/circulation/domain/OverdueFineCalculatorService.java
+++ b/src/main/java/org/folio/circulation/domain/OverdueFineCalculatorService.java
@@ -93,7 +93,7 @@ public class OverdueFineCalculatorService {
       return completedFuture(succeeded(null));
     }
 
-    if (isDeclaredLost(renewalContext.getItemStatusBeforeRenewal())) {
+    if (isLost(renewalContext.getItemStatusBeforeRenewal())) {
       return repos.lostItemPolicyRepository.getLostItemPolicyById(loan.getLostItemPolicyId())
         .thenApply(r -> r.map(policy -> policy.shouldChargeOverdueFee()
           && renewalContext.isLostItemFeesRefundedOrCancelled()));
@@ -119,7 +119,7 @@ public class OverdueFineCalculatorService {
       return completedFuture(succeeded(false));
     }
 
-    if (isDeclaredLost(context.getItemStatusBeforeCheckIn())) {
+    if (isLost(context.getItemStatusBeforeCheckIn())) {
       return repos.lostItemPolicyRepository.getLostItemPolicyById(loan.getLostItemPolicyId())
         .thenApply(r -> r.map(policy -> policy.shouldChargeOverdueFee()
           && context.areLostItemFeesRefundedOrCancelled()));
@@ -275,8 +275,8 @@ public class OverdueFineCalculatorService {
       .build());
   }
 
-  private boolean isDeclaredLost(ItemStatus itemStatus) {
-    return itemStatus == ItemStatus.DECLARED_LOST;
+  private boolean isLost(ItemStatus itemStatus) {
+    return itemStatus == ItemStatus.DECLARED_LOST || itemStatus == ItemStatus.AGED_TO_LOST;
   }
 
   @With

--- a/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
@@ -26,6 +26,7 @@ public class LoanProperties {
   public static final String PATRON_GROUP_ID_AT_CHECKOUT = "patronGroupIdAtCheckout";
   public static final String PATRON_GROUP_AT_CHECKOUT = "patronGroupAtCheckout";
   public static final String DECLARED_LOST_DATE = "declaredLostDate";
+  public static final String AGED_TO_LOST_DATE = "agedToLostDate";
   public static final String CLAIMED_RETURNED_DATE = "claimedReturnedDate";
   public static final String LOAN_DATE = "loanDate";
   public static final String AGED_TO_LOST_DELAYED_BILLING = "agedToLostDelayedBilling";

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
@@ -53,7 +53,7 @@ final class LostItemFeeRefundContext {
   }
 
   boolean anyAccountNeedsRefund() {
-    return accountsNeedingRefunds().size() > 0;
+    return !accountsNeedingRefunds().isEmpty();
   }
 
   DateTime getItemLostDate() {

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
@@ -1,0 +1,92 @@
+package org.folio.circulation.services;
+
+import static java.util.Collections.emptyList;
+import static org.folio.circulation.domain.FeeFine.LOST_ITEM_PROCESSING_FEE_TYPE;
+import static org.folio.circulation.domain.ItemStatus.AGED_TO_LOST;
+import static org.folio.circulation.domain.ItemStatus.DECLARED_LOST;
+import static org.folio.circulation.domain.ItemStatus.LOST_AND_PAID;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.folio.circulation.domain.Account;
+import org.folio.circulation.domain.CheckInContext;
+import org.folio.circulation.domain.ItemStatus;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.policy.lostitem.LostItemPolicy;
+import org.folio.circulation.resources.context.RenewalContext;
+import org.folio.circulation.services.support.RefundAccountCommand;
+import org.joda.time.DateTime;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.With;
+
+@With(AccessLevel.PACKAGE)
+@Getter(AccessLevel.PACKAGE)
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+final class LostItemFeeRefundContext {
+  private final ItemStatus itemStatus;
+  private final String itemId;
+  private final String staffUserId;
+  private final String servicePointId;
+  private final Loan loan;
+  private final Collection<Account> accounts;
+  private final LostItemPolicy lostItemPolicy;
+
+  private Collection<Account> accountsNeedingRefunds() {
+    if (!lostItemPolicy.isRefundProcessingFeeWhenReturned()) {
+      return accounts.stream()
+        .filter(account -> !account.getFeeFineType().equals(LOST_ITEM_PROCESSING_FEE_TYPE))
+        .collect(Collectors.toList());
+    }
+
+    return accounts;
+  }
+
+  List<RefundAccountCommand> accountRefundCommands() {
+    return accountsNeedingRefunds().stream()
+      .map(account -> new RefundAccountCommand(account, staffUserId, servicePointId))
+      .collect(Collectors.toList());
+  }
+
+  boolean anyAccountNeedsRefund() {
+    return accountsNeedingRefunds().size() > 0;
+  }
+
+  DateTime getItemLostDate() {
+    if(itemStatus == DECLARED_LOST) {
+      return loan.getDeclareLostDateTime();
+    }
+
+    if (itemStatus == AGED_TO_LOST) {
+      return loan.getAgedToLostDateTime();
+    }
+
+    return null;
+  }
+
+  boolean itemIsNotLost() {
+    return itemStatus != DECLARED_LOST && itemStatus != AGED_TO_LOST
+      && itemStatus != LOST_AND_PAID;
+  }
+
+  boolean hasLoan() {
+    return loan != null;
+  }
+
+  public static LostItemFeeRefundContext using(CheckInContext context) {
+    return new LostItemFeeRefundContext(context.getItemStatusBeforeCheckIn(),
+      context.getItem().getItemId(), context.getLoggedInUserId(),
+      context.getCheckInServicePointId().toString(), context.getLoan(),
+      emptyList(), null);
+  }
+
+  public static LostItemFeeRefundContext using(RenewalContext context, String servicePointId) {
+    return new LostItemFeeRefundContext(context.getItemStatusBeforeRenewal(),
+      context.getLoan().getItemId(), context.getLoggedInUserId(),
+      servicePointId, context.getLoan(), emptyList(), null);
+  }
+}

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
@@ -80,14 +80,14 @@ final class LostItemFeeRefundContext {
     return loan != null;
   }
 
-  public static LostItemFeeRefundContext using(CheckInContext context) {
+  public static LostItemFeeRefundContext forCheckIn(CheckInContext context) {
     return new LostItemFeeRefundContext(context.getItemStatusBeforeCheckIn(),
       context.getItem().getItemId(), context.getLoggedInUserId(),
       context.getCheckInServicePointId().toString(), context.getLoan(),
       emptyList(), null);
   }
 
-  public static LostItemFeeRefundContext using(RenewalContext context, String servicePointId) {
+  public static LostItemFeeRefundContext forRenewal(RenewalContext context, String servicePointId) {
     return new LostItemFeeRefundContext(context.getItemStatusBeforeRenewal(),
       context.getLoan().getItemId(), context.getLoggedInUserId(),
       servicePointId, context.getLoan(), emptyList(), null);

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
@@ -57,11 +57,11 @@ final class LostItemFeeRefundContext {
   }
 
   DateTime getItemLostDate() {
-    if(itemStatus == DECLARED_LOST) {
+    if (itemStatus == DECLARED_LOST) {
       return loan.getDeclareLostDateTime();
     }
 
-    if(itemStatus == LOST_AND_PAID) {
+    if (itemStatus == LOST_AND_PAID) {
       return loan.getDeclareLostDateTime();
     }
 
@@ -72,9 +72,8 @@ final class LostItemFeeRefundContext {
     return null;
   }
 
-  boolean itemIsNotLost() {
-    return itemStatus != DECLARED_LOST && itemStatus != AGED_TO_LOST
-      && itemStatus != LOST_AND_PAID;
+  boolean shouldRefundFeesForItem() {
+    return itemStatus.isLost() || itemStatus == LOST_AND_PAID;
   }
 
   boolean hasLoan() {

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
@@ -73,7 +73,7 @@ final class LostItemFeeRefundContext {
   }
 
   boolean shouldRefundFeesForItem() {
-    return itemStatus.isLost() || itemStatus == LOST_AND_PAID;
+    return itemStatus.isLostNotResolved() || itemStatus == LOST_AND_PAID;
   }
 
   boolean hasLoan() {

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
@@ -61,6 +61,10 @@ final class LostItemFeeRefundContext {
       return loan.getDeclareLostDateTime();
     }
 
+    if(itemStatus == LOST_AND_PAID) {
+      return loan.getDeclareLostDateTime();
+    }
+
     if (itemStatus == AGED_TO_LOST) {
       return loan.getAgedToLostDateTime();
     }

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
@@ -59,7 +59,7 @@ public class LostItemFeeRefundService {
   }
 
   private CompletableFuture<Result<Boolean>> refundLostItemFees(LostItemFeeRefundContext refundFeeContext) {
-    if (refundFeeContext.itemIsNotLost()) {
+    if (!refundFeeContext.shouldRefundFeesForItem()) {
       return completedFuture(succeeded(false));
     }
 

--- a/src/main/java/org/folio/circulation/services/agedtolost/MarkOverdueLoansAsAgedLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/MarkOverdueLoansAsAgedLostService.java
@@ -69,7 +69,7 @@ public class MarkOverdueLoansAsAgedLostService {
       .calculateDateTimeWhenPatronBilledForAgedToLost(loanDueDate);
 
     loan.setAgedToLostDelayedBilling(false, whenToBill);
-    return loan.ageOverdueItemToLost();
+    return loan.ageOverdueItemToLost(getClockManager().getDateTime());
   }
 
   private CompletableFuture<Result<Void>> updateLoansAndItemsInStorage(

--- a/src/main/java/org/folio/circulation/support/JsonPropertyFetcher.java
+++ b/src/main/java/org/folio/circulation/support/JsonPropertyFetcher.java
@@ -6,7 +6,6 @@ import java.math.BigDecimal;
 import java.util.UUID;
 import java.util.function.BiFunction;
 
-import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 

--- a/src/main/java/org/folio/circulation/support/JsonPropertyFetcher.java
+++ b/src/main/java/org/folio/circulation/support/JsonPropertyFetcher.java
@@ -1,9 +1,12 @@
 package org.folio.circulation.support;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import java.math.BigDecimal;
 import java.util.UUID;
 import java.util.function.BiFunction;
 
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
@@ -79,7 +82,7 @@ public class JsonPropertyFetcher {
     JsonObject representation,
     String propertyName) {
 
-    if (representation != null && representation.containsKey(propertyName)) {
+    if (representation != null && isNotBlank(representation.getString(propertyName))) {
       return DateTime.parse(
         representation.getString(propertyName));
     } else {

--- a/src/main/java/org/folio/circulation/support/JsonPropertyFetcher.java
+++ b/src/main/java/org/folio/circulation/support/JsonPropertyFetcher.java
@@ -2,6 +2,7 @@ package org.folio.circulation.support;
 
 import java.math.BigDecimal;
 import java.util.UUID;
+import java.util.function.BiFunction;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -194,5 +195,24 @@ public class JsonPropertyFetcher {
     if (from.containsKey(propertyName)) {
       to.put(propertyName, from.getValue(propertyName));
     }
+  }
+
+  public static DateTime getDateTimePropertyByPath(JsonObject from, String... paths) {
+    return getByPath(from, JsonPropertyFetcher::getDateTimeProperty, paths);
+  }
+
+  private static <T> T getByPath(JsonObject from, BiFunction<JsonObject, String, T> getter,
+    String... paths) {
+
+    if (from == null || paths.length == 0) {
+      return null;
+    }
+
+    JsonObject currentObject = from;
+    for (int pathIndex = 0; pathIndex < paths.length - 1; pathIndex++) {
+      currentObject = currentObject.getJsonObject(paths[pathIndex], new JsonObject());
+    }
+
+    return getter.apply(currentObject, paths[paths.length - 1]);
   }
 }

--- a/src/main/java/org/folio/circulation/support/JsonPropertyWriter.java
+++ b/src/main/java/org/folio/circulation/support/JsonPropertyWriter.java
@@ -102,4 +102,42 @@ public class JsonPropertyWriter {
 
     from.remove(propertyName);
   }
+
+  public static void writeByPath(JsonObject to, String value, String... paths) {
+    writeByPath(to, JsonPropertyWriter::write, value, paths);
+  }
+
+  public static void writeByPath(JsonObject to, DateTime value, String... paths) {
+    writeByPath(to, JsonPropertyWriter::write, value, paths);
+  }
+
+  public static void writeByPath(JsonObject to, boolean value, String... paths) {
+    writeByPath(to, JsonPropertyWriter::write, value, paths);
+  }
+
+  private static <T> void writeByPath(JsonObject to, JsonPropertySetter<T> setter,
+    T value, String... paths) {
+
+    if (to == null || value == null || paths.length == 0) {
+      return;
+    }
+
+    JsonObject currentObject = to;
+    for (int pathIndex = 0; pathIndex < paths.length - 1; pathIndex++) {
+      final String currentPath = paths[pathIndex];
+
+      if (!currentObject.containsKey(currentPath)) {
+        currentObject.put(currentPath, new JsonObject());
+      }
+
+      currentObject = currentObject.getJsonObject(currentPath);
+    }
+
+    setter.set(currentObject, paths[paths.length - 1], value);
+  }
+
+  @FunctionalInterface
+  private interface JsonPropertySetter<T> {
+    void set(JsonObject object, String path, T value);
+  }
 }

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostApiTest.java
@@ -58,8 +58,8 @@ public class ScheduledAgeToLostApiTest extends SpringApiTest {
 
     assertThat(itemsClient.get(overdueItem).getJson(), isAgedToLost());
     assertThat(getLoanActions(), hasAgedToLostAction());
-    assertThat(loansClient.get(overdueLoan).getJson(), hasPatronBillingDate());
-    assertThat(loansClient.get(overdueLoan).getJson(), hasAgedToLostDate());
+    assertThat(loansStorageClient.get(overdueLoan).getJson(), hasPatronBillingDate());
+    assertThat(loansStorageClient.get(overdueLoan).getJson(), hasAgedToLostDate());
   }
 
   @Test
@@ -70,12 +70,12 @@ public class ScheduledAgeToLostApiTest extends SpringApiTest {
 
     loanToItemMap.forEach((loan, item) -> {
       val itemFromStorage = itemsClient.get(item);
-      val loanFromStorage = loansClient.get(loan);
+      val loanFromStorage = loansStorageClient.get(loan);
 
       assertThat(itemFromStorage.getJson(), isAgedToLost());
       assertThat(getLoanActions(loanFromStorage), hasAgedToLostAction());
       assertThat(loanFromStorage.getJson(), hasPatronBillingDate(loanFromStorage));
-      assertThat(loansClient.get(overdueLoan).getJson(), hasAgedToLostDate());
+      assertThat(loanFromStorage.getJson(), hasAgedToLostDate());
     });
   }
 
@@ -128,7 +128,7 @@ public class ScheduledAgeToLostApiTest extends SpringApiTest {
 
     assertThat(itemsClient.get(overdueItem).getJson(), isAgedToLost());
     assertThat(getLoanActions(), hasAgedToLostAction());
-    assertThat(loansClient.get(overdueLoan).getJson(), hasPatronBillingDate());
+    assertThat(loansStorageClient.get(overdueLoan).getJson(), hasPatronBillingDate());
 
     val agedToLostActions = getLoanActions().stream()
       .filter(json -> "itemAgedToLost".equals(json.getJsonObject("loan").getString("action")))

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostApiTest.java
@@ -7,6 +7,7 @@ import static api.support.matchers.ItemMatchers.isClaimedReturned;
 import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.iterableWithSize;
@@ -58,6 +59,7 @@ public class ScheduledAgeToLostApiTest extends SpringApiTest {
     assertThat(itemsClient.get(overdueItem).getJson(), isAgedToLost());
     assertThat(getLoanActions(), hasAgedToLostAction());
     assertThat(loansClient.get(overdueLoan).getJson(), hasPatronBillingDate());
+    assertThat(loansClient.get(overdueLoan).getJson(), hasAgedToLostDate());
   }
 
   @Test
@@ -73,6 +75,7 @@ public class ScheduledAgeToLostApiTest extends SpringApiTest {
       assertThat(itemFromStorage.getJson(), isAgedToLost());
       assertThat(getLoanActions(loanFromStorage), hasAgedToLostAction());
       assertThat(loanFromStorage.getJson(), hasPatronBillingDate(loanFromStorage));
+      assertThat(loansClient.get(overdueLoan).getJson(), hasAgedToLostDate());
     });
   }
 
@@ -193,5 +196,9 @@ public class ScheduledAgeToLostApiTest extends SpringApiTest {
     return allOf(hasJsonPath("agedToLostDelayedBilling.lostItemHasBeenBilled", false),
       hasJsonPath("agedToLostDelayedBilling.dateLostItemShouldBeBilled",
         isEquivalentTo(expectedBillingDate)));
+  }
+
+  private Matcher<JsonObject> hasAgedToLostDate() {
+    return hasJsonPath("agedToLostDelayedBilling.agedToLostDate", notNullValue());
   }
 }

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
@@ -129,7 +129,7 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
     ageToLostFixture.ageToLostAndChargeFees();
 
     loanToFeeMap.forEach((loan, expectedFee) -> {
-      val loanFromStorage = loansClient.get(loan);
+      val loanFromStorage = loansStorageClient.get(loan);
 
       assertThat(loanFromStorage.getJson(), isLostItemHasBeenBilled());
 
@@ -157,10 +157,10 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
     ageToLostFixture.ageToLostAndAttemptChargeFees();
 
     loansExpectedToBeFailed.forEach((loan, fee) ->
-        assertThat(loansClient.get(loan).getJson(), isLostItemHasNotBeenBilled()));
+        assertThat(loansStorageClient.get(loan).getJson(), isLostItemHasNotBeenBilled()));
 
     loansExpectedToBeProcessedSuccessfully.forEach((loan, fee) -> {
-      val loanFromStorage = loansClient.get(loan);
+      val loanFromStorage = loansStorageClient.get(loan);
       assertThat(loanFromStorage.getJson(), isLostItemHasBeenBilled());
 
       assertThat(loanFromStorage, hasLostItemFee(isOpen(fee)));

--- a/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
@@ -1,0 +1,141 @@
+package api.loans.scenarios;
+
+import static api.support.matchers.AccountActionsMatchers.arePaymentRefundActionsCreated;
+import static api.support.matchers.AccountActionsMatchers.areTransferRefundActionsCreated;
+import static api.support.matchers.AccountActionsMatchers.isCancelledItemReturnedActionCreated;
+import static api.support.matchers.AccountMatchers.isClosedCancelledItemReturned;
+import static api.support.matchers.AccountMatchers.isPaidFully;
+import static api.support.matchers.AccountMatchers.isRefundedFully;
+import static api.support.matchers.AccountMatchers.isTransferredFully;
+import static api.support.matchers.LoanAccountActionsMatcher.hasLostItemFeeActions;
+import static api.support.matchers.LoanAccountActionsMatcher.hasLostItemProcessingFeeActions;
+import static api.support.matchers.LoanAccountMatcher.hasLostItemFee;
+import static api.support.matchers.LoanAccountMatcher.hasLostItemProcessingFee;
+import static api.support.matchers.LoanAccountMatcher.hasOverdueFine;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimePropertyByPath;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.joda.time.DateTime.now;
+
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.Test;
+
+import api.support.APITests;
+import api.support.builders.CheckInByBarcodeRequestBuilder;
+import lombok.val;
+
+/**
+ * This test contains just basic expected scenarios.
+ * All possible scenarios are covered by {@code api.loans.scenarios.CheckInDeclaredLostItemTest}
+ * for {@code Declared lost} items.
+ */
+public class CheckInAgedToLostItemTest extends APITests {
+  @Before
+  public void createOwnerAndFeeTypes() {
+    feeFineOwnerFixture.cd1Owner();
+    feeFineTypeFixture.lostItemProcessingFee();
+    feeFineTypeFixture.lostItemFee();
+    feeFineTypeFixture.overdueFine();
+  }
+
+  @Test
+  public void shouldRefundPaidAmountAndCancelRemaining() {
+    final double setCostFee = 10.55;
+    final double processingFee = 12.99;
+
+    val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
+      .withName("Check in aged to lost loan")
+      .chargeItemAgedToLostProcessingFee(processingFee)
+      .withSetCost(setCostFee)
+      .withNoFeeRefundInterval();
+
+    val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
+
+    feeFineAccountFixture.transferLostItemFee(result.getLoanId());
+
+    checkInFixture.checkInByBarcode(result.getItem());
+
+    final IndividualResource loan = result.getLoan();
+    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
+    assertThat(loan, hasLostItemFeeActions(areTransferRefundActionsCreated(setCostFee)));
+
+    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      isCancelledItemReturnedActionCreated(processingFee)));
+
+    assertThatBillingInformationRemoved(loan);
+  }
+
+  @Test
+  public void shouldAssignOverdueFine() {
+    final double processingFee = 12.99;
+
+    val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
+      .withName("Check in aged to lost loan")
+      .chargeItemAgedToLostProcessingFee(processingFee)
+      .chargeOverdueFineWhenReturned()
+      .withNoFeeRefundInterval();
+
+    val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
+
+    feeFineAccountFixture.payLostItemProcessingFee(result.getLoanId());
+
+    final DateTime returnDate = now(DateTimeZone.UTC).plusMonths(8);
+    mockClockManagerToReturnFixedDateTime(returnDate);
+    checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
+      .on(returnDate)
+      .forItem(result.getItem())
+      .at(servicePointsFixture.cd1()));
+
+    final IndividualResource loan = result.getLoan();
+    assertThat(loan, hasLostItemProcessingFee(isRefundedFully(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      arePaymentRefundActionsCreated(processingFee)));
+
+    assertThat(loan, hasOverdueFine());
+  }
+
+  @Test
+  public void shouldNotRefundFeesWhenReturnedAfterRefundPeriod() {
+    final double setCostFee = 10.55;
+    final double processingFee = 12.99;
+
+    val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
+      .withName("Check in aged to lost loan")
+      .chargeItemAgedToLostProcessingFee(processingFee)
+      .withSetCost(setCostFee)
+      .refundFeesWithinMinutes(1);
+
+    val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
+    final IndividualResource loan = result.getLoan();
+
+    feeFineAccountFixture.transferLostItemFee(result.getLoanId());
+    feeFineAccountFixture.payLostItemProcessingFee(result.getLoanId());
+
+    final DateTime agedToLostDate = getDateTimePropertyByPath(loan.getJson(),
+      "agedToLostDelayedBilling", "agedToLostDate");
+    mockClockManagerToReturnFixedDateTime(agedToLostDate.plusMinutes(2));
+
+    checkInFixture.checkInByBarcode(result.getItem());
+
+    assertThat(loan, hasLostItemFee(isTransferredFully(setCostFee)));
+    assertThat(loan, hasLostItemFeeActions(
+      not(areTransferRefundActionsCreated(setCostFee))));
+
+    assertThat(loan, hasLostItemProcessingFee(isPaidFully(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      not(arePaymentRefundActionsCreated(processingFee))));
+  }
+
+  private void assertThatBillingInformationRemoved(IndividualResource loan) {
+    assertThat(loansClient.get(loan).getJson().toString(), allOf(
+      hasNoJsonPath("agedToLostDelayedBilling.lostItemHasBeenBilled"),
+      hasNoJsonPath("agedToLostDelayedBilling.dateLostItemShouldBeBilled")
+    ));
+  }
+}

--- a/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
@@ -44,7 +44,7 @@ public class CheckInAgedToLostItemTest extends APITests {
   }
 
   @Test
-  public void shouldRefundPaidAmountAndCancelRemaining() {
+  public void shouldRefundPartiallyPaidAmountAndCancelRemaining() {
     final double setCostFee = 10.55;
     final double processingFee = 12.99;
 
@@ -72,7 +72,7 @@ public class CheckInAgedToLostItemTest extends APITests {
   }
 
   @Test
-  public void shouldAssignOverdueFine() {
+  public void shouldChargeOverdueFine() {
     final double processingFee = 12.99;
 
     val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()

--- a/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
@@ -112,7 +112,7 @@ public class CheckInAgedToLostItemTest extends APITests {
       .refundFeesWithinMinutes(1);
 
     val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
-    final IndividualResource loan = result.getLoan();
+    final IndividualResource loan = loansStorageClient.get(result.getLoan());
 
     feeFineAccountFixture.transferLostItemFee(result.getLoanId());
     feeFineAccountFixture.payLostItemProcessingFee(result.getLoanId());

--- a/src/test/java/api/support/fakes/StorageSchema.java
+++ b/src/test/java/api/support/fakes/StorageSchema.java
@@ -12,7 +12,7 @@ public class StorageSchema {
   }
 
   public static JsonSchemaValidator validatorForStorageLoanSchema() throws IOException {
-    return JsonSchemaValidator.fromResource("/storage-loan-7-0.json");
+    return JsonSchemaValidator.fromResource("/storage-loan-7-1.json");
   }
 
   public static JsonSchemaValidator validatorForLocationInstSchema() throws IOException {

--- a/src/test/java/org/folio/circulation/support/JsonPropertyFetcherTest.java
+++ b/src/test/java/org/folio/circulation/support/JsonPropertyFetcherTest.java
@@ -1,0 +1,45 @@
+package org.folio.circulation.support;
+
+import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimePropertyByPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.is;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import io.vertx.core.json.JsonObject;
+
+public class JsonPropertyFetcherTest {
+
+  @Test
+  public void shouldReturnNullIfSomeObjectsNotExistInPath() {
+    final String[] paths = {"1", "2", "3", "4", "5"};
+    final JsonObject object = new JsonObject()
+      .put("1", new JsonObject().put("2", new JsonObject()));
+
+    final DateTime actualValue = getDateTimePropertyByPath(object, paths);
+
+    assertThat(actualValue, nullValue());
+  }
+
+  @Test
+  public void shouldReturnDateTimePropertyByPath() {
+    final String[] paths = {"1", "2", "3", "4", "5"};
+    final String expectedDate = "2020-12-12T20:00:00.123Z";
+    final String json = "{\n" +
+      "    \"1\": {\n" +
+      "        \"2\": {\n" +
+      "            \"3\": {\n" +
+      "                \"4\": {\n" +
+      "                    \"5\": \"" + expectedDate + "\"\n" +
+      "                }\n" +
+      "            }\n" +
+      "        }\n" +
+      "    }\n" +
+      "}";
+
+    final DateTime actualValue = getDateTimePropertyByPath(new JsonObject(json), paths);
+    assertThat(actualValue, is(DateTime.parse("2020-12-12T20:00:00.123Z")));
+  }
+}

--- a/src/test/java/org/folio/circulation/support/JsonPropertyFetcherTest.java
+++ b/src/test/java/org/folio/circulation/support/JsonPropertyFetcherTest.java
@@ -12,18 +12,6 @@ import org.junit.Test;
 import io.vertx.core.json.JsonObject;
 
 public class JsonPropertyFetcherTest {
-
-  @Test
-  public void shouldReturnNullIfSomeObjectsNotExistInPath() {
-    final String[] paths = {"1", "2", "3", "4", "5"};
-    final JsonObject object = new JsonObject()
-      .put("1", new JsonObject().put("2", new JsonObject()));
-
-    final DateTime actualValue = getDateTimePropertyByPath(object, paths);
-
-    assertThat(actualValue, nullValue());
-  }
-
   @Test
   public void shouldReturnDateTimePropertyByPath() {
     final String[] paths = {"1", "2", "3", "4", "5"};
@@ -34,5 +22,27 @@ public class JsonPropertyFetcherTest {
 
     final DateTime actualValue = getDateTimePropertyByPath(object, paths);
     assertThat(actualValue, is(expectedDate));
+  }
+
+  @Test
+  public void shouldReturnNullWhenObjectsInThePathAreNotPresent() {
+    final String[] paths = {"1", "2", "3", "4", "5"};
+    final JsonObject object = new JsonObject()
+      .put("1", new JsonObject().put("2", new JsonObject()));
+
+    final DateTime actualValue = getDateTimePropertyByPath(object, paths);
+
+    assertThat(actualValue, nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullIfPropertyIsNull() {
+    final String[] paths = {"1", "2"};
+    final JsonObject object = new JsonObject()
+      .put("1", new JsonObject().put("2", (String) null));
+
+    final DateTime actualValue = getDateTimePropertyByPath(object, paths);
+
+    assertThat(actualValue, nullValue());
   }
 }

--- a/src/test/java/org/folio/circulation/support/JsonPropertyFetcherTest.java
+++ b/src/test/java/org/folio/circulation/support/JsonPropertyFetcherTest.java
@@ -1,9 +1,10 @@
 package org.folio.circulation.support;
 
 import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimePropertyByPath;
+import static org.folio.circulation.support.JsonPropertyWriter.writeByPath;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
@@ -26,20 +27,12 @@ public class JsonPropertyFetcherTest {
   @Test
   public void shouldReturnDateTimePropertyByPath() {
     final String[] paths = {"1", "2", "3", "4", "5"};
-    final String expectedDate = "2020-12-12T20:00:00.123Z";
-    final String json = "{\n" +
-      "    \"1\": {\n" +
-      "        \"2\": {\n" +
-      "            \"3\": {\n" +
-      "                \"4\": {\n" +
-      "                    \"5\": \"" + expectedDate + "\"\n" +
-      "                }\n" +
-      "            }\n" +
-      "        }\n" +
-      "    }\n" +
-      "}";
+    final DateTime expectedDate = DateTime.parse("2020-12-12T20:00:00.123Z");
 
-    final DateTime actualValue = getDateTimePropertyByPath(new JsonObject(json), paths);
-    assertThat(actualValue, is(DateTime.parse("2020-12-12T20:00:00.123Z")));
+    final JsonObject object = new JsonObject();
+    writeByPath(object, expectedDate, paths);
+
+    final DateTime actualValue = getDateTimePropertyByPath(object, paths);
+    assertThat(actualValue, is(expectedDate));
   }
 }

--- a/src/test/java/org/folio/circulation/support/JsonPropertyWriterTest.java
+++ b/src/test/java/org/folio/circulation/support/JsonPropertyWriterTest.java
@@ -35,17 +35,8 @@ public class JsonPropertyWriterTest {
   public void shouldWriteStringByPath() {
     final String[] paths = {"1", "2", "3", "4", "5"};
     final String expectedString = "A string";
-    final String json = "{\n" +
-      "    \"1\": {\n" +
-      "        \"2\": {\n" +
-      "            \"3\": {\n" +
-      "                \"4\": {}\n" +
-      "            }\n" +
-      "        }\n" +
-      "    }\n" +
-      "}";
 
-    final JsonObject object = new JsonObject(json);
+    final JsonObject object = new JsonObject();
     writeByPath(object, expectedString, paths);
 
     assertThat(object, hasJsonPath("1.2.3.4.5", "A string"));

--- a/src/test/java/org/folio/circulation/support/JsonPropertyWriterTest.java
+++ b/src/test/java/org/folio/circulation/support/JsonPropertyWriterTest.java
@@ -10,9 +10,8 @@ import org.junit.Test;
 import io.vertx.core.json.JsonObject;
 
 public class JsonPropertyWriterTest {
-
   @Test
-  public void shouldCreateMissingObjects() {
+  public void shouldCreateMissingObjectsInThePath() {
     final String[] paths = {"1", "2", "3", "4", "5"};
     final JsonObject object2 = new JsonObject()
       .put("21", 2.1)
@@ -29,16 +28,5 @@ public class JsonPropertyWriterTest {
       hasJsonPath("11", "1.1"),
       hasJsonPath("1.21", 2.1)
     ));
-  }
-
-  @Test
-  public void shouldWriteStringByPath() {
-    final String[] paths = {"1", "2", "3", "4", "5"};
-    final String expectedString = "A string";
-
-    final JsonObject object = new JsonObject();
-    writeByPath(object, expectedString, paths);
-
-    assertThat(object, hasJsonPath("1.2.3.4.5", "A string"));
   }
 }

--- a/src/test/java/org/folio/circulation/support/JsonPropertyWriterTest.java
+++ b/src/test/java/org/folio/circulation/support/JsonPropertyWriterTest.java
@@ -1,0 +1,53 @@
+package org.folio.circulation.support;
+
+import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
+import static org.folio.circulation.support.JsonPropertyWriter.writeByPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+
+import org.junit.Test;
+
+import io.vertx.core.json.JsonObject;
+
+public class JsonPropertyWriterTest {
+
+  @Test
+  public void shouldCreateMissingObjects() {
+    final String[] paths = {"1", "2", "3", "4", "5"};
+    final JsonObject object2 = new JsonObject()
+      .put("21", 2.1)
+      .put("2", new JsonObject());
+
+    final JsonObject object = new JsonObject()
+      .put("11", "1.1")
+      .put("1", object2);
+
+    writeByPath(object, "5", paths);
+
+    assertThat(object, allOf(
+      hasJsonPath("1.2.3.4.5", "5"),
+      hasJsonPath("11", "1.1"),
+      hasJsonPath("1.21", 2.1)
+    ));
+  }
+
+  @Test
+  public void shouldWriteStringByPath() {
+    final String[] paths = {"1", "2", "3", "4", "5"};
+    final String expectedString = "A string";
+    final String json = "{\n" +
+      "    \"1\": {\n" +
+      "        \"2\": {\n" +
+      "            \"3\": {\n" +
+      "                \"4\": {}\n" +
+      "            }\n" +
+      "        }\n" +
+      "    }\n" +
+      "}";
+
+    final JsonObject object = new JsonObject(json);
+    writeByPath(object, expectedString, paths);
+
+    assertThat(object, hasJsonPath("1.2.3.4.5", "A string"));
+  }
+}

--- a/src/test/resources/storage-loan-7-1.json
+++ b/src/test/resources/storage-loan-7-1.json
@@ -121,13 +121,18 @@
     "agedToLostDelayedBilling": {
       "description": "Aged to Lost Delayed Billing processing",
       "type": "object",
-      "properties": {  
+      "properties": {
         "lostItemHasBeenBilled": {
           "description": "Indicates if the aged to lost fee has been billed (for use where delayed billing is set up)",
           "type": "boolean"
         },
         "dateLostItemShouldBeBilled": {
           "description": "Indicates when the aged to lost fee should be billed (for use where delayed billing is set up)",
+          "type": "string",
+          "format": "date-time"
+        },
+        "agedToLostDate": {
+          "description": "Date and time the item was aged to lost for this loan",
           "type": "string",
           "format": "date-time"
         }


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-845 - Aged to lost: Check in (effect on fees/fines) - SET COST

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
* Use `loan-storage v7.1` API
* Save date and time when item was aged to lost.
* Remove delayed billing information when an aged to lost loan is checked in.
* Refund lost item fees when aged to lost item is checked in by reusing existing service.
* Assign overdue fine when aged to lost item is overdue.
* Add `writeByPath` and `getPropertyByPath` methods to allow get/write nested properties.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
