### PR TITLE
CIRC-844: Refund lost item fees when aged to lost item is renewed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,9 +405,9 @@
         <version>2.22.2</version>
         <configuration>
           <!-- 0.5 * 'number of available cores', i.e. 2 for quad core envs -->
-          <forkCount>0.5C</forkCount>
+          <forkCount>3</forkCount>
           <reuseForks>true</reuseForks>
-          <argLine>@{argLine} -Xmx512m</argLine>
+          <argLine>@{argLine} -Xmx256m</argLine>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,6 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
         <configuration>
-          <!-- 0.5 * 'number of available cores', i.e. 2 for quad core envs -->
           <forkCount>3</forkCount>
           <reuseForks>true</reuseForks>
           <argLine>@{argLine} -Xmx256m</argLine>

--- a/src/main/java/org/folio/circulation/domain/OverdueFineCalculatorService.java
+++ b/src/main/java/org/folio/circulation/domain/OverdueFineCalculatorService.java
@@ -298,12 +298,15 @@ public class OverdueFineCalculatorService {
     }
   }
 
-  @AllArgsConstructor(access = PRIVATE)
   enum Scenario {
     CHECKIN(policy -> !policy.isUnknown()),
     RENEWAL(policy -> !policy.isUnknown() && isFalse(policy.getForgiveFineForRenewals()));
 
     private final Predicate<OverdueFinePolicy> shouldCreateFine;
+
+    Scenario(Predicate<OverdueFinePolicy> shouldCreateFine) {
+      this.shouldCreateFine = shouldCreateFine;
+    }
 
     private boolean shouldCreateFine(OverdueFinePolicy overdueFinePolicy) {
       return shouldCreateFine.test(overdueFinePolicy);

--- a/src/main/java/org/folio/circulation/infrastructure/storage/CirculationPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/CirculationPolicyRepository.java
@@ -56,8 +56,8 @@ public abstract class CirculationPolicyRepository<T> {
   }
 
   private Result<T> mapToPolicy(JsonObject json, AppliedRuleConditions ruleConditionsEntity) {
-    if (log.isInfoEnabled()) {
-      log.info("Mapping json to policy {}", json.encodePrettily());
+    if (log.isDebugEnabled()) {
+      log.debug("Mapping json to policy {}", json.encodePrettily());
     }
 
     return toPolicy(json, ruleConditionsEntity);

--- a/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalStrategy.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalStrategy.java
@@ -78,7 +78,13 @@ public class OverrideRenewalStrategy implements RenewalStrategy {
 
       if (loan.isItemLost()) {
         return processRenewal(proposedDueDateResult, loan, comment)
-          .map(dueDate -> loan.changeItemStatusForItemAndLoan(CHECKED_OUT));
+          .map(dueDate -> {
+            if (loan.isAgedToLost()) {
+              loan.removeAgedToLostBillingInfo();
+            }
+
+            return loan.changeItemStatusForItemAndLoan(CHECKED_OUT);
+          });
       }
 
       return failedValidation(errorForNotMatchingOverrideCases(loanPolicy));

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
@@ -28,7 +28,7 @@ import lombok.With;
 @Getter(AccessLevel.PACKAGE)
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 final class LostItemFeeRefundContext {
-  private final ItemStatus itemStatus;
+  private final ItemStatus initialItemStatus;
   private final String itemId;
   private final String staffUserId;
   private final String servicePointId;
@@ -57,15 +57,15 @@ final class LostItemFeeRefundContext {
   }
 
   DateTime getItemLostDate() {
-    if (itemStatus == DECLARED_LOST) {
+    if (initialItemStatus == DECLARED_LOST) {
       return loan.getDeclareLostDateTime();
     }
 
-    if (itemStatus == LOST_AND_PAID) {
+    if (initialItemStatus == LOST_AND_PAID) {
       return loan.getDeclareLostDateTime();
     }
 
-    if (itemStatus == AGED_TO_LOST) {
+    if (initialItemStatus == AGED_TO_LOST) {
       return loan.getAgedToLostDateTime();
     }
 
@@ -73,7 +73,7 @@ final class LostItemFeeRefundContext {
   }
 
   boolean shouldRefundFeesForItem() {
-    return itemStatus.isLostNotResolved() || itemStatus == LOST_AND_PAID;
+    return initialItemStatus.isLostNotResolved() || initialItemStatus == LOST_AND_PAID;
   }
 
   boolean hasLoan() {

--- a/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
@@ -1,141 +1,21 @@
 package api.loans.scenarios;
 
-import static api.support.matchers.AccountActionsMatchers.arePaymentRefundActionsCreated;
-import static api.support.matchers.AccountActionsMatchers.areTransferRefundActionsCreated;
-import static api.support.matchers.AccountActionsMatchers.isCancelledItemReturnedActionCreated;
-import static api.support.matchers.AccountMatchers.isClosedCancelledItemReturned;
-import static api.support.matchers.AccountMatchers.isPaidFully;
-import static api.support.matchers.AccountMatchers.isRefundedFully;
-import static api.support.matchers.AccountMatchers.isTransferredFully;
-import static api.support.matchers.LoanAccountActionsMatcher.hasLostItemFeeActions;
-import static api.support.matchers.LoanAccountActionsMatcher.hasLostItemProcessingFeeActions;
-import static api.support.matchers.LoanAccountMatcher.hasLostItemFee;
-import static api.support.matchers.LoanAccountMatcher.hasLostItemProcessingFee;
-import static api.support.matchers.LoanAccountMatcher.hasOverdueFine;
-import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
-import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimePropertyByPath;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.joda.time.DateTime.now;
-
-import org.folio.circulation.support.http.client.IndividualResource;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.junit.Before;
-import org.junit.Test;
 
-import api.support.APITests;
 import api.support.builders.CheckInByBarcodeRequestBuilder;
-import lombok.val;
+import api.support.fixtures.AgeToLostFixture;
 
-/**
- * This test contains just basic expected scenarios.
- * All possible scenarios are covered by {@code api.loans.scenarios.CheckInDeclaredLostItemTest}
- * for {@code Declared lost} items.
- */
-public class CheckInAgedToLostItemTest extends APITests {
-  @Before
-  public void createOwnerAndFeeTypes() {
-    feeFineOwnerFixture.cd1Owner();
-    feeFineTypeFixture.lostItemProcessingFee();
-    feeFineTypeFixture.lostItemFee();
-    feeFineTypeFixture.overdueFine();
-  }
+public class CheckInAgedToLostItemTest extends RefundAgedToLostFeesTestBase {
 
-  @Test
-  public void shouldRefundPartiallyPaidAmountAndCancelRemaining() {
-    final double setCostFee = 10.55;
-    final double processingFee = 12.99;
+  @Override
+  protected void performActionThatRequiresRefund(AgeToLostFixture.AgeToLostResult result,
+    DateTime actionDate) {
 
-    val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
-      .withName("Check in aged to lost loan")
-      .chargeProcessingFeeWhenAgedToLost(processingFee)
-      .withSetCost(setCostFee)
-      .withNoFeeRefundInterval();
+    mockClockManagerToReturnFixedDateTime(actionDate);
 
-    val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
-
-    feeFineAccountFixture.transferLostItemFee(result.getLoanId());
-
-    checkInFixture.checkInByBarcode(result.getItem());
-
-    final IndividualResource loan = result.getLoan();
-    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
-    assertThat(loan, hasLostItemFeeActions(areTransferRefundActionsCreated(setCostFee)));
-
-    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      isCancelledItemReturnedActionCreated(processingFee)));
-
-    assertThatBillingInformationRemoved(loan);
-  }
-
-  @Test
-  public void shouldChargeOverdueFine() {
-    final double processingFee = 12.99;
-
-    val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
-      .withName("Check in aged to lost loan")
-      .chargeProcessingFeeWhenAgedToLost(processingFee)
-      .chargeOverdueFineWhenReturned()
-      .withNoFeeRefundInterval();
-
-    val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
-
-    feeFineAccountFixture.payLostItemProcessingFee(result.getLoanId());
-
-    final DateTime returnDate = now(DateTimeZone.UTC).plusMonths(8);
-    mockClockManagerToReturnFixedDateTime(returnDate);
     checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
-      .on(returnDate)
-      .forItem(result.getItem())
-      .at(servicePointsFixture.cd1()));
-
-    final IndividualResource loan = result.getLoan();
-    assertThat(loan, hasLostItemProcessingFee(isRefundedFully(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      arePaymentRefundActionsCreated(processingFee)));
-
-    assertThat(loan, hasOverdueFine());
-  }
-
-  @Test
-  public void shouldNotRefundFeesWhenReturnedAfterRefundPeriod() {
-    final double setCostFee = 10.55;
-    final double processingFee = 12.99;
-
-    val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
-      .withName("Check in aged to lost loan")
-      .chargeProcessingFeeWhenAgedToLost(processingFee)
-      .withSetCost(setCostFee)
-      .refundFeesWithinMinutes(1);
-
-    val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
-    final IndividualResource loan = loansStorageClient.get(result.getLoan());
-
-    feeFineAccountFixture.transferLostItemFee(result.getLoanId());
-    feeFineAccountFixture.payLostItemProcessingFee(result.getLoanId());
-
-    final DateTime agedToLostDate = getDateTimePropertyByPath(loan.getJson(),
-      "agedToLostDelayedBilling", "agedToLostDate");
-    mockClockManagerToReturnFixedDateTime(agedToLostDate.plusMinutes(2));
-
-    checkInFixture.checkInByBarcode(result.getItem());
-
-    assertThat(loan, hasLostItemFee(isTransferredFully(setCostFee)));
-    assertThat(loan, hasLostItemFeeActions(
-      not(areTransferRefundActionsCreated(setCostFee))));
-
-    assertThat(loan, hasLostItemProcessingFee(isPaidFully(processingFee)));
-    assertThat(loan, hasLostItemProcessingFeeActions(
-      not(arePaymentRefundActionsCreated(processingFee))));
-  }
-
-  private void assertThatBillingInformationRemoved(IndividualResource loan) {
-    assertThat(loansClient.get(loan).getJson().toString(), allOf(
-      hasNoJsonPath("agedToLostDelayedBilling.lostItemHasBeenBilled"),
-      hasNoJsonPath("agedToLostDelayedBilling.dateLostItemShouldBeBilled")
-    ));
+      .on(actionDate)
+      .at(servicePointsFixture.cd1())
+      .forItem(result.getItem()));
   }
 }

--- a/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import api.support.builders.CheckInByBarcodeRequestBuilder;
 import io.vertx.core.json.JsonObject;
 
-public class CheckInDeclaredLostItemTest extends RefundLostItemFeesTestBase {
+public class CheckInDeclaredLostItemTest extends RefundDeclaredLostFeesTestBase {
   @Override
   protected void performActionThatRequiresRefund() {
     checkInFixture.checkInByBarcode(item);

--- a/src/test/java/api/loans/scenarios/OverrideRenewAgedToLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/OverrideRenewAgedToLostItemTest.java
@@ -1,0 +1,22 @@
+package api.loans.scenarios;
+
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import api.support.fixtures.AgeToLostFixture;
+import api.support.fixtures.OverrideRenewalFixture;
+
+public class OverrideRenewAgedToLostItemTest extends RefundAgedToLostFeesTestBase {
+  @Autowired
+  private OverrideRenewalFixture overrideRenewalFixture;
+
+  @Override
+  protected void performActionThatRequiresRefund(AgeToLostFixture.AgeToLostResult result,
+     DateTime actionDate) {
+
+    mockClockManagerToReturnFixedDateTime(actionDate);
+
+    overrideRenewalFixture.overrideRenewalByBarcode(result.getLoan(),
+      servicePointsFixture.cd1().getId());
+  }
+}

--- a/src/test/java/api/loans/scenarios/OverrideRenewDeclaredLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/OverrideRenewDeclaredLostItemTest.java
@@ -15,7 +15,7 @@ import api.support.spring.TestSpringConfiguration;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = TestSpringConfiguration.class)
-public class OverrideRenewDeclaredLostItemTest extends RefundLostItemFeesTestBase {
+public class OverrideRenewDeclaredLostItemTest extends RefundDeclaredLostFeesTestBase {
   @Autowired
   private OverrideRenewalFixture overrideRenewalFixture;
 

--- a/src/test/java/api/loans/scenarios/RefundAgedToLostFeesTestBase.java
+++ b/src/test/java/api/loans/scenarios/RefundAgedToLostFeesTestBase.java
@@ -1,0 +1,174 @@
+package api.loans.scenarios;
+
+import static api.support.matchers.AccountActionsMatchers.arePaymentRefundActionsCreated;
+import static api.support.matchers.AccountActionsMatchers.areTransferRefundActionsCreated;
+import static api.support.matchers.AccountActionsMatchers.isCancelledItemReturnedActionCreated;
+import static api.support.matchers.AccountMatchers.isClosedCancelledItemReturned;
+import static api.support.matchers.AccountMatchers.isOpen;
+import static api.support.matchers.AccountMatchers.isPaidFully;
+import static api.support.matchers.AccountMatchers.isRefundedFully;
+import static api.support.matchers.AccountMatchers.isTransferredFully;
+import static api.support.matchers.LoanAccountActionsMatcher.hasLostItemFeeActions;
+import static api.support.matchers.LoanAccountActionsMatcher.hasLostItemProcessingFeeActions;
+import static api.support.matchers.LoanAccountMatcher.hasLostItemFee;
+import static api.support.matchers.LoanAccountMatcher.hasLostItemProcessingFee;
+import static api.support.matchers.LoanAccountMatcher.hasOverdueFine;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static org.folio.circulation.support.JsonPropertyFetcher.getDateTimePropertyByPath;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.joda.time.DateTime.now;
+import static org.joda.time.DateTimeZone.UTC;
+
+import org.folio.circulation.support.http.client.IndividualResource;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+
+import api.support.fixtures.AgeToLostFixture;
+import api.support.spring.SpringApiTest;
+import lombok.val;
+
+/**
+ * This test contains just basic expected scenarios.
+ * All possible scenarios are covered by {@code api.loans.scenarios.RefundDeclaredLostFeesTestBase}
+ * for {@code Declared lost} items.
+ */
+public abstract class RefundAgedToLostFeesTestBase extends SpringApiTest {
+  @Before
+  public void createOwnerAndFeeTypes() {
+    feeFineOwnerFixture.cd1Owner();
+    feeFineTypeFixture.lostItemProcessingFee();
+    feeFineTypeFixture.lostItemFee();
+    feeFineTypeFixture.overdueFine();
+  }
+
+  protected abstract void performActionThatRequiresRefund(AgeToLostFixture.AgeToLostResult result,
+    DateTime actionDate);
+
+  @Test
+  public void shouldRefundPartiallyPaidAmountAndCancelRemaining() {
+    final double setCostFee = 10.55;
+    final double processingFee = 12.99;
+
+    val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
+      .withName("shouldRefundPartiallyPaidAmountAndCancelRemaining")
+      .chargeProcessingFeeWhenAgedToLost(processingFee)
+      .withSetCost(setCostFee)
+      .withNoFeeRefundInterval();
+
+    val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
+
+    feeFineAccountFixture.transferLostItemFee(result.getLoanId());
+
+    performActionThatRequiresRefund(result);
+
+    final IndividualResource loan = result.getLoan();
+    assertThat(loan, hasLostItemFee(isRefundedFully(setCostFee)));
+    assertThat(loan, hasLostItemFeeActions(areTransferRefundActionsCreated(setCostFee)));
+
+    assertThat(loan, hasLostItemProcessingFee(isClosedCancelledItemReturned(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      isCancelledItemReturnedActionCreated(processingFee)));
+
+    assertThatBillingInformationRemoved(loan);
+  }
+
+  @Test
+  public void shouldChargeOverdueFine() {
+    final double processingFee = 12.99;
+
+    val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
+      .withName("shouldChargeOverdueFine")
+      .chargeProcessingFeeWhenAgedToLost(processingFee)
+      .chargeOverdueFineWhenReturned()
+      .withNoFeeRefundInterval();
+
+    val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
+
+    feeFineAccountFixture.payLostItemProcessingFee(result.getLoanId());
+
+    performActionThatRequiresRefund(result, now(UTC).plusMonths(8));
+
+    final IndividualResource loan = result.getLoan();
+    assertThat(loan, hasLostItemProcessingFee(isRefundedFully(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      arePaymentRefundActionsCreated(processingFee)));
+
+    assertThat(loan, hasOverdueFine());
+
+    assertThatBillingInformationRemoved(loan);
+  }
+
+  @Test
+  public void shouldNotRefundFeesWhenReturnedAfterRefundPeriod() {
+    final double setCostFee = 10.55;
+    final double processingFee = 12.99;
+    final int feeRefundPeriodMinutes = 1;
+
+    val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
+      .withName("shouldNotRefundFeesWhenReturnedAfterRefundPeriod")
+      .chargeProcessingFeeWhenAgedToLost(processingFee)
+      .withSetCost(setCostFee)
+      .refundFeesWithinMinutes(feeRefundPeriodMinutes);
+
+    val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
+    final IndividualResource loan = loansStorageClient.get(result.getLoan());
+
+    feeFineAccountFixture.transferLostItemFee(result.getLoanId());
+    feeFineAccountFixture.payLostItemProcessingFee(result.getLoanId());
+
+    final DateTime feeRefundDisallowedDate = getDateTimePropertyByPath(loan.getJson(),
+      "agedToLostDelayedBilling", "agedToLostDate")
+      .plusMinutes(feeRefundPeriodMinutes + 1);
+
+    performActionThatRequiresRefund(result, feeRefundDisallowedDate);
+
+    assertThat(loan, hasLostItemFee(isTransferredFully(setCostFee)));
+    assertThat(loan, hasLostItemFeeActions(
+      not(areTransferRefundActionsCreated(setCostFee))));
+
+    assertThat(loan, hasLostItemProcessingFee(isPaidFully(processingFee)));
+    assertThat(loan, hasLostItemProcessingFeeActions(
+      not(arePaymentRefundActionsCreated(processingFee))));
+
+    assertThatBillingInformationRemoved(loan);
+  }
+
+  @Test
+  public void subsequentRunOfChargeFeeProcessNotAssignsFeesWhenItemAlreadyReturned() {
+    final double processingFee = 12.99;
+
+    val policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
+      .withName("subsequentRunOfChargeFeeProcessNotAssignsFeesWhenItemWasRemoved")
+      .chargeProcessingFeeWhenAgedToLost(processingFee)
+      .withNoFeeRefundInterval();
+
+    val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
+
+    feeFineAccountFixture.payLostItemProcessingFee(result.getLoanId());
+
+    performActionThatRequiresRefund(result);
+
+    final IndividualResource loan = result.getLoan();
+    assertThat(loan, hasLostItemProcessingFee(isRefundedFully(processingFee)));
+
+    // Run the charging process again
+    ageToLostFixture.chargeFees();
+
+    // make sure fees are not assigned for the loan again
+    assertThat(loan, not(hasLostItemProcessingFee(isOpen(processingFee))));
+  }
+
+  private void assertThatBillingInformationRemoved(IndividualResource loan) {
+    assertThat(loansStorageClient.get(loan).getJson().toString(), allOf(
+      hasNoJsonPath("agedToLostDelayedBilling.lostItemHasBeenBilled"),
+      hasNoJsonPath("agedToLostDelayedBilling.dateLostItemShouldBeBilled")
+    ));
+  }
+
+  private void performActionThatRequiresRefund(AgeToLostFixture.AgeToLostResult result) {
+    performActionThatRequiresRefund(result, now(UTC));
+  }
+}

--- a/src/test/java/api/loans/scenarios/RefundDeclaredLostFeesTestBase.java
+++ b/src/test/java/api/loans/scenarios/RefundDeclaredLostFeesTestBase.java
@@ -48,7 +48,7 @@ import api.support.builders.CheckInByBarcodeRequestBuilder;
 import api.support.builders.DeclareItemLostRequestBuilder;
 import io.vertx.core.json.JsonObject;
 
-public abstract class RefundLostItemFeesTestBase extends APITests {
+public abstract class RefundDeclaredLostFeesTestBase extends APITests {
   private static final String DATE_ACTION_PROPERTY = "dateAction";
 
   protected final IndividualResource item = itemsFixture.basedUponNod();


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-844 - Aged to lost: Renewal (effect on lost item fees) - SET COST

## Purpose
We need to refund lost item fees, depending on policy configuration, when aged to lost item is renewed through override.

## Approach
* Refactor `OverdueFineCalculatorService` and add lombok annotations.
* Remove loan billing information when it is renewed through override.
* Consolidate age to lost check in and renewal refunding tests into a single class and just override the testable API.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
