### PR TITLE
Remove duplicate key in regular expression CIRC-381

### DIFF
--- a/src/main/java/org/folio/circulation/support/SingleRecordFetcher.java
+++ b/src/main/java/org/folio/circulation/support/SingleRecordFetcher.java
@@ -61,7 +61,7 @@ public class SingleRecordFetcher<T> {
 
   public CompletableFuture<Result<T>> fetch(String id) {
     if (log.isInfoEnabled()) {
-      log.info("Fetching {} with ID: {}", sanitizeLogParameter(recordType), sanitizeLogParameter(id));
+      log.info("Fetching {} with ID: {}", recordType, sanitizeLogParameter(id));
     }
 
     requireNonNull(id, format("Cannot fetch single %s with null ID", recordType));

--- a/src/main/java/org/folio/circulation/support/logging/LogMessageSanitizer.java
+++ b/src/main/java/org/folio/circulation/support/logging/LogMessageSanitizer.java
@@ -22,6 +22,6 @@ public class LogMessageSanitizer {
       return null;
     }
 
-    return parameterValue.replaceAll("[\n|\r|\t]", "_");
+    return parameterValue.replaceAll("[\n\r\t]", "_");
   }
 }


### PR DESCRIPTION
## Purpose

The example log sanitisation regular expression provided by Sonar used pipe characters as separators. However these are erroneously interpreted as extra characters in the character class. This pull request removes them.

It also removes a (hopefully) now redundant sanitisation of a parameter that was considered tainted because it was in the same class as a tainted value. Sonar has recently improved its analysis of this and so this workaround should no longer be necessary.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
