### PR TITLE
CIRC-919 Timing of overnight scheduled notices processing

### DIFF
--- a/src/main/java/org/folio/circulation/resources/DueDateNotRealTimeScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/DueDateNotRealTimeScheduledNoticeProcessingResource.java
@@ -15,17 +15,17 @@ import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.notice.schedule.DueDateNotRealTimeScheduledNoticeHandler;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.domain.notice.schedule.ScheduledNoticeGroupDefinition;
-import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.domain.notice.schedule.TriggeringEvent;
+import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.ClockManager;
 import org.folio.circulation.support.CqlSortBy;
 import org.folio.circulation.support.CqlSortClause;
-import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.http.client.PageLimit;
+import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDate;
-import org.joda.time.LocalTime;
 
 import io.vertx.core.http.HttpClient;
 
@@ -47,12 +47,15 @@ public class DueDateNotRealTimeScheduledNoticeProcessingResource extends Schedul
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNoticesToSend(
+    ConfigurationRepository configurationRepository,
     ScheduledNoticesRepository scheduledNoticesRepository, PageLimit pageLimit) {
 
-    DateTime timeLimit = LocalDate.now().toDateTime(LocalTime.MIDNIGHT);
-    return scheduledNoticesRepository.findNotices(timeLimit, false,
-      Collections.singletonList(TriggeringEvent.DUE_DATE),
-      FETCH_NOTICES_SORT_CLAUSE, pageLimit);
+    return configurationRepository.findTimeZoneConfiguration()
+      .thenApply(r -> r.map(tz -> ClockManager.getClockManager().getDateTime()
+        .withZone(tz).withTimeAtStartOfDay()))
+      .thenCompose(r -> r.after(timeLimit -> scheduledNoticesRepository.findNotices(timeLimit,
+        false, Collections.singletonList(TriggeringEvent.DUE_DATE),
+        FETCH_NOTICES_SORT_CLAUSE, pageLimit)));
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/resources/DueDateScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/DueDateScheduledNoticeProcessingResource.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.notice.schedule.DueDateScheduledNoticeHandler;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
+import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.domain.notice.schedule.TriggeringEvent;
 import org.folio.circulation.support.Clients;
@@ -27,6 +28,7 @@ public class DueDateScheduledNoticeProcessingResource extends ScheduledNoticePro
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNoticesToSend(
+    ConfigurationRepository configurationRepository,
     ScheduledNoticesRepository scheduledNoticesRepository, PageLimit pageLimit) {
 
     return scheduledNoticesRepository.findNotices(

--- a/src/main/java/org/folio/circulation/resources/FeeFineScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/FeeFineScheduledNoticeProcessingResource.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.notice.schedule.FeeFineScheduledNoticeHandler;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
+import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.domain.notice.schedule.TriggeringEvent;
 import org.folio.circulation.support.Clients;
@@ -26,6 +27,7 @@ public class FeeFineScheduledNoticeProcessingResource extends ScheduledNoticePro
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNoticesToSend(
+    ConfigurationRepository configurationRepository,
     ScheduledNoticesRepository scheduledNoticesRepository, PageLimit pageLimit) {
 
     return scheduledNoticesRepository.findNotices(

--- a/src/main/java/org/folio/circulation/resources/RequestScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestScheduledNoticeProcessingResource.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.notice.schedule.RequestScheduledNoticeHandler;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
+import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.domain.notice.schedule.TriggeringEvent;
 import org.folio.circulation.support.Clients;
@@ -27,6 +28,7 @@ public class RequestScheduledNoticeProcessingResource extends ScheduledNoticePro
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNoticesToSend(
+    ConfigurationRepository configurationRepository,
     ScheduledNoticesRepository scheduledNoticesRepository, PageLimit pageLimit) {
 
     return scheduledNoticesRepository.findNotices(

--- a/src/main/java/org/folio/circulation/resources/ScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledNoticeProcessingResource.java
@@ -45,8 +45,8 @@ public abstract class ScheduledNoticeProcessingResource extends Resource {
       new ConfigurationRepository(clients);
 
     safelyInitialise(configurationRepository::lookupSchedulerNoticesProcessingLimit)
-      .thenCompose(r -> r.after(limit -> findNoticesToSend(scheduledNoticesRepository,
-        limit)))
+      .thenCompose(r -> r.after(limit -> findNoticesToSend(configurationRepository,
+        scheduledNoticesRepository, limit)))
       .thenCompose(r -> r.after(notices -> handleNotices(clients, notices)))
       .thenApply(r -> r.toFixedValue(NoContentResponse::noContent))
       .exceptionally(CommonFailures::failedDueToServerError)
@@ -54,6 +54,7 @@ public abstract class ScheduledNoticeProcessingResource extends Resource {
   }
 
   protected abstract CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNoticesToSend(
+    ConfigurationRepository configurationRepository,
     ScheduledNoticesRepository scheduledNoticesRepository, PageLimit pageLimit);
 
   protected abstract CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> handleNotices(


### PR DESCRIPTION
Resolves [CIRC-919](https://issues.folio.org/browse/CIRC-919) - overnight scheduled notices are delivered the next day for a tenant in CDT timezone.
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Overnight (non-realtime) notices are supposed to be delivered at midnight, but in our current implementation we only deliver the notices that are scheduled for `before the last UTC midnight` instead of `before the last midnight in tenant's timezone`. At the same time, loans' due dates are set to 23:59:59 **tenant time**, which means that for all tenants west of UTC the notices will be sent at the next UTC midnight (e.g. 7PM of the next day for CDT timezone).

## Approach
Fetch tenant's timezone configuration and use it to determine midnight in tenant's timezone - this point is time is used later for filtering of the scheduled notices we want to deliver.
 
#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
