### PR TITLE
Require pubsub.events.post

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -920,7 +920,7 @@
           ],
           "pathPattern": "/circulation/handlers/loan-related-fee-fine-closed",
           "permissionsRequired": [
-            "circulation.events.post"
+            "pubsub.events.post"
           ],
           "modulePermissions": [
             "modperms.circulation.handlers.loan-related-fee-fine-closed.post"
@@ -1277,11 +1277,6 @@
       "permissionName": "circulation.end-patron-action-session.post",
       "displayName": "circulation - end patron action session",
       "description": "end patron action session"
-    },
-    {
-      "permissionName": "circulation.events.post",
-      "displayName": "Circulation - post event",
-      "description": "Post event to handle in circulation"
     },
     {
       "permissionName": "circulation.all",


### PR DESCRIPTION
Rename circulation.events.post to pubsub.events.post as this is will be defined by mod-pubsub  https://issues.folio.org/browse/MODPUBSUB-145