### PR TITLE
CIRC-774: Renew is not blocked when automated patron block exists

### DIFF
--- a/src/main/java/org/folio/circulation/domain/AutomatedPatronBlock.java
+++ b/src/main/java/org/folio/circulation/domain/AutomatedPatronBlock.java
@@ -26,8 +26,8 @@ public class AutomatedPatronBlock {
     return new AutomatedPatronBlock(
       getProperty(representation, "patronBlockConditionId"),
       getBooleanProperty(representation, "blockBorrowing"),
-      getBooleanProperty(representation, "blockRenewal"),
-      getBooleanProperty(representation, "blockRequest"),
+      getBooleanProperty(representation, "blockRenewals"),
+      getBooleanProperty(representation, "blockRequests"),
       getProperty(representation, "message")
     );
   }

--- a/src/test/java/api/support/fixtures/AutomatedPatronBlocksFixture.java
+++ b/src/test/java/api/support/fixtures/AutomatedPatronBlocksFixture.java
@@ -30,13 +30,13 @@ public class AutomatedPatronBlocksFixture {
       .put("automatedPatronBlocks", new JsonArray(Arrays.asList(
         new JsonObject().put("patronBlockConditionId", "2149fff5-a64c-4943-aa79-bb1d09511382")
           .put("blockBorrowing", blockBorrowing)
-          .put("blockRenewal", blockRenewal)
-          .put("blockRequest", blockRequest)
+          .put("blockRenewals", blockRenewal)
+          .put("blockRequests", blockRequest)
           .put("message", MAX_NUMBER_OF_ITEMS_CHARGED_OUT_MESSAGE),
         new JsonObject().put("patronBlockConditionId", "ac13a725-b25f-48fa-84a6-4af021d13afe")
           .put("blockBorrowing", blockBorrowing)
-          .put("blockRenewal", blockRenewal)
-          .put("blockRequest", blockRequest)
+          .put("blockRenewals", blockRenewal)
+          .put("blockRequests", blockRequest)
           .put("message", MAX_OUTSTANDING_FEE_FINE_BALANCE_MESSAGE)
       )));
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose

- Fix typos in property names for AutomatedPatronBlock

Resolves: https://issues.folio.org/browse/CIRC-774
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  

