### PR TITLE
Date-time properties should be represented in UTC CIRC-1019

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -52,6 +52,7 @@ import static org.folio.circulation.support.results.CommonFailures.failedDueToSe
 import static org.folio.circulation.support.results.Result.succeeded;
 import static org.folio.circulation.support.utils.CommonUtils.executeIfNotNull;
 import static org.folio.circulation.support.utils.DateTimeUtil.mostRecentDate;
+import static org.joda.time.DateTimeZone.UTC;
 
 import java.util.Collection;
 import java.util.Objects;
@@ -110,7 +111,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   public Loan changeDueDate(DateTime newDueDate) {
-    write(representation, DUE_DATE, newDueDate);
+    write(representation, DUE_DATE, newDueDate.withZone(UTC));
 
     return this;
   }

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -202,12 +202,10 @@ public class TemplateContextUtil {
       .ifPresent(value -> requestContext.put("servicePointPickup", value));
     optionalRequest
       .map(Request::getRequestExpirationDate)
-      .map(DateTime::toString)
-      .ifPresent(value -> requestContext.put("requestExpirationDate", value));
+      .ifPresent(value -> write(requestContext, "requestExpirationDate", value));
     optionalRequest
       .map(Request::getHoldShelfExpirationDate)
-      .map(DateTime::toString)
-      .ifPresent(value -> requestContext.put("holdShelfExpirationDate", value));
+      .ifPresent(value -> write(requestContext, "holdShelfExpirationDate", value));
     optionalRequest
       .map(Request::getCancellationAdditionalInformation)
       .ifPresent(value -> requestContext.put("additionalInfo", value));

--- a/src/main/java/org/folio/circulation/support/json/JsonPropertyWriter.java
+++ b/src/main/java/org/folio/circulation/support/json/JsonPropertyWriter.java
@@ -1,5 +1,7 @@
 package org.folio.circulation.support.json;
 
+import static org.joda.time.DateTimeZone.UTC;
+
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
@@ -71,8 +73,8 @@ public class JsonPropertyWriter {
   }
 
   public static void write(JsonObject to, String propertyName, DateTime value) {
-    if(value != null) {
-      write(to, propertyName, value.toString(ISODateTimeFormat.dateTime()));
+    if (value != null) {
+      write(to, propertyName, value.withZone(UTC).toString(ISODateTimeFormat.dateTime()));
     }
   }
 

--- a/src/test/java/api/loans/ClaimItemReturnedAPITests.java
+++ b/src/test/java/api/loans/ClaimItemReturnedAPITests.java
@@ -4,8 +4,9 @@ import static api.support.PubsubPublisherTestUtils.assertThatPublishedLoanLogRec
 import static api.support.matchers.EventMatchers.isValidItemClaimedReturnedEvent;
 import static api.support.matchers.EventTypeMatchers.ITEM_CLAIMED_RETURNED;
 import static api.support.matchers.LoanMatchers.hasLoanProperty;
-import static api.support.matchers.LoanMatchers.isOpen;
 import static api.support.matchers.LoanMatchers.hasStatus;
+import static api.support.matchers.LoanMatchers.isOpen;
+import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasNullParameter;
@@ -23,7 +24,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
-import api.support.http.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -32,6 +32,7 @@ import org.junit.Test;
 import api.support.APITests;
 import api.support.builders.ClaimItemReturnedRequestBuilder;
 import api.support.fakes.FakePubSub;
+import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
 import io.vertx.core.json.JsonObject;
 
@@ -146,8 +147,8 @@ public class ClaimItemReturnedAPITests extends APITests {
     assertThat(response.getStatusCode(), is(204));
     assertThat(actualItem, hasStatus("Claimed returned"));
     assertThat(actualLoan, isOpen());
-    assertThat(actualLoan, hasLoanProperty(ACTION, "claimedReturned"));
-    assertThat(actualLoan, hasLoanProperty(ACTION_COMMENT, comment));
-    assertThat(actualLoan, hasLoanProperty(CLAIMED_RETURNED_DATE, dateTime.toString()));
+    assertThat(actualLoan, hasLoanProperty(ACTION, is("claimedReturned")));
+    assertThat(actualLoan, hasLoanProperty(ACTION_COMMENT, is(comment)));
+    assertThat(actualLoan, hasLoanProperty(CLAIMED_RETURNED_DATE, isEquivalentTo(dateTime)));
   }
 }

--- a/src/test/java/api/loans/DeclareLostAPITests.java
+++ b/src/test/java/api/loans/DeclareLostAPITests.java
@@ -1,5 +1,6 @@
 package api.loans;
 
+import static api.support.PubsubPublisherTestUtils.assertThatPublishedLoanLogRecordEventsAreValid;
 import static api.support.http.CqlQuery.exactMatch;
 import static api.support.http.CqlQuery.queryFromTemplate;
 import static api.support.matchers.EventMatchers.isValidItemDeclaredLostEvent;
@@ -11,12 +12,13 @@ import static api.support.matchers.LoanMatchers.hasLoanProperty;
 import static api.support.matchers.LoanMatchers.hasStatus;
 import static api.support.matchers.LoanMatchers.isClosed;
 import static api.support.matchers.LoanMatchers.isOpen;
+import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static api.support.matchers.TextDateTimeMatcher.withinSecondsBeforeNow;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
-import static api.support.PubsubPublisherTestUtils.assertThatPublishedLoanLogRecordEventsAreValid;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -34,9 +36,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.awaitility.Awaitility;
-import api.support.http.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
@@ -51,6 +51,7 @@ import api.support.builders.DeclareItemLostRequestBuilder;
 import api.support.builders.ItemBuilder;
 import api.support.builders.LostItemFeePolicyBuilder;
 import api.support.fakes.FakePubSub;
+import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
 import io.vertx.core.json.JsonObject;
 import junitparams.JUnitParamsRunner;
@@ -88,9 +89,9 @@ public class DeclareLostAPITests extends APITests {
     assertThat(response.getStatusCode(), is(204));
     assertThat(actualItem, hasStatus("Declared lost"));
     assertThat(actualLoan, isOpen());
-    assertThat(actualLoan, hasLoanProperty("action", "declaredLost"));
-    assertThat(actualLoan, hasLoanProperty("actionComment", comment));
-    assertThat(actualLoan, hasLoanProperty("declaredLostDate", dateTime.toString()));
+    assertThat(actualLoan, hasLoanProperty("action", is("declaredLost")));
+    assertThat(actualLoan, hasLoanProperty("actionComment", is(comment)));
+    assertThat(actualLoan, hasLoanProperty("declaredLostDate", isEquivalentTo(dateTime)));
   }
 
   @Test
@@ -112,9 +113,9 @@ public class DeclareLostAPITests extends APITests {
     assertThat(response.getStatusCode(), is(204));
     assertThat(actualItem, hasStatus("Declared lost"));
     assertThat(actualLoan, isOpen());
-    assertThat(actualLoan, hasLoanProperty("action", "declaredLost"));
-    assertThat(actualLoan, hasLoanProperty("actionComment", StringUtils.EMPTY));
-    assertThat(actualLoan, hasLoanProperty("declaredLostDate", dateTime.toString()));
+    assertThat(actualLoan, hasLoanProperty("action", is("declaredLost")));
+    assertThat(actualLoan, hasLoanProperty("actionComment", is(EMPTY)));
+    assertThat(actualLoan, hasLoanProperty("declaredLostDate", isEquivalentTo(dateTime)));
   }
 
   @Test

--- a/src/test/java/api/support/matchers/DateTimeMatchers.java
+++ b/src/test/java/api/support/matchers/DateTimeMatchers.java
@@ -1,10 +1,11 @@
 package api.support.matchers;
 
 import static org.folio.circulation.support.utils.DateTimeUtil.toOffsetDateTime;
+import static org.hamcrest.CoreMatchers.is;
+import static org.joda.time.DateTimeZone.UTC;
 
 import java.time.OffsetDateTime;
 
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 
@@ -12,6 +13,7 @@ public class DateTimeMatchers {
   private DateTimeMatchers() { }
 
   public static Matcher<OffsetDateTime> isEquivalentTo(DateTime expected) {
-    return CoreMatchers.is(toOffsetDateTime(expected));
+    // All date times produced by the APIs should be in UTC
+    return is(toOffsetDateTime(expected.withZone(UTC)));
   }
 }

--- a/src/test/java/api/support/matchers/EventMatchers.java
+++ b/src/test/java/api/support/matchers/EventMatchers.java
@@ -6,18 +6,18 @@ import static api.support.matchers.EventTypeMatchers.isItemClaimedReturnedEventT
 import static api.support.matchers.EventTypeMatchers.isItemDeclaredLostEventType;
 import static api.support.matchers.EventTypeMatchers.isLoanDueDateChangedEventType;
 import static api.support.matchers.EventTypeMatchers.isLogRecordEventType;
+import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getBooleanProperty;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.core.Is.is;
 
-import io.vertx.core.json.JsonArray;
 import org.hamcrest.Matcher;
+import org.joda.time.DateTime;
 
 import io.vertx.core.json.JsonObject;
 
 public class EventMatchers {
-
   public static Matcher<JsonObject> isValidItemCheckedOutEvent(JsonObject loan) {
     return allOf(JsonObjectMatcher.allOfPaths(
       hasJsonPath("eventPayload", allOf(
@@ -96,7 +96,7 @@ public class EventMatchers {
       hasJsonPath("eventPayload", allOf(
         hasJsonPath("userId", is(loan.getString("userId"))),
         hasJsonPath("loanId", is(loan.getString("id"))),
-        hasJsonPath("dueDate", is(loan.getString("dueDate"))),
+        hasJsonPath("dueDate", isEquivalentTo(DateTime.parse(loan.getString("dueDate")))),
         hasJsonPath("dueDateChangedByRecall",
           is(getBooleanProperty(loan, "dueDateChangedByRecall")))
       ))),
@@ -117,7 +117,7 @@ public class EventMatchers {
         hasJsonPath("loanId", is(loanCtx.getString("loanId")))
       ))),
       isLogRecordEventType());
-  }  
+  }
 
   public static Matcher<JsonObject> isValidNoticeLogRecordEvent(JsonObject notice) {
     return allOf(JsonObjectMatcher.allOfPaths(

--- a/src/test/java/api/support/matchers/LoanMatchers.java
+++ b/src/test/java/api/support/matchers/LoanMatchers.java
@@ -1,13 +1,15 @@
 package api.support.matchers;
 
 import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
-import io.vertx.core.json.JsonObject;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import io.vertx.core.json.JsonObject;
 
 public class LoanMatchers {
   public static TypeSafeDiagnosingMatcher<JsonObject> isOpen() {
@@ -20,6 +22,28 @@ public class LoanMatchers {
 
   public static TypeSafeDiagnosingMatcher<JsonObject> isAnonymized() {
     return doesNotHaveUserId();
+  }
+
+  public static TypeSafeDiagnosingMatcher<JsonObject> hasLoanProperty(
+    String propertyName, Matcher<String> matcher) {
+    return new TypeSafeDiagnosingMatcher<>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Loan should have a ")
+          .appendText(propertyName).appendText(" property that is ").appendDescriptionOf(matcher);
+      }
+
+      @Override
+      protected boolean matchesSafely(JsonObject representation,
+        Description description) {
+
+        final String actualValue = getProperty(representation, propertyName);
+
+        matcher.describeMismatch(actualValue, description);
+
+        return matcher.matches(actualValue);
+      }
+    };
   }
 
   public static TypeSafeDiagnosingMatcher<JsonObject> hasLoanProperty(

--- a/src/test/java/api/support/matchers/TextDateTimeMatcher.java
+++ b/src/test/java/api/support/matchers/TextDateTimeMatcher.java
@@ -42,7 +42,7 @@ public class TextDateTimeMatcher {
       @Override
       public void describeTo(Description description) {
         description.appendText(String.format(
-          "a date and time matching: %s", expected.toString()));
+          "an RFC-3339 formatted date and time with a UTC (zero) offset matching: %s", expected.toString()));
       }
 
       @Override

--- a/src/test/java/api/support/matchers/TextDateTimeMatcher.java
+++ b/src/test/java/api/support/matchers/TextDateTimeMatcher.java
@@ -1,8 +1,10 @@
 package api.support.matchers;
 
+import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoUnit.MILLIS;
 
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 
 import org.folio.circulation.support.ClockManager;
@@ -46,13 +48,14 @@ public class TextDateTimeMatcher {
       @Override
       protected boolean matchesSafely(String textRepresentation) {
         //response representation might vary from request representation
-        Instant actual = ZonedDateTime.parse(textRepresentation).toInstant();
+        final var actual = OffsetDateTime.parse(textRepresentation);
 
         //The zoned date time could have a higher precision than milliseconds
         //This makes comparison to an ISO formatted date time using milliseconds
         //excessively precise and brittle
         //Discovered when using JDK 13.0.1 instead of JDK 1.8.0_202-b08
-        return expected.truncatedTo(MILLIS).equals(actual);
+        return expected.truncatedTo(MILLIS).equals(actual.toInstant())
+          && actual.getOffset().equals(UTC);
       }
     };
   }


### PR DESCRIPTION
## Purpose
A recent [change](https://github.com/folio-org/mod-circulation/pull/741/files) caused mod-circulation to stop outputting some date time properties in UTC

A quick fix was put in place to resolve this by [weakening](https://github.com/folio-org/mod-circulation/pull/749) the checking in the tests.

## Approach
* Reproduce the issue by reverting the obscuring change and executing the tests in a non-UTC timezone
* Change tests using string comparisons for date-time checks to more specific matchers
* Change the JSON property writer to enforce UTC offset when writing date time properties
* Change the matchers to explicitly check for UTC offset / zone

#### TODOS and Open Questions
* Move use of string based matching of loan properties to type specific matching

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
