### PR TITLE
Update item in storage after business logic CIRC-995

### DIFF
--- a/src/main/java/org/folio/circulation/StoreLoanAndItem.java
+++ b/src/main/java/org/folio/circulation/StoreLoanAndItem.java
@@ -13,7 +13,6 @@ import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.resources.context.RenewalContext;
 import org.folio.circulation.support.Clients;
-import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.results.Result;
 
 public class StoreLoanAndItem {
@@ -45,9 +44,9 @@ public class StoreLoanAndItem {
       .thenComposeAsync(response -> loanRepository.updateLoan(loan));
   }
 
-  private CompletableFuture<Result<Response>> updateItem(Item item) {
+  private CompletableFuture<Result<Item>> updateItem(Item item) {
     if (!item.hasChanged()) {
-      return completedFuture(succeeded(null));
+      return completedFuture(succeeded(item));
     }
 
     return itemRepository.updateItem(item);

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -270,7 +270,7 @@ public class Item {
   }
 
 
-  Item changeStatus(ItemStatus newStatus) {
+  public Item changeStatus(ItemStatus newStatus) {
     if (isNotSameStatus(newStatus)) {
       changed = true;
     }

--- a/src/main/java/org/folio/circulation/domain/LoanAndRelatedRecords.java
+++ b/src/main/java/org/folio/circulation/domain/LoanAndRelatedRecords.java
@@ -1,7 +1,8 @@
 package org.folio.circulation.domain;
 
-import io.vertx.core.json.JsonObject;
 import org.joda.time.DateTimeZone;
+
+import io.vertx.core.json.JsonObject;
 
 public class LoanAndRelatedRecords implements UserRelatedRecord {
   public static final String REASON_TO_OVERRIDE = "reasonToOverride";
@@ -24,6 +25,10 @@ public class LoanAndRelatedRecords implements UserRelatedRecord {
 
   public LoanAndRelatedRecords(Loan loan, DateTimeZone timeZone) {
     this(loan, null, timeZone, new JsonObject());
+  }
+
+  public LoanAndRelatedRecords changeItemStatus(ItemStatus status) {
+    return withItem(getLoan().getItem().changeStatus(status));
   }
 
   public LoanAndRelatedRecords withLoan(Loan newLoan) {

--- a/src/main/java/org/folio/circulation/domain/LoanAndRelatedRecords.java
+++ b/src/main/java/org/folio/circulation/domain/LoanAndRelatedRecords.java
@@ -28,8 +28,9 @@ public class LoanAndRelatedRecords implements UserRelatedRecord {
   }
 
   public LoanAndRelatedRecords changeItemStatus(ItemStatus status) {
-    return withItem(getLoan().getItem().changeStatus(status));
+    return withItem(getItem().changeStatus(status));
   }
+
 
   public LoanAndRelatedRecords withLoan(Loan newLoan) {
     return new LoanAndRelatedRecords(newLoan, requestQueue, timeZone, logContextProperties);
@@ -53,8 +54,7 @@ public class LoanAndRelatedRecords implements UserRelatedRecord {
   }
 
   public LoanAndRelatedRecords withItemEffectiveLocationIdAtCheckOut() {
-    Item item = this.loan.getItem();
-    return withLoan(loan.changeItemEffectiveLocationIdAtCheckOut(item.getLocationId()));
+    return withLoan(loan.changeItemEffectiveLocationIdAtCheckOut(getItem().getLocationId()));
   }
 
   public LoanAndRelatedRecords withTimeZone(DateTimeZone newTimeZone) {
@@ -63,6 +63,10 @@ public class LoanAndRelatedRecords implements UserRelatedRecord {
 
   public Loan getLoan() {
     return loan;
+  }
+
+  public Item getItem() {
+    return getLoan().getItem();
   }
 
   public RequestQueue getRequestQueue() {

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -112,12 +112,6 @@ public class UpdateItem {
       records -> updateItemStatusOnCheckOut(relatedRecords));
   }
 
-  public CompletableFuture<Result<LoanAndRelatedRecords>> onCheckOut(
-    LoanAndRelatedRecords relatedRecords) {
-
-    return updateItemStatusOnCheckOut(relatedRecords);
-  }
-
   public CompletableFuture<Result<LoanAndRelatedRecords>> onLoanUpdate(
     LoanAndRelatedRecords loanAndRelatedRecords) {
 

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -115,11 +115,7 @@ public class UpdateItem {
   public CompletableFuture<Result<LoanAndRelatedRecords>> onCheckOut(
     LoanAndRelatedRecords relatedRecords) {
 
-    //Hack for creating returned loan - should distinguish further up the chain
-    return succeeded(relatedRecords).afterWhen(
-      records -> loanIsClosed(relatedRecords),
-      UpdateItem::skip,
-      records -> updateItemStatusOnCheckOut(relatedRecords));
+    return updateItemStatusOnCheckOut(relatedRecords);
   }
 
   public CompletableFuture<Result<LoanAndRelatedRecords>> onLoanUpdate(

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -102,6 +102,16 @@ public class UpdateItem {
     return succeeded(item.changeStatus(request.checkedInItemStatus()));
   }
 
+  public CompletableFuture<Result<LoanAndRelatedRecords>> onLoanCreated(
+    LoanAndRelatedRecords relatedRecords) {
+
+    //Hack for creating returned loan - should distinguish further up the chain
+    return succeeded(relatedRecords).afterWhen(
+      records -> loanIsClosed(relatedRecords),
+      UpdateItem::skip,
+      records -> updateItemStatusOnCheckOut(relatedRecords));
+  }
+
   public CompletableFuture<Result<LoanAndRelatedRecords>> onCheckOut(
     LoanAndRelatedRecords relatedRecords) {
 

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -175,10 +175,10 @@ public class CheckOutByBarcodeResource extends Resource {
       .thenComposeAsync(r -> r.after(relatedRecords -> checkOutStrategy.checkOut(relatedRecords,
         routingContext.getBodyAsJson(), clients)))
       .thenComposeAsync(r -> r.after(requestQueueUpdate::onCheckOut))
-      .thenComposeAsync(r -> r.after(updateItem::onCheckOut))
       .thenComposeAsync(r -> r.after(loanService::truncateLoanWhenItemRecalled))
       .thenComposeAsync(r -> r.after(loanService::truncateLoanDueDateIfPatronExpiresEarlier))
       .thenComposeAsync(r -> r.after(patronGroupRepository::findPatronGroupForLoanAndRelatedRecords))
+      .thenComposeAsync(r -> r.after(updateItem::onCheckOut))
       .thenComposeAsync(r -> r.after(loanRepository::createLoan))
       .thenComposeAsync(r -> r.after(patronActionSessionService::saveCheckOutSessionRecord))
       .thenComposeAsync(r -> r.after(eventPublisher::publishItemCheckedOutEvent))

--- a/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
@@ -113,7 +113,7 @@ public class LoanCollectionResource extends CollectionResource {
       .thenApply(requestedByAnotherPatronValidator::refuseWhenRequestedByAnotherPatron)
       .thenComposeAsync(r -> r.after(loanPolicyRepository::lookupLoanPolicy))
       .thenComposeAsync(r -> r.after(requestQueueUpdate::onCheckOut))
-      .thenComposeAsync(r -> r.after(updateItem::onCheckOut))
+      .thenComposeAsync(r -> r.after(updateItem::onLoanCreated))
       .thenComposeAsync(r -> r.after(loanService::truncateLoanWhenItemRecalled))
       .thenComposeAsync(r -> r.after(loanRepository::createLoan))
       .thenComposeAsync(r -> r.after(eventPublisher::publishDueDateChangedEvent))

--- a/src/test/java/api/loans/CheckOutToExpiringPatronTests.java
+++ b/src/test/java/api/loans/CheckOutToExpiringPatronTests.java
@@ -71,10 +71,10 @@ public class CheckOutToExpiringPatronTests extends APITests {
     assertThat(response.getJson(), hasErrorWith(allOf(
       hasMessage("Calendar timetable is absent for requested date"))));
 
+    // An earlier version of the code erroneously updated the item status
+    // this check is to confirm that no longer happens
     final var incorrectlyUpdateItem = itemsClient.get(item);
 
-    // As the truncation of the due date happens after the item has been updated
-    // the item is checked out in error
-    assertThat(incorrectlyUpdateItem, hasItemStatus("Checked out"));
+    assertThat(incorrectlyUpdateItem, hasItemStatus("Available"));
   }
 }


### PR DESCRIPTION
## Purpose

An underlying contributing factor to CIRC-995 is that the logic for truncating the loan due date for expiring patrons happens *after* the item status change has been persisted to storage.

## Approach
* Remove complexity from the item update code that was used in multiple places
* Move the persistence of the item till after the truncation of the due date for expiring patrons
* Change the item status explicitly in the domain
* Remove the old logic for deciding how to change the item during storage

#### TODOS and Open Questions
* Split the business logic for updating the request queue and storage (CIRC-1025)

## Learning
* With the process defined as it currently is, it is too easy to perform operations in an inappropriate order, the process needs to be split up to discourage that from happening in the future

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
