### PR TITLE
CIRC-1074 use correct whitespace after a colon

### DIFF
--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -103,7 +103,7 @@ public class CheckInByBarcodeResource extends Resource {
 
   private ValidationErrorFailure errorWhenInIncorrectStatus(Item item) {
     String message =
-      String.format("%s (%s) (Barcode:%s) has the item status %s and cannot be checked in",
+      String.format("%s (%s) (Barcode: %s) has the item status %s and cannot be checked in",
         item.getTitle(),
         item.getMaterialTypeName(),
         item.getBarcode(),

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -228,7 +228,7 @@ public class CheckOutByBarcodeResource extends Resource {
 
   private static ValidationErrorFailure errorWhenInIncorrectStatus(Item item) {
     String message =
-      String.format("%s (%s) (Barcode:%s) has the item status %s and cannot be checked out",
+      String.format("%s (%s) (Barcode: %s) has the item status %s and cannot be checked out",
         item.getTitle(),
         item.getMaterialTypeName(),
         item.getBarcode(),

--- a/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
@@ -361,7 +361,7 @@ public class LoanCollectionResource extends CollectionResource {
 
   private static ValidationErrorFailure errorWhenInIncorrectStatus(Item item) {
     String message =
-      String.format("%s (%s) (Barcode:%s) has the item status %s, loan cannot be created",
+      String.format("%s (%s) (Barcode: %s) has the item status %s, loan cannot be created",
         item.getTitle(),
         item.getMaterialTypeName(),
         item.getBarcode(),

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -471,7 +471,7 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
     assertThat(response, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
 
     assertThat(response.getJson(), hasErrorWith(allOf(
-      hasMessage("Nod (Book) (Barcode:10304054) has the item status Intellectual item and cannot be checked in"),
+      hasMessage("Nod (Book) (Barcode: 10304054) has the item status Intellectual item and cannot be checked in"),
       hasItemBarcodeParameter(nod))));
 
     final var fetchedNod = itemsFixture.getById(nod.getId());

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -508,7 +508,7 @@ public class CheckOutByBarcodeTests extends APITests {
       .attemptCheckOutByBarcode(claimedReturnedItem, usersFixture.steve());
 
     final String expectedMessage = String.format(
-      "%s (Book) (Barcode:%s) has the item status Claimed returned and cannot be checked out",
+      "%s (Book) (Barcode: %s) has the item status Claimed returned and cannot be checked out",
       claimedReturnedItem.getInstance().getJson().getString("title"), barcode);
 
     assertThat(response.getJson(), hasErrorWith(allOf(hasMessage(expectedMessage),


### PR DESCRIPTION
Some error messages were missing whitespace around their punctuation;this
drove some people crazy.Most people never noticed.

Refs [CIRC-1074](https://issues.folio.org/browse/CIRC-1074)
