### PR TITLE
CIRC-1059 - Return a full list of errors when renewal fails

### DIFF
--- a/src/main/java/org/folio/circulation/resources/handlers/error/CirculationErrorType.java
+++ b/src/main/java/org/folio/circulation/resources/handlers/error/CirculationErrorType.java
@@ -1,8 +1,6 @@
 package org.folio.circulation.resources.handlers.error;
 
 public enum CirculationErrorType {
-  DEFAULT,
-
   // Errors related to the service point
   INVALID_PICKUP_SERVICE_POINT,
   SERVICE_POINT_IS_NOT_PRESENT,
@@ -41,6 +39,9 @@ public enum CirculationErrorType {
   // Errors related to requests
   REQUESTING_DISALLOWED,
   REQUESTING_DISALLOWED_BY_POLICY,
+
+  // Errors related ro renewal
+  RENEWAL_VALIDATION_ERROR,
 
   // Errors related to block overrides
   INSUFFICIENT_OVERRIDE_PERMISSIONS

--- a/src/main/java/org/folio/circulation/resources/handlers/error/CirculationErrorType.java
+++ b/src/main/java/org/folio/circulation/resources/handlers/error/CirculationErrorType.java
@@ -1,6 +1,8 @@
 package org.folio.circulation.resources.handlers.error;
 
 public enum CirculationErrorType {
+  DEFAULT,
+
   // Errors related to the service point
   INVALID_PICKUP_SERVICE_POINT,
   SERVICE_POINT_IS_NOT_PRESENT,
@@ -19,6 +21,9 @@ public enum CirculationErrorType {
   ITEM_HAS_OPEN_LOANS,
   ITEM_LIMIT_IS_REACHED,
 
+  // Errors related to the loan
+  FAILED_TO_FIND_SINGLE_OPEN_LOAN,
+
   // Errors that represent fetch failures
   FAILED_TO_FETCH_ITEM,
   FAILED_TO_FETCH_USER,
@@ -31,6 +36,7 @@ public enum CirculationErrorType {
   USER_IS_BLOCKED_AUTOMATICALLY,
   INVALID_USER_OR_PATRON_GROUP_ID,
   INVALID_PROXY_RELATIONSHIP,
+  USER_DOES_NOT_MATCH,
 
   // Errors related to requests
   REQUESTING_DISALLOWED,

--- a/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalByBarcodeResource.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletableFuture;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
+import org.folio.circulation.resources.handlers.error.CirculationErrorHandler;
 import org.folio.circulation.storage.SingleOpenLoanByUserAndItemBarcodeFinder;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.support.results.Result;
@@ -23,7 +24,8 @@ public class OverrideRenewalByBarcodeResource extends RenewalResource {
 
   @Override
   protected CompletableFuture<Result<Loan>> findLoan(JsonObject request,
-    LoanRepository loanRepository, ItemRepository itemRepository, UserRepository userRepository) {
+    LoanRepository loanRepository, ItemRepository itemRepository, UserRepository userRepository,
+    CirculationErrorHandler errorHandler) {
 
     final SingleOpenLoanByUserAndItemBarcodeFinder finder
       = new SingleOpenLoanByUserAndItemBarcodeFinder(loanRepository,

--- a/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/OverrideRenewalByBarcodeResource.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.resources.renewal;
 
+import static org.folio.circulation.resources.handlers.error.CirculationErrorType.FAILED_TO_FIND_SINGLE_OPEN_LOAN;
 import static org.folio.circulation.resources.renewal.RenewByBarcodeRequest.renewalRequestFrom;
 
 import java.util.concurrent.CompletableFuture;
@@ -32,6 +33,8 @@ public class OverrideRenewalByBarcodeResource extends RenewalResource {
       itemRepository, userRepository);
 
     return renewalRequestFrom(request)
-      .after(renewal -> finder.findLoan(renewal.getItemBarcode(), renewal.getUserBarcode()));
+      .after(renewal -> finder.findLoan(renewal.getItemBarcode(), renewal.getUserBarcode())
+        .thenApply(r -> errorHandler.handleValidationResult(r, FAILED_TO_FIND_SINGLE_OPEN_LOAN,
+          (Loan) null)));
   }
 }

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewByIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewByIdResource.java
@@ -6,7 +6,7 @@ import static org.folio.circulation.resources.handlers.error.CirculationErrorTyp
 import static org.folio.circulation.resources.handlers.error.CirculationErrorType.FAILED_TO_FIND_SINGLE_OPEN_LOAN;
 import static org.folio.circulation.resources.handlers.error.CirculationErrorType.ITEM_DOES_NOT_EXIST;
 import static org.folio.circulation.resources.handlers.error.CirculationErrorType.USER_DOES_NOT_MATCH;
-import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.results.Result.succeeded;
 
 import java.util.concurrent.CompletableFuture;
@@ -103,9 +103,11 @@ public class RenewByIdResource extends RenewalResource {
       return succeeded(loan);
     }
     else {
-      return errorHandler.handleValidationError(
-        singleValidationError("Cannot renew item checked out to different user",
-          RenewByIdRequest.USER_ID, idRequest.getUserId()), USER_DOES_NOT_MATCH, loan);
+      Result<Loan> result = failedValidation("Cannot renew item checked out to different user",
+        RenewByIdRequest.USER_ID, idRequest.getUserId());
+
+      return result.mapFailure(failure -> errorHandler.handleValidationError(failure,
+          USER_DOES_NOT_MATCH, loan));
     }
   }
 

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -32,6 +32,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static api.support.matchers.ValidationErrorMatchers.hasUUIDParameter;
+import static api.support.utl.BlockOverridesUtils.getMissingPermissions;
 import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
 import static org.folio.circulation.domain.EventType.ITEM_CHECKED_OUT;
 import static org.folio.circulation.domain.policy.DueDateManagement.KEEP_THE_CURRENT_DUE_DATE;
@@ -50,11 +51,9 @@ import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import org.awaitility.Awaitility;
 import org.folio.circulation.domain.override.BlockOverrides;
@@ -1709,19 +1708,6 @@ public class CheckOutByBarcodeTests extends APITests {
     return getOkapiHeadersFromContext()
       .withRequestId("override-check-out-by-barcode-request")
       .withOkapiPermissions("[\"" + permissions + "\"]");
-  }
-
-  private List<String> getMissingPermissions(Response response) {
-    return response.getJson().getJsonArray("errors")
-      .stream()
-      .filter(JsonObject.class::isInstance)
-      .map(JsonObject.class::cast)
-      .filter(error -> Objects.nonNull(error.getJsonObject("overridableBlock")))
-      .map(error -> error.getJsonObject("overridableBlock"))
-      .map(block -> block.getJsonArray("missingPermissions"))
-      .flatMap(JsonArray::stream)
-      .map(String.class::cast)
-      .collect(Collectors.toList());
   }
 
   private void setNotLoanablePolicy() {

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -1,5 +1,6 @@
 package api.loans;
 
+import static api.loans.CheckOutByBarcodeTests.OVERRIDE_PATRON_BLOCK_PERMISSION;
 import static api.support.PubsubPublisherTestUtils.assertThatPublishedLoanLogRecordEventsAreValid;
 import static api.support.PubsubPublisherTestUtils.assertThatPublishedLogRecordEventsAreValid;
 import static api.support.builders.FixedDueDateSchedule.forDay;
@@ -29,12 +30,14 @@ import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static api.support.matchers.ValidationErrorMatchers.hasUUIDParameter;
+import static api.support.utl.BlockOverridesUtils.getMissingPermissions;
 import static org.awaitility.Awaitility.waitAtMost;
 import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
 import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -1475,6 +1478,44 @@ public abstract class RenewalAPITests extends APITests {
       hasMessage(MAX_NUMBER_OF_ITEMS_CHARGED_OUT_MESSAGE))));
     assertThat(response.getJson(), hasErrorWith(allOf(
       hasMessage(MAX_OUTSTANDING_FEE_FINE_BALANCE_MESSAGE))));
+  }
+
+  @Test
+  public void multipleReasonsWhyCannotRenewWhenPatronIsBlockedAndNotLoanablePolicy() {
+    IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource jessica = usersFixture.jessica();
+
+    LoanPolicyBuilder policyForCheckout = new LoanPolicyBuilder()
+      .withName("Policy for checkout")
+      .rolling(Period.days(2));
+    use(policyForCheckout);
+
+    checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
+      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+
+    LoanPolicyBuilder nonLoanablePolicy = new LoanPolicyBuilder()
+      .withName("Non loanable policy")
+      .withLoanable(false);
+    UUID notLoanablePolicyId = loanPoliciesFixture
+      .create(nonLoanablePolicy).getId();
+    use(nonLoanablePolicy);
+
+    automatedPatronBlocksFixture.blockAction(jessica.getId().toString(), false, true, false);
+
+    final Response response = attemptRenewal(smallAngryPlanet, jessica);
+
+    assertThat(response.getJson(), hasErrorWith(allOf(
+      hasMessage("item is not loanable"),
+      hasLoanPolicyIdParameter(notLoanablePolicyId),
+      hasLoanPolicyNameParameter("Non loanable policy"))));
+
+    assertThat(response.getJson(), hasErrorWith(allOf(
+      hasMessage(MAX_NUMBER_OF_ITEMS_CHARGED_OUT_MESSAGE))));
+    assertThat(response.getJson(), hasErrorWith(allOf(
+      hasMessage(MAX_OUTSTANDING_FEE_FINE_BALANCE_MESSAGE))));
+    assertThat(getMissingPermissions(response), hasSize(1));
+    assertThat(getMissingPermissions(response),
+      hasItem(OVERRIDE_PATRON_BLOCK_PERMISSION));
   }
 
   private void checkRenewalAttempt(DateTime expectedDueDate, UUID dueDateLimitedPolicyId) {

--- a/src/test/java/api/support/matchers/ValidationErrorMatchers.java
+++ b/src/test/java/api/support/matchers/ValidationErrorMatchers.java
@@ -1,12 +1,17 @@
 package api.support.matchers;
 
+import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
+import static java.util.Collections.singletonList;
 import static java.util.Optional.ofNullable;
 import static org.folio.circulation.support.StreamToListMapper.toList;
 import static org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher.toStream;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
 
 import java.util.Collection;
 import java.util.List;
@@ -182,5 +187,32 @@ public class ValidationErrorMatchers {
   public static List<ValidationError> errorsFromJson(JsonObject representation) {
     return toList(toStream(representation, "errors")
       .map(ValidationErrorMatchers::fromJson));
+  }
+
+  public static Matcher<JsonObject> isBlockRelatedError(String message, String blockName,
+    String missingPermission) {
+
+    return isBlockRelatedError(message, blockName, singletonList(missingPermission));
+  }
+
+  public static Matcher<JsonObject> isBlockRelatedError(String message, String blockName,
+    List<String> missingPermissions) {
+
+    return allOf(
+      hasJsonPath("message", is(message)),
+      hasJsonPath("overridableBlock.name", is(blockName)),
+      hasJsonPath("overridableBlock.missingPermissions", hasItems(missingPermissions.toArray()))
+    );
+  }
+
+  public static Matcher<JsonObject> isInsufficientPermissionsError(
+    String blockName, List<String> missingPermissions) {
+
+    return isBlockRelatedError("Insufficient override permissions", blockName, missingPermissions);
+  }
+
+  public static Matcher<JsonObject> isInsufficientPermissionsToOverridePatronBlockError() {
+    return isInsufficientPermissionsError("patronBlock",
+      List.of("circulation.override-patron-block"));
   }
 }

--- a/src/test/java/api/support/utl/BlockOverridesUtils.java
+++ b/src/test/java/api/support/utl/BlockOverridesUtils.java
@@ -1,0 +1,26 @@
+package api.support.utl;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.folio.circulation.support.http.client.Response;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public final class BlockOverridesUtils {
+  public static List<String> getMissingPermissions(Response response) {
+    return response.getJson().getJsonArray("errors")
+      .stream()
+      .filter(JsonObject.class::isInstance)
+      .map(JsonObject.class::cast)
+      .filter(error -> Objects.nonNull(error.getJsonObject("overridableBlock")))
+      .map(error -> error.getJsonObject("overridableBlock"))
+      .map(block -> block.getJsonArray("missingPermissions"))
+      .flatMap(JsonArray::stream)
+      .map(String.class::cast)
+      .distinct()
+      .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
Resolves CIRC-1059.

## Purpose
Handle multiple validation errors during renewal instead of failing with the first one

## Approach
Use CirculationErrorHandler to accumulate validation errors

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
