### PR TITLE
Introduce async result CIRC-1066

### DIFF
--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -197,9 +197,9 @@ public class RequestCollectionResource extends CollectionResource {
       requestRepository, new ServicePointRepository(clients), new ConfigurationRepository(clients));
 
     fromFutureResult(requestRepository.getById(id))
+      .flatMapFuture(requestRepository::delete)
+      .flatMapFuture(updateRequestQueue::onDeletion)
       .toCompletionStage()
-      .thenComposeAsync(r -> r.after(requestRepository::delete))
-      .thenComposeAsync(r -> r.after(updateRequestQueue::onDeletion))
       .thenApply(r -> r.map(toFixedValue(NoContentResponse::noContent)))
       .thenAccept(context::writeResultToHttpResponse);
   }

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -12,6 +12,8 @@ import org.folio.circulation.domain.CreateRequestRepositories;
 import org.folio.circulation.domain.CreateRequestService;
 import org.folio.circulation.domain.MoveRequestProcessAdapter;
 import org.folio.circulation.domain.MoveRequestService;
+import org.folio.circulation.domain.MultipleRecords;
+import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestAndRelatedRecords;
 import org.folio.circulation.domain.RequestRepresentation;
 import org.folio.circulation.domain.RequestType;
@@ -209,13 +211,17 @@ public class RequestCollectionResource extends CollectionResource {
     final var clients = Clients.create(context, client);
 
     final var requestRepository = RequestRepository.using(clients);
-    final var requestRepresentation = new RequestRepresentation();
 
     fromFutureResult(requestRepository.findBy(routingContext.request().query()))
-      .map(requests ->
-        requests.asJson(requestRepresentation::extendedRepresentation, "requests"))
+      .map(this::mapToJson)
       .map(JsonHttpResponse::ok)
       .onComplete(context::write, context::write);
+  }
+
+  private JsonObject mapToJson(MultipleRecords<Request> requests) {
+    final var requestRepresentation = new RequestRepresentation();
+
+    return requests.asJson(requestRepresentation::extendedRepresentation, "requests");
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -181,7 +181,7 @@ public class RequestCollectionResource extends CollectionResource {
     fromFutureResult(requestRepository.getById(id))
       .map(new RequestRepresentation()::extendedRepresentation)
       .map(JsonHttpResponse::ok)
-      .onSuccess(context::write).onFailure(context::write);
+      .onComplete(context::write, context::write);
   }
 
   @Override
@@ -200,7 +200,7 @@ public class RequestCollectionResource extends CollectionResource {
       .flatMapFuture(requestRepository::delete)
       .flatMapFuture(updateRequestQueue::onDeletion)
       .map(toFixedValue(NoContentResponse::noContent))
-      .onSuccess(context::write).onFailure(context::write);
+      .onComplete(context::write, context::write);
   }
 
   @Override
@@ -215,7 +215,7 @@ public class RequestCollectionResource extends CollectionResource {
       .map(requests ->
         requests.asJson(requestRepresentation::extendedRepresentation, "requests"))
       .map(JsonHttpResponse::ok)
-      .onSuccess(context::write).onFailure(context::write);
+      .onComplete(context::write, context::write);
   }
 
   @Override
@@ -225,7 +225,7 @@ public class RequestCollectionResource extends CollectionResource {
 
     fromFutureResult(clients.requestsStorage().delete())
       .map(toFixedValue(NoContentResponse::noContent))
-      .onSuccess(context::write).onFailure(context::write);
+      .onComplete(context::write, context::write);
   }
 
   void move(RoutingContext routingContext) {

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -178,10 +178,11 @@ public class RequestCollectionResource extends CollectionResource {
 
     final var id = getRequestId(routingContext);
 
-    requestRepository.getById(id)
-      .thenApply(r -> r.map(new RequestRepresentation()::extendedRepresentation))
-      .thenApply(r -> r.map(JsonHttpResponse::ok))
-      .thenAccept(context::writeResultToHttpResponse);
+    fromFutureResult(requestRepository.getById(id))
+      .map(new RequestRepresentation()::extendedRepresentation)
+      .map(JsonHttpResponse::ok)
+      .onSuccess(context::write)
+      .onFailure(context::write);
   }
 
   @Override
@@ -212,11 +213,12 @@ public class RequestCollectionResource extends CollectionResource {
     final var requestRepository = RequestRepository.using(clients);
     final var requestRepresentation = new RequestRepresentation();
 
-    requestRepository.findBy(routingContext.request().query())
-      .thenApply(r -> r.map(requests ->
-        requests.asJson(requestRepresentation::extendedRepresentation, "requests")))
-      .thenApply(r -> r.map(JsonHttpResponse::ok))
-      .thenAccept(context::writeResultToHttpResponse);
+    fromFutureResult(requestRepository.findBy(routingContext.request().query()))
+      .map(requests ->
+        requests.asJson(requestRepresentation::extendedRepresentation, "requests"))
+      .map(JsonHttpResponse::ok)
+      .onSuccess(context::write)
+      .onFailure(context::write);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -200,8 +200,8 @@ public class RequestCollectionResource extends CollectionResource {
       .flatMapFuture(requestRepository::delete)
       .flatMapFuture(updateRequestQueue::onDeletion)
       .map(toFixedValue(NoContentResponse::noContent))
-      .toCompletionStage()
-      .thenAccept(context::writeResultToHttpResponse);
+      .onSuccess(context::write)
+      .onFailure(context::write);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -199,8 +199,8 @@ public class RequestCollectionResource extends CollectionResource {
     fromFutureResult(requestRepository.getById(id))
       .flatMapFuture(requestRepository::delete)
       .flatMapFuture(updateRequestQueue::onDeletion)
+      .map(toFixedValue(NoContentResponse::noContent))
       .toCompletionStage()
-      .thenApply(r -> r.map(toFixedValue(NoContentResponse::noContent)))
       .thenAccept(context::writeResultToHttpResponse);
   }
 

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -181,8 +181,7 @@ public class RequestCollectionResource extends CollectionResource {
     fromFutureResult(requestRepository.getById(id))
       .map(new RequestRepresentation()::extendedRepresentation)
       .map(JsonHttpResponse::ok)
-      .onSuccess(context::write)
-      .onFailure(context::write);
+      .onSuccess(context::write).onFailure(context::write);
   }
 
   @Override
@@ -201,8 +200,7 @@ public class RequestCollectionResource extends CollectionResource {
       .flatMapFuture(requestRepository::delete)
       .flatMapFuture(updateRequestQueue::onDeletion)
       .map(toFixedValue(NoContentResponse::noContent))
-      .onSuccess(context::write)
-      .onFailure(context::write);
+      .onSuccess(context::write).onFailure(context::write);
   }
 
   @Override
@@ -217,8 +215,7 @@ public class RequestCollectionResource extends CollectionResource {
       .map(requests ->
         requests.asJson(requestRepresentation::extendedRepresentation, "requests"))
       .map(JsonHttpResponse::ok)
-      .onSuccess(context::write)
-      .onFailure(context::write);
+      .onSuccess(context::write).onFailure(context::write);
   }
 
   @Override
@@ -226,9 +223,9 @@ public class RequestCollectionResource extends CollectionResource {
     final var context = new WebContext(routingContext);
     final var clients = Clients.create(context, client);
 
-    clients.requestsStorage().delete()
-      .thenApply(r -> r.map(toFixedValue(NoContentResponse::noContent)))
-      .thenAccept(context::writeResultToHttpResponse);
+    fromFutureResult(clients.requestsStorage().delete())
+      .map(toFixedValue(NoContentResponse::noContent))
+      .onSuccess(context::write).onFailure(context::write);
   }
 
   void move(RoutingContext routingContext) {

--- a/src/main/java/org/folio/circulation/support/http/server/WebContext.java
+++ b/src/main/java/org/folio/circulation/support/http/server/WebContext.java
@@ -12,9 +12,9 @@ import java.net.URL;
 import java.util.Map;
 
 import org.folio.circulation.support.InvalidOkapiLocationException;
-import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.client.VertxWebClientOkapiHttpClient;
+import org.folio.circulation.support.results.Result;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.ext.web.RoutingContext;
@@ -94,8 +94,8 @@ public class WebContext {
     response.writeTo(routingContext.response());
   }
 
-  public void writeResultToHttpResponse(Result<HttpResponse> httpResponseResult) {
-    httpResponseResult.applySideEffect(this::write, this::write);
+  public void writeResultToHttpResponse(Result<HttpResponse> result) {
+    result.applySideEffect(this::write, this::write);
   }
 
   public Map<String, String> getHeaders() {

--- a/src/main/java/org/folio/circulation/support/results/AsynchronousResult.java
+++ b/src/main/java/org/folio/circulation/support/results/AsynchronousResult.java
@@ -76,4 +76,8 @@ public class AsynchronousResult<T> {
   public <R> AsynchronousResult<R> flatMapFuture(Function<T, CompletableFuture<Result<R>>> map) {
     return fromFutureResult(completionStage.thenComposeAsync(r -> r.after(map)));
   }
+
+  public <R> AsynchronousResult<R> map(Function<T, R> mapper) {
+    return fromFutureResult(completionStage.thenApply(r -> r.map(mapper)));
+  }
 }

--- a/src/main/java/org/folio/circulation/support/results/AsynchronousResult.java
+++ b/src/main/java/org/folio/circulation/support/results/AsynchronousResult.java
@@ -83,20 +83,24 @@ public class AsynchronousResult<T> {
   }
 
   public AsynchronousResult<T> onSuccess(Consumer<T> consumer) {
-    return fromFutureResult(completionStage.thenCompose(r -> {
+    return run(r -> {
       if (r.succeeded()) {
         consumer.accept(r.value());
       }
-
-      return completionStage;
-    }));
+    });
   }
 
   public AsynchronousResult<T> onFailure(Consumer<HttpFailure> consumer) {
-    return fromFutureResult(completionStage.thenCompose(r -> {
+    return run(r -> {
       if (r.failed()) {
         consumer.accept(r.cause());
       }
+    });
+  }
+
+  private AsynchronousResult<T> run(Consumer<Result<T>> consumer) {
+    return fromFutureResult(completionStage.thenCompose(r -> {
+      consumer.accept(r);
 
       return completionStage;
     }));

--- a/src/main/java/org/folio/circulation/support/results/AsynchronousResult.java
+++ b/src/main/java/org/folio/circulation/support/results/AsynchronousResult.java
@@ -4,6 +4,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.folio.circulation.support.HttpFailure;
@@ -79,5 +80,25 @@ public class AsynchronousResult<T> {
 
   public <R> AsynchronousResult<R> map(Function<T, R> mapper) {
     return fromFutureResult(completionStage.thenApply(r -> r.map(mapper)));
+  }
+
+  public AsynchronousResult<T> onSuccess(Consumer<T> consumer) {
+    return fromFutureResult(completionStage.thenCompose(r -> {
+      if (r.succeeded()) {
+        consumer.accept(r.value());
+      }
+
+      return completionStage;
+    }));
+  }
+
+  public AsynchronousResult<T> onFailure(Consumer<HttpFailure> consumer) {
+    return fromFutureResult(completionStage.thenCompose(r -> {
+      if (r.failed()) {
+        consumer.accept(r.cause());
+      }
+
+      return completionStage;
+    }));
   }
 }

--- a/src/main/java/org/folio/circulation/support/results/AsynchronousResult.java
+++ b/src/main/java/org/folio/circulation/support/results/AsynchronousResult.java
@@ -1,6 +1,12 @@
 package org.folio.circulation.support.results;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import org.folio.circulation.support.HttpFailure;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -9,11 +15,65 @@ import lombok.AllArgsConstructor;
 public class AsynchronousResult<T> {
   private final CompletionStage<Result<T>> completionStage;
 
+  /**
+   * Initialises a {@link org.folio.circulation.support.results.AsynchronousResult} from a result that could be completed in the future
+   *
+   * Mostly for interoperability with the previous result handling
+   *
+   * @param futureResult the future result to use for initialisation
+   * @param <T> type of the value of a successful result
+   * @return a new {@link org.folio.circulation.support.results.AsynchronousResult}
+   */
   public static <T> AsynchronousResult<T> fromFutureResult(CompletionStage<Result<T>> futureResult) {
     return new AsynchronousResult<>(futureResult);
   }
 
+  /**
+   * Initialises a successful {@link org.folio.circulation.support.results.AsynchronousResult}
+   *
+   * @param value value of the successful result
+   * @param <T> type of the value of a successful result
+   * @return a new {@link org.folio.circulation.support.results.AsynchronousResult}
+   */
+  public static <T> AsynchronousResult<T> successful(T value) {
+    return new AsynchronousResult<>(completedFuture(Result.of(() -> value)));
+  }
+
+  /**
+   * Initialises a failed {@link org.folio.circulation.support.results.AsynchronousResult}
+   *
+   * @param cause cause of the failure
+   * @param <T> type of the value of a successful result
+   * @return a new {@link org.folio.circulation.support.results.AsynchronousResult}
+   */
+  public static <T> AsynchronousResult<T> failure(HttpFailure cause) {
+    return new AsynchronousResult<>(completedFuture(Result.failed(cause)));
+  }
+
+  /**
+   * Converts an {@link org.folio.circulation.support.results.AsynchronousResult} to a completion stage of a result
+   *
+   * Mostly for interoperability with the previous result handling
+   *
+   * @return a new {@link java.util.concurrent.CompletableFuture} of a result
+   */
   public CompletionStage<Result<T>> toCompletionStage() {
     return completionStage.toCompletableFuture().copy();
+  }
+
+  /**
+   * Maps a successful result to a new {@link org.folio.circulation.support.results.AsynchronousResult} with the inner value of the applied map function
+   *
+   * Preserves the pre-existing failure if the current result is a failure
+   *
+   * Not strictly a flat map, mostly for interoperability with the previous result handling
+   *
+   * @param map function to map this to a new {@link org.folio.circulation.support.results.AsynchronousResult}
+   * @param <R> Type of the successful result following the mapping
+   * @return a successful {@link org.folio.circulation.support.results.AsynchronousResult}
+   * when the current result is successful and the mapping succeeds, otherwise a failure
+   */
+  public <R> AsynchronousResult<R> flatMapFuture(Function<T, CompletableFuture<Result<R>>> map) {
+    return fromFutureResult(completionStage.thenComposeAsync(r -> r.after(map)));
   }
 }

--- a/src/main/java/org/folio/circulation/support/results/AsynchronousResult.java
+++ b/src/main/java/org/folio/circulation/support/results/AsynchronousResult.java
@@ -1,0 +1,19 @@
+package org.folio.circulation.support.results;
+
+import java.util.concurrent.CompletionStage;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AsynchronousResult<T> {
+  private final CompletionStage<Result<T>> completionStage;
+
+  public static <T> AsynchronousResult<T> fromFutureResult(CompletionStage<Result<T>> futureResult) {
+    return new AsynchronousResult<>(futureResult);
+  }
+
+  public CompletionStage<Result<T>> toCompletionStage() {
+    return completionStage.toCompletableFuture().copy();
+  }
+}

--- a/src/main/java/org/folio/circulation/support/results/AsynchronousResult.java
+++ b/src/main/java/org/folio/circulation/support/results/AsynchronousResult.java
@@ -98,6 +98,10 @@ public class AsynchronousResult<T> {
     });
   }
 
+  public AsynchronousResult<T> onComplete(Consumer<T> onSuccess, Consumer<HttpFailure> onFailure) {
+    return onSuccess(onSuccess).onFailure(onFailure);
+  }
+
   private AsynchronousResult<T> run(Consumer<Result<T>> consumer) {
     return fromFutureResult(completionStage.thenCompose(r -> {
       consumer.accept(r);

--- a/src/test/java/org/folio/circulation/support/results/AsynchronousResultCreationTests.java
+++ b/src/test/java/org/folio/circulation/support/results/AsynchronousResultCreationTests.java
@@ -1,0 +1,31 @@
+package org.folio.circulation.support.results;
+
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.folio.circulation.support.results.AsynchronousResult.fromFutureResult;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import lombok.SneakyThrows;
+
+class AsynchronousResultCreationTests {
+  @Test
+  void shouldCreateNewResultFromFutureResult() {
+    final var futureResult = Result.ofAsync(() -> 5);
+    final var asynchronousResult = fromFutureResult(futureResult);
+
+    assertThat(get(asynchronousResult, 1, SECONDS), is(5));
+    assertThat(asynchronousResult.toCompletionStage(), not(sameInstance(futureResult)));
+  }
+
+  @SneakyThrows
+  private <T> T get(AsynchronousResult<T> asynchronousResult, int timeout, TimeUnit unit) {
+    return asynchronousResult.toCompletionStage().toCompletableFuture().get(timeout, unit).value();
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/AsynchronousResultCreationTests.java
+++ b/src/test/java/org/folio/circulation/support/results/AsynchronousResultCreationTests.java
@@ -1,18 +1,14 @@
 package org.folio.circulation.support.results;
 
-
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.circulation.support.results.AsynchronousResult.fromFutureResult;
+import static org.folio.circulation.support.results.AsynchronousResultTestHelper.getValue;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.util.concurrent.TimeUnit;
-
 import org.junit.jupiter.api.Test;
-
-import lombok.SneakyThrows;
 
 class AsynchronousResultCreationTests {
   @Test
@@ -20,12 +16,7 @@ class AsynchronousResultCreationTests {
     final var futureResult = Result.ofAsync(() -> 5);
     final var asynchronousResult = fromFutureResult(futureResult);
 
-    assertThat(get(asynchronousResult, 1, SECONDS), is(5));
+    assertThat(getValue(asynchronousResult, 1, SECONDS), is(5));
     assertThat(asynchronousResult.toCompletionStage(), not(sameInstance(futureResult)));
-  }
-
-  @SneakyThrows
-  private <T> T get(AsynchronousResult<T> asynchronousResult, int timeout, TimeUnit unit) {
-    return asynchronousResult.toCompletionStage().toCompletableFuture().get(timeout, unit).value();
   }
 }

--- a/src/test/java/org/folio/circulation/support/results/AsynchronousResultExamples.java
+++ b/src/test/java/org/folio/circulation/support/results/AsynchronousResultExamples.java
@@ -1,0 +1,10 @@
+package org.folio.circulation.support.results;
+
+import static org.folio.circulation.support.results.AsynchronousResult.failure;
+import static org.folio.circulation.support.results.ResultExamples.exampleFailure;
+
+public class AsynchronousResultExamples {
+  static AsynchronousResult<Integer> alreadyFailed() {
+    return failure(exampleFailure("Already failed"));
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/AsynchronousResultFlatMapFutureTests.java
+++ b/src/test/java/org/folio/circulation/support/results/AsynchronousResultFlatMapFutureTests.java
@@ -1,0 +1,56 @@
+package org.folio.circulation.support.results;
+
+import static api.support.matchers.FailureMatcher.isFailureContaining;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.folio.circulation.support.results.AsynchronousResult.failure;
+import static org.folio.circulation.support.results.AsynchronousResult.successful;
+import static org.folio.circulation.support.results.AsynchronousResultTestHelper.getCause;
+import static org.folio.circulation.support.results.AsynchronousResultTestHelper.getValue;
+import static org.folio.circulation.support.results.Result.succeeded;
+import static org.folio.circulation.support.results.ResultExamples.exampleFailure;
+import static org.folio.circulation.support.results.ResultExamples.shouldNotExecute;
+import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AsynchronousResultFlatMapFutureTests {
+  @Test
+  void shouldSucceedWhenNextStepIsSuccessful() {
+    final var result = successful(10)
+      .flatMapFuture(value -> completedFuture(succeeded(value + 10)));
+
+    assertThat(getValue(result, 1, SECONDS), is(20));
+  }
+
+  @Test
+  void shouldFailWhenAlreadyFailed() {
+    final var result = alreadyFailed()
+      .<Integer>flatMapFuture(value -> { throw shouldNotExecute(); });
+
+    assertThat(getCause(result, 1, SECONDS), isFailureContaining("Already failed"));
+  }
+
+  @Test
+  void shouldFailWhenExceptionThrownDuringNextStep() {
+    final var result = successful(10)
+      .<Integer>flatMapFuture(value -> { throw somethingWentWrong(); });
+
+    assertThat(getCause(result, 1, SECONDS), isFailureContaining("Something went wrong"));
+  }
+
+  @Test
+  void shouldFailWhenFutureFailsAsynchronously() {
+    final var result = successful(10)
+      .<Integer>flatMapFuture(value -> supplyAsync(() -> { throw somethingWentWrong(); }));
+
+    assertThat(getCause(result, 1, SECONDS), isFailureContaining("Something went wrong"));
+  }
+
+  static AsynchronousResult<Integer> alreadyFailed() {
+    return failure(exampleFailure("Already failed"));
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/AsynchronousResultMapTests.java
+++ b/src/test/java/org/folio/circulation/support/results/AsynchronousResultMapTests.java
@@ -1,14 +1,11 @@
 package org.folio.circulation.support.results;
 
 import static api.support.matchers.FailureMatcher.isFailureContaining;
-import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.circulation.support.results.AsynchronousResult.successful;
 import static org.folio.circulation.support.results.AsynchronousResultExamples.alreadyFailed;
 import static org.folio.circulation.support.results.AsynchronousResultTestHelper.getCause;
 import static org.folio.circulation.support.results.AsynchronousResultTestHelper.getValue;
-import static org.folio.circulation.support.results.Result.succeeded;
 import static org.folio.circulation.support.results.ResultExamples.shouldNotExecute;
 import static org.folio.circulation.support.results.ResultExamples.somethingWentWrong;
 import static org.hamcrest.CoreMatchers.is;
@@ -16,11 +13,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-class AsynchronousResultFlatMapFutureTests {
+class AsynchronousResultMapTests {
   @Test
   void shouldSucceedWhenNextStepIsSuccessful() {
     final var result = successful(10)
-      .flatMapFuture(value -> completedFuture(succeeded(value + 10)));
+      .map(value -> value + 10);
 
     assertThat(getValue(result, 1, SECONDS), is(20));
   }
@@ -28,7 +25,7 @@ class AsynchronousResultFlatMapFutureTests {
   @Test
   void shouldFailWhenAlreadyFailed() {
     final var result = alreadyFailed()
-      .<Integer>flatMapFuture(value -> { throw shouldNotExecute(); });
+      .<Integer>map(value -> { throw shouldNotExecute(); });
 
     assertThat(getCause(result, 1, SECONDS), isFailureContaining("Already failed"));
   }
@@ -36,15 +33,7 @@ class AsynchronousResultFlatMapFutureTests {
   @Test
   void shouldFailWhenExceptionThrownDuringNextStep() {
     final var result = successful(10)
-      .<Integer>flatMapFuture(value -> { throw somethingWentWrong(); });
-
-    assertThat(getCause(result, 1, SECONDS), isFailureContaining("Something went wrong"));
-  }
-
-  @Test
-  void shouldFailWhenFutureFailsAsynchronously() {
-    final var result = successful(10)
-      .<Integer>flatMapFuture(value -> supplyAsync(() -> { throw somethingWentWrong(); }));
+      .<Integer>map(value -> { throw somethingWentWrong(); });
 
     assertThat(getCause(result, 1, SECONDS), isFailureContaining("Something went wrong"));
   }

--- a/src/test/java/org/folio/circulation/support/results/AsynchronousResultSideEffectTests.java
+++ b/src/test/java/org/folio/circulation/support/results/AsynchronousResultSideEffectTests.java
@@ -1,0 +1,80 @@
+package org.folio.circulation.support.results;
+
+import static api.support.matchers.FailureMatcher.isFailureContaining;
+import static org.folio.circulation.support.results.AsynchronousResult.successful;
+import static org.folio.circulation.support.results.AsynchronousResultExamples.alreadyFailed;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.folio.circulation.support.HttpFailure;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class AsynchronousResultSideEffectTests {
+  private final Invocable<Integer> onSuccess = new Invocable<>();
+  private final Invocable<HttpFailure> onFailure = new Invocable<>();
+
+  @Nested
+  class whenSuccessful {
+    private final AsynchronousResult<Integer> result = successful(10);
+
+    @Test
+    void onSuccessConsumerShouldBeExecuted() {
+      result.onSuccess(onSuccess.consumer());
+
+      assertThat(onSuccess.hasBeenInvoked(), is(true));
+      assertThat(onSuccess.invokedValue(), is(10));
+    }
+
+    @Test
+    void onFailureConsumerShouldNotBeExecuted() {
+      result.onFailure(onFailure.consumer());
+
+      assertThat(onSuccess.hasBeenInvoked(), is(false));
+    }
+  }
+
+  @Nested
+  class whenFailed {
+    private final AsynchronousResult<Integer> result = alreadyFailed();
+
+    @Test
+    void onSuccessConsumerShouldNotBeExecuted() {
+      result.onSuccess(onSuccess.consumer());
+
+      assertThat(onSuccess.hasBeenInvoked(), is(false));
+    }
+
+    @Test
+    void onFailureConsumerShouldBeExecuted() {
+      result.onFailure(onFailure.consumer());
+
+      assertThat(onFailure.hasBeenInvoked(), is(true));
+      assertThat(onFailure.invokedValue(), isFailureContaining("Already failed"));
+    }
+  }
+
+  private static class Invocable<T> {
+    private final AtomicBoolean invoked = new AtomicBoolean();
+    private final AtomicReference<T> invokedWithValue = new AtomicReference<>();
+
+    public Consumer<T> consumer() {
+      return (T x) -> {
+        invoked.set(true);
+        invokedWithValue.set(x);
+      };
+    }
+
+    public boolean hasBeenInvoked() {
+      return invoked.get();
+    }
+
+    public T invokedValue() {
+      return invokedWithValue.get();
+    }
+  }
+}

--- a/src/test/java/org/folio/circulation/support/results/AsynchronousResultSideEffectTests.java
+++ b/src/test/java/org/folio/circulation/support/results/AsynchronousResultSideEffectTests.java
@@ -36,6 +36,16 @@ class AsynchronousResultSideEffectTests {
 
       assertThat(onSuccess.hasBeenInvoked(), is(false));
     }
+
+    @Test
+    void onCompletionOnlySuccessConsumerShouldBeExecuted() {
+      result.onComplete(onSuccess.consumer(), onFailure.consumer());
+
+      assertThat(onSuccess.hasBeenInvoked(), is(true));
+      assertThat(onSuccess.invokedValue(), is(10));
+
+      assertThat(onFailure.hasBeenInvoked(), is(false));
+    }
   }
 
   @Nested
@@ -52,6 +62,16 @@ class AsynchronousResultSideEffectTests {
     @Test
     void onFailureConsumerShouldBeExecuted() {
       result.onFailure(onFailure.consumer());
+
+      assertThat(onFailure.hasBeenInvoked(), is(true));
+      assertThat(onFailure.invokedValue(), isFailureContaining("Already failed"));
+    }
+
+    @Test
+    void onCompletionOnlySuccessConsumerShouldBeExecuted() {
+      result.onComplete(onSuccess.consumer(), onFailure.consumer());
+
+      assertThat(onSuccess.hasBeenInvoked(), is(false));
 
       assertThat(onFailure.hasBeenInvoked(), is(true));
       assertThat(onFailure.invokedValue(), isFailureContaining("Already failed"));

--- a/src/test/java/org/folio/circulation/support/results/AsynchronousResultTestHelper.java
+++ b/src/test/java/org/folio/circulation/support/results/AsynchronousResultTestHelper.java
@@ -1,0 +1,24 @@
+package org.folio.circulation.support.results;
+
+import java.util.concurrent.TimeUnit;
+
+import org.folio.circulation.support.HttpFailure;
+
+import lombok.SneakyThrows;
+
+public class AsynchronousResultTestHelper {
+  @SneakyThrows
+  public static <T> T getValue(AsynchronousResult<T> asynchronousResult, int timeout, TimeUnit unit) {
+    return get(asynchronousResult, timeout, unit).value();
+  }
+
+  @SneakyThrows
+  public static <T> HttpFailure getCause(AsynchronousResult<T> asynchronousResult, int timeout, TimeUnit unit) {
+    return get(asynchronousResult, timeout, unit).cause();
+  }
+
+  @SneakyThrows
+  private static <T> Result<T> get(AsynchronousResult<T> asynchronousResult, int timeout, TimeUnit unit) {
+    return asynchronousResult.toCompletionStage().toCompletableFuture().get(timeout, unit);
+  }
+}


### PR DESCRIPTION
## Purpose
Introduces a new `AsynchronousResult` class to represent an asynchronous result that could succeed or fail.

Intended to simplify the implementation of chains of asynchronous method calls. And improve the readability of the chains by reducing the noise when using CompletableFuture.

Uses more functional-esque language similar to vert.x and other libraries.

Should eventually make moving the code to different tools easier as less dependent upon CompletableFuture all over the code base.

## Approach
* Uses JUnit 5 to reduce the noise in unit tests
* Demonstrates use of the new class by migration `RequestCollectionResource` to use it. This should get cleaner still as more code is moved to `AsynchronousResult` and the mapping between it and `CompletableFuture<Result>` can be reduced.

## Learning
`flatMapFuture` is a compromise method because so much of the existing code uses `CompletableFuture`. Several attempts were made to change the existing code, however the chains rely on the expanded interface of `AsynchronousResult` which is lost when using methods that rely on `CompletableFuture`

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
