### PR TITLE
Stop using deprecated matchers CIRC-381

### DIFF
--- a/src/test/java/api/requests/RequestsAPIRetrievalTests.java
+++ b/src/test/java/api/requests/RequestsAPIRetrievalTests.java
@@ -15,7 +15,7 @@ import static java.util.function.Function.identity;
 import static org.folio.circulation.domain.representations.ItemProperties.CALL_NUMBER_COMPONENTS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
@@ -242,7 +242,7 @@ public class RequestsAPIRetrievalTests extends APITests {
 
     JsonObject representation = requestsFixture.getById(createdRequest.getId()).getJson();
 
-    assertThat(representation.getString("id"), is(not(isEmptyString())));
+    assertThat(representation.getString("id"), is(not(emptyString())));
     assertThat(representation.getString("requestType"), is("Recall"));
     assertThat(representation.getString("fulfilmentPreference"), is("Delivery"));
     assertThat(representation.getString("deliveryAddressTypeId"), is(workAddressType.getId()));
@@ -395,7 +395,7 @@ public class RequestsAPIRetrievalTests extends APITests {
 
     JsonObject representation = allRequests.getFirst();
 
-    assertThat(representation.getString("id"), is(not(isEmptyString())));
+    assertThat(representation.getString("id"), is(not(emptyString())));
     assertThat(representation.getString("requestType"), is("Recall"));
     assertThat(representation.getString("fulfilmentPreference"), is("Delivery"));
     assertThat(representation.getString("deliveryAddressTypeId"), is(workAddressType.getId()));

--- a/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
+++ b/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
@@ -14,7 +14,7 @@ import static org.folio.HttpStatus.HTTP_OK;
 import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfTheDay;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.emptyOrNullString;
 
 import java.lang.reflect.Method;
 import java.time.Clock;
@@ -327,7 +327,7 @@ public class HoldShelfExpirationDateTests extends APITests{
       storedSecondCheckInRequest.getString("status"), is(OPEN_IN_TRANSIT));
 
     assertThat("request hold shelf expiration date is not set",
-      storedSecondCheckInRequest.getString("holdShelfExpirationDate"), isEmptyOrNullString());
+      storedSecondCheckInRequest.getString("holdShelfExpirationDate"), is(emptyOrNullString()));
   }
 
   @Test
@@ -401,7 +401,7 @@ public class HoldShelfExpirationDateTests extends APITests{
       storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
 
     assertThat("request hold shelf expiration date is not set",
-      storedRequest.getString("holdShelfExpirationDate"), isEmptyOrNullString());
+      storedRequest.getString("holdShelfExpirationDate"), is(emptyOrNullString()));
   }
 
   @Test
@@ -439,7 +439,7 @@ public class HoldShelfExpirationDateTests extends APITests{
       storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
 
     assertThat("request hold shelf expiration date is not set",
-      storedRequest.getString("holdShelfExpirationDate"), isEmptyOrNullString());
+      storedRequest.getString("holdShelfExpirationDate"), is(emptyOrNullString()));
   }
 
   @Test
@@ -474,7 +474,7 @@ public class HoldShelfExpirationDateTests extends APITests{
       storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
 
     assertThat("request hold shelf expiration date is not set",
-      storedRequest.getString("holdShelfExpirationDate"), isEmptyOrNullString());
+      storedRequest.getString("holdShelfExpirationDate"), is(emptyOrNullString()));
 
     checkInFixture.checkInByBarcode(
         new CheckInByBarcodeRequestBuilder()
@@ -492,6 +492,6 @@ public class HoldShelfExpirationDateTests extends APITests{
       storedRequest.getString("status"), is(OPEN_IN_TRANSIT));
 
     assertThat("request hold shelf expiration date is not set",
-      storedRequest.getString("holdShelfExpirationDate"), isEmptyOrNullString());
+      storedRequest.getString("holdShelfExpirationDate"), is(emptyOrNullString()));
   }
 }

--- a/src/test/java/org/folio/circulation/support/http/client/VertxWebClientOkapiHttpClientTests.java
+++ b/src/test/java/org/folio/circulation/support/http/client/VertxWebClientOkapiHttpClientTests.java
@@ -23,7 +23,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.emptyOrNullString;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -32,9 +32,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.VertxAssistant;
+import org.folio.circulation.support.results.Result;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -162,7 +162,7 @@ public class VertxWebClientOkapiHttpClientTests {
     final Response response = postCompleted.get(2, SECONDS).value();
 
     assertThat(response, hasStatus(HTTP_NO_CONTENT));
-    assertThat(response.getBody(), isEmptyOrNullString());
+    assertThat(response.getBody(), is(emptyOrNullString()));
   }
 
   @Test


### PR DESCRIPTION
## Purpose

Stop the compiler warnings caused by using deprecated Hamcrest matchers

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
