### PR TITLE
Add test to recreate erroneous updating of item status when checking out to expiring patron CIRC-995

### DIFF
--- a/src/test/java/api/loans/CheckOutToExpiringPatronTests.java
+++ b/src/test/java/api/loans/CheckOutToExpiringPatronTests.java
@@ -22,10 +22,22 @@ import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonObject;
 
 public class CheckOutToExpiringPatronTests extends APITests {
+  @Override
+  public void beforeEach() throws InterruptedException {
+    super.beforeEach();
+
+    mockClockManagerToReturnFixedDateTime(new DateTime(2020, 10, 27, 10, 0, UTC));
+  }
+
+  @Override
+  public void afterEach() {
+    super.afterEach();
+
+    mockClockManagerToReturnDefaultDateTime();
+  }
+
   @Test
   public void dueDateShouldBeTruncatedToTheEndOfLastWorkingDayBeforePatronExpiration() {
-    mockClockManagerToReturnFixedDateTime(new DateTime(2020, 10, 27, 10, 0, UTC));
-
     useExampleFixedPolicyCirculationRules();
 
     IndividualResource item = itemsFixture.basedUponNod();
@@ -38,14 +50,11 @@ public class CheckOutToExpiringPatronTests extends APITests {
         .to(steve)
         .at(CASE_ONE_DAY_IS_OPEN_NEXT_TWO_DAYS_CLOSED)).getJson();
 
-    mockClockManagerToReturnDefaultDateTime();
     assertThat(DateTime.parse(response.getString("dueDate")).toLocalDate(), is(FIRST_DAY_OPEN));
   }
 
   @Test
   public void dueDateTruncationForPatronExpirationFailsWhenNoCalendarIsDefinedForServicePoint() {
-    mockClockManagerToReturnFixedDateTime(new DateTime(2020, 10, 27, 10, 0, UTC));
-
     useExampleFixedPolicyCirculationRules();
 
     IndividualResource item = itemsFixture.basedUponNod();
@@ -57,8 +66,6 @@ public class CheckOutToExpiringPatronTests extends APITests {
         .forItem(item)
         .to(steve)
         .at(CASE_CALENDAR_IS_EMPTY_SERVICE_POINT_ID));
-
-    mockClockManagerToReturnDefaultDateTime();
 
     assertThat(response, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
     assertThat(response.getJson(), hasErrorWith(allOf(

--- a/src/test/java/api/loans/CheckOutToExpiringPatronTests.java
+++ b/src/test/java/api/loans/CheckOutToExpiringPatronTests.java
@@ -1,0 +1,117 @@
+package api.loans;
+
+import static api.support.fixtures.CalendarExamples.CASE_CALENDAR_IS_EMPTY_SERVICE_POINT_ID;
+import static api.support.fixtures.CalendarExamples.CASE_ONE_DAY_IS_OPEN_NEXT_TWO_DAYS_CLOSED;
+import static api.support.fixtures.CalendarExamples.FIRST_DAY_OPEN;
+import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
+import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
+import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
+import static api.support.matchers.ValidationErrorMatchers.hasMessage;
+import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
+import static org.folio.circulation.domain.policy.DueDateManagement.KEEP_THE_CURRENT_DUE_DATE;
+import static org.folio.circulation.domain.policy.Period.months;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.joda.time.DateTimeZone.UTC;
+
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import api.support.APITests;
+import api.support.builders.CheckOutByBarcodeRequestBuilder;
+import api.support.builders.LoanPolicyBuilder;
+import api.support.http.IndividualResource;
+import io.vertx.core.json.JsonObject;
+
+public class CheckOutToExpiringPatronTests extends APITests {
+  @Test
+  public void dueDateShouldBeTruncatedToTheEndOfLastWorkingDayBeforePatronExpiration() {
+    mockClockManagerToReturnFixedDateTime(new DateTime(2020, 10, 27, 10, 0, UTC));
+    final UUID book = materialTypesFixture.book().getId();
+
+    circulationRulesFixture.updateCirculationRules(
+      createRulesWithFixedDueDateInLoanPolicy("m " + book));
+
+    IndividualResource item = itemsFixture.basedUponNod();
+    IndividualResource steve = usersFixture.steve(user -> user.expires(
+      DateTime.now().plusDays(3)));
+
+    JsonObject response = checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(steve)
+        .at(CASE_ONE_DAY_IS_OPEN_NEXT_TWO_DAYS_CLOSED)).getJson();
+
+    mockClockManagerToReturnDefaultDateTime();
+    assertThat(DateTime.parse(response.getString("dueDate")).toLocalDate(), is(FIRST_DAY_OPEN));
+  }
+
+  @Test
+  public void dueDateTruncationForPatronExpirationFailsWhenNoCalendarIsDefinedForServicePoint() {
+    mockClockManagerToReturnFixedDateTime(new DateTime(2020, 10, 27, 10, 0, UTC));
+
+    final UUID book = materialTypesFixture.book().getId();
+
+    circulationRulesFixture.updateCirculationRules(
+      createRulesWithFixedDueDateInLoanPolicy("m " + book));
+
+    IndividualResource item = itemsFixture.basedUponNod();
+    IndividualResource steve = usersFixture.steve(user -> user.expires(
+      DateTime.now().plusDays(3)));
+
+    final var response = checkOutFixture.attemptCheckOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(steve)
+        .at(CASE_CALENDAR_IS_EMPTY_SERVICE_POINT_ID));
+
+    mockClockManagerToReturnDefaultDateTime();
+
+    assertThat(response, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
+    assertThat(response.getJson(), hasErrorWith(allOf(
+      hasMessage("Calendar timetable is absent for requested date"))));
+
+    final var incorrectlyUpdateItem = itemsClient.get(item);
+
+    // As the truncation of the due date happens after the item has been updated
+    // the item is checked out in error
+    assertThat(incorrectlyUpdateItem, hasItemStatus("Checked out"));
+  }
+
+  private IndividualResource prepareLoanPolicyWithItemLimitAndFixedDueDate(
+    int itemLimit, UUID fixedDueDateScheduleId) {
+    return loanPoliciesFixture.create(
+      new LoanPolicyBuilder()
+        .withName("Loan Policy with item limit and fixed due date")
+        .withItemLimit(itemLimit)
+        .fixed(fixedDueDateScheduleId)
+        .withClosedLibraryDueDateManagement(KEEP_THE_CURRENT_DUE_DATE.getValue()));
+  }
+
+  private IndividualResource prepareLoanPolicyWithoutItemLimit() {
+    return loanPoliciesFixture.create(
+      new LoanPolicyBuilder()
+        .withName("Loan Policy without item limit")
+        .rolling(months(2))
+        .renewFromCurrentDueDate());
+  }
+
+  private String createRulesWithFixedDueDateInLoanPolicy(String ruleCondition) {
+    UUID fixedDueDateScheduleId = loanPoliciesFixture.createExampleFixedDueDateSchedule().getId();
+    final String loanPolicyWithItemLimitAndFixedDueDateId = prepareLoanPolicyWithItemLimitAndFixedDueDate(
+      1, fixedDueDateScheduleId).getId().toString();
+    final String loanPolicyWithoutItemLimitId = prepareLoanPolicyWithoutItemLimit().getId().toString();
+    final String anyRequestPolicy = requestPoliciesFixture.allowAllRequestPolicy().getId().toString();
+    final String anyNoticePolicy = noticePoliciesFixture.activeNotice().getId().toString();
+    final String anyOverdueFinePolicy = overdueFinePoliciesFixture.facultyStandard().getId().toString();
+    final String anyLostItemFeePolicy = lostItemFeePoliciesFixture.facultyStandard().getId().toString();
+
+    return String.join("\n",
+      "priority: t, s, c, b, a, m, g",
+      "fallback-policy: l " + loanPolicyWithoutItemLimitId + " r " + anyRequestPolicy + " n " + anyNoticePolicy + " o " + anyOverdueFinePolicy + " i " + anyLostItemFeePolicy,
+      ruleCondition + " : l " + loanPolicyWithItemLimitAndFixedDueDateId + " r " + anyRequestPolicy + " n " + anyNoticePolicy  + " o " + anyOverdueFinePolicy + " i " + anyLostItemFeePolicy);
+  }
+}


### PR DESCRIPTION
## Purpose
A recent change, #718 started truncating the due date for new loans to when the borrowing patron expires.

This truncation always uses a move to previous day closed due date management approach, in order to avoid due dates that go beyond the expiration of the patron.

This approach requires a calendar to be defined for the patron, meaning a calendar is required for a check out to an expiring patron. 

Unfortunately, this process is applied after the item being checked out is updating, leading to an inconsistent state in the system.

## Approach
* Recreate the issue in a new API test
* Move the tests for check out to expiring patron to a separate class
* Consolidate the logic used in those tests

## Learning
* Reusing methods from other tests can sometimes add unnecessary complexity

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
