### PR TITLE
CIRC-1025 simplify request queue unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -90,18 +90,6 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
     return isAwaitingPickup() || isNotYetFilled() || isInTransit();
   }
 
-  public boolean isNotDisplaceable() {
-    return isAwaitingPickup() || isInTransit() || (isItemPaged() && isFirst());
-  }
-
-  private boolean isItemPaged() {
-    return item != null && item.isPaged();
-  }
-
-  private boolean isFirst() {
-    return hasPosition() && getPosition().equals(1);
-  }
-
   private boolean isInTransit() {
     return getStatus() == OPEN_IN_TRANSIT;
   }
@@ -277,10 +265,6 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
 
   public Integer getPosition() {
     return getIntegerProperty(requestRepresentation, POSITION, null);
-  }
-
-  boolean hasPosition() {
-    return getPosition() != null;
   }
 
   public boolean hasChangedPosition() {

--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain;
 
+import static java.util.Arrays.asList;
 import static org.folio.circulation.domain.ItemStatus.AVAILABLE;
 
 import java.util.ArrayList;
@@ -11,9 +12,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 public class RequestQueue {
-
   private List<Request> requests;
   private final List<UpdatedRequestPair> updatedRequests;
+
+  public static RequestQueue requestQueueOf(Request... requests) {
+    return new RequestQueue(asList(requests));
+  }
 
   public RequestQueue(Collection<Request> requests) {
     this.requests = new ArrayList<>(requests);

--- a/src/test/java/org/folio/circulation/domain/RequestQueueRemoveRequestTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueRemoveRequestTests.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import api.support.builders.RequestBuilder;
 
-class RequestQueueTests {
+class RequestQueueRemoveRequestTests {
   private final UUID itemId = UUID.randomUUID();
 
   @Test

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -2,6 +2,7 @@ package org.folio.circulation.domain;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.folio.circulation.matchers.requests.RequestQueueMatchers.hasSize;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,7 +26,7 @@ class RequestQueueTests {
 
     requestQueue.remove(onlyRequest);
 
-    assertThat("Should have no requests", requestQueue.size(), is(0));
+    assertThat(requestQueue, hasSize(0));
 
     assertThat("Should not contain removed request",
       requestQueue.contains(onlyRequest), is(false));
@@ -50,7 +51,7 @@ class RequestQueueTests {
 
     requestQueue.remove(thirdRequest);
 
-    assertThat("Should have two requests", requestQueue.size(), is(2));
+    assertThat(requestQueue, hasSize(2));
 
     assertThat("Should not contain removed request",
       requestQueue.contains(thirdRequest), is(false));
@@ -87,7 +88,7 @@ class RequestQueueTests {
 
     requestQueue.remove(firstRequest);
 
-    assertThat("Should have two requests", requestQueue.size(), is(2));
+    assertThat("Should have two requests", requestQueue, hasSize(2));
 
     assertThat("Should not contain removed request",
       requestQueue.contains(firstRequest), is(false));
@@ -125,7 +126,7 @@ class RequestQueueTests {
 
     requestQueue.remove(secondRequest);
 
-    assertThat("Should have three requests", requestQueue.size(), is(3));
+    assertThat(requestQueue, hasSize(3));
 
     assertThat("Should not contain removed request",
       requestQueue.contains(secondRequest), is(false));

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -2,7 +2,9 @@ package org.folio.circulation.domain;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.folio.circulation.matchers.requests.RequestQueueMatchers.doesNotInclude;
 import static org.folio.circulation.matchers.requests.RequestQueueMatchers.hasSize;
+import static org.folio.circulation.matchers.requests.RequestQueueMatchers.includes;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,8 +30,7 @@ class RequestQueueTests {
 
     assertThat(requestQueue, hasSize(0));
 
-    assertThat("Should not contain removed request",
-      requestQueue.contains(onlyRequest), is(false));
+    assertThat(requestQueue, doesNotInclude(onlyRequest));
 
     assertThat("Removed request should not have a position",
       onlyRequest.getPosition(), is(nullValue()));
@@ -52,18 +53,12 @@ class RequestQueueTests {
     requestQueue.remove(thirdRequest);
 
     assertThat(requestQueue, hasSize(2));
-
-    assertThat("Should not contain removed request",
-      requestQueue.contains(thirdRequest), is(false));
+    assertThat(requestQueue, doesNotInclude(thirdRequest));
+    assertThat(requestQueue, includes(firstRequest));
+    assertThat(requestQueue, includes(secondRequest));
 
     assertThat("Removed request should not have a position",
       thirdRequest.getPosition(), is(nullValue()));
-
-    assertThat("Should contain first request",
-      requestQueue.contains(firstRequest), is(true));
-
-    assertThat("Should contain second request",
-      requestQueue.contains(secondRequest), is(true));
 
     assertThat("First request should still in correct position",
       firstRequest.getPosition(), is(1));
@@ -88,19 +83,13 @@ class RequestQueueTests {
 
     requestQueue.remove(firstRequest);
 
-    assertThat("Should have two requests", requestQueue, hasSize(2));
-
-    assertThat("Should not contain removed request",
-      requestQueue.contains(firstRequest), is(false));
+    assertThat(requestQueue, hasSize(2));
+    assertThat(requestQueue, doesNotInclude(firstRequest));
+    assertThat(requestQueue, includes(secondRequest));
+    assertThat(requestQueue, includes(thirdRequest));
 
     assertThat("Removed request should not have a position",
       firstRequest.getPosition(), is(nullValue()));
-
-    assertThat("Should contain second request",
-      requestQueue.contains(secondRequest), is(true));
-
-    assertThat("Should contain third request",
-      requestQueue.contains(thirdRequest), is(true));
 
     assertThat("Second request should have moved up the queue",
       secondRequest.getPosition(), is(1));
@@ -127,21 +116,13 @@ class RequestQueueTests {
     requestQueue.remove(secondRequest);
 
     assertThat(requestQueue, hasSize(3));
-
-    assertThat("Should not contain removed request",
-      requestQueue.contains(secondRequest), is(false));
+    assertThat(requestQueue, doesNotInclude(secondRequest));
+    assertThat(requestQueue, includes(firstRequest));
+    assertThat(requestQueue, includes(thirdRequest));
+    assertThat(requestQueue, includes(fourthRequest));
 
     assertThat("Removed request should not have a position",
       secondRequest.getPosition(), is(nullValue()));
-
-    assertThat("Should contain first request",
-      requestQueue.contains(firstRequest), is(true));
-
-    assertThat("Should contain third request",
-      requestQueue.contains(thirdRequest), is(true));
-
-    assertThat("Should contain fourth request",
-      requestQueue.contains(fourthRequest), is(true));
 
     assertThat("First request should be at the same position",
       firstRequest.getPosition(), is(1));

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -42,20 +42,23 @@ class RequestQueueTests {
     final var firstRequest = requestAtPosition(itemId, 1);
     final var secondRequest = requestAtPosition(itemId, 2);
     final var thirdRequest = requestAtPosition(itemId, 3);
+    final var fourthRequest = requestAtPosition(itemId, 4);
 
-    final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest);
+    final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
 
-    queue.remove(thirdRequest);
+    queue.remove(fourthRequest);
 
-    assertThat(queue, hasSize(2));
+    assertThat(queue, hasSize(3));
 
     assertThat(queue, includes(firstRequest));
     assertThat(queue, includes(secondRequest));
-    assertThat(queue, doesNotInclude(thirdRequest));
+    assertThat(queue, includes(thirdRequest));
+    assertThat(queue, doesNotInclude(fourthRequest));
 
     assertThat(firstRequest, is(inPosition(1)));
     assertThat(secondRequest, is(inPosition(2)));
-    assertThat(thirdRequest, hasNoPosition());
+    assertThat(thirdRequest, is(inPosition(3)));
+    assertThat(fourthRequest, hasNoPosition());
 
     assertThat(queue.getRequestsWithChangedPosition(), is(empty()));
   }
@@ -65,22 +68,25 @@ class RequestQueueTests {
     final var firstRequest = requestAtPosition(itemId, 1);
     final var secondRequest = requestAtPosition(itemId, 2);
     final var thirdRequest = requestAtPosition(itemId, 3);
+    final var fourthRequest = requestAtPosition(itemId, 4);
 
-    final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest);
+    final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
 
     queue.remove(firstRequest);
 
-    assertThat(queue, hasSize(2));
+    assertThat(queue, hasSize(3));
 
     assertThat(queue, doesNotInclude(firstRequest));
     assertThat(queue, includes(secondRequest));
     assertThat(queue, includes(thirdRequest));
+    assertThat(queue, includes(fourthRequest));
 
     assertThat(firstRequest, hasNoPosition());
     assertThat(secondRequest, is(inPosition(1)));
     assertThat(thirdRequest, is(inPosition(2)));
+    assertThat(fourthRequest, is(inPosition(3)));
 
-    assertThat(queue.getRequestsWithChangedPosition(), contains(thirdRequest, secondRequest));
+    assertThat(queue.getRequestsWithChangedPosition(), contains(fourthRequest, thirdRequest, secondRequest));
   }
 
   @Test

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -10,13 +10,13 @@ import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import api.support.builders.RequestBuilder;
 
-public class RequestQueueTests {
+class RequestQueueTests {
   @Test
-  public void canRemoveOnlyRequestInQueue() {
+  void canRemoveOnlyRequestInQueue() {
     final UUID itemId = UUID.randomUUID();
 
     Request onlyRequest = requestAtPosition(itemId, 1);
@@ -38,7 +38,7 @@ public class RequestQueueTests {
   }
 
   @Test
-  public void canRemoveLastRequestInQueue() {
+  void canRemoveLastRequestInQueue() {
     final UUID itemId = UUID.randomUUID();
 
     Request firstRequest = requestAtPosition(itemId, 1);
@@ -64,7 +64,6 @@ public class RequestQueueTests {
     assertThat("Should contain second request",
       requestQueue.contains(secondRequest), is(true));
 
-
     assertThat("First request should still in correct position",
       firstRequest.getPosition(), is(1));
 
@@ -76,7 +75,7 @@ public class RequestQueueTests {
   }
 
   @Test
-  public void canRemoveFirstRequestInQueue() {
+  void canRemoveFirstRequestInQueue() {
     final UUID itemId = UUID.randomUUID();
 
     Request firstRequest = requestAtPosition(itemId, 1);
@@ -102,7 +101,6 @@ public class RequestQueueTests {
     assertThat("Should contain third request",
       requestQueue.contains(thirdRequest), is(true));
 
-
     assertThat("Second request should have moved up the queue",
       secondRequest.getPosition(), is(1));
 
@@ -114,7 +112,7 @@ public class RequestQueueTests {
   }
 
   @Test
-  public void canRemoveMiddleRequestInQueue() {
+  void canRemoveMiddleRequestInQueue() {
     final UUID itemId = UUID.randomUUID();
 
     Request firstRequest = requestAtPosition(itemId, 1);

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -1,11 +1,12 @@
 package org.folio.circulation.domain;
 
 import static org.folio.circulation.domain.RequestQueue.requestQueueOf;
+import static org.folio.circulation.matchers.requests.RequestMatchers.hasNoPosition;
+import static org.folio.circulation.matchers.requests.RequestMatchers.inPosition;
 import static org.folio.circulation.matchers.requests.RequestQueueMatchers.doesNotInclude;
 import static org.folio.circulation.matchers.requests.RequestQueueMatchers.hasSize;
 import static org.folio.circulation.matchers.requests.RequestQueueMatchers.includes;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
@@ -19,117 +20,99 @@ import api.support.builders.RequestBuilder;
 class RequestQueueTests {
   @Test
   void canRemoveOnlyRequestInQueue() {
-    final UUID itemId = UUID.randomUUID();
+    final var itemId = UUID.randomUUID();
 
-    Request onlyRequest = requestAtPosition(itemId, 1);
+    final var onlyRequest = requestAtPosition(itemId, 1);
 
-    final var requestQueue = requestQueueOf(onlyRequest);
+    final var queue = requestQueueOf(onlyRequest);
 
-    requestQueue.remove(onlyRequest);
+    queue.remove(onlyRequest);
 
-    assertThat(requestQueue, hasSize(0));
-    assertThat(requestQueue, doesNotInclude(onlyRequest));
+    assertThat(queue, hasSize(0));
 
-    assertThat("Removed request should not have a position",
-      onlyRequest.getPosition(), is(nullValue()));
+    assertThat(queue, doesNotInclude(onlyRequest));
 
-    assertThat("No requests have changed position",
-      requestQueue.getRequestsWithChangedPosition(), is(empty()));
+    assertThat(onlyRequest, hasNoPosition());
+
+    assertThat(queue.getRequestsWithChangedPosition(), is(empty()));
   }
 
   @Test
   void canRemoveLastRequestInQueue() {
-    final UUID itemId = UUID.randomUUID();
+    final var itemId = UUID.randomUUID();
 
-    final var first = requestAtPosition(itemId, 1);
-    final var second = requestAtPosition(itemId, 2);
-    final var third = requestAtPosition(itemId, 3);
+    final var firstRequest = requestAtPosition(itemId, 1);
+    final var secondRequest = requestAtPosition(itemId, 2);
+    final var thirdRequest = requestAtPosition(itemId, 3);
 
-    final var requestQueue = requestQueueOf(first, second, third);
+    final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest);
 
-    requestQueue.remove(third);
+    queue.remove(thirdRequest);
 
-    assertThat(requestQueue, hasSize(2));
-    assertThat(requestQueue, doesNotInclude(third));
-    assertThat(requestQueue, includes(first));
-    assertThat(requestQueue, includes(second));
+    assertThat(queue, hasSize(2));
 
-    assertThat("Removed request should not have a position",
-      third.getPosition(), is(nullValue()));
+    assertThat(queue, includes(firstRequest));
+    assertThat(queue, includes(secondRequest));
+    assertThat(queue, doesNotInclude(thirdRequest));
 
-    assertThat("First request should still in correct position",
-      first.getPosition(), is(1));
+    assertThat(firstRequest, is(inPosition(1)));
+    assertThat(secondRequest, is(inPosition(2)));
+    assertThat(thirdRequest, hasNoPosition());
 
-    assertThat("Second request should still in correct position",
-      second.getPosition(), is(2));
-
-    assertThat("No requests have changed position",
-      requestQueue.getRequestsWithChangedPosition(), is(empty()));
+    assertThat(queue.getRequestsWithChangedPosition(), is(empty()));
   }
 
   @Test
   void canRemoveFirstRequestInQueue() {
-    final UUID itemId = UUID.randomUUID();
+    final var itemId = UUID.randomUUID();
 
-    final var first = requestAtPosition(itemId, 1);
-    final var second = requestAtPosition(itemId, 2);
-    final var third = requestAtPosition(itemId, 3);
+    final var firstRequest = requestAtPosition(itemId, 1);
+    final var secondRequest = requestAtPosition(itemId, 2);
+    final var thirdRequest = requestAtPosition(itemId, 3);
 
-    final var requestQueue = requestQueueOf(first, second, third);
+    final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest);
 
-    requestQueue.remove(first);
+    queue.remove(firstRequest);
 
-    assertThat(requestQueue, hasSize(2));
-    assertThat(requestQueue, doesNotInclude(first));
-    assertThat(requestQueue, includes(second));
-    assertThat(requestQueue, includes(third));
+    assertThat(queue, hasSize(2));
 
-    assertThat("Removed request should not have a position",
-      first.getPosition(), is(nullValue()));
+    assertThat(queue, doesNotInclude(firstRequest));
+    assertThat(queue, includes(secondRequest));
+    assertThat(queue, includes(thirdRequest));
 
-    assertThat("Second request should have moved up the queue",
-      second.getPosition(), is(1));
+    assertThat(firstRequest, hasNoPosition());
+    assertThat(secondRequest, is(inPosition(1)));
+    assertThat(thirdRequest, is(inPosition(2)));
 
-    assertThat("Third request should have moved up the queue",
-      third.getPosition(), is(2));
-
-    assertThat("Second and third requests have changed position",
-      requestQueue.getRequestsWithChangedPosition(), contains(third, second));
+    assertThat(queue.getRequestsWithChangedPosition(), contains(thirdRequest, secondRequest));
   }
 
   @Test
   void canRemoveMiddleRequestInQueue() {
-    final UUID itemId = UUID.randomUUID();
+    final var itemId = UUID.randomUUID();
 
-    Request first = requestAtPosition(itemId, 1);
-    Request second = requestAtPosition(itemId, 2);
-    Request third = requestAtPosition(itemId, 3);
-    Request fourth = requestAtPosition(itemId, 4);
+    final var firstRequest = requestAtPosition(itemId, 1);
+    final var secondRequest = requestAtPosition(itemId, 2);
+    final var thirdRequest = requestAtPosition(itemId, 3);
+    final var fourthRequest = requestAtPosition(itemId, 4);
 
-    final var requestQueue = requestQueueOf(first, second, third, fourth);
+    final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
 
-    requestQueue.remove(second);
+    queue.remove(secondRequest);
 
-    assertThat(requestQueue, hasSize(3));
-    assertThat(requestQueue, doesNotInclude(second));
-    assertThat(requestQueue, includes(first));
-    assertThat(requestQueue, includes(third));
-    assertThat(requestQueue, includes(fourth));
+    assertThat(queue, hasSize(3));
 
-    assertThat("Removed request should not have a position",
-      second.getPosition(), is(nullValue()));
+    assertThat(queue, includes(firstRequest));
+    assertThat(queue, doesNotInclude(secondRequest));
+    assertThat(queue, includes(thirdRequest));
+    assertThat(queue, includes(fourthRequest));
 
-    assertThat("First request should be at the same position",
-      first.getPosition(), is(1));
+    assertThat(firstRequest, is(inPosition(1)));
+    assertThat(secondRequest, hasNoPosition());
+    assertThat(thirdRequest, is(inPosition(2)));
+    assertThat(fourthRequest, is(inPosition(3)));
 
-    assertThat("Third request should have moved up the queue",
-      third.getPosition(), is(2));
-
-    assertThat("Fourth request should have moved up the queue",
-      fourth.getPosition(), is(3));
-
-    assertThat("Second and third requests have changed position",
-      requestQueue.getRequestsWithChangedPosition(), contains(fourth, third));
+    assertThat(queue.getRequestsWithChangedPosition(), contains(fourthRequest, thirdRequest));
   }
 
   private Request requestAtPosition(UUID itemId, Integer position) {

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -18,10 +18,10 @@ import org.junit.jupiter.api.Test;
 import api.support.builders.RequestBuilder;
 
 class RequestQueueTests {
+  private final UUID itemId = UUID.randomUUID();
+
   @Test
   void canRemoveOnlyRequestInQueue() {
-    final var itemId = UUID.randomUUID();
-
     final var onlyRequest = requestAtPosition(itemId, 1);
 
     final var queue = requestQueueOf(onlyRequest);
@@ -39,8 +39,6 @@ class RequestQueueTests {
 
   @Test
   void canRemoveLastRequestInQueue() {
-    final var itemId = UUID.randomUUID();
-
     final var firstRequest = requestAtPosition(itemId, 1);
     final var secondRequest = requestAtPosition(itemId, 2);
     final var thirdRequest = requestAtPosition(itemId, 3);
@@ -64,8 +62,6 @@ class RequestQueueTests {
 
   @Test
   void canRemoveFirstRequestInQueue() {
-    final var itemId = UUID.randomUUID();
-
     final var firstRequest = requestAtPosition(itemId, 1);
     final var secondRequest = requestAtPosition(itemId, 2);
     final var thirdRequest = requestAtPosition(itemId, 3);
@@ -89,8 +85,6 @@ class RequestQueueTests {
 
   @Test
   void canRemoveMiddleRequestInQueue() {
-    final var itemId = UUID.randomUUID();
-
     final var firstRequest = requestAtPosition(itemId, 1);
     final var secondRequest = requestAtPosition(itemId, 2);
     final var thirdRequest = requestAtPosition(itemId, 3);

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -1,7 +1,6 @@
 package org.folio.circulation.domain;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
+import static org.folio.circulation.domain.RequestQueue.requestQueueOf;
 import static org.folio.circulation.matchers.requests.RequestQueueMatchers.doesNotInclude;
 import static org.folio.circulation.matchers.requests.RequestQueueMatchers.hasSize;
 import static org.folio.circulation.matchers.requests.RequestQueueMatchers.includes;
@@ -24,12 +23,11 @@ class RequestQueueTests {
 
     Request onlyRequest = requestAtPosition(itemId, 1);
 
-    final RequestQueue requestQueue = new RequestQueue(singletonList(onlyRequest));
+    final var requestQueue = requestQueueOf(onlyRequest);
 
     requestQueue.remove(onlyRequest);
 
     assertThat(requestQueue, hasSize(0));
-
     assertThat(requestQueue, doesNotInclude(onlyRequest));
 
     assertThat("Removed request should not have a position",
@@ -43,28 +41,27 @@ class RequestQueueTests {
   void canRemoveLastRequestInQueue() {
     final UUID itemId = UUID.randomUUID();
 
-    Request firstRequest = requestAtPosition(itemId, 1);
-    Request secondRequest = requestAtPosition(itemId, 2);
-    Request thirdRequest = requestAtPosition(itemId, 3);
+    final var first = requestAtPosition(itemId, 1);
+    final var second = requestAtPosition(itemId, 2);
+    final var third = requestAtPosition(itemId, 3);
 
-    final RequestQueue requestQueue = new RequestQueue(
-      asList(firstRequest, secondRequest, thirdRequest));
+    final var requestQueue = requestQueueOf(first, second, third);
 
-    requestQueue.remove(thirdRequest);
+    requestQueue.remove(third);
 
     assertThat(requestQueue, hasSize(2));
-    assertThat(requestQueue, doesNotInclude(thirdRequest));
-    assertThat(requestQueue, includes(firstRequest));
-    assertThat(requestQueue, includes(secondRequest));
+    assertThat(requestQueue, doesNotInclude(third));
+    assertThat(requestQueue, includes(first));
+    assertThat(requestQueue, includes(second));
 
     assertThat("Removed request should not have a position",
-      thirdRequest.getPosition(), is(nullValue()));
+      third.getPosition(), is(nullValue()));
 
     assertThat("First request should still in correct position",
-      firstRequest.getPosition(), is(1));
+      first.getPosition(), is(1));
 
     assertThat("Second request should still in correct position",
-      secondRequest.getPosition(), is(2));
+      second.getPosition(), is(2));
 
     assertThat("No requests have changed position",
       requestQueue.getRequestsWithChangedPosition(), is(empty()));
@@ -74,67 +71,65 @@ class RequestQueueTests {
   void canRemoveFirstRequestInQueue() {
     final UUID itemId = UUID.randomUUID();
 
-    Request firstRequest = requestAtPosition(itemId, 1);
-    Request secondRequest = requestAtPosition(itemId, 2);
-    Request thirdRequest = requestAtPosition(itemId, 3);
+    final var first = requestAtPosition(itemId, 1);
+    final var second = requestAtPosition(itemId, 2);
+    final var third = requestAtPosition(itemId, 3);
 
-    final RequestQueue requestQueue = new RequestQueue(
-      asList(firstRequest, secondRequest, thirdRequest));
+    final var requestQueue = requestQueueOf(first, second, third);
 
-    requestQueue.remove(firstRequest);
+    requestQueue.remove(first);
 
     assertThat(requestQueue, hasSize(2));
-    assertThat(requestQueue, doesNotInclude(firstRequest));
-    assertThat(requestQueue, includes(secondRequest));
-    assertThat(requestQueue, includes(thirdRequest));
+    assertThat(requestQueue, doesNotInclude(first));
+    assertThat(requestQueue, includes(second));
+    assertThat(requestQueue, includes(third));
 
     assertThat("Removed request should not have a position",
-      firstRequest.getPosition(), is(nullValue()));
+      first.getPosition(), is(nullValue()));
 
     assertThat("Second request should have moved up the queue",
-      secondRequest.getPosition(), is(1));
+      second.getPosition(), is(1));
 
     assertThat("Third request should have moved up the queue",
-      thirdRequest.getPosition(), is(2));
+      third.getPosition(), is(2));
 
     assertThat("Second and third requests have changed position",
-      requestQueue.getRequestsWithChangedPosition(), contains(thirdRequest, secondRequest));
+      requestQueue.getRequestsWithChangedPosition(), contains(third, second));
   }
 
   @Test
   void canRemoveMiddleRequestInQueue() {
     final UUID itemId = UUID.randomUUID();
 
-    Request firstRequest = requestAtPosition(itemId, 1);
-    Request secondRequest = requestAtPosition(itemId, 2);
-    Request thirdRequest = requestAtPosition(itemId, 3);
-    Request fourthRequest = requestAtPosition(itemId, 4);
+    Request first = requestAtPosition(itemId, 1);
+    Request second = requestAtPosition(itemId, 2);
+    Request third = requestAtPosition(itemId, 3);
+    Request fourth = requestAtPosition(itemId, 4);
 
-    final RequestQueue requestQueue = new RequestQueue(
-      asList(firstRequest, secondRequest, thirdRequest, fourthRequest));
+    final var requestQueue = requestQueueOf(first, second, third, fourth);
 
-    requestQueue.remove(secondRequest);
+    requestQueue.remove(second);
 
     assertThat(requestQueue, hasSize(3));
-    assertThat(requestQueue, doesNotInclude(secondRequest));
-    assertThat(requestQueue, includes(firstRequest));
-    assertThat(requestQueue, includes(thirdRequest));
-    assertThat(requestQueue, includes(fourthRequest));
+    assertThat(requestQueue, doesNotInclude(second));
+    assertThat(requestQueue, includes(first));
+    assertThat(requestQueue, includes(third));
+    assertThat(requestQueue, includes(fourth));
 
     assertThat("Removed request should not have a position",
-      secondRequest.getPosition(), is(nullValue()));
+      second.getPosition(), is(nullValue()));
 
     assertThat("First request should be at the same position",
-      firstRequest.getPosition(), is(1));
+      first.getPosition(), is(1));
 
     assertThat("Third request should have moved up the queue",
-      thirdRequest.getPosition(), is(2));
+      third.getPosition(), is(2));
 
     assertThat("Fourth request should have moved up the queue",
-      fourthRequest.getPosition(), is(3));
+      fourth.getPosition(), is(3));
 
     assertThat("Second and third requests have changed position",
-      requestQueue.getRequestsWithChangedPosition(), contains(fourthRequest, thirdRequest));
+      requestQueue.getRequestsWithChangedPosition(), contains(fourth, third));
   }
 
   private Request requestAtPosition(UUID itemId, Integer position) {

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -13,6 +13,7 @@ import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 
 import java.util.UUID;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import api.support.builders.RequestBuilder;
@@ -37,82 +38,85 @@ class RequestQueueTests {
     assertThat(queue.getRequestsWithChangedPosition(), is(empty()));
   }
 
-  @Test
-  void canRemoveLastRequestInQueue() {
-    final var firstRequest = requestAtPosition(itemId, 1);
-    final var secondRequest = requestAtPosition(itemId, 2);
-    final var thirdRequest = requestAtPosition(itemId, 3);
-    final var fourthRequest = requestAtPosition(itemId, 4);
+  @Nested
+  class whenQueueIncludesMultipleRequests {
+    @Test
+    void canRemoveLastRequestInQueue() {
+      final var firstRequest = requestAtPosition(itemId, 1);
+      final var secondRequest = requestAtPosition(itemId, 2);
+      final var thirdRequest = requestAtPosition(itemId, 3);
+      final var fourthRequest = requestAtPosition(itemId, 4);
 
-    final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
+      final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
 
-    queue.remove(fourthRequest);
+      queue.remove(fourthRequest);
 
-    assertThat(queue, hasSize(3));
+      assertThat(queue, hasSize(3));
 
-    assertThat(queue, includes(firstRequest));
-    assertThat(queue, includes(secondRequest));
-    assertThat(queue, includes(thirdRequest));
-    assertThat(queue, doesNotInclude(fourthRequest));
+      assertThat(queue, includes(firstRequest));
+      assertThat(queue, includes(secondRequest));
+      assertThat(queue, includes(thirdRequest));
+      assertThat(queue, doesNotInclude(fourthRequest));
 
-    assertThat(firstRequest, is(inPosition(1)));
-    assertThat(secondRequest, is(inPosition(2)));
-    assertThat(thirdRequest, is(inPosition(3)));
-    assertThat(fourthRequest, hasNoPosition());
+      assertThat(firstRequest, is(inPosition(1)));
+      assertThat(secondRequest, is(inPosition(2)));
+      assertThat(thirdRequest, is(inPosition(3)));
+      assertThat(fourthRequest, hasNoPosition());
 
-    assertThat(queue.getRequestsWithChangedPosition(), is(empty()));
-  }
+      assertThat(queue.getRequestsWithChangedPosition(), is(empty()));
+    }
 
-  @Test
-  void canRemoveFirstRequestInQueue() {
-    final var firstRequest = requestAtPosition(itemId, 1);
-    final var secondRequest = requestAtPosition(itemId, 2);
-    final var thirdRequest = requestAtPosition(itemId, 3);
-    final var fourthRequest = requestAtPosition(itemId, 4);
+    @Test
+    void canRemoveFirstRequestInQueue() {
+      final var firstRequest = requestAtPosition(itemId, 1);
+      final var secondRequest = requestAtPosition(itemId, 2);
+      final var thirdRequest = requestAtPosition(itemId, 3);
+      final var fourthRequest = requestAtPosition(itemId, 4);
 
-    final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
+      final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
 
-    queue.remove(firstRequest);
+      queue.remove(firstRequest);
 
-    assertThat(queue, hasSize(3));
+      assertThat(queue, hasSize(3));
 
-    assertThat(queue, doesNotInclude(firstRequest));
-    assertThat(queue, includes(secondRequest));
-    assertThat(queue, includes(thirdRequest));
-    assertThat(queue, includes(fourthRequest));
+      assertThat(queue, doesNotInclude(firstRequest));
+      assertThat(queue, includes(secondRequest));
+      assertThat(queue, includes(thirdRequest));
+      assertThat(queue, includes(fourthRequest));
 
-    assertThat(firstRequest, hasNoPosition());
-    assertThat(secondRequest, is(inPosition(1)));
-    assertThat(thirdRequest, is(inPosition(2)));
-    assertThat(fourthRequest, is(inPosition(3)));
+      assertThat(firstRequest, hasNoPosition());
+      assertThat(secondRequest, is(inPosition(1)));
+      assertThat(thirdRequest, is(inPosition(2)));
+      assertThat(fourthRequest, is(inPosition(3)));
 
-    assertThat(queue.getRequestsWithChangedPosition(), contains(fourthRequest, thirdRequest, secondRequest));
-  }
+      assertThat(queue.getRequestsWithChangedPosition(), contains(fourthRequest, thirdRequest, secondRequest));
+    }
 
-  @Test
-  void canRemoveMiddleRequestInQueue() {
-    final var firstRequest = requestAtPosition(itemId, 1);
-    final var secondRequest = requestAtPosition(itemId, 2);
-    final var thirdRequest = requestAtPosition(itemId, 3);
-    final var fourthRequest = requestAtPosition(itemId, 4);
+    @Test
+    void canRemoveMiddleRequestInQueue() {
+      final var firstRequest = requestAtPosition(itemId, 1);
+      final var secondRequest = requestAtPosition(itemId, 2);
+      final var thirdRequest = requestAtPosition(itemId, 3);
+      final var fourthRequest = requestAtPosition(itemId, 4);
 
-    final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
+      final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
 
-    queue.remove(secondRequest);
+      queue.remove(secondRequest);
 
-    assertThat(queue, hasSize(3));
+      assertThat(queue, hasSize(3));
 
-    assertThat(queue, includes(firstRequest));
-    assertThat(queue, doesNotInclude(secondRequest));
-    assertThat(queue, includes(thirdRequest));
-    assertThat(queue, includes(fourthRequest));
+      assertThat(queue, includes(firstRequest));
+      assertThat(queue, doesNotInclude(secondRequest));
+      assertThat(queue, includes(thirdRequest));
+      assertThat(queue, includes(fourthRequest));
 
-    assertThat(firstRequest, is(inPosition(1)));
-    assertThat(secondRequest, hasNoPosition());
-    assertThat(thirdRequest, is(inPosition(2)));
-    assertThat(fourthRequest, is(inPosition(3)));
+      assertThat(firstRequest, is(inPosition(1)));
+      assertThat(secondRequest, hasNoPosition());
+      assertThat(thirdRequest, is(inPosition(2)));
+      assertThat(fourthRequest, is(inPosition(3)));
 
-    assertThat(queue.getRequestsWithChangedPosition(), contains(fourthRequest, thirdRequest));
+      assertThat(queue.getRequestsWithChangedPosition(), contains(fourthRequest, thirdRequest));
+    }
   }
 
   private Request requestAtPosition(UUID itemId, Integer position) {

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -1,26 +1,27 @@
 package org.folio.circulation.domain;
 
-import api.support.builders.RequestBuilder;
-import org.junit.Test;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 
 import java.util.UUID;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.Test;
+
+import api.support.builders.RequestBuilder;
 
 public class RequestQueueTests {
-
   @Test
   public void canRemoveOnlyRequestInQueue() {
     final UUID itemId = UUID.randomUUID();
 
     Request onlyRequest = requestAtPosition(itemId, 1);
 
-    final RequestQueue requestQueue = new RequestQueue(asList(onlyRequest));
+    final RequestQueue requestQueue = new RequestQueue(singletonList(onlyRequest));
 
     requestQueue.remove(onlyRequest);
 

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -40,15 +40,35 @@ class RequestQueueTests {
 
   @Nested
   class whenQueueIncludesMultipleRequests {
+    final Request firstRequest = requestAtPosition(itemId, 1);
+    final Request secondRequest = requestAtPosition(itemId, 2);
+    final Request thirdRequest = requestAtPosition(itemId, 3);
+    final Request fourthRequest = requestAtPosition(itemId, 4);
+
+    final RequestQueue queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
+
+    @Test
+    void canRemoveFirstRequestInQueue() {
+      queue.remove(firstRequest);
+
+      assertThat(queue, hasSize(3));
+
+      assertThat(queue, doesNotInclude(firstRequest));
+      assertThat(queue, includes(secondRequest));
+      assertThat(queue, includes(thirdRequest));
+      assertThat(queue, includes(fourthRequest));
+
+      assertThat(firstRequest, hasNoPosition());
+      assertThat(secondRequest, is(inPosition(1)));
+      assertThat(thirdRequest, is(inPosition(2)));
+      assertThat(fourthRequest, is(inPosition(3)));
+
+      assertThat(queue.getRequestsWithChangedPosition(),
+        contains(fourthRequest, thirdRequest, secondRequest));
+    }
+
     @Test
     void canRemoveLastRequestInQueue() {
-      final var firstRequest = requestAtPosition(itemId, 1);
-      final var secondRequest = requestAtPosition(itemId, 2);
-      final var thirdRequest = requestAtPosition(itemId, 3);
-      final var fourthRequest = requestAtPosition(itemId, 4);
-
-      final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
-
       queue.remove(fourthRequest);
 
       assertThat(queue, hasSize(3));
@@ -67,40 +87,7 @@ class RequestQueueTests {
     }
 
     @Test
-    void canRemoveFirstRequestInQueue() {
-      final var firstRequest = requestAtPosition(itemId, 1);
-      final var secondRequest = requestAtPosition(itemId, 2);
-      final var thirdRequest = requestAtPosition(itemId, 3);
-      final var fourthRequest = requestAtPosition(itemId, 4);
-
-      final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
-
-      queue.remove(firstRequest);
-
-      assertThat(queue, hasSize(3));
-
-      assertThat(queue, doesNotInclude(firstRequest));
-      assertThat(queue, includes(secondRequest));
-      assertThat(queue, includes(thirdRequest));
-      assertThat(queue, includes(fourthRequest));
-
-      assertThat(firstRequest, hasNoPosition());
-      assertThat(secondRequest, is(inPosition(1)));
-      assertThat(thirdRequest, is(inPosition(2)));
-      assertThat(fourthRequest, is(inPosition(3)));
-
-      assertThat(queue.getRequestsWithChangedPosition(), contains(fourthRequest, thirdRequest, secondRequest));
-    }
-
-    @Test
     void canRemoveMiddleRequestInQueue() {
-      final var firstRequest = requestAtPosition(itemId, 1);
-      final var secondRequest = requestAtPosition(itemId, 2);
-      final var thirdRequest = requestAtPosition(itemId, 3);
-      final var fourthRequest = requestAtPosition(itemId, 4);
-
-      final var queue = requestQueueOf(firstRequest, secondRequest, thirdRequest, fourthRequest);
-
       queue.remove(secondRequest);
 
       assertThat(queue, hasSize(3));
@@ -115,7 +102,8 @@ class RequestQueueTests {
       assertThat(thirdRequest, is(inPosition(2)));
       assertThat(fourthRequest, is(inPosition(3)));
 
-      assertThat(queue.getRequestsWithChangedPosition(), contains(fourthRequest, thirdRequest));
+      assertThat(queue.getRequestsWithChangedPosition(),
+        contains(fourthRequest, thirdRequest));
     }
   }
 

--- a/src/test/java/org/folio/circulation/matchers/requests/RequestMatchers.java
+++ b/src/test/java/org/folio/circulation/matchers/requests/RequestMatchers.java
@@ -1,0 +1,48 @@
+package org.folio.circulation.matchers.requests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+import org.folio.circulation.domain.Request;
+import org.hamcrest.Description;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+public class RequestMatchers {
+  public static Matcher<Request> hasNoPosition() {
+    return new NoPositionMatcher();
+  }
+
+  public static Matcher<Request> inPosition(Integer position) {
+    return new PositionMatcher(position);
+  }
+
+  private static class NoPositionMatcher extends TypeSafeDiagnosingMatcher<Request> {
+    @Override
+    protected boolean matchesSafely(Request request, Description mismatchDescription) {
+      final var matcher = is(nullValue());
+
+      mismatchDescription.appendText("request has position ").appendValue(request.getPosition());
+
+      return matcher.matches(request.getPosition());
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("request has no position");
+    }
+  }
+
+  private static class PositionMatcher extends FeatureMatcher<Request, Integer> {
+    PositionMatcher(Integer position) {
+      super(equalTo(position), "request with position", "position");
+    }
+
+    @Override
+    protected Integer featureValueOf(Request actual) {
+      return actual.getPosition();
+    }
+  }
+}

--- a/src/test/java/org/folio/circulation/matchers/requests/RequestQueueMatchers.java
+++ b/src/test/java/org/folio/circulation/matchers/requests/RequestQueueMatchers.java
@@ -2,23 +2,82 @@ package org.folio.circulation.matchers.requests;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 
+import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestQueue;
+import org.hamcrest.Description;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 public class RequestQueueMatchers {
   public static Matcher<RequestQueue> hasSize(Integer expectedSize) {
-    return new RequestQueueSizeMatcher(expectedSize);
+    return new SizeMatcher(expectedSize);
   }
-  
-  private static class RequestQueueSizeMatcher extends FeatureMatcher<RequestQueue, Integer> {
-    private RequestQueueSizeMatcher(Integer expectedSize) {
+
+  public static Matcher<RequestQueue> doesNotInclude(Request request) {
+    return new DoesNotIncludeMatcher(request);
+  }
+
+  public static Matcher<RequestQueue> includes(Request request) {
+    return new IncludesMatcher(request);
+  }
+
+  private static class SizeMatcher extends FeatureMatcher<RequestQueue, Integer> {
+    private SizeMatcher(Integer expectedSize) {
       super(equalTo(expectedSize), "a request queue with size", "request queue size");
     }
 
     @Override
     protected Integer featureValueOf(RequestQueue actual) {
       return actual.size();
+    }
+  }
+
+  private static class IncludesMatcher extends TypeSafeDiagnosingMatcher<RequestQueue> {
+    private final Request request;
+
+    private IncludesMatcher(Request request) {
+      this.request = request;
+    }
+
+    @Override
+    protected boolean matchesSafely(RequestQueue queue, Description mismatchDescription) {
+      final var contains = queue.contains(request);
+
+      if (!contains) {
+        mismatchDescription.appendText(" does not contain request with ID ").appendValue(request.getId());
+      }
+
+      return contains;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("does contain request with ID ").appendValue(request.getId());
+    }
+  }
+
+  private static class DoesNotIncludeMatcher extends TypeSafeDiagnosingMatcher<RequestQueue> {
+    private final Request request;
+
+    private DoesNotIncludeMatcher(Request request) {
+      this.request = request;
+    }
+
+    @Override
+    protected boolean matchesSafely(RequestQueue queue, Description mismatchDescription) {
+      final var contains = queue.contains(request);
+
+      if (contains) {
+        mismatchDescription.appendText(" does contain request with ID ").appendValue(request.getId());
+      }
+
+      return !contains;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("does not contain request with ID ").appendValue(request.getId());
     }
   }
 }

--- a/src/test/java/org/folio/circulation/matchers/requests/RequestQueueMatchers.java
+++ b/src/test/java/org/folio/circulation/matchers/requests/RequestQueueMatchers.java
@@ -1,0 +1,24 @@
+package org.folio.circulation.matchers.requests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import org.folio.circulation.domain.RequestQueue;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+public class RequestQueueMatchers {
+  public static Matcher<RequestQueue> hasSize(Integer expectedSize) {
+    return new RequestQueueSizeMatcher(expectedSize);
+  }
+  
+  private static class RequestQueueSizeMatcher extends FeatureMatcher<RequestQueue, Integer> {
+    private RequestQueueSizeMatcher(Integer expectedSize) {
+      super(equalTo(expectedSize), "a request queue with size", "request queue size");
+    }
+
+    @Override
+    protected Integer featureValueOf(RequestQueue actual) {
+      return actual.size();
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
The overall purpose of this work is to move the updating of records in storage to after the business logic during a check out.

In order to do that, it is necessary to restructure when the records are changed and when they are stored. Unfortunately, these two are quite coupled together at the moment. In order to reduce that, the request queue code needs to change.

In preparation for that (and adding more tests) it seemed a good idea to simplify the current tests and hopefully reduce duplication in future tests.

## Approach
* Move the tests to JUnit 5 (mostly to start that migration and to use nesting)
* Introduce custom matchers to simplify the assertions (and reduce the need for descriptions)
* Reduce the duplication in the tests for queues with multiple requests (including by nesting them)
* Move these tests to a specific class for removing requests from a queue

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
