### PR TITLE
Stop periodic execution of aged to lost processes CIRC-1084

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
+
 ## 20.0.0 (in-progress)
 
-* No longer periodically excutes age to lost background processes (CIRC-1084)
+* No longer periodically executes age to lost background processes (CIRC-1084)
 * Does not charge overdue fees when fee refund period has passed (CIRC-1000)
 * Loan dates now truncate if there is a recall in any position in the item hold queue (CIRC-1018)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 19.3.0 (in-progress)
+## 20.0.0 (in-progress)
 
 * Does not charge overdue fees when fee refund period has passed (CIRC-1000)
 * Loan dates now truncate if there is a recall in any position in the item hold queue (CIRC-1018)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 20.0.0 (in-progress)
 
+* No longer periodically excutes age to lost background processes (CIRC-1084)
 * Does not charge overdue fees when fee refund period has passed (CIRC-1000)
 * Loan dates now truncate if there is a recall in any position in the item hold queue (CIRC-1018)
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1292,13 +1292,13 @@
     },
     {
       "permissionName": "circulation.scheduled-age-to-lost.post",
-      "displayName": "circulation - age to lost process",
-      "description": "age some borrowed items to lost"
+      "displayName": "circulation - scheduled age to lost process",
+      "description": "scheduled process to age overdue borrowed items to lost"
     },
     {
       "permissionName": "circulation.scheduled-age-to-lost-fee-charging.post",
-      "displayName": "circulation - age to lost fee charging process",
-      "description": "Issue fees to patrons for items that have aged to lost"
+      "displayName": "circulation - scheduled age to lost fee charging process",
+      "description": "scheduled process to issue fees to patrons for aged to lost items"
     },
     {
       "permissionName": "circulation.all",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -617,7 +617,7 @@
             "POST"
           ],
           "pathPattern": "/circulation/scheduled-age-to-lost",
-          "permissionsRequired": [],
+          "permissionsRequired": ["circulation.scheduled-age-to-lost.post"],
           "modulePermissions": [
             "circulation-storage.loans.item.put",
             "circulation-storage.loans.item.get",
@@ -646,7 +646,7 @@
             "POST"
           ],
           "pathPattern": "/circulation/scheduled-age-to-lost-fee-charging",
-          "permissionsRequired": [],
+          "permissionsRequired": ["circulation.scheduled-age-to-lost-fee-charging.post"],
           "modulePermissions": [
             "circulation-storage.loans.item.put",
             "circulation-storage.loans.item.get",
@@ -1291,6 +1291,16 @@
       "description": "end patron action session"
     },
     {
+      "permissionName": "circulation.scheduled-age-to-lost.post",
+      "displayName": "circulation - age to lost process",
+      "description": "age some borrowed items to lost"
+    },
+    {
+      "permissionName": "circulation.scheduled-age-to-lost-fee-charging.post",
+      "displayName": "circulation - age to lost fee charging process",
+      "description": "Issue fees to patrons for items that have aged to lost"
+    },
+    {
       "permissionName": "circulation.all",
       "displayName": "circulation - all permissions",
       "description": "Entire set of permissions needed to use the circulation",
@@ -1330,7 +1340,9 @@
         "circulation.requests.instances.item.post",
         "circulation.requests.hold-shelf-clearance-report.get",
         "circulation.inventory.items-in-transit-report.get",
-        "circulation.pick-slips.get"
+        "circulation.pick-slips.get",
+        "circulation.scheduled-age-to-lost.post",
+        "circulation.scheduled-age-to-lost-fee-charging.post"
       ]
     },
     {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -609,6 +609,76 @@
       ]
     },
     {
+      "id": "age-to-lost-background-processes",
+      "version": "0.1",
+      "handlers": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/circulation/scheduled-age-to-lost",
+          "permissionsRequired": [],
+          "modulePermissions": [
+            "circulation-storage.loans.item.put",
+            "circulation-storage.loans.item.get",
+            "circulation-storage.loans.collection.get",
+            "circulation-storage.circulation-rules.get",
+            "circulation-storage.patron-notice-policies.collection.get",
+            "circulation-storage.patron-notice-policies.item.get",
+            "inventory-storage.items.item.put",
+            "inventory-storage.items.item.get",
+            "inventory-storage.items.collection.get",
+            "inventory-storage.locations.collection.get",
+            "inventory-storage.locations.item.get",
+            "inventory-storage.holdings.collection.get",
+            "inventory-storage.instances.collection.get",
+            "inventory-storage.material-types.collection.get",
+            "lost-item-fees-policies.item.get",
+            "lost-item-fees-policies.collection.get",
+            "pubsub.publish.post",
+            "users.item.get",
+            "users.collection.get",
+            "scheduled-notice-storage.scheduled-notices.item.post"
+          ]
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/circulation/scheduled-age-to-lost-fee-charging",
+          "permissionsRequired": [],
+          "modulePermissions": [
+            "circulation-storage.loans.item.put",
+            "circulation-storage.loans.item.get",
+            "circulation-storage.loans.collection.get",
+            "inventory-storage.items.item.put",
+            "inventory-storage.items.item.get",
+            "inventory-storage.items.collection.get",
+            "inventory-storage.locations.collection.get",
+            "inventory-storage.location-units.libraries.collection.get",
+            "inventory-storage.holdings.collection.get",
+            "inventory-storage.instances.collection.get",
+            "inventory-storage.material-types.collection.get",
+            "lost-item-fees-policies.item.get",
+            "lost-item-fees-policies.collection.get",
+            "owners.collection.get",
+            "feefines.collection.get",
+            "accounts.item.post",
+            "feefineactions.item.post",
+            "pubsub.publish.post",
+            "users.item.get",
+            "users.collection.get",
+            "circulation-storage.circulation-rules.get",
+            "circulation-storage.patron-notice-policies.item.get",
+            "circulation-storage.patron-notice-policies.collection.get",
+            "circulation.rules.notice-policy.get",
+            "inventory-storage.locations.item.get",
+            "scheduled-notice-storage.scheduled-notices.item.post"
+          ]
+        }
+      ]
+    },
+    {
       "id": "_timer",
       "version": "1.0",
       "interfaceType": "system",
@@ -849,72 +919,6 @@
           ],
           "unit": "minute",
           "delay": "1"
-        },
-        {
-          "methods": [
-            "POST"
-          ],
-          "pathPattern": "/circulation/scheduled-age-to-lost",
-          "modulePermissions": [
-            "circulation-storage.loans.item.put",
-            "circulation-storage.loans.item.get",
-            "circulation-storage.loans.collection.get",
-            "circulation-storage.circulation-rules.get",
-            "circulation-storage.patron-notice-policies.collection.get",
-            "circulation-storage.patron-notice-policies.item.get",
-            "inventory-storage.items.item.put",
-            "inventory-storage.items.item.get",
-            "inventory-storage.items.collection.get",
-            "inventory-storage.locations.collection.get",
-            "inventory-storage.locations.item.get",
-            "inventory-storage.holdings.collection.get",
-            "inventory-storage.instances.collection.get",
-            "inventory-storage.material-types.collection.get",
-            "lost-item-fees-policies.item.get",
-            "lost-item-fees-policies.collection.get",
-            "pubsub.publish.post",
-            "users.item.get",
-            "users.collection.get",
-            "scheduled-notice-storage.scheduled-notices.item.post"
-          ],
-          "unit": "minute",
-          "delay": "30"
-        },
-        {
-          "methods": [
-            "POST"
-          ],
-          "pathPattern": "/circulation/scheduled-age-to-lost-fee-charging",
-          "modulePermissions": [
-            "circulation-storage.loans.item.put",
-            "circulation-storage.loans.item.get",
-            "circulation-storage.loans.collection.get",
-            "inventory-storage.items.item.put",
-            "inventory-storage.items.item.get",
-            "inventory-storage.items.collection.get",
-            "inventory-storage.locations.collection.get",
-            "inventory-storage.location-units.libraries.collection.get",
-            "inventory-storage.holdings.collection.get",
-            "inventory-storage.instances.collection.get",
-            "inventory-storage.material-types.collection.get",
-            "lost-item-fees-policies.item.get",
-            "lost-item-fees-policies.collection.get",
-            "owners.collection.get",
-            "feefines.collection.get",
-            "accounts.item.post",
-            "feefineactions.item.post",
-            "pubsub.publish.post",
-            "users.item.get",
-            "users.collection.get",
-            "circulation-storage.circulation-rules.get",
-            "circulation-storage.patron-notice-policies.item.get",
-            "circulation-storage.patron-notice-policies.collection.get",
-            "circulation.rules.notice-policy.get",
-            "inventory-storage.locations.item.get",
-            "scheduled-notice-storage.scheduled-notices.item.post"
-          ],
-          "unit": "minute",
-          "delay": "35"
         }
       ]
     },

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.3.0-SNAPSHOT</version>
+  <version>20.0.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/ramls/age-to-lost-background-processes.raml
+++ b/ramls/age-to-lost-background-processes.raml
@@ -1,0 +1,31 @@
+#%RAML 1.0
+title: Age to lost background processes
+version: v0.1
+protocols: [ HTTP, HTTPS ]
+baseUri: http://localhost:9130
+
+documentation:
+  - title: Background processes for ageing borrowed items to lost
+    content: <b>Background processes for ageing borrowed items to lost</b>
+
+/circulation/scheduled-age-to-lost:
+  post:
+    responses:
+      204:
+        description: "The process completed successfully"
+      500:
+        description: "Internal server error, e.g. due to misconfiguration"
+        body:
+          text/plain:
+            example: "Internal server error, contact administrator"
+
+/circulation/scheduled-age-to-lost-fee-charging:
+  post:
+    responses:
+      204:
+        description: "The process completed successfully"
+      500:
+        description: "Internal server error, e.g. due to misconfiguration"
+        body:
+          text/plain:
+            example: "Internal server error, contact administrator"


### PR DESCRIPTION
## Purpose
In order to allow FOLIO implementors to [define their own schedule](https://issues.folio.org/browse/CIRC-1084) for the age to lost processes, the processes must no longer be scheduled using Okapi's timer interface.

## Approach
* Change the major version of the module (to indicate that changes need to be made to preserve the current behaviour)
* Define a new interface for age to lost process endpoints so they can be requested externally (using the same endpoints to minimise the changes)
* Change the module descriptor to provide the new interface

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [x] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
