### PR TITLE
CIRC-993 add permissions for getting notice policies

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -625,6 +625,7 @@
             "circulation-storage.loan-policies.collection.get",
             "users.item.get",
             "users.collection.get",
+            "circulation-storage.circulation-rules.get",
             "circulation.rules.notice-policy.get",
             "circulation-storage.patron-notice-policies.item.get",
             "patron-notice.post",
@@ -662,7 +663,9 @@
             "patron-notice.post",
             "users.item.get",
             "templates.item.get",
-            "pubsub.publish.post"
+            "pubsub.publish.post",
+            "circulation-storage.circulation-rules.get",
+            "circulation.rules.notice-policy.get"
           ],
           "unit": "minute",
           "delay": "5"
@@ -695,7 +698,9 @@
             "patron-notice.post",
             "users.item.get",
             "templates.item.get",
-            "pubsub.publish.post"
+            "pubsub.publish.post",
+            "circulation-storage.circulation-rules.get",
+            "circulation.rules.notice-policy.get"
           ],
           "unit": "minute",
           "delay": "2"
@@ -726,7 +731,8 @@
             "usergroups.collection.get",
             "configuration.entries.collection.get",
             "pubsub.publish.post",
-            "circulation-storage.circulation-rules.get"
+            "circulation-storage.circulation-rules.get",
+            "circulation.rules.notice-policy.get"
           ],
           "unit": "minute",
           "delay": "2"


### PR DESCRIPTION
This error has been found during debug: 
org.folio.circulation.domain.notice.schedule.RequestScheduledNoticeHandler#sendNotice
Access requires permission: circulation.rules.notice-policy.get

![image](https://user-images.githubusercontent.com/53909129/99368772-3bfbf080-28c4-11eb-8090-00e1742e56c6.png)

Resolves: https://issues.folio.org/browse/CIRC-993

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.