### PR TITLE
CIRC-239 Reduce changes to clients class during circulation rules changes

### DIFF
--- a/src/main/java/org/folio/circulation/resources/AbstractCirculationRulesEngineResource.java
+++ b/src/main/java/org/folio/circulation/resources/AbstractCirculationRulesEngineResource.java
@@ -5,6 +5,8 @@ import static org.folio.circulation.support.results.Result.succeeded;
 
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.folio.circulation.domain.Location;
 import org.folio.circulation.rules.CirculationRuleMatch;
@@ -43,8 +45,6 @@ public abstract class AbstractCirculationRulesEngineResource extends Resource {
 
   private final String applyPath;
   private final String applyAllPath;
-
-
 
   /**
    * Create a circulation rules engine that listens at applyPath and applyAllPath.
@@ -85,30 +85,10 @@ public abstract class AbstractCirculationRulesEngineResource extends Resource {
 
   private void apply(RoutingContext routingContext) {
     HttpServerRequest request = routingContext.request();
-    if (invalidApplyParameters(request)) {
-      return;
-    }
 
-    Clients clients = Clients.create(routingContext, client);
-
-    val droolsFuture = CirculationRulesProcessor.getInstance().getDrools(routingContext, client);
-
-    final WebContext context = new WebContext(routingContext);
-    final CollectionResourceClient locationsStorageClient
-      = clients.locationsStorage();
-    CompletableFuture<Result<Location>> locationFuture = FetchSingleRecord.<Location>forRecord("location")
-      .using(locationsStorageClient)
-      .mapTo(Location::from)
-      .whenNotFound(failed(new ServerErrorFailure("Can`t find location")))
-      .fetch(request.params().get(LOCATION_ID_NAME));
-
-    CompletableFuture<Result<CirculationRuleMatch>> circulationRuleMatchFuture =
-        droolsFuture.thenCombine(locationFuture, (droolsResult, locationResult) ->
-          locationResult.combine(droolsResult, (location,drools) -> getPolicyIdAndRuleMatch(request.params(),drools,location)));
-
-    circulationRuleMatchFuture.thenCompose(r -> r.after(this::buildJsonResult))
-    .thenApply(r -> r.map(JsonHttpResponse::ok))
-    .thenAccept(context::writeResultToHttpResponse);
+    applyRules(routingContext,
+      (location, drools) -> getPolicyIdAndRuleMatch(request.params(), drools, location),
+      this::buildJsonResult);
   }
 
   private CompletableFuture<Result<JsonObject>> buildJsonResult(CirculationRuleMatch entity) {
@@ -125,13 +105,31 @@ public abstract class AbstractCirculationRulesEngineResource extends Resource {
 
   private void applyAll(RoutingContext routingContext) {
     HttpServerRequest request = routingContext.request();
+
+    applyRules(routingContext,
+      (location, drools) -> getPolicies(request.params(), drools, location),
+      this::buildJsonResult);
+  }
+
+  private CompletableFuture<Result<JsonObject>> buildJsonResult(JsonArray matches) {
+    return CompletableFuture.completedFuture(succeeded(new JsonObject().put("circulationRuleMatches",
+      matches)));
+  }
+
+  private <T> void applyRules(RoutingContext routingContext,
+    BiFunction<Location, Drools, T> interpretMatches,
+    Function<T, CompletableFuture<Result<JsonObject>>> mapToJson) {
+
+    val request = routingContext.request();
+
     if (invalidApplyParameters(request)) {
       return;
     }
 
     Clients clients = Clients.create(routingContext, client);
 
-    val droolsFuture = CirculationRulesProcessor.getInstance().getDrools(routingContext, client);
+    val droolsFuture = CirculationRulesProcessor.getInstance().getDrools(
+      routingContext, client);
 
     final WebContext context = new WebContext(routingContext);
     final CollectionResourceClient locationsStorageClient
@@ -142,19 +140,13 @@ public abstract class AbstractCirculationRulesEngineResource extends Resource {
       .whenNotFound(failed(new ServerErrorFailure("Can`t find location")))
       .fetch(request.params().get(LOCATION_ID_NAME));
 
-    CompletableFuture<Result<JsonArray>> circulationRuleMatchFuture =
-        droolsFuture.thenCombine(locationFuture, (droolsResult, locationResult) ->
-          locationResult.combine(droolsResult, (location, drools) -> getPolicies(request.params(),drools,location)));
+    val circulationRuleMatchFuture =
+      droolsFuture.thenCombine(locationFuture, (droolsResult, locationResult) ->
+        locationResult.combine(droolsResult, interpretMatches));
 
-    circulationRuleMatchFuture
-        .thenCompose(r -> r.after(this::buildJsonResult))
-        .thenApply(r -> r.map(JsonHttpResponse::ok))
-        .thenAccept(context::writeResultToHttpResponse);
-  }
-
-  private CompletableFuture<Result<JsonObject>> buildJsonResult(JsonArray matches) {
-    return CompletableFuture.completedFuture(succeeded(new JsonObject().put("circulationRuleMatches",
-      matches)));
+    circulationRuleMatchFuture.thenCompose(r -> r.after(mapToJson))
+      .thenApply(r -> r.map(JsonHttpResponse::ok))
+      .thenAccept(context::writeResultToHttpResponse);
   }
 
   private boolean invalidApplyParameters(HttpServerRequest request) {

--- a/src/main/java/org/folio/circulation/resources/AbstractCirculationRulesEngineResource.java
+++ b/src/main/java/org/folio/circulation/resources/AbstractCirculationRulesEngineResource.java
@@ -27,6 +27,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import lombok.val;
 
 /**
  * The circulation rules engine calculates the loan policy based on
@@ -90,7 +91,7 @@ public abstract class AbstractCirculationRulesEngineResource extends Resource {
 
     Clients clients = Clients.create(routingContext, client);
 
-    CompletableFuture<Result<Drools>> droolsFuture = clients.getCirculationDrools();
+    val droolsFuture = CirculationRulesProcessor.getInstance().getDrools(routingContext, client);
 
     final WebContext context = new WebContext(routingContext);
     final CollectionResourceClient locationsStorageClient
@@ -130,7 +131,7 @@ public abstract class AbstractCirculationRulesEngineResource extends Resource {
 
     Clients clients = Clients.create(routingContext, client);
 
-    CompletableFuture<Result<Drools>> droolsFuture = clients.getCirculationDrools();
+    val droolsFuture = CirculationRulesProcessor.getInstance().getDrools(routingContext, client);
 
     final WebContext context = new WebContext(routingContext);
     final CollectionResourceClient locationsStorageClient
@@ -143,7 +144,7 @@ public abstract class AbstractCirculationRulesEngineResource extends Resource {
 
     CompletableFuture<Result<JsonArray>> circulationRuleMatchFuture =
         droolsFuture.thenCombine(locationFuture, (droolsResult, locationResult) ->
-          locationResult.combine(droolsResult, (location,drools) -> getPolicies(request.params(),drools,location)));
+          locationResult.combine(droolsResult, (location, drools) -> getPolicies(request.params(),drools,location)));
 
     circulationRuleMatchFuture
         .thenCompose(r -> r.after(this::buildJsonResult))

--- a/src/main/java/org/folio/circulation/resources/AbstractCirculationRulesEngineResource.java
+++ b/src/main/java/org/folio/circulation/resources/AbstractCirculationRulesEngineResource.java
@@ -126,9 +126,9 @@ public abstract class AbstractCirculationRulesEngineResource extends Resource {
       return;
     }
 
-    Clients clients = Clients.create(routingContext, client);
-
     final WebContext context = new WebContext(routingContext);
+    Clients clients = Clients.create(context, client);
+
     final CollectionResourceClient locationsStorageClient = clients.locationsStorage();
 
     val droolsFuture = CirculationRulesProcessor.getInstance()

--- a/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
+++ b/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
@@ -55,7 +55,7 @@ public class ChangeDueDateResource extends Resource {
     final ChangeDueDateRequest request, RoutingContext routingContext) {
 
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     final LoanRepository loanRepository = new LoanRepository(clients);
 

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -34,7 +34,7 @@ public class CheckInByBarcodeResource extends Resource {
   private void checkIn(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
 
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     final Result<CheckInByBarcodeRequest> checkInRequestResult
       = CheckInByBarcodeRequest.from(routingContext.getBodyAsJson());

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -83,7 +83,7 @@ public class CheckOutByBarcodeResource extends Resource {
     CheckOutByBarcodeRequest request = CheckOutByBarcodeRequest.fromJson(
       routingContext.getBodyAsJson());
 
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     final UserRepository userRepository = new UserRepository(clients);
     final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);

--- a/src/main/java/org/folio/circulation/resources/CirculationRulesProcessor.java
+++ b/src/main/java/org/folio/circulation/resources/CirculationRulesProcessor.java
@@ -24,6 +24,7 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import lombok.val;
 
 public class CirculationRulesProcessor {
   protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -184,10 +185,14 @@ public class CirculationRulesProcessor {
   public CompletableFuture<Result<Drools>> getDrools(RoutingContext routingContext,
     HttpClient client) {
 
-    String tenantId = new WebContext(routingContext).getTenantId();
+    val clients = Clients.create(routingContext, client);
+    val webContext = new WebContext(routingContext);
 
-    final Clients clients = Clients.create(routingContext, client);
-    CollectionResourceClient circulationRulesClient = clients.circulationRulesStorage();
+    return getDrools(webContext.getTenantId(), clients.circulationRulesStorage());
+  }
+
+  public CompletableFuture<Result<Drools>> getDrools(String tenantId,
+    CollectionResourceClient circulationRulesClient) {
 
     CompletableFuture<Result<Drools>> cfDrools = new CompletableFuture<>();
 

--- a/src/main/java/org/folio/circulation/resources/CirculationRulesProcessor.java
+++ b/src/main/java/org/folio/circulation/resources/CirculationRulesProcessor.java
@@ -12,19 +12,14 @@ import org.folio.circulation.domain.Location;
 import org.folio.circulation.rules.CirculationRuleMatch;
 import org.folio.circulation.rules.Drools;
 import org.folio.circulation.rules.Text2Drools;
-import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
-import org.folio.circulation.support.http.server.WebContext;
 import org.folio.circulation.support.results.Result;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.RoutingContext;
-import lombok.val;
 
 public class CirculationRulesProcessor {
   protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -180,15 +175,6 @@ public class CirculationRulesProcessor {
 
   public static JsonArray getRequestPolicies(Drools drools, MultiMap params, Location location) {
     return drools.requestPolicies(params, location);
-  }
-
-  public CompletableFuture<Result<Drools>> getDrools(RoutingContext routingContext,
-    HttpClient client) {
-
-    val clients = Clients.create(routingContext, client);
-    val webContext = new WebContext(routingContext);
-
-    return getDrools(webContext.getTenantId(), clients.circulationRulesStorage());
   }
 
   public CompletableFuture<Result<Drools>> getDrools(String tenantId,

--- a/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
+++ b/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
@@ -79,7 +79,7 @@ public class CirculationRulesResource extends Resource {
 
   private void get(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
     CollectionResourceClient circulationRulesClient = clients.circulationRulesStorage();
 
     log.debug("get(RoutingContext) client={}", circulationRulesClient);
@@ -111,7 +111,7 @@ public class CirculationRulesResource extends Resource {
   //Cannot combine exception catching as cannot resolve overloaded method for error
   @SuppressWarnings("squid:S2147")
   private void put(RoutingContext routingContext) {
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(new WebContext(routingContext), client);
     CollectionResourceClient loansRulesClient = clients.circulationRulesStorage();
 
     if (loansRulesClient == null) {

--- a/src/main/java/org/folio/circulation/resources/ClaimItemReturnedResource.java
+++ b/src/main/java/org/folio/circulation/resources/ClaimItemReturnedResource.java
@@ -47,7 +47,7 @@ public class ClaimItemReturnedResource extends Resource {
   private CompletableFuture<Result<Loan>> processClaimItemReturned(
     RoutingContext routingContext, ClaimItemReturnedRequest request) {
 
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(new WebContext(routingContext), client);
     final ChangeItemStatusService changeItemStatusService =
       new ChangeItemStatusService(clients);
 

--- a/src/main/java/org/folio/circulation/resources/DeclareClaimedReturnedItemAsMissingResource.java
+++ b/src/main/java/org/folio/circulation/resources/DeclareClaimedReturnedItemAsMissingResource.java
@@ -47,7 +47,7 @@ public class DeclareClaimedReturnedItemAsMissingResource extends Resource {
   private CompletableFuture<Result<Loan>> processDeclareClaimedReturnedItemAsMissing(
     RoutingContext routingContext, ChangeItemStatusRequest request) {
 
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(new WebContext(routingContext), client);
     final ChangeItemStatusService changeItemStatusService = new ChangeItemStatusService(clients);
 
     return changeItemStatusService.getOpenLoan(request)

--- a/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
+++ b/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
@@ -43,7 +43,7 @@ public class DeclareLostResource extends Resource {
   private void declareLost(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
 
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
     final EventPublisher eventPublisher = new EventPublisher(routingContext);
 
     validateDeclaredLostRequest(routingContext)

--- a/src/main/java/org/folio/circulation/resources/EndPatronActionSessionResource.java
+++ b/src/main/java/org/folio/circulation/resources/EndPatronActionSessionResource.java
@@ -30,7 +30,7 @@ public class EndPatronActionSessionResource extends Resource {
 
   private void process(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
-    Clients clients = Clients.create(routingContext, client);
+    Clients clients = Clients.create(context, client);
 
     PatronActionSessionService patronActionSessionService =
       PatronActionSessionService.using(clients);

--- a/src/main/java/org/folio/circulation/resources/ExpiredSessionProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ExpiredSessionProcessingResource.java
@@ -41,7 +41,7 @@ public class ExpiredSessionProcessingResource extends Resource {
 
   private void process(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     final ConfigurationRepository configurationRepository
       = new ConfigurationRepository(clients);

--- a/src/main/java/org/folio/circulation/resources/ItemsInTransitResource.java
+++ b/src/main/java/org/folio/circulation/resources/ItemsInTransitResource.java
@@ -67,7 +67,7 @@ public class ItemsInTransitResource extends Resource {
 
   private void getMany(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     final GetManyRecordsClient loansStorageClient = clients.loansStorage();
     final GetManyRecordsClient requestsStorageClient = clients.requestsStorage();

--- a/src/main/java/org/folio/circulation/resources/LoanAnonymizationResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanAnonymizationResource.java
@@ -27,7 +27,7 @@ public class LoanAnonymizationResource extends Resource {
 
   private void anonymizeLoans(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     String borrowerId = routingContext.request().getParam("userId");
 

--- a/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
@@ -61,7 +61,7 @@ public class LoanCollectionResource extends CollectionResource {
 
     final Loan loan = Loan.from(incomingRepresentation);
 
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     final ItemRepository itemRepository = new ItemRepository(clients, true, true, false);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
@@ -133,7 +133,7 @@ public class LoanCollectionResource extends CollectionResource {
 
     final Loan loan = Loan.from(incomingRepresentation);
 
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
     final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
@@ -191,7 +191,7 @@ public class LoanCollectionResource extends CollectionResource {
   @Override
   void get(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     final LoanRepository loanRepository = new LoanRepository(clients);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
@@ -221,7 +221,7 @@ public class LoanCollectionResource extends CollectionResource {
   @Override
   void delete(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
-    Clients clients = Clients.create(routingContext, client);
+    Clients clients = Clients.create(context, client);
 
     String id = routingContext.request().getParam("id");
 
@@ -233,7 +233,7 @@ public class LoanCollectionResource extends CollectionResource {
   @Override
   void getMany(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
-    Clients clients = Clients.create(routingContext, client);
+    Clients clients = Clients.create(context, client);
 
     final LoanRepository loanRepository = new LoanRepository(clients);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
@@ -269,7 +269,7 @@ public class LoanCollectionResource extends CollectionResource {
   @Override
   void empty(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
-    Clients clients = Clients.create(routingContext, client);
+    Clients clients = Clients.create(context, client);
 
     clients.loansStorage().delete()
       .thenApply(r -> r.toFixedValue(NoContentResponse::noContent))

--- a/src/main/java/org/folio/circulation/resources/PickSlipsResource.java
+++ b/src/main/java/org/folio/circulation/resources/PickSlipsResource.java
@@ -77,7 +77,7 @@ public class PickSlipsResource extends Resource {
 
   private void getMany(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     final UserRepository userRepository = new UserRepository(clients);
     final AddressTypeRepository addressTypeRepository = new AddressTypeRepository(clients);

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -98,7 +98,7 @@ public class RequestByInstanceIdResource extends Resource {
 
   private void createInstanceLevelRequests(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
     final ItemByInstanceIdFinder finder = new ItemByInstanceIdFinder(clients.holdingsStorage(), itemRepository);

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -64,7 +64,7 @@ public class RequestCollectionResource extends CollectionResource {
 
     JsonObject representation = routingContext.getBodyAsJson();
 
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
     final EventPublisher eventPublisher = new EventPublisher(routingContext);
 
     final UserRepository userRepository = new UserRepository(clients);
@@ -121,7 +121,7 @@ public class RequestCollectionResource extends CollectionResource {
     write(representation, "id", getRequestId(routingContext));
 
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     final RequestRepository requestRepository = RequestRepository.using(clients);
     final UpdateRequestQueue updateRequestQueue = UpdateRequestQueue.using(clients);
@@ -185,7 +185,7 @@ public class RequestCollectionResource extends CollectionResource {
   @Override
   void get(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
-    Clients clients = Clients.create(routingContext, client);
+    Clients clients = Clients.create(context, client);
 
     final RequestRepository requestRepository = RequestRepository.using(clients);
 
@@ -200,7 +200,7 @@ public class RequestCollectionResource extends CollectionResource {
   @Override
   void delete(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
-    Clients clients = Clients.create(routingContext, client);
+    Clients clients = Clients.create(context, client);
 
     String id = getRequestId(routingContext);
 
@@ -223,7 +223,7 @@ public class RequestCollectionResource extends CollectionResource {
   @Override
   void getMany(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
-    Clients clients = Clients.create(routingContext, client);
+    Clients clients = Clients.create(context, client);
 
     final RequestRepository requestRepository = RequestRepository.using(clients);
     final RequestRepresentation requestRepresentation = new RequestRepresentation();
@@ -238,7 +238,7 @@ public class RequestCollectionResource extends CollectionResource {
   @Override
   void empty(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
-    Clients clients = Clients.create(routingContext, client);
+    Clients clients = Clients.create(context, client);
 
     clients.requestsStorage().delete()
       .thenApply(r -> r.toFixedValue(NoContentResponse::noContent))
@@ -247,7 +247,7 @@ public class RequestCollectionResource extends CollectionResource {
 
   void move(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
-    Clients clients = Clients.create(routingContext, client);
+    Clients clients = Clients.create(context, client);
 
     JsonObject representation = routingContext.getBodyAsJson();
 

--- a/src/main/java/org/folio/circulation/resources/RequestHoldShelfClearanceResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestHoldShelfClearanceResource.java
@@ -81,7 +81,7 @@ public class RequestHoldShelfClearanceResource extends Resource {
 
   private void getMany(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     final ItemRepository itemRepository = new ItemRepository(clients, false, false, false);
     final GetManyRecordsClient requestsStorage = clients.requestsStorage();

--- a/src/main/java/org/folio/circulation/resources/RequestQueueResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestQueueResource.java
@@ -44,7 +44,7 @@ public class RequestQueueResource extends Resource {
 
   private void getMany(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
-    Clients clients = Clients.create(routingContext, client);
+    Clients clients = Clients.create(context, client);
 
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
     final RequestRepresentation requestRepresentation = new RequestRepresentation();
@@ -66,7 +66,7 @@ public class RequestQueueResource extends Resource {
       routingContext.getBodyAsJson().mapTo(ReorderQueueRequest.class));
 
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
     final RequestRepository requestRepository = RequestRepository.using(clients);
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
 

--- a/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
@@ -34,7 +34,7 @@ public class ScheduledAnonymizationProcessingResource extends Resource {
 
   private void scheduledAnonymizeLoans(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
     LoanAnonymization loanAnonymization = new LoanAnonymization(clients);

--- a/src/main/java/org/folio/circulation/resources/ScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledNoticeProcessingResource.java
@@ -37,7 +37,7 @@ public abstract class ScheduledNoticeProcessingResource extends Resource {
 
   private void process(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(context, client);
 
     final ScheduledNoticesRepository scheduledNoticesRepository =
       ScheduledNoticesRepository.using(clients);

--- a/src/main/java/org/folio/circulation/resources/agedtolost/ScheduledAgeToLostFeeChargingResource.java
+++ b/src/main/java/org/folio/circulation/resources/agedtolost/ScheduledAgeToLostFeeChargingResource.java
@@ -26,7 +26,7 @@ public class ScheduledAgeToLostFeeChargingResource extends Resource {
   private void scheduledAgeToLostFeeCharging(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
     final ChargeLostFeesWhenAgedToLostService chargingService =
-      new ChargeLostFeesWhenAgedToLostService(create(routingContext, client));
+      new ChargeLostFeesWhenAgedToLostService(create(context, client));
 
     chargingService.chargeFees()
       .thenApply(r -> r.toFixedValue(NoContentResponse::noContent))

--- a/src/main/java/org/folio/circulation/resources/agedtolost/ScheduledAgeToLostResource.java
+++ b/src/main/java/org/folio/circulation/resources/agedtolost/ScheduledAgeToLostResource.java
@@ -26,7 +26,7 @@ public class ScheduledAgeToLostResource extends Resource {
   private void scheduledAgeToLost(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
     final MarkOverdueLoansAsAgedLostService ageToLostService =
-      new MarkOverdueLoansAsAgedLostService(create(routingContext, client));
+      new MarkOverdueLoansAsAgedLostService(create(context, client));
 
     ageToLostService.processAgeToLost()
       .thenApply(r -> r.toFixedValue(NoContentResponse::noContent))

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -59,7 +59,7 @@ public abstract class RenewalResource extends Resource {
 
   private void renew(RoutingContext routingContext) {
     final WebContext webContext = new WebContext(routingContext);
-    final Clients clients = Clients.create(routingContext, client);
+    final Clients clients = Clients.create(webContext, client);
 
     final LoanRepository loanRepository = new LoanRepository(clients);
     final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -322,7 +322,8 @@ public class Clients {
   }
 
   public CompletableFuture<Result<Drools>> getCirculationDrools() {
-    return CirculationRulesProcessor.getInstance().getDrools(routingContext, httpClient);
+    return CirculationRulesProcessor.getInstance()
+      .getDrools(new WebContext(routingContext).getTenantId(), circulationRulesStorage());
   }
 
   public PubSubPublishingService pubSubPublishingService() {

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -61,17 +61,18 @@ public class Clients {
   private final CollectionResourceClient automatedPatronBlocksClient;
   private final CollectionResourceClient notesClient;
   private final CollectionResourceClient noteTypesClient;
-  private final RoutingContext routingContext;
   private final PubSubPublishingService pubSubPublishingService;
+  private final WebContext context;
 
   public static Clients create(RoutingContext routingContext, HttpClient httpClient) {
     return new Clients(routingContext, httpClient);
   }
 
   private Clients(RoutingContext routingContext, HttpClient httpClient) {
-    this.routingContext = routingContext;
-    WebContext context = new WebContext(routingContext);
+    this.context = new WebContext(routingContext);
+
     OkapiHttpClient client = context.createHttpClient(httpClient);
+
     try {
       requestsStorageClient = createRequestsStorageClient(client, context);
       requestsBatchStorageClient = createRequestsBatchStorageClient(client, context);
@@ -311,13 +312,9 @@ public class Clients {
     return noteTypesClient;
   }
 
-  protected RoutingContext getRoutingContext() {
-    return routingContext;
-  }
-
   public CompletableFuture<Result<Drools>> getCirculationDrools() {
     return CirculationRulesProcessor.getInstance()
-      .getDrools(new WebContext(routingContext).getTenantId(), circulationRulesStorage());
+      .getDrools(context.getTenantId(), circulationRulesStorage());
   }
 
   public PubSubPublishingService pubSubPublishingService() {

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -11,7 +11,6 @@ import org.folio.circulation.support.http.server.WebContext;
 import org.folio.circulation.support.results.Result;
 
 import io.vertx.core.http.HttpClient;
-import io.vertx.ext.web.RoutingContext;
 
 public class Clients {
   private final CollectionResourceClient requestsStorageClient;
@@ -64,14 +63,12 @@ public class Clients {
   private final PubSubPublishingService pubSubPublishingService;
   private final WebContext context;
 
-  public static Clients create(RoutingContext routingContext, HttpClient httpClient) {
-    return new Clients(routingContext, httpClient);
+  public static Clients create(WebContext context, HttpClient httpClient) {
+    return new Clients(context.createHttpClient(httpClient), context);
   }
 
-  private Clients(RoutingContext routingContext, HttpClient httpClient) {
-    this.context = new WebContext(routingContext);
-
-    OkapiHttpClient client = context.createHttpClient(httpClient);
+  private Clients(OkapiHttpClient client, WebContext context) {
+    this.context = context;
 
     try {
       requestsStorageClient = createRequestsStorageClient(client, context);

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -61,7 +61,6 @@ public class Clients {
   private final CollectionResourceClient automatedPatronBlocksClient;
   private final CollectionResourceClient notesClient;
   private final CollectionResourceClient noteTypesClient;
-  private final HttpClient httpClient;
   private final RoutingContext routingContext;
   private final PubSubPublishingService pubSubPublishingService;
 
@@ -70,7 +69,6 @@ public class Clients {
   }
 
   private Clients(RoutingContext routingContext, HttpClient httpClient) {
-    this.httpClient = httpClient;
     this.routingContext = routingContext;
     WebContext context = new WebContext(routingContext);
     OkapiHttpClient client = context.createHttpClient(httpClient);
@@ -311,10 +309,6 @@ public class Clients {
 
   public CollectionResourceClient noteTypesClient() {
     return noteTypesClient;
-  }
-
-  protected HttpClient getHttpClient() {
-    return httpClient;
   }
 
   protected RoutingContext getRoutingContext() {


### PR DESCRIPTION
## Purpose

Reinstates the previous dependencies for the Clients class to reduce the impact of changes on other classes

## Approach
* Extract method to reduce duplication in circulation rules engine resource
* Extract overload of get drools that requires rules client and tenant ID
* Use that overload instead of the one relying on clients and a HTTP client
* Remove fields added to the clients class
* Reinstate previous dependencies for clients class

#### TODOS and Open Questions
* Introduce the correct dependencies in the relevant repositories so they can access the drools processing directly

## Learning
* Don't let large classes like Clients get so far down the chain of dependencies, it's a mess

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
