### PR TITLE
CIRC-1013: Always use original date for KeepCurrentDate closed library strategy.

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/library/KeepCurrentDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/KeepCurrentDateStrategy.java
@@ -9,7 +9,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 public class KeepCurrentDateStrategy implements ClosedLibraryStrategy {
-
   private final DateTimeZone zone;
 
   public KeepCurrentDateStrategy(DateTimeZone zone) {
@@ -18,11 +17,6 @@ public class KeepCurrentDateStrategy implements ClosedLibraryStrategy {
 
   @Override
   public Result<DateTime> calculateDueDate(DateTime requestedDate, AdjacentOpeningDays openingDays) {
-    final DateTime dueDate = requestedDate.withZone(zone)
-      // Always keep the requested date
-      .withDate(requestedDate.toLocalDate())
-      .withTime(END_OF_A_DAY);
-
-    return succeeded(dueDate);
+    return succeeded(requestedDate.withZoneRetainFields(zone).withTime(END_OF_A_DAY));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/library/KeepCurrentDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/KeepCurrentDateStrategy.java
@@ -18,6 +18,11 @@ public class KeepCurrentDateStrategy implements ClosedLibraryStrategy {
 
   @Override
   public Result<DateTime> calculateDueDate(DateTime requestedDate, AdjacentOpeningDays openingDays) {
-    return succeeded(requestedDate.withZone(zone).withTime(END_OF_A_DAY));
+    final DateTime dueDate = requestedDate.withZone(zone)
+      // Always keep the requested date
+      .withDate(requestedDate.toLocalDate())
+      .withTime(END_OF_A_DAY);
+
+    return succeeded(dueDate);
   }
 }

--- a/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
@@ -18,9 +18,9 @@ public class KeepCurrentStrategyTest {
   @Test
   public void testKeepCurrentDateStrategy() {
     ClosedLibraryStrategy keepCurrentStrategy = new KeepCurrentDateStrategy(UTC);
-    DateTime requestDate =
-      new DateTime(2019, JANUARY, 1, 0, 0)
-        .withZoneRetainFields(UTC);
+    DateTime requestDate = new DateTime(2019, JANUARY, 1, 0, 0)
+      .withZoneRetainFields(UTC);
+
     Result<DateTime> calculatedDateTime = keepCurrentStrategy.calculateDueDate(requestDate, null);
 
     DateTime expectedDate = requestDate.withTime(END_OF_A_DAY);
@@ -30,9 +30,9 @@ public class KeepCurrentStrategyTest {
   @Test
   public void testKeepCurrentDateTimeStrategy() {
     ClosedLibraryStrategy keepCurrentStrategy = new KeepCurrentDateTimeStrategy();
-    DateTime requestDate =
-      new DateTime(2019, JANUARY, 1, 0, 0)
-        .withZoneRetainFields(UTC);
+    DateTime requestDate = new DateTime(2019, JANUARY, 1, 0, 0)
+      .withZoneRetainFields(UTC);
+
     Result<DateTime> calculatedDateTime = keepCurrentStrategy.calculateDueDate(requestDate, null);
 
     assertEquals(requestDate, calculatedDateTime.value());

--- a/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
@@ -1,17 +1,17 @@
 package org.folio.circulation.domain.policy.library;
 
-import org.folio.circulation.support.results.Result;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeConstants;
-import org.joda.time.DateTimeZone;
-import org.junit.Test;
-
 import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
+import static org.joda.time.DateTimeConstants.JANUARY;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.joda.time.DateTimeZone.forOffsetHours;
 import static org.junit.Assert.assertEquals;
 
 import java.util.stream.IntStream;
+
+import org.folio.circulation.support.results.Result;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
 
 public class KeepCurrentStrategyTest {
 
@@ -19,7 +19,7 @@ public class KeepCurrentStrategyTest {
   public void testKeepCurrentDateStrategy() {
     ClosedLibraryStrategy keepCurrentStrategy = new KeepCurrentDateStrategy(UTC);
     DateTime requestDate =
-      new DateTime(2019, DateTimeConstants.JANUARY, 1, 0, 0)
+      new DateTime(2019, JANUARY, 1, 0, 0)
         .withZoneRetainFields(UTC);
     Result<DateTime> calculatedDateTime = keepCurrentStrategy.calculateDueDate(requestDate, null);
 
@@ -31,7 +31,7 @@ public class KeepCurrentStrategyTest {
   public void testKeepCurrentDateTimeStrategy() {
     ClosedLibraryStrategy keepCurrentStrategy = new KeepCurrentDateTimeStrategy();
     DateTime requestDate =
-      new DateTime(2019, DateTimeConstants.JANUARY, 1, 0, 0)
+      new DateTime(2019, JANUARY, 1, 0, 0)
         .withZoneRetainFields(UTC);
     Result<DateTime> calculatedDateTime = keepCurrentStrategy.calculateDueDate(requestDate, null);
 

--- a/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
@@ -4,23 +4,27 @@ import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeConstants;
 import org.joda.time.DateTimeZone;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
+import static org.joda.time.DateTimeZone.UTC;
+import static org.joda.time.DateTimeZone.forOffsetHours;
+import static org.junit.Assert.assertEquals;
+
+import java.util.stream.IntStream;
 
 public class KeepCurrentStrategyTest {
 
   @Test
   public void testKeepCurrentDateStrategy() {
-    ClosedLibraryStrategy keepCurrentStrategy = new KeepCurrentDateStrategy(DateTimeZone.UTC);
+    ClosedLibraryStrategy keepCurrentStrategy = new KeepCurrentDateStrategy(UTC);
     DateTime requestDate =
       new DateTime(2019, DateTimeConstants.JANUARY, 1, 0, 0)
-        .withZoneRetainFields(DateTimeZone.UTC);
+        .withZoneRetainFields(UTC);
     Result<DateTime> calculatedDateTime = keepCurrentStrategy.calculateDueDate(requestDate, null);
 
     DateTime expectedDate = requestDate.withTime(END_OF_A_DAY);
-    Assert.assertEquals(expectedDate, calculatedDateTime.value());
+    assertEquals(expectedDate, calculatedDateTime.value());
   }
 
   @Test
@@ -28,9 +32,37 @@ public class KeepCurrentStrategyTest {
     ClosedLibraryStrategy keepCurrentStrategy = new KeepCurrentDateTimeStrategy();
     DateTime requestDate =
       new DateTime(2019, DateTimeConstants.JANUARY, 1, 0, 0)
-        .withZoneRetainFields(DateTimeZone.UTC);
+        .withZoneRetainFields(UTC);
     Result<DateTime> calculatedDateTime = keepCurrentStrategy.calculateDueDate(requestDate, null);
 
-    Assert.assertEquals(requestDate, calculatedDateTime.value());
+    assertEquals(requestDate, calculatedDateTime.value());
+  }
+
+  @Test
+  public void shouldAlwaysKeepCurrentDateWhenConvertingToTimeZone() {
+    final int year = 2020;
+    final int month = 11;
+    final int dayOfMonth = 17;
+
+    final DateTime now = new DateTime(year, month, dayOfMonth, 9, 47, UTC);
+
+    IntStream.rangeClosed(-12, 12)
+      .forEach(zoneOffset -> {
+        final DateTimeZone timeZone = forOffsetHours(zoneOffset);
+        final KeepCurrentDateStrategy strategy = new KeepCurrentDateStrategy(timeZone);
+
+        final DateTime newDueDate = strategy.calculateDueDate(now, null).value();
+
+        assertEquals(year, newDueDate.getYear());
+        assertEquals(month, newDueDate.getMonthOfYear());
+        assertEquals(dayOfMonth, newDueDate.getDayOfMonth());
+
+        assertEquals(23, newDueDate.getHourOfDay());
+        assertEquals(59, newDueDate.getMinuteOfHour());
+        assertEquals(59, newDueDate.getSecondOfMinute());
+
+        final int zoneOffsetInMs = zoneOffset * 60 * 60 * 1000;
+        assertEquals(zoneOffsetInMs, newDueDate.getZone().getOffset(now));
+      });
   }
 }


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-1013 - Checked out an item with due date/time in the past.
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Given:

* Fixed due date schedule:
   * from: 2020-11-11T00:00:00+00:00 - (note that midnight is set by UI);
   * to: 2020-11-16T00:00:00+00:00 - (note that midnight is set by UI);
   * due: 2020-11-16T00:00:00+00:00 - (note that midnight is set by UI);
* Keep current due date closed library strategy is used and it always sets time to the end of the current day in the timezone that defined in settings.

When user checks out item, due date is calculated to 2020-11-16T00:00:00+00:00 as it is configured by fixed due date schedule, but then we convert the due date to GMT -5:00 time zone (to calculate EOD in the given time zone) but now due date becomes previous day, so EOD set for the previous day.

## Approach
Always set origin UTC date.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
