### PR TITLE
CIRC-852: Do not charge aged to lost processing fee if disabled by policy.

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
@@ -24,7 +24,7 @@ import org.joda.time.DateTime;
 import io.vertx.core.json.JsonObject;
 
 public class LostItemPolicy extends Policy {
-  private final AutomaticallyChargeableFee processingFee;
+  private final AutomaticallyChargeableFee declareLostProcessingFee;
   private final AutomaticallyChargeableFee setCostFee;
   private final ChargeableFee actualCostFee;
   private final Period feeRefundInterval;
@@ -37,14 +37,14 @@ public class LostItemPolicy extends Policy {
   // to simplify logic.
   private final AutomaticallyChargeableFee ageToLostProcessingFee;
 
-  private LostItemPolicy(String id, String name, AutomaticallyChargeableFee processingFee,
+  private LostItemPolicy(String id, String name, AutomaticallyChargeableFee declareLostProcessingFee,
     AutomaticallyChargeableFee setCostFee, ChargeableFee actualCostFee,
     Period feeRefundInterval, boolean refundProcessingFeeWhenFound, boolean chargeOverdueFine,
     Period agedToLostAfterOverdueInterval, Period patronBilledAfterAgedToLostInterval,
     AutomaticallyChargeableFee ageToLostProcessingFee) {
 
     super(id, name);
-    this.processingFee = processingFee;
+    this.declareLostProcessingFee = declareLostProcessingFee;
     this.setCostFee = setCostFee;
     this.actualCostFee = actualCostFee;
     this.feeRefundInterval = feeRefundInterval;
@@ -116,8 +116,8 @@ public class LostItemPolicy extends Policy {
     return setCostFee;
   }
 
-  public AutomaticallyChargeableFee getProcessingFee() {
-    return processingFee;
+  public AutomaticallyChargeableFee getDeclareLostProcessingFee() {
+    return declareLostProcessingFee;
   }
 
   public ChargeableFee getActualCostFee() {

--- a/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
@@ -78,7 +78,7 @@ public class LostItemFeeChargingService {
   }
 
   private boolean shouldCloseLoan(LostItemPolicy policy) {
-    return !policy.getProcessingFee().isChargeable()
+    return !policy.getDeclareLostProcessingFee().isChargeable()
       && policy.hasNoLostItemFee();
   }
 
@@ -108,12 +108,12 @@ public class LostItemFeeChargingService {
         accountsToCreate.add(lostItemFeeResult);
       }
 
-      if (policy.getProcessingFee().isChargeable()) {
+      if (policy.getDeclareLostProcessingFee().isChargeable()) {
         log.debug("Charging lost item processing fee");
 
         final Result<CreateAccountCommand> processingFeeResult =
           getFeeFineOfType(feeFines, LOST_ITEM_PROCESSING_FEE_TYPE)
-            .map(createAccountCreation(context, policy.getProcessingFee()));
+            .map(createAccountCreation(context, policy.getDeclareLostProcessingFee()));
 
         accountsToCreate.add(processingFeeResult);
       }

--- a/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
+++ b/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
@@ -31,7 +31,7 @@ public class CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests extends APITes
       lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
         .withName("Age to lost policy")
         .withSetCost(10.0)
-        .chargeItemAgedToLostProcessingFee(15.00));
+        .chargeProcessingFeeWhenAgedToLost(15.00));
 
     item = result.getItem();
     loan = result.getLoan();

--- a/src/test/java/api/handlers/CloseDeclaredLostLoanWhenLostItemFeesAreClosedApiTests.java
+++ b/src/test/java/api/handlers/CloseDeclaredLostLoanWhenLostItemFeesAreClosedApiTests.java
@@ -87,7 +87,7 @@ public class CloseDeclaredLostLoanWhenLostItemFeesAreClosedApiTests extends APIT
   public void shouldNotCloseLoanIfActualCostFeeShouldBeCharged() {
     useLostItemPolicy(lostItemFeePoliciesFixture.create(
       lostItemFeePoliciesFixture.facultyStandardPolicy()
-        .chargeProcessingFee(10.00)
+        .chargeProcessingFeeWhenDeclaredLost(10.00)
         .withActualCost(10.0)).getId());
 
     feeFineAccountFixture.payLostItemProcessingFee(loan.getId());

--- a/src/test/java/api/loans/DeclareLostAPITests.java
+++ b/src/test/java/api/loans/DeclareLostAPITests.java
@@ -188,7 +188,7 @@ public class DeclareLostAPITests extends APITests {
     final LostItemFeePolicyBuilder lostItemPolicy = lostItemFeePoliciesFixture
       .facultyStandardPolicy()
       .withName("Declared lost fee test policy")
-      .doNotChargeProcessingFee()
+      .doNotChargeProcessingFeeWhenDeclaredLost()
       .withSetCost(expectedItemFee);
 
     useLostItemPolicy(lostItemFeePoliciesFixture.create(lostItemPolicy).getId());
@@ -311,7 +311,7 @@ public class DeclareLostAPITests extends APITests {
     final LostItemFeePolicyBuilder lostItemPolicy = lostItemFeePoliciesFixture
       .facultyStandardPolicy()
       .withName("Declared lost fee test policy")
-      .doNotChargeProcessingFee()
+      .doNotChargeProcessingFeeWhenDeclaredLost()
       .withLostItemProcessingFee(processingFee)
       .withNoChargeAmountItem();
 
@@ -332,7 +332,7 @@ public class DeclareLostAPITests extends APITests {
     final LostItemFeePolicyBuilder lostItemPolicy = lostItemFeePoliciesFixture
       .facultyStandardPolicy()
       .withName("Declared lost fee test policy")
-      .doNotChargeProcessingFee()
+      .doNotChargeProcessingFeeWhenDeclaredLost()
       .withSetCost(itemFee);
 
     useLostItemPolicy(lostItemFeePoliciesFixture.create(lostItemPolicy).getId());
@@ -348,7 +348,7 @@ public class DeclareLostAPITests extends APITests {
     final LostItemFeePolicyBuilder lostItemPolicy = lostItemFeePoliciesFixture
       .facultyStandardPolicy()
       .withName("Declared lost fee test policy")
-      .doNotChargeProcessingFee()
+      .doNotChargeProcessingFeeWhenDeclaredLost()
       .withActualCost(10.0);
 
     useLostItemPolicy(lostItemFeePoliciesFixture.create(lostItemPolicy).getId());
@@ -385,7 +385,7 @@ public class DeclareLostAPITests extends APITests {
     final LostItemFeePolicyBuilder lostItemPolicy = lostItemFeePoliciesFixture
       .facultyStandardPolicy()
       .withName("Declared lost fee test policy")
-      .doNotChargeProcessingFee()
+      .doNotChargeProcessingFeeWhenDeclaredLost()
       .withChargeAmountItem(null);
 
     useLostItemPolicy(lostItemFeePoliciesFixture.create(lostItemPolicy).getId());

--- a/src/test/java/api/loans/DeclareLostAPITests.java
+++ b/src/test/java/api/loans/DeclareLostAPITests.java
@@ -158,7 +158,7 @@ public class DeclareLostAPITests extends APITests {
     final LostItemFeePolicyBuilder lostItemPolicy = lostItemFeePoliciesFixture
       .facultyStandardPolicy()
       .withName("Declared lost fee test policy")
-      .chargeProcessingFee(expectedProcessingFee)
+      .chargeProcessingFeeWhenDeclaredLost(expectedProcessingFee)
       .withSetCost(expectedItemFee);
 
     useLostItemPolicy(lostItemFeePoliciesFixture.create(lostItemPolicy).getId());
@@ -212,7 +212,7 @@ public class DeclareLostAPITests extends APITests {
     final LostItemFeePolicyBuilder lostItemPolicy = lostItemFeePoliciesFixture
       .facultyStandardPolicy()
       .withName("Declared lost fee test policy")
-      .chargeProcessingFee(expectedProcessingFee)
+      .chargeProcessingFeeWhenDeclaredLost(expectedProcessingFee)
       .withSetCost(0.0);
 
     useLostItemPolicy(lostItemFeePoliciesFixture.create(lostItemPolicy).getId());
@@ -369,7 +369,7 @@ public class DeclareLostAPITests extends APITests {
     final LostItemFeePolicyBuilder lostItemPolicy = lostItemFeePoliciesFixture
       .facultyStandardPolicy()
       .withName("Declared lost fee test policy")
-      .chargeProcessingFee(processingFee)
+      .chargeProcessingFeeWhenDeclaredLost(processingFee)
       .withNoChargeAmountItem();
 
     useLostItemPolicy(lostItemFeePoliciesFixture.create(lostItemPolicy).getId());

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import api.support.builders.FeeFineOwnerBuilder;
 import api.support.builders.ItemBuilder;
+import api.support.builders.LostItemFeePolicyBuilder;
 import api.support.builders.ServicePointBuilder;
 import api.support.spring.SpringApiTest;
 import io.vertx.core.json.JsonObject;
@@ -62,9 +63,12 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
   public void shouldChargeItemProcessingFee() {
     final double expectedProcessingFee = 99.54;
 
-    val policy = lostItemFeePoliciesFixture
-      .ageToLostAfterOneMinutePolicy()
+    val policy = new LostItemFeePolicyBuilder()
+      .withName("shouldChargeItemProcessingFee")
+      .withItemAgedToLostAfterOverdue(Period.weeks(1))
+      .withPatronBilledAfterAgedLost(Period.weeks(2))
       .withNoChargeAmountItem()
+      .doNotChargeProcessingFee()
       .chargeItemAgedToLostProcessingFee(expectedProcessingFee);
 
     val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
@@ -58,7 +58,7 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
     val policy = lostItemFeePoliciesFixture
       .ageToLostAfterOneMinutePolicy()
       .withSetCost(expectedSetCost)
-      .doNotChargeItemAgedToLostProcessingFee();
+      .doNotChargeProcessingFeeWhenAgedToLost();
 
     val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
 
@@ -82,7 +82,7 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
       .withItemAgedToLostAfterOverdue(Period.weeks(1))
       .withPatronBilledAfterAgedLost(Period.weeks(2))
       .withNoChargeAmountItem()
-      .doNotChargeProcessingFee()
+      .doNotChargeProcessingFeeWhenDeclaredLost()
       .chargeItemAgedToLostProcessingFee(expectedProcessingFee);
 
     val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
@@ -118,7 +118,7 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
     val policy = lostItemFeePoliciesFixture
       .ageToLostAfterOneMinutePolicy()
       .withNoChargeAmountItem()
-      .doNotChargeItemAgedToLostProcessingFee();
+      .doNotChargeProcessingFeeWhenAgedToLost();
 
     val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
 
@@ -133,7 +133,7 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
     val policy = lostItemFeePoliciesFixture
       .ageToLostAfterOneMinutePolicy()
       .withSetCost(10.00)
-      .doNotChargeItemAgedToLostProcessingFee();
+      .doNotChargeProcessingFeeWhenAgedToLost();
 
     val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
 
@@ -213,7 +213,7 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
     val policy = lostItemFeePoliciesFixture
       .ageToLostAfterOneMinutePolicy()
       .withSetCost(11.00)
-      .doNotChargeItemAgedToLostProcessingFee();
+      .doNotChargeProcessingFeeWhenAgedToLost();
 
     useLostItemPolicy(lostItemFeePoliciesFixture.create(policy).getId());
 
@@ -261,7 +261,7 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
       .ageToLostAfterOneMinutePolicy()
       .billPatronImmediatelyWhenAgedToLost()
       .withNoChargeAmountItem()
-      .doNotChargeItemAgedToLostProcessingFee();
+      .doNotChargeProcessingFeeWhenAgedToLost();
 
     val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
 
@@ -292,7 +292,7 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
       val setCostFee = 10.0 + itemIndex;
       val policyBuilder = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
         .withName("Age to lost item " + itemIndex)
-        .doNotChargeItemAgedToLostProcessingFee()
+        .doNotChargeProcessingFeeWhenAgedToLost()
         .withSetCost(setCostFee);
 
       useLostItemPolicy(lostItemFeePoliciesFixture.create(policyBuilder).getId());

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
@@ -83,7 +83,7 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
       .withPatronBilledAfterAgedLost(Period.weeks(2))
       .withNoChargeAmountItem()
       .doNotChargeProcessingFeeWhenDeclaredLost()
-      .chargeItemAgedToLostProcessingFee(expectedProcessingFee);
+      .chargeProcessingFeeWhenAgedToLost(expectedProcessingFee);
 
     val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
 
@@ -100,7 +100,7 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
     val policy = lostItemFeePoliciesFixture
       .ageToLostAfterOneMinutePolicy()
       .withSetCost(expectedItemFee)
-      .chargeItemAgedToLostProcessingFee(expectedProcessingFee);
+      .chargeProcessingFeeWhenAgedToLost(expectedProcessingFee);
 
     val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
 
@@ -193,7 +193,7 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
     val policy = lostItemFeePoliciesFixture
       .ageToLostAfterOneMinutePolicy()
       .withNoChargeAmountItem()
-      .chargeItemAgedToLostProcessingFee(10.0);
+      .chargeProcessingFeeWhenAgedToLost(10.0);
 
     useLostItemPolicy(lostItemFeePoliciesFixture.create(policy).getId());
 

--- a/src/test/java/api/loans/scenarios/ChangeDueDateAPITests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateAPITests.java
@@ -269,7 +269,7 @@ public class ChangeDueDateAPITests extends APITests {
     final LostItemFeePolicyBuilder lostItemPolicy = lostItemFeePoliciesFixture
       .facultyStandardPolicy()
       .withName("Declared lost fee test policy")
-      .chargeProcessingFee(5.00)
+      .chargeProcessingFeeWhenDeclaredLost(5.00)
       .withSetCost(10.00);
 
     useLostItemPolicy(lostItemFeePoliciesFixture.create(lostItemPolicy).getId());

--- a/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
@@ -50,7 +50,7 @@ public class CheckInAgedToLostItemTest extends APITests {
 
     val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
       .withName("Check in aged to lost loan")
-      .chargeItemAgedToLostProcessingFee(processingFee)
+      .chargeProcessingFeeWhenAgedToLost(processingFee)
       .withSetCost(setCostFee)
       .withNoFeeRefundInterval();
 
@@ -77,7 +77,7 @@ public class CheckInAgedToLostItemTest extends APITests {
 
     val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
       .withName("Check in aged to lost loan")
-      .chargeItemAgedToLostProcessingFee(processingFee)
+      .chargeProcessingFeeWhenAgedToLost(processingFee)
       .chargeOverdueFineWhenReturned()
       .withNoFeeRefundInterval();
 
@@ -107,7 +107,7 @@ public class CheckInAgedToLostItemTest extends APITests {
 
     val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
       .withName("Check in aged to lost loan")
-      .chargeItemAgedToLostProcessingFee(processingFee)
+      .chargeProcessingFeeWhenAgedToLost(processingFee)
       .withSetCost(setCostFee)
       .refundFeesWithinMinutes(1);
 

--- a/src/test/java/api/loans/scenarios/RefundLostItemFeesTestBase.java
+++ b/src/test/java/api/loans/scenarios/RefundLostItemFeesTestBase.java
@@ -88,7 +88,7 @@ public abstract class RefundLostItemFeesTestBase extends APITests {
     useLostItemPolicy(lostItemFeePoliciesFixture.create(
       lostItemFeePoliciesFixture.facultyStandardPolicy()
         .withName("Test check in")
-        .chargeProcessingFee(processingFee)
+        .chargeProcessingFeeWhenDeclaredLost(processingFee)
         .withNoChargeAmountItem()).getId());
 
     declareItemLost();
@@ -107,7 +107,7 @@ public abstract class RefundLostItemFeesTestBase extends APITests {
     useLostItemPolicy(lostItemFeePoliciesFixture.create(
       lostItemFeePoliciesFixture.facultyStandardPolicy()
         .withName("Test check in")
-        .chargeProcessingFee(processingFee)
+        .chargeProcessingFeeWhenDeclaredLost(processingFee)
         .doNotRefundProcessingFeeWhenReturned()
         .withNoChargeAmountItem()).getId());
 
@@ -155,7 +155,7 @@ public abstract class RefundLostItemFeesTestBase extends APITests {
     useLostItemPolicy(lostItemFeePoliciesFixture.create(
       lostItemFeePoliciesFixture.facultyStandardPolicy()
         .withName("Test check in")
-        .chargeProcessingFee(processingFee)
+        .chargeProcessingFeeWhenDeclaredLost(processingFee)
         .withSetCost(setCostFee)
         .withNoFeeRefundInterval()).getId());
 
@@ -300,7 +300,7 @@ public abstract class RefundLostItemFeesTestBase extends APITests {
     useLostItemPolicy(lostItemFeePoliciesFixture.create(
       lostItemFeePoliciesFixture.facultyStandardPolicy()
         .withName("Test check in")
-        .chargeProcessingFee(processingFee)
+        .chargeProcessingFeeWhenDeclaredLost(processingFee)
         .withNoChargeAmountItem()
         .chargeOverdueFineWhenReturned()).getId());
 
@@ -328,7 +328,7 @@ public abstract class RefundLostItemFeesTestBase extends APITests {
     useLostItemPolicy(lostItemFeePoliciesFixture.create(
       lostItemFeePoliciesFixture.facultyStandardPolicy()
         .withName("Test check in")
-        .chargeProcessingFee(processingFee)
+        .chargeProcessingFeeWhenDeclaredLost(processingFee)
         .withNoChargeAmountItem()
         .doNotChargeOverdueFineWhenReturned()).getId());
 
@@ -376,7 +376,7 @@ public abstract class RefundLostItemFeesTestBase extends APITests {
     useLostItemPolicy(lostItemFeePoliciesFixture.create(
       lostItemFeePoliciesFixture.facultyStandardPolicy()
         .withName("Test check in")
-        .chargeProcessingFee(processingFee)
+        .chargeProcessingFeeWhenDeclaredLost(processingFee)
         .withNoChargeAmountItem()
         .doNotRefundProcessingFeeWhenReturned()
         .chargeOverdueFineWhenReturned()).getId());
@@ -419,7 +419,7 @@ public abstract class RefundLostItemFeesTestBase extends APITests {
       lostItemFeePoliciesFixture.facultyStandardPolicy()
         .withName(String.format("Test lost policy processing fee %s, item fee %s",
           itemFee, processingFee))
-        .chargeProcessingFee(processingFee)
+        .chargeProcessingFeeWhenDeclaredLost(processingFee)
         .withSetCost(itemFee)
         .refundFeesWithinMinutes(1)).getId());
   }

--- a/src/test/java/api/loans/scenarios/RefundLostItemFeesTestBase.java
+++ b/src/test/java/api/loans/scenarios/RefundLostItemFeesTestBase.java
@@ -36,7 +36,6 @@ import static org.joda.time.DateTime.parse;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.folio.circulation.support.ClockManager;
 import org.folio.circulation.support.http.client.IndividualResource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -71,7 +70,7 @@ public abstract class RefundLostItemFeesTestBase extends APITests {
     useLostItemPolicy(lostItemFeePoliciesFixture.create(
       lostItemFeePoliciesFixture.facultyStandardPolicy()
         .withName("Test check in")
-        .doNotChargeProcessingFee()
+        .doNotChargeProcessingFeeWhenDeclaredLost()
         .withSetCost(itemFee)).getId());
 
     declareItemLost();
@@ -353,7 +352,7 @@ public abstract class RefundLostItemFeesTestBase extends APITests {
     useLostItemPolicy(lostItemFeePoliciesFixture.create(
       lostItemFeePoliciesFixture.facultyStandardPolicy()
         .withName("Test check in")
-        .doNotChargeProcessingFee()
+        .doNotChargeProcessingFeeWhenDeclaredLost()
         .withSetCost(itemFee)
         .refundFeesWithinMinutes(1)
         .chargeOverdueFineWhenReturned()).getId());

--- a/src/test/java/api/support/builders/LostItemFeePolicyBuilder.java
+++ b/src/test/java/api/support/builders/LostItemFeePolicyBuilder.java
@@ -77,12 +77,12 @@ public class LostItemFeePolicyBuilder extends JsonBuilder implements Builder {
       .withChargeAmountItemSystem(true);
   }
 
-  public LostItemFeePolicyBuilder doNotChargeProcessingFee() {
+  public LostItemFeePolicyBuilder doNotChargeProcessingFeeWhenDeclaredLost() {
     return withLostItemProcessingFee(0.0)
       .withChargeAmountItemPatron(false);
   }
 
-  public LostItemFeePolicyBuilder doNotChargeItemAgedToLostProcessingFee() {
+  public LostItemFeePolicyBuilder doNotChargeProcessingFeeWhenAgedToLost() {
     return withLostItemProcessingFee(0.0)
       .withChargeAmountItemSystem(false);
   }

--- a/src/test/java/api/support/builders/LostItemFeePolicyBuilder.java
+++ b/src/test/java/api/support/builders/LostItemFeePolicyBuilder.java
@@ -67,12 +67,12 @@ public class LostItemFeePolicyBuilder extends JsonBuilder implements Builder {
     return withChargeAmountItem("actualCost", amount);
   }
 
-  public LostItemFeePolicyBuilder chargeProcessingFee(Double amount) {
+  public LostItemFeePolicyBuilder chargeProcessingFeeWhenDeclaredLost(Double amount) {
     return withLostItemProcessingFee(amount)
       .withChargeAmountItemPatron(true);
   }
 
-  public LostItemFeePolicyBuilder chargeItemAgedToLostProcessingFee(Double amount) {
+  public LostItemFeePolicyBuilder chargeProcessingFeeWhenAgedToLost(Double amount) {
     return withLostItemProcessingFee(amount)
       .withChargeAmountItemSystem(true);
   }

--- a/src/test/java/api/support/fixtures/LostItemFeePoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/LostItemFeePoliciesFixture.java
@@ -81,6 +81,8 @@ public class LostItemFeePoliciesFixture {
       .withName("Age to lost after one minute overdue")
       .withItemAgedToLostAfterOverdue(minutes(1))
       .withPatronBilledAfterAgedLost(minutes(5))
+      // disable lost item processing fee
+      .withChargeAmountItemPatron(false)
       .withChargeAmountItemSystem(true);
   }
 

--- a/src/test/java/api/support/fixtures/LostItemFeePoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/LostItemFeePoliciesFixture.java
@@ -68,7 +68,7 @@ public class LostItemFeePoliciesFixture {
       .withItemAgedToLostAfterOverdue(itemAgedLostOverdue)
       .withPatronBilledAfterAgedLost(patronBilledAfterAgedLost)
       .withSetCost(10.00)
-      .chargeProcessingFee(5.00)
+      .chargeProcessingFeeWhenDeclaredLost(5.00)
       .withChargeAmountItemSystem(true)
       .refundProcessingFeeWhenReturned()
       .withReplacedLostItemProcessingFee(true)

--- a/src/test/java/api/support/fixtures/LostItemFeePoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/LostItemFeePoliciesFixture.java
@@ -51,7 +51,7 @@ public class LostItemFeePoliciesFixture {
       .withItemAgedToLostAfterOverdue(itemAgedLostOverdue)
       .withPatronBilledAfterAgedLost(patronBilledAfterAgedLost)
       .withNoChargeAmountItem()
-      .doNotChargeProcessingFee()
+      .doNotChargeProcessingFeeWhenDeclaredLost()
       .withChargeAmountItemSystem(true)
       .refundProcessingFeeWhenReturned()
       .withReplacedLostItemProcessingFee(true)

--- a/src/test/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicyTest.java
@@ -205,7 +205,7 @@ public class LostItemPolicyTest {
     final DateTime expectedBillingDate = loanDueDate.plus(ageToLostAfterPeriod.timePeriod())
       .plus(billPatronAfterPeriod.timePeriod());
 
-    final LostItemPolicy lostItemPolicy =  LostItemPolicy.from(
+    final LostItemPolicy lostItemPolicy = LostItemPolicy.from(
       new LostItemFeePolicyBuilder()
         .withPatronBilledAfterAgedLost(billPatronAfterPeriod)
         .withItemAgedToLostAfterOverdue(ageToLostAfterPeriod)
@@ -221,7 +221,7 @@ public class LostItemPolicyTest {
 
   @Test
   public void ageToLostProcessingFeeIsNotChargeableIfAmountIsSetButFlagIsFalse() {
-    final LostItemPolicy lostItemPolicy =  LostItemPolicy.from(
+    final LostItemPolicy lostItemPolicy = LostItemPolicy.from(
       new LostItemFeePolicyBuilder()
         .doNotChargeProcessingFeeWhenAgedToLost()
         .chargeProcessingFeeWhenDeclaredLost(10.0)
@@ -233,7 +233,7 @@ public class LostItemPolicyTest {
 
   @Test
   public void ageToLostProcessingFeeIsChargeableEvenIfDeclaredLostFlagIsFalse() {
-    final LostItemPolicy lostItemPolicy =  LostItemPolicy.from(
+    final LostItemPolicy lostItemPolicy = LostItemPolicy.from(
       new LostItemFeePolicyBuilder()
         .doNotChargeProcessingFeeWhenDeclaredLost()
         .chargeProcessingFeeWhenAgedToLost(10.00)

--- a/src/test/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicyTest.java
@@ -219,6 +219,30 @@ public class LostItemPolicyTest {
     assertThat(actualBillingDate, is(expectedBillingDate));
   }
 
+  @Test
+  public void ageToLostProcessingFeeIsNotChargeableIfAmountIsSetButFlagIsFalse() {
+    final LostItemPolicy lostItemPolicy =  LostItemPolicy.from(
+      new LostItemFeePolicyBuilder()
+        .doNotChargeProcessingFeeWhenAgedToLost()
+        .chargeProcessingFeeWhenDeclaredLost(10.0)
+        .create());
+
+    assertFalse(lostItemPolicy.getAgeToLostProcessingFee().isChargeable());
+    assertTrue(lostItemPolicy.getDeclareLostProcessingFee().isChargeable());
+  }
+
+  @Test
+  public void ageToLostProcessingFeeIsChargeableEvenIfDeclaredLostFlagIsFalse() {
+    final LostItemPolicy lostItemPolicy =  LostItemPolicy.from(
+      new LostItemFeePolicyBuilder()
+        .doNotChargeProcessingFeeWhenDeclaredLost()
+        .chargeProcessingFeeWhenAgedToLost(10.00)
+        .create());
+
+    assertTrue(lostItemPolicy.getAgeToLostProcessingFee().isChargeable());
+    assertFalse(lostItemPolicy.getDeclareLostProcessingFee().isChargeable());
+  }
+
   private LostItemPolicy lostItemPolicyWithAgePeriod(Period period) {
     return LostItemPolicy.from(new LostItemFeePolicyBuilder()
       .withItemAgedToLostAfterOverdue(period)

--- a/src/test/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicyTest.java
@@ -188,7 +188,7 @@ public class LostItemPolicyTest {
         .withPatronBilledAfterAgedLost(billPatronInterval)
         .withItemAgedToLostAfterOverdue(ageToLostAfterPeriod)
         .withSetCost(10.0)
-        .doNotChargeItemAgedToLostProcessingFee()
+        .doNotChargeProcessingFeeWhenAgedToLost()
         .create());
 
     final DateTime actualBillingDate = lostItemPolicy
@@ -210,7 +210,7 @@ public class LostItemPolicyTest {
         .withPatronBilledAfterAgedLost(billPatronAfterPeriod)
         .withItemAgedToLostAfterOverdue(ageToLostAfterPeriod)
         .withSetCost(10.0)
-        .doNotChargeItemAgedToLostProcessingFee()
+        .doNotChargeProcessingFeeWhenAgedToLost()
         .create());
 
     final DateTime actualBillingDate = lostItemPolicy

--- a/src/test/java/org/folio/circulation/services/agedtolost/LoanToChargeFeesTest.java
+++ b/src/test/java/org/folio/circulation/services/agedtolost/LoanToChargeFeesTest.java
@@ -37,7 +37,7 @@ public class LoanToChargeFeesTest {
   public void shouldNotCloseLoanIfProcessingFeeIsCharged() {
     val lostItemPolicy = new LostItemFeePolicyBuilder()
       .billPatronImmediatelyWhenAgedToLost()
-      .chargeItemAgedToLostProcessingFee(10.00);
+      .chargeProcessingFeeWhenAgedToLost(10.00);
 
     assertFalse(loanForLostItemPolicy(lostItemPolicy).shouldCloseLoan());
   }

--- a/src/test/java/org/folio/circulation/services/agedtolost/LoanToChargeFeesTest.java
+++ b/src/test/java/org/folio/circulation/services/agedtolost/LoanToChargeFeesTest.java
@@ -20,7 +20,7 @@ public class LoanToChargeFeesTest {
     val lostItemPolicy = new LostItemFeePolicyBuilder()
       .billPatronImmediatelyWhenAgedToLost()
       .withNoChargeAmountItem()
-      .doNotChargeItemAgedToLostProcessingFee();
+      .doNotChargeProcessingFeeWhenAgedToLost();
 
     assertTrue(loanForLostItemPolicy(lostItemPolicy).shouldCloseLoan());
   }


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-852 - Age to lost: Assign lost fees for aged to lost loans - SET COST

## Purpose
If the Lost Item Fee Policy in effect for the loan has _Charge lost item processing fee if item aged to lost by system set to 'No'_, the Lost item processing fee should not be charged for the item.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
