### PR TITLE
Upgrade to XStream 1.4.14 fixing Remote Code Execution (CVE-2020-26217)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,16 @@
       <artifactId>drools-compiler</artifactId>
       <version>${drools.version}</version>
     </dependency>
+    <!--
+    Remove xstream dependency after drools has upgraded its
+    xstream dependency to >= 1.4.14:
+    https://x-stream.github.io/CVE-2020-26217.html
+    -->
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <version>1.4.14</version>
+    </dependency>
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>


### PR DESCRIPTION
https://x-stream.github.io/CVE-2020-26217.html
XStream is a Drools dependency. Drools hasn't fixed the dependency yet.