### PR TITLE
Simplify delete request api tests CIRC-1025 

### DIFF
--- a/src/test/java/api/requests/RequestsAPIDeletionTests.java
+++ b/src/test/java/api/requests/RequestsAPIDeletionTests.java
@@ -8,9 +8,9 @@ import static org.hamcrest.core.Is.is;
 import org.junit.Test;
 
 import api.support.APITests;
-import api.support.MultipleJsonRecords;
 import api.support.builders.RequestBuilder;
 import api.support.http.ItemResource;
+import api.support.http.UserResource;
 
 public class RequestsAPIDeletionTests extends APITests {
   @Test
@@ -19,22 +19,17 @@ public class RequestsAPIDeletionTests extends APITests {
 
     checkOutFixture.checkOutByBarcode(nod);
 
-    final var firstRequestId = requestsFixture.place(requestFor(nod)).getId();
-    final var secondRequestId = requestsFixture.place(requestFor(nod)).getId();
-    final var thirdRequestId = requestsFixture.place(requestFor(nod)).getId();
+    final var firstRequest = requestsFixture.place(requestFor(nod, usersFixture.rebecca()));
+    final var secondRequest = requestsFixture.place(requestFor(nod, usersFixture.charlotte()));
+    final var thirdRequest = requestsFixture.place(requestFor(nod, usersFixture.james()));
 
-    requestsFixture.deleteRequest(secondRequestId);
+    requestsFixture.deleteRequest(secondRequest.getId());
 
-    assertThat(requestsFixture.getById(firstRequestId).getStatusCode(),
-      is(HTTP_OK));
+    assertThat(requestsFixture.getById(firstRequest.getId()).getStatusCode(), is(HTTP_OK));
+    assertThat(requestsFixture.getById(secondRequest.getId()).getStatusCode(), is(HTTP_NOT_FOUND));
+    assertThat(requestsFixture.getById(thirdRequest.getId()).getStatusCode(), is(HTTP_OK));
 
-    assertThat(requestsFixture.getById(secondRequestId).getStatusCode(),
-      is(HTTP_NOT_FOUND));
-
-    assertThat(requestsFixture.getById(thirdRequestId).getStatusCode(),
-      is(HTTP_OK));
-
-    MultipleJsonRecords allRequests = requestsFixture.getAllRequests();
+    final var allRequests = requestsFixture.getAllRequests();
 
     assertThat(allRequests.size(), is(2));
     assertThat(allRequests.totalRecords(), is(2));
@@ -42,9 +37,9 @@ public class RequestsAPIDeletionTests extends APITests {
 
   @Test
   public void canDeleteAllRequests() {
-    final ItemResource nod = itemsFixture.basedUponNod();
-    final ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
-    final ItemResource temeraire = itemsFixture.basedUponTemeraire();
+    final var nod = itemsFixture.basedUponNod();
+    final var smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final var temeraire = itemsFixture.basedUponTemeraire();
 
     checkOutFixture.checkOutByBarcode(nod);
     checkOutFixture.checkOutByBarcode(smallAngryPlanet);
@@ -56,16 +51,20 @@ public class RequestsAPIDeletionTests extends APITests {
 
     requestsFixture.deleteAllRequests();
 
-    MultipleJsonRecords allRequests = requestsFixture.getAllRequests();
+    final var allRequests = requestsFixture.getAllRequests();
 
     assertThat(allRequests.size(), is(0));
     assertThat(allRequests.totalRecords(), is(0));
   }
 
   private RequestBuilder requestFor(ItemResource item) {
+    return requestFor(item, usersFixture.rebecca());
+  }
+
+  private RequestBuilder requestFor(ItemResource item, UserResource requester) {
     return new RequestBuilder()
       .withItemId(item.getId())
       .withPickupServicePoint(servicePointsFixture.cd1())
-      .withRequesterId(usersFixture.rebecca().getId());
+      .withRequesterId(requester.getId());
   }
 }

--- a/src/test/java/api/requests/RequestsAPIDeletionTests.java
+++ b/src/test/java/api/requests/RequestsAPIDeletionTests.java
@@ -5,8 +5,6 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import java.util.UUID;
-
 import org.junit.Test;
 
 import api.support.APITests;
@@ -15,6 +13,33 @@ import api.support.builders.RequestBuilder;
 import api.support.http.ItemResource;
 
 public class RequestsAPIDeletionTests extends APITests {
+  @Test
+  public void canDeleteARequestFromTheQueue() {
+    final var nod = itemsFixture.basedUponNod();
+
+    checkOutFixture.checkOutByBarcode(nod);
+
+    final var firstRequestId = requestsFixture.place(requestFor(nod)).getId();
+    final var secondRequestId = requestsFixture.place(requestFor(nod)).getId();
+    final var thirdRequestId = requestsFixture.place(requestFor(nod)).getId();
+
+    requestsFixture.deleteRequest(secondRequestId);
+
+    assertThat(requestsFixture.getById(firstRequestId).getStatusCode(),
+      is(HTTP_OK));
+
+    assertThat(requestsFixture.getById(secondRequestId).getStatusCode(),
+      is(HTTP_NOT_FOUND));
+
+    assertThat(requestsFixture.getById(thirdRequestId).getStatusCode(),
+      is(HTTP_OK));
+
+    MultipleJsonRecords allRequests = requestsFixture.getAllRequests();
+
+    assertThat(allRequests.size(), is(2));
+    assertThat(allRequests.totalRecords(), is(2));
+  }
+
   @Test
   public void canDeleteAllRequests() {
     final ItemResource nod = itemsFixture.basedUponNod();
@@ -35,37 +60,6 @@ public class RequestsAPIDeletionTests extends APITests {
 
     assertThat(allRequests.size(), is(0));
     assertThat(allRequests.totalRecords(), is(0));
-  }
-
-  @Test
-  public void canDeleteAnIndividualRequest() {
-    final ItemResource nod = itemsFixture.basedUponNod();
-    final ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
-    final ItemResource temeraire = itemsFixture.basedUponTemeraire();
-
-    checkOutFixture.checkOutByBarcode(nod);
-    checkOutFixture.checkOutByBarcode(smallAngryPlanet);
-    checkOutFixture.checkOutByBarcode(temeraire);
-
-    final UUID firstRequestId = requestsFixture.place(requestFor(nod)).getId();
-    final UUID secondRequestId = requestsFixture.place(requestFor(smallAngryPlanet)).getId();
-    final UUID thirdRequestId = requestsFixture.place(requestFor(temeraire)).getId();
-
-    requestsFixture.deleteRequest(secondRequestId);
-
-    assertThat(requestsFixture.getById(firstRequestId).getStatusCode(),
-      is(HTTP_OK));
-
-    assertThat(requestsFixture.getById(secondRequestId).getStatusCode(),
-      is(HTTP_NOT_FOUND));
-
-    assertThat(requestsFixture.getById(thirdRequestId).getStatusCode(),
-      is(HTTP_OK));
-
-    MultipleJsonRecords allRequests = requestsFixture.getAllRequests();
-
-    assertThat(allRequests.size(), is(2));
-    assertThat(allRequests.totalRecords(), is(2));
   }
 
   private RequestBuilder requestFor(ItemResource item) {

--- a/src/test/java/api/requests/RequestsAPIDeletionTests.java
+++ b/src/test/java/api/requests/RequestsAPIDeletionTests.java
@@ -6,9 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
-import org.folio.circulation.support.http.client.Response;
 import org.junit.Test;
 
 import api.support.APITests;
@@ -33,22 +31,19 @@ public class RequestsAPIDeletionTests extends APITests {
     requestsFixture.place(new RequestBuilder()
       .withItemId(nod.getId())
       .withPickupServicePointId(pickupServicePointId)
-      .withRequesterId(requesterId))
-      .getId();
+      .withRequesterId(requesterId));
 
     requestsFixture.place(new RequestBuilder()
       .withItemId(smallAngryPlanet.getId())
       .withPickupServicePointId(pickupServicePointId)
-      .withRequesterId(requesterId))
-      .getId();
+      .withRequesterId(requesterId));
 
     requestsFixture.place(new RequestBuilder()
       .withItemId(temeraire.getId())
       .withPickupServicePointId(pickupServicePointId)
-      .withRequesterId(requesterId))
-      .getId();
+      .withRequesterId(requesterId));
 
-    Response deleteResponse = requestsFixture.deleteAllRequests();
+    requestsFixture.deleteAllRequests();
 
     MultipleJsonRecords allRequests = requestsFixture.getAllRequests();
 
@@ -86,8 +81,6 @@ public class RequestsAPIDeletionTests extends APITests {
       .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(requesterId))
       .getId();
-
-    CompletableFuture<Response> deleteCompleted = new CompletableFuture<>();
 
     requestsFixture.deleteRequest(secondRequestId);
 

--- a/src/test/java/api/requests/RequestsAPIDeletionTests.java
+++ b/src/test/java/api/requests/RequestsAPIDeletionTests.java
@@ -17,31 +17,17 @@ import api.support.http.ItemResource;
 public class RequestsAPIDeletionTests extends APITests {
   @Test
   public void canDeleteAllRequests() {
-    UUID requesterId = usersFixture.rebecca().getId();
-
     final ItemResource nod = itemsFixture.basedUponNod();
     final ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final ItemResource temeraire = itemsFixture.basedUponTemeraire();
-    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     checkOutFixture.checkOutByBarcode(nod);
     checkOutFixture.checkOutByBarcode(smallAngryPlanet);
     checkOutFixture.checkOutByBarcode(temeraire);
 
-    requestsFixture.place(new RequestBuilder()
-      .withItemId(nod.getId())
-      .withPickupServicePointId(pickupServicePointId)
-      .withRequesterId(requesterId));
-
-    requestsFixture.place(new RequestBuilder()
-      .withItemId(smallAngryPlanet.getId())
-      .withPickupServicePointId(pickupServicePointId)
-      .withRequesterId(requesterId));
-
-    requestsFixture.place(new RequestBuilder()
-      .withItemId(temeraire.getId())
-      .withPickupServicePointId(pickupServicePointId)
-      .withRequesterId(requesterId));
+    requestsFixture.place(requestFor(nod));
+    requestsFixture.place(requestFor(smallAngryPlanet));
+    requestsFixture.place(requestFor(temeraire));
 
     requestsFixture.deleteAllRequests();
 
@@ -53,34 +39,17 @@ public class RequestsAPIDeletionTests extends APITests {
 
   @Test
   public void canDeleteAnIndividualRequest() {
-    UUID requesterId = usersFixture.rebecca().getId();
-
     final ItemResource nod = itemsFixture.basedUponNod();
     final ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final ItemResource temeraire = itemsFixture.basedUponTemeraire();
-    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
     checkOutFixture.checkOutByBarcode(nod);
     checkOutFixture.checkOutByBarcode(smallAngryPlanet);
     checkOutFixture.checkOutByBarcode(temeraire);
 
-    final UUID firstRequestId = requestsFixture.place(new RequestBuilder()
-      .withItemId(nod.getId())
-      .withPickupServicePointId(pickupServicePointId)
-      .withRequesterId(requesterId))
-      .getId();
-
-    final UUID secondRequestId = requestsFixture.place(new RequestBuilder()
-      .withItemId(smallAngryPlanet.getId())
-      .withPickupServicePointId(pickupServicePointId)
-      .withRequesterId(requesterId))
-      .getId();
-
-    final UUID thirdRequestId = requestsFixture.place(new RequestBuilder()
-      .withItemId(temeraire.getId())
-      .withPickupServicePointId(pickupServicePointId)
-      .withRequesterId(requesterId))
-      .getId();
+    final UUID firstRequestId = requestsFixture.place(requestFor(nod)).getId();
+    final UUID secondRequestId = requestsFixture.place(requestFor(smallAngryPlanet)).getId();
+    final UUID thirdRequestId = requestsFixture.place(requestFor(temeraire)).getId();
 
     requestsFixture.deleteRequest(secondRequestId);
 
@@ -97,5 +66,12 @@ public class RequestsAPIDeletionTests extends APITests {
 
     assertThat(allRequests.size(), is(2));
     assertThat(allRequests.totalRecords(), is(2));
+  }
+
+  private RequestBuilder requestFor(ItemResource item) {
+    return new RequestBuilder()
+      .withItemId(item.getId())
+      .withPickupServicePoint(servicePointsFixture.cd1())
+      .withRequesterId(usersFixture.rebecca().getId());
   }
 }

--- a/src/test/java/api/requests/RequestsAPIDeletionTests.java
+++ b/src/test/java/api/requests/RequestsAPIDeletionTests.java
@@ -1,7 +1,8 @@
 package api.requests;
 
-import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
-import static java.net.HttpURLConnection.HTTP_OK;
+import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
+import static org.folio.HttpStatus.HTTP_NOT_FOUND;
+import static org.folio.HttpStatus.HTTP_OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
@@ -25,9 +26,9 @@ public class RequestsAPIDeletionTests extends APITests {
 
     requestsFixture.deleteRequest(secondRequest.getId());
 
-    assertThat(requestsFixture.getById(firstRequest.getId()).getStatusCode(), is(HTTP_OK));
-    assertThat(requestsFixture.getById(secondRequest.getId()).getStatusCode(), is(HTTP_NOT_FOUND));
-    assertThat(requestsFixture.getById(thirdRequest.getId()).getStatusCode(), is(HTTP_OK));
+    assertThat(requestsFixture.getById(firstRequest.getId()), hasStatus(HTTP_OK));
+    assertThat(requestsFixture.getById(secondRequest.getId()), hasStatus(HTTP_NOT_FOUND));
+    assertThat(requestsFixture.getById(thirdRequest.getId()), hasStatus(HTTP_OK));
 
     final var allRequests = requestsFixture.getAllRequests();
 


### PR DESCRIPTION
## Purpose
As preparation for the ongoing work on re-organising the business logic when changing requests (CIRC-1025) and introducing an asynchronous result class to simplify how business logic is described (CIRC-1066) the request deletion tests could do with being updated to reflect more recent changes in the code

## Approach
* Move single request deletion test to top of class to emphasise most common scenario
* Check the requests in the request queue when deleting a single request
* Use requests fixture and private methods to simplify placing requests
* Use local variable type inference to reduce noise in the tests
* Use status code matcher to simplify API response checks

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
