### PR TITLE
CIRC-1086: XStream 1.4.15 Arbitrary File Deletion (CVE-2020-26259)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,13 +128,13 @@
     </dependency>
     <!--
     Remove xstream dependency after drools has upgraded its
-    xstream dependency to >= 1.4.14:
-    https://x-stream.github.io/CVE-2020-26217.html
+    xstream dependency to >= 1.4.15:
+    https://x-stream.github.io/CVE-2020-26259.html
     -->
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.14</version>
+      <version>1.4.15</version>
     </dependency>
     <dependency>
       <groupId>org.antlr</groupId>


### PR DESCRIPTION
XStream is vulnerable to an Arbitrary File Deletion on the local host
when unmarshalling as long as the executing process has sufficient rights.

All versions until and including version 1.4.14 are affected running in a
Java environment containing the JAX-WS runtime, if using the version out of
the box.

Details: https://x-stream.github.io/CVE-2020-26259.html

Fix:

Update the XStream version from 1.4.14 to 1.4.15.

## Purpose
Use a XStream version without security vulnerability.

## Approach
Bump the XStream version.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [x] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [x] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.