### PR TITLE
CIRC-927: Use agedToLostDate as base for calculating billing date.

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
@@ -155,10 +155,8 @@ public class LostItemPolicy extends Policy {
     return agedToLostAfterOverdueInterval.hasPassedSinceDateTillNow(loanDueDate);
   }
 
-  public DateTime calculateDateTimeWhenPatronBilledForAgedToLost(DateTime loanDueDate) {
-    // dueDate + age to lost after interval + patron billed after aged to lost interval
-    return loanDueDate
-      .plus(agedToLostAfterOverdueInterval.timePeriod())
+  public DateTime calculateDateTimeWhenPatronBilledForAgedToLost(DateTime ageToLostDate) {
+    return ageToLostDate
       .plus(patronBilledAfterAgedToLostInterval.timePeriod());
   }
 

--- a/src/main/java/org/folio/circulation/services/agedtolost/MarkOverdueLoansAsAgedLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/MarkOverdueLoansAsAgedLostService.java
@@ -64,12 +64,13 @@ public class MarkOverdueLoansAsAgedLostService {
 
   private Loan ageItemToLost(Loan loan) {
     final LostItemPolicy lostItemPolicy = loan.getLostItemPolicy();
-    final DateTime loanDueDate = loan.getDueDate();
+    final DateTime ageToLostDate = getClockManager().getDateTime();
+
     final DateTime whenToBill = lostItemPolicy
-      .calculateDateTimeWhenPatronBilledForAgedToLost(loanDueDate);
+      .calculateDateTimeWhenPatronBilledForAgedToLost(ageToLostDate);
 
     loan.setAgedToLostDelayedBilling(false, whenToBill);
-    return loan.ageOverdueItemToLost(getClockManager().getDateTime());
+    return loan.ageOverdueItemToLost(ageToLostDate);
   }
 
   private CompletableFuture<Result<Void>> updateLoansAndItemsInStorage(

--- a/src/test/java/api/support/fixtures/AgeToLostFixture.java
+++ b/src/test/java/api/support/fixtures/AgeToLostFixture.java
@@ -142,8 +142,8 @@ public final class AgeToLostFixture {
     moveTimeForward(8);
   }
 
-  private void moveTimeForward(int months) {
-    final DateTime newDateTime = now().plusMonths(months);
+  private void moveTimeForward(int weeks) {
+    final DateTime newDateTime = now().plusWeeks(weeks);
     final Clock fixedClocks = fixed(ofEpochMilli(newDateTime.getMillis()), ZoneOffset.UTC);
 
     getClockManager().setClock(fixedClocks);

--- a/src/test/java/api/support/fixtures/AgeToLostFixture.java
+++ b/src/test/java/api/support/fixtures/AgeToLostFixture.java
@@ -18,6 +18,7 @@ import java.util.function.UnaryOperator;
 
 import api.support.http.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
+import org.joda.time.DateTime;
 
 import api.support.builders.HoldingBuilder;
 import api.support.builders.ItemBuilder;
@@ -73,8 +74,6 @@ public final class AgeToLostFixture {
 
     assertThat(ageToLostResult.getItem().getJson(), isAgedToLost());
 
-    getClockManager().setDefaultClock();
-
     return ageToLostResult;
   }
 
@@ -101,7 +100,7 @@ public final class AgeToLostFixture {
   }
 
   public void ageToLost() {
-    moveTimeForwardSixMonths();
+    moveTimeForwardForAgeToLost();
 
     timedTaskClient.start(scheduledAgeToLostUrl(), 204, "scheduled-age-to-lost");
 
@@ -109,7 +108,7 @@ public final class AgeToLostFixture {
   }
 
   public void chargeFees() {
-    moveTimeForwardSixMonths();
+    moveTimeForwardForChargeFee();
 
     timedTaskClient.start(scheduledAgeToLostFeeChargingUrl(), 204,
       "scheduled-age-to-lost-fee-charging");
@@ -125,7 +124,7 @@ public final class AgeToLostFixture {
   public Response ageToLostAndAttemptChargeFees() {
     ageToLost();
 
-    moveTimeForwardSixMonths();
+    moveTimeForwardForChargeFee();
 
     final Response response = timedTaskClient.attemptRun(scheduledAgeToLostFeeChargingUrl(),
       "scheduled-age-to-lost-fee-charging");
@@ -135,9 +134,17 @@ public final class AgeToLostFixture {
     return response;
   }
 
-  private void moveTimeForwardSixMonths() {
-    final Clock fixedClocks = fixed(ofEpochMilli(now().plusMonths(6).getMillis()),
-      ZoneOffset.UTC);
+  private void moveTimeForwardForAgeToLost() {
+    moveTimeForward(6);
+  }
+
+  private void moveTimeForwardForChargeFee() {
+    moveTimeForward(8);
+  }
+
+  private void moveTimeForward(int months) {
+    final DateTime newDateTime = now().plusMonths(months);
+    final Clock fixedClocks = fixed(ofEpochMilli(newDateTime.getMillis()), ZoneOffset.UTC);
 
     getClockManager().setClock(fixedClocks);
   }

--- a/src/test/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicyTest.java
@@ -176,45 +176,39 @@ public class LostItemPolicyTest {
   public void canCalculateBillingDateWhenPatronIsBilledImmediately(
     @Nullable String interval, @Nullable Integer duration) {
 
-    final Period ageToLostAfterPeriod = Period.weeks(6);
     final Period billPatronInterval = duration == null && interval == null
       ? null : Period.from(duration, interval);
 
-    final DateTime loanDueDate = DateTime.now();
-    final DateTime expectedBillingDate = loanDueDate.plus(ageToLostAfterPeriod.timePeriod());
+    final DateTime agedToLostDate = DateTime.now();
 
     final LostItemPolicy lostItemPolicy = LostItemPolicy.from(
       new LostItemFeePolicyBuilder()
         .withPatronBilledAfterAgedLost(billPatronInterval)
-        .withItemAgedToLostAfterOverdue(ageToLostAfterPeriod)
         .withSetCost(10.0)
         .doNotChargeProcessingFeeWhenAgedToLost()
         .create());
 
     final DateTime actualBillingDate = lostItemPolicy
-      .calculateDateTimeWhenPatronBilledForAgedToLost(loanDueDate);
+      .calculateDateTimeWhenPatronBilledForAgedToLost(agedToLostDate);
 
-    assertThat(actualBillingDate, is(expectedBillingDate));
+    assertThat(actualBillingDate, is(agedToLostDate));
   }
 
   @Test
   public void canCalculateBillingDateWhenPatronBillingIsDelayed() {
-    final Period ageToLostAfterPeriod = Period.weeks(6);
     final Period billPatronAfterPeriod = Period.weeks(1);
-    final DateTime loanDueDate = DateTime.now();
-    final DateTime expectedBillingDate = loanDueDate.plus(ageToLostAfterPeriod.timePeriod())
-      .plus(billPatronAfterPeriod.timePeriod());
+    final DateTime ageToLostDate = DateTime.now();
+    final DateTime expectedBillingDate = ageToLostDate.plus(billPatronAfterPeriod.timePeriod());
 
     final LostItemPolicy lostItemPolicy = LostItemPolicy.from(
       new LostItemFeePolicyBuilder()
         .withPatronBilledAfterAgedLost(billPatronAfterPeriod)
-        .withItemAgedToLostAfterOverdue(ageToLostAfterPeriod)
         .withSetCost(10.0)
         .doNotChargeProcessingFeeWhenAgedToLost()
         .create());
 
     final DateTime actualBillingDate = lostItemPolicy
-      .calculateDateTimeWhenPatronBilledForAgedToLost(loanDueDate);
+      .calculateDateTimeWhenPatronBilledForAgedToLost(ageToLostDate);
 
     assertThat(actualBillingDate, is(expectedBillingDate));
   }


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-927 - Aged to lost billed date should be based on when item was aged to lost

## Purpose
Calculate `dateLostItemShouldBeBilled` as `agedToLostDate` + `patronBilledAfterAgedToLost`. 

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
