### PR TITLE
CIRC-1031 Remove checking of dueDateChanged for moved requests

### DIFF
--- a/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
@@ -84,9 +84,7 @@ public class RequestNoticeSender {
     Request request = relatedRecords.getRequest();
 
     Loan loan = request.getLoan();
-    if (request.getRequestType() == RequestType.RECALL &&
-      loan != null && loan.hasDueDateChanged()) {
-
+    if (request.getRequestType() == RequestType.RECALL && loan != null) {
       sendNoticeOnItemRecalledEvent(loan);
     }
     return Result.succeeded(relatedRecords);
@@ -119,14 +117,16 @@ public class RequestNoticeSender {
   }
 
   private Result<Void> sendNoticeOnItemRecalledEvent(Loan loan) {
-    PatronNoticeEvent itemRecalledEvent = new PatronNoticeEventBuilder()
-      .withItem(loan.getItem())
-      .withUser(loan.getUser())
-      .withEventType(NoticeEventType.ITEM_RECALLED)
-      .withNoticeContext(TemplateContextUtil.createLoanNoticeContext(loan))
-      .build();
-    patronNoticeService.acceptNoticeEvent(itemRecalledEvent, NoticeLogContext.from(loan))
-      .thenCompose(r -> r.after(v -> eventPublisher.publishRecallRequestedEvent(loan)));
+    if (loan.getUser() != null && loan.getItem() != null) {
+      PatronNoticeEvent itemRecalledEvent = new PatronNoticeEventBuilder()
+        .withItem(loan.getItem())
+        .withUser(loan.getUser())
+        .withEventType(NoticeEventType.ITEM_RECALLED)
+        .withNoticeContext(TemplateContextUtil.createLoanNoticeContext(loan))
+        .build();
+      patronNoticeService.acceptNoticeEvent(itemRecalledEvent, NoticeLogContext.from(loan))
+        .thenCompose(r -> r.after(v -> eventPublisher.publishRecallRequestedEvent(loan)));
+    }
     return Result.succeeded(null);
   }
 


### PR DESCRIPTION
This PR follows up the previous https://github.com/folio-org/mod-circulation/pull/763. 
The checking of dueDateChanged for moved requests was removed as well.

## Approach
- remove dueDateChanged checking for moved recall sending notice;
- fix NPE;
- create test;

Resolves: https://issues.folio.org/browse/CIRC-1031

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  