### PR TITLE
CIRC-934: Allow refund for `Lost and paid` items that was `Aged to lost` before

### DIFF
--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
@@ -96,10 +96,10 @@ public class LostItemFeeRefundService {
             return noLoanFoundForLostItem(context.getItemId());
           }
 
-          if (loan.getDeclareLostDateTime() == null) {
-            log.error("The last loan [{}] for lost item [{}] is not declared lost",
+          if (loan.getLostDate() == null) {
+            log.error("The last loan [{}] for lost item [{}] is neither aged to lost not declared lost",
               loan.getId(), context.getItemId());
-            return lastLoanForLostItemIsNotDeclaredLost(loan);
+            return lastLoanForLostItemIsNotLost(loan);
           }
 
           log.info("Loan [{}] retrieved for lost item [{}]", loan.getId(), context.getItemId());
@@ -129,14 +129,15 @@ public class LostItemFeeRefundService {
       LostItemFeeRefundContext::withLostItemPolicy);
   }
 
-  private Result<LostItemFeeRefundContext> lastLoanForLostItemIsNotDeclaredLost(Loan loan) {
+  private Result<LostItemFeeRefundContext> lastLoanForLostItemIsNotLost(Loan loan) {
     return failed(singleValidationError(
-      "Last loan for lost item is not declared lost", "loanId", loan.getId()));
+      "Last loan for lost item is neither aged to lost nor declared lost",
+      "loanId", loan.getId()));
   }
 
   private Result<LostItemFeeRefundContext> noLoanFoundForLostItem(String itemId) {
     return failed(singleValidationError(
-      "Item is lost however there is no declared lost loan found",
+      "Item is lost however there is no aged to lost nor declared lost loan found",
       "itemId", itemId));
   }
 }

--- a/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
@@ -1,6 +1,13 @@
 package api.loans.scenarios;
 
+import static api.support.matchers.AccountMatchers.isRefundedFully;
+import static api.support.matchers.ItemMatchers.isLostAndPaid;
+import static api.support.matchers.LoanAccountMatcher.hasLostItemFee;
+import static api.support.matchers.LoanAccountMatcher.hasLostItemProcessingFee;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.joda.time.DateTime;
+import org.junit.Test;
 
 import api.support.builders.CheckInByBarcodeRequestBuilder;
 import api.support.fixtures.AgeToLostFixture;
@@ -16,5 +23,30 @@ public class CheckInAgedToLostItemTest extends RefundAgedToLostFeesTestBase {
       .on(actionDate)
       .at(servicePointsFixture.cd1())
       .forItem(result.getItem()));
+  }
+
+  @Test
+  public void canRefundFeesForLostAndPaidItemsThatWasAgedToLost() {
+    final double processingFee = 12.99;
+    final double itemFee = 12.99;
+
+    final var policy = lostItemFeePoliciesFixture.ageToLostAfterOneMinutePolicy()
+      .withName("canRefundFeesForLostAndPaidItemsThatWasAgedToLost")
+      .chargeProcessingFeeWhenAgedToLost(processingFee)
+      .withSetCost(itemFee)
+      .withNoFeeRefundInterval();
+
+    final var result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
+
+    feeFineAccountFixture.payLostItemFee(result.getLoanId());
+    feeFineAccountFixture.payLostItemProcessingFee(result.getLoanId());
+    eventSubscribersFixture.publishLoanRelatedFeeFineClosedEvent(result.getLoanId());
+
+    assertThat(itemsClient.get(result.getItem()).getJson(), isLostAndPaid());
+
+    checkInFixture.checkInByBarcode(result.getItem());
+
+    assertThat(result.getLoan(), hasLostItemFee(isRefundedFully(itemFee)));
+    assertThat(result.getLoan(), hasLostItemProcessingFee(isRefundedFully(processingFee)));
   }
 }

--- a/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInAgedToLostItemTest.java
@@ -26,7 +26,7 @@ public class CheckInAgedToLostItemTest extends RefundAgedToLostFeesTestBase {
   }
 
   @Test
-  public void canRefundFeesForLostAndPaidItemsThatWasAgedToLost() {
+  public void shouldRefundFeesForLostAndPaidItemsThatWasAgedToLost() {
     final double processingFee = 12.99;
     final double itemFee = 12.99;
 

--- a/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
@@ -80,7 +80,7 @@ public class CheckInDeclaredLostItemTest extends RefundDeclaredLostFeesTestBase 
         .forItem(item));
 
     assertThat(checkInResponse.getJson(), hasErrorWith(allOf(
-      hasMessage("Item is lost however there is no declared lost loan found"),
+      hasMessage("Item is lost however there is no aged to lost nor declared lost loan found"),
       hasParameter("itemId", item.getId().toString()))));
   }
 
@@ -100,7 +100,7 @@ public class CheckInDeclaredLostItemTest extends RefundDeclaredLostFeesTestBase 
         .forItem(item));
 
     assertThat(checkInResponse.getJson(), hasErrorWith(allOf(
-      hasMessage("Last loan for lost item is not declared lost"),
+      hasMessage("Last loan for lost item is neither aged to lost nor declared lost"),
       hasParameter("loanId", loan.getId().toString()))));
   }
 

--- a/src/test/java/org/folio/circulation/domain/LoanLostDateTest.java
+++ b/src/test/java/org/folio/circulation/domain/LoanLostDateTest.java
@@ -1,0 +1,85 @@
+package org.folio.circulation.domain;
+
+import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
+import static org.hamcrest.Matchers.allOf;
+import static org.joda.time.DateTime.now;
+import static org.joda.time.DateTimeZone.UTC;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import api.support.builders.LoanBuilder;
+
+public class LoanLostDateTest {
+  @Test
+  public void declaredLostDateReturnedWhenSet() {
+    final var declaredLostDate = now(UTC);
+    final var loan = new LoanBuilder().asDomainObject()
+      .declareItemLost("Lost", declaredLostDate);
+
+    assertTrue(declaredLostDate.isEqual(loan.getLostDate()));
+  }
+
+  @Test
+  public void agedToLostDateReturnedWhenSet() {
+    final var agedToLostDate = now(UTC);
+    final var loan = new LoanBuilder().asDomainObject()
+      .ageOverdueItemToLost(agedToLostDate);
+
+    assertTrue(agedToLostDate.isEqual(loan.getLostDate()));
+  }
+
+  @Test
+  public void declaredLostDateReturnedWhenIsAfterAgedToLostDate() {
+    final var agedToLostDate = now(UTC).minusDays(2);
+    final var declaredLostDate = now(UTC);
+
+    final var loan = new LoanBuilder().asDomainObject()
+      .ageOverdueItemToLost(agedToLostDate)
+      .declareItemLost("Lost", declaredLostDate);
+
+    assertTrue(declaredLostDate.isEqual(loan.getLostDate()));
+    // make sure properties are not cleared
+    assertThat(loan.asJson(), allOf(
+      hasJsonPath("declaredLostDate", declaredLostDate.toString()),
+      hasJsonPath("agedToLostDelayedBilling.agedToLostDate", agedToLostDate.toString())
+    ));
+  }
+
+  @Test
+  public void agedToLostDateReturnedWhenIsAfterDeclaredLostDate() {
+    final var declaredLostDate = now(UTC).minusDays(3);
+    final var agedToLostDate = now(UTC);
+
+    final var loan = new LoanBuilder().asDomainObject()
+      .ageOverdueItemToLost(agedToLostDate)
+      .declareItemLost("Lost", declaredLostDate);
+
+    assertTrue(agedToLostDate.isEqual(loan.getLostDate()));
+    // make sure properties are not cleared
+    assertThat(loan.asJson(), allOf(
+      hasJsonPath("declaredLostDate", declaredLostDate.toString()),
+      hasJsonPath("agedToLostDelayedBilling.agedToLostDate", agedToLostDate.toString())
+    ));
+  }
+
+  @Test
+  public void lostDateIsNotNullWhenBothLostDatesAreEqual() {
+    final var lostDate = now(UTC);
+
+    final var loan = new LoanBuilder().asDomainObject()
+      .ageOverdueItemToLost(lostDate)
+      .declareItemLost("Lost", lostDate);
+
+    assertTrue(lostDate.isEqual(loan.getLostDate()));
+  }
+
+  @Test
+  public void lostDateIsNullWhenLoanWasNeverLost() {
+    final var loan = new LoanBuilder().asDomainObject();
+
+    assertNull(loan.getLostDate());
+  }
+}


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-934 - 'Lost and paid' aged to lost items that are returned or renewed must have lost item fees refunded as is done with declared lost items

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
