### PR TITLE
CIRC-993 Notices triggered by hold shelf expiration not received as expected

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -725,7 +725,8 @@
             "users.item.get",
             "usergroups.collection.get",
             "configuration.entries.collection.get",
-            "pubsub.publish.post"
+            "pubsub.publish.post",
+            "circulation-storage.circulation-rules.get"
           ],
           "unit": "minute",
           "delay": "2"


### PR DESCRIPTION
Failed to decode:Unrecognized token 'Access': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (String)"Access requires permission: circulation-storage.circulation-rules.get"; line: 1, column: 7]

## Approach 
- Add permission for  /request-scheduled-notices-processing endpoint;

Resolves: https://issues.folio.org/browse/CIRC-993

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  