### PR TITLE
CIRC-1055: Update notes dependency

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1077,7 +1077,7 @@
     },
     {
       "id": "notes",
-      "version": "2.0"
+      "version": "1.0 2.0"
     }
   ],
   "permissionSets": [

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1077,7 +1077,7 @@
     },
     {
       "id": "notes",
-      "version": "1.0"
+      "version": "2.0"
     }
   ],
   "permissionSets": [

--- a/src/test/java/api/support/fakes/StorageSchema.java
+++ b/src/test/java/api/support/fakes/StorageSchema.java
@@ -32,7 +32,7 @@ public class StorageSchema {
   }
 
   public static JsonSchemaValidator validatorForNoteSchema() throws IOException {
-    return JsonSchemaValidator.fromResource("/note-2-9.json");
+    return JsonSchemaValidator.fromResource("/note-2-0.json");
   }
 
   public static JsonSchemaValidator validatorForFeeFineOperationSchema() throws IOException {

--- a/src/test/resources/link.json
+++ b/src/test/resources/link.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Link to object associated with a note",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Id of object linked to note",
+      "example": "1234-5678"
+    },
+    "type": {
+      "type": "string",
+      "description": "Type of object linked to note",
+      "example": "package"
+    }
+  },
+  "required": [
+    "id",
+    "type"
+  ]
+}

--- a/src/test/resources/note-2-0.json
+++ b/src/test/resources/note-2-0.json
@@ -7,7 +7,7 @@
     "id": {
       "type": "string",
       "description": "Unique generated identifier for the note",
-      "$ref": "raml-util/schemas/uuid.schema",
+      "$ref": "/raml-util/schemas/uuid.schema",
       "example": "62d00c36-a94f-434d-9cd2-c7ea159303da"
     },
     "typeId": {
@@ -59,23 +59,15 @@
     },
     "metadata": {
       "type": "object",
-      "$ref": "raml-util/schemas/metadata.schema",
+      "$ref": "/raml-util/schemas/metadata.schema",
       "readonly": true
     },
     "links": {
       "description": "Collection of links to associated objects",
       "type": "array",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Id of object linked to note",
-          "example": "1234-5678"
-        },
-        "type": {
-          "type": "string",
-          "description": "Type of object linked to note",
-          "example": "package"
-        }
+      "items": {
+        "type": "object",
+        "$ref": "link.json"
       }
     }
   },


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/FOLIO-2910 and https://issues.folio.org/browse/CIRC-1055 were brought to our attention that mod-circulation build is failing due to notes interface version mismatch. Fix the problem to alleviate the situation for tomorrow's system demo.

## Approach
Change interface version from 1.0 to 2.0

#### TODOS and Open Questions
From a high level, looks like no other changes are needed but look deeper in implementation and tests to see if any functionality should be changed. 
/note-links/domain/{domain}/type/{type}/id/{id}/ endpoint's query param has changed from 'title' to 'search' in this [PR](https://github.com/folio-org/mod-notes/pull/163/files?file-filters%5B%5D=.java&file-filters%5B%5D=.json&file-filters%5B%5D=.raml&file-filters%5B%5D=.sql)
