### PR TITLE
CIRC-986 - User details are absent in aged to lost loan circ log record

### DIFF
--- a/src/main/java/org/folio/circulation/domain/representations/logs/LoanLogContext.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/LoanLogContext.java
@@ -46,9 +46,9 @@ public class LoanLogContext {
   public static LoanLogContext from(Loan loan) {
     return new LoanLogContext()
       .withUser(ofNullable(loan.getUser())
-        .orElse(new User(new JsonObject().put("id", loan.getUserId()))))
+        .orElse(userFromRepresentation(loan)))
       .withItem(ofNullable(loan.getItem())
-        .orElse(Item.from(new JsonObject().put("id", loan.getItemId()))))
+        .orElse(itemFromRepresentation(loan)))
       .withAction(LogContextActionResolver.resolveAction(loan.getAction()))
       .withDate(DateTime.now())
       .withServicePointId(ofNullable(loan.getCheckInServicePointId())
@@ -58,18 +58,30 @@ public class LoanLogContext {
       .withUpdatedByUserId(loan.getUpdatedByUserId());
   }
 
-  public LoanLogContext withUser(User user) {
+  private LoanLogContext withUser(User user) {
     userBarcode = user.getBarcode();
     userId = user.getId();
     return this;
   }
 
-  public LoanLogContext withItem(Item item) {
+  private LoanLogContext withItem(Item item) {
     itemBarcode = item.getBarcode();
     itemId = item.getItemId();
     instanceId = item.getInstanceId();
     holdingsRecordId = item.getHoldingsRecordId();
     return this;
+  }
+
+  private static User userFromRepresentation(Loan loan) {
+    JsonObject userJson = new JsonObject();
+    ofNullable(loan).ifPresent(l -> write(userJson, "id", l.getUserId()));
+    return new User(userJson);
+  }
+
+  private static Item itemFromRepresentation(Loan loan) {
+    JsonObject itemJson = new JsonObject();
+    ofNullable(loan).ifPresent(l -> write(itemJson, "id", l.getItemId()));
+    return Item.from(itemJson);
   }
 
   public JsonObject asJson() {

--- a/src/main/java/org/folio/circulation/domain/representations/logs/LoanLogContext.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/LoanLogContext.java
@@ -19,7 +19,6 @@ import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import io.vertx.core.json.JsonObject;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.With;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Loan;
@@ -37,51 +36,39 @@ public class LoanLogContext {
   private String instanceId;
   private String holdingsRecordId;
   private String action;
-  @Setter private String actionComment;
+  private String actionComment;
   private DateTime date;
-  @Setter private String servicePointId;
-  @Setter private String updatedByUserId;
+  private String servicePointId;
+  private String updatedByUserId;
   private String description;
   private String loanId;
 
   public static LoanLogContext from(Loan loan) {
-    LoanLogContext loanLogContext = new LoanLogContext()
-      .withUser(loan.getUser())
-      .withItem(loan.getItem())
+    return new LoanLogContext()
+      .withUser(ofNullable(loan.getUser())
+        .orElse(new User(new JsonObject().put("id", loan.getUserId()))))
+      .withItem(ofNullable(loan.getItem())
+        .orElse(Item.from(new JsonObject().put("id", loan.getItemId()))))
       .withAction(LogContextActionResolver.resolveAction(loan.getAction()))
       .withDate(DateTime.now())
-      .withLoanId(loan.getId());
-    ofNullable(loan.getActionComment()).ifPresent(loanLogContext::setActionComment);
-    ofNullable(loan.getUpdatedByUserId()).ifPresent(loanLogContext::setUpdatedByUserId);
-    ofNullable(loan.getCheckoutServicePointId()).ifPresent(loanLogContext::setServicePointId);
-    return loanLogContext;
-  }
-
-  public static LoanLogContext fromAnonymize(Loan loan) {
-    return new LoanLogContext()
-      .withItemId(loan.getItemId())
-      .withAction("Anonymize")
-      .withDate(DateTime.now())
-      .withLoanId(loan.getId())
       .withServicePointId(ofNullable(loan.getCheckInServicePointId())
-        .orElse(loan.getCheckoutServicePointId()));
+        .orElse(loan.getCheckoutServicePointId()))
+      .withLoanId(loan.getId())
+      .withActionComment(loan.getActionComment())
+      .withUpdatedByUserId(loan.getUpdatedByUserId());
   }
 
   public LoanLogContext withUser(User user) {
-    ofNullable(user).ifPresent(usr -> {
-      userBarcode = usr.getBarcode();
-      userId = usr.getId();
-    });
-      return this;
+    userBarcode = user.getBarcode();
+    userId = user.getId();
+    return this;
   }
 
   public LoanLogContext withItem(Item item) {
-    ofNullable(item).ifPresent(i -> {
-      itemBarcode = i.getBarcode();
-      itemId = i.getItemId();
-      instanceId = i.getInstanceId();
-      holdingsRecordId = i.getHoldingsRecordId();
-    });
+    itemBarcode = item.getBarcode();
+    itemId = item.getItemId();
+    instanceId = item.getInstanceId();
+    holdingsRecordId = item.getHoldingsRecordId();
     return this;
   }
 

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -218,7 +218,7 @@ public class EventPublisher {
   }
 
   public CompletableFuture<Result<Void>> publishAnonymizeEvent(Loan loan) {
-    return publishLogRecord(LoanLogContext.fromAnonymize(loan).asJson(), LOAN);
+    return publishLogRecord(LoanLogContext.from(loan).withAction("Anonymize").asJson(), LOAN);
   }
 
   public CompletableFuture<Result<Void>> publishRecallRequestedEvent(Loan loan) {

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -13,7 +13,6 @@ import static org.folio.circulation.domain.representations.logs.CirculationCheck
 import static org.folio.circulation.domain.representations.logs.CirculationCheckInCheckOutLogEventMapper.mapToCheckOutLogEventJson;
 import static org.folio.circulation.domain.representations.logs.LogEventPayloadField.PAYLOAD;
 import static org.folio.circulation.domain.representations.logs.LogEventType.LOAN;
-import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE;
 import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.domain.representations.logs.RequestUpdateLogEventMapper.mapToRequestLogEventJson;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
@@ -228,11 +227,10 @@ public class EventPublisher {
   }
 
   public CompletableFuture<Result<Void>> publishLogRecord(JsonObject context, LogEventType payloadType) {
-    if (NOTICE.equals(payloadType)) {
-      context = new JsonObject().put(PAYLOAD.value(), context.encode());
-    }
-    write(context, LOG_EVENT_TYPE.value(), payloadType.value());
-    return pubSubPublishingService.publishEvent(LOG_RECORD.name(), context.encode())
+    JsonObject eventJson = new JsonObject();
+    write(eventJson, LOG_EVENT_TYPE.value(), payloadType.value());
+    write(eventJson, PAYLOAD.value(), context);
+    return pubSubPublishingService.publishEvent(LOG_RECORD.name(), eventJson.encode())
       .thenApply(r -> succeeded(null));
   }
 

--- a/src/test/java/api/queue/RequestQueueResourceTest.java
+++ b/src/test/java/api/queue/RequestQueueResourceTest.java
@@ -259,6 +259,7 @@ public class RequestQueueResourceTest extends APITests {
 
     List<JsonObject> reorderedRequests = new JsonObject(JsonObject.mapFrom(reorderedLogEvents.get(0))
       .getString("eventPayload"))
+        .getJsonObject("payload")
         .getJsonObject("requests")
         .getJsonArray("reordered")
         .stream()

--- a/src/test/java/api/requests/RequestsAPIUpdatingTests.java
+++ b/src/test/java/api/requests/RequestsAPIUpdatingTests.java
@@ -778,11 +778,11 @@ public class RequestsAPIUpdatingTests extends APITests {
     Map<String, List<JsonObject>> logEvents = events.get(LOG_RECORD.name()).stream()
       .collect(groupingBy(e -> new JsonObject(e.getString("eventPayload")).getString("logEventType")));
 
-    Request requestCreatedFromEventPayload = Request.from(new JsonObject(logEvents.get(REQUEST_CREATED.value()).get(0).getString("eventPayload")).getJsonObject("requests").getJsonObject("created"));
+    Request requestCreatedFromEventPayload = Request.from(new JsonObject(logEvents.get(REQUEST_CREATED.value()).get(0).getString("eventPayload")).getJsonObject("payload").getJsonObject("requests").getJsonObject("created"));
     assertThat(requestCreatedFromEventPayload, notNullValue());
 
-    Request originalCreatedFromEventPayload = Request.from(new JsonObject(logEvents.get(REQUEST_UPDATED.value()).get(0).getString("eventPayload")).getJsonObject("requests").getJsonObject("original"));
-    Request updatedCreatedFromEventPayload = Request.from(new JsonObject(logEvents.get(REQUEST_UPDATED.value()).get(0).getString("eventPayload")).getJsonObject("requests").getJsonObject("updated"));
+    Request originalCreatedFromEventPayload = Request.from(new JsonObject(logEvents.get(REQUEST_UPDATED.value()).get(0).getString("eventPayload")).getJsonObject("payload").getJsonObject("requests").getJsonObject("original"));
+    Request updatedCreatedFromEventPayload = Request.from(new JsonObject(logEvents.get(REQUEST_UPDATED.value()).get(0).getString("eventPayload")).getJsonObject("payload").getJsonObject("requests").getJsonObject("updated"));
 
     assertThat(requestCreatedFromEventPayload.getRequestType(), equalTo(originalCreatedFromEventPayload.getRequestType()));
     assertThat(originalCreatedFromEventPayload.getRequestType(), not(equalTo(updatedCreatedFromEventPayload.getRequestType())));

--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -1030,8 +1030,8 @@ public class MoveRequestTests extends APITests {
     Map<String, List<JsonObject>> logEvents = events.get(LOG_RECORD.name()).stream()
       .collect(groupingBy(e -> new JsonObject(e.getString("eventPayload")).getString("logEventType")));
 
-    Request originalCreatedFromEventPayload = Request.from(new JsonObject(logEvents.get(REQUEST_MOVED.value()).get(0).getString("eventPayload")).getJsonObject("requests").getJsonObject("original"));
-    Request updatedCreatedFromEventPayload = Request.from(new JsonObject(logEvents.get(REQUEST_MOVED.value()).get(0).getString("eventPayload")).getJsonObject("requests").getJsonObject("updated"));
+    Request originalCreatedFromEventPayload = Request.from(new JsonObject(logEvents.get(REQUEST_MOVED.value()).get(0).getString("eventPayload")).getJsonObject("payload").getJsonObject("requests").getJsonObject("original"));
+    Request updatedCreatedFromEventPayload = Request.from(new JsonObject(logEvents.get(REQUEST_MOVED.value()).get(0).getString("eventPayload")).getJsonObject("payload").getJsonObject("requests").getJsonObject("updated"));
     assertThat(originalCreatedFromEventPayload.asJson(), Matchers.not(equalTo(updatedCreatedFromEventPayload.asJson())));
 
     assertThat(originalCreatedFromEventPayload.getItemId(), not(equalTo(updatedCreatedFromEventPayload.getItemId())));


### PR DESCRIPTION
[CIRC-986](https://issues.folio.org/browse/CIRC-986) - User details are absent in aged to lost loan circ log record

## Purpose
User details should be present in aged to lost loan circ log record

## Approach
This PR introduces minor improvements

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
