### PR TITLE
CIRC-1094 Remove pubsub unregistering

### DIFF
--- a/src/main/java/org/folio/circulation/resources/TenantActivationResource.java
+++ b/src/main/java/org/folio/circulation/resources/TenantActivationResource.java
@@ -3,6 +3,8 @@ package org.folio.circulation.resources;
 import static org.folio.circulation.support.http.server.JsonHttpResponse.created;
 import static org.folio.circulation.support.http.server.NoContentResponse.noContent;
 
+import java.util.Map;
+
 import org.folio.circulation.services.PubSubRegistrationService;
 import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.server.ServerErrorResponse;
@@ -12,33 +14,20 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
-import java.util.Map;
-
 public class TenantActivationResource {
 
   public void register(Router router) {
     RouteRegistration routeRegistration = new RouteRegistration("/_/tenant", router);
     routeRegistration.create(this::enableModuleForTenant);
-    routeRegistration.deleteAll(this::disableModuleForTenant);
+    routeRegistration.deleteAll(ctx -> noContent().writeTo(ctx.response()));
   }
 
-  public void enableModuleForTenant(RoutingContext routingContext) {
+  private void enableModuleForTenant(RoutingContext routingContext) {
     Map<String, String> headers = new WebContext(routingContext).getHeaders();
     PubSubRegistrationService.registerModule(headers,routingContext.vertx())
       .thenRun(() -> created(new JsonObject()).writeTo(routingContext.response()))
       .exceptionally(throwable -> {
         ServerErrorResponse.internalError(routingContext.response(), throwable.getLocalizedMessage());
-        return null;
-      });
-  }
-
-  public void disableModuleForTenant(RoutingContext routingContext) {
-    PubSubRegistrationService.unregisterModule(new WebContext(routingContext).getHeaders(),
-      routingContext.vertx())
-      .thenRun(() -> noContent().writeTo(routingContext.response()))
-      .exceptionally(throwable -> {
-        ServerErrorResponse.internalError(routingContext.response(),
-          throwable.getLocalizedMessage());
         return null;
       });
   }

--- a/src/test/java/api/TenantActivationResourceTests.java
+++ b/src/test/java/api/TenantActivationResourceTests.java
@@ -27,7 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import api.support.APITests;
-import api.support.matchers.EventTypeMatchers;
 
 public class TenantActivationResourceTests extends APITests {
 
@@ -68,27 +67,12 @@ public class TenantActivationResourceTests extends APITests {
   }
 
   @Test
-  public void tenantDeactivationFailsWhenCannotUnregisterWithPubSub() {
+  public void tenantDeactivationSucceedsWhenCannotUnregisterInPubSub() {
     setFailPubSubUnregistering(true);
 
     Response response = tenantActivationFixture.deleteTenant();
-    assertThat(response.getStatusCode(), is(HTTP_INTERNAL_SERVER_ERROR.toInt()));
-  }
-
-  @Test
-  public void tenantDeactivationSucceedsWhenCanUnregisterInPubSub() {
-    Response response = tenantActivationFixture.deleteTenant();
 
     assertThat(response.getStatusCode(), is(HTTP_NO_CONTENT.toInt()));
-
-    assertThat(getDeletedEventTypes().size(), is(6));
-    assertThat(getDeletedEventTypes(), hasItems(
-      EventTypeMatchers.ITEM_CHECKED_OUT,
-      EventTypeMatchers.ITEM_CHECKED_IN,
-      EventTypeMatchers.ITEM_DECLARED_LOST,
-      EventTypeMatchers.ITEM_CLAIMED_RETURNED,
-      EventTypeMatchers.LOAN_DUE_DATE_CHANGED,
-      EventTypeMatchers.LOG_RECORD
-    ));
+    assertThat(getDeletedEventTypes().size(), is(0));
   }
 }


### PR DESCRIPTION
[CIRC-1094](https://issues.folio.org/browse/CIRC-1094)

## Purpose
According to investigation in MODPUBSUB-147, when module is restarted it unregisters itself from pubsub after Okapi's call to `DELETE _tenant` and doesn't get registered again, because in some situations Okapi doesn't make a call to `POST _tenant` endpoint when module is started. This leads to mod-circulation being unable to publish events. mod-pubsub developers say that unregistering is unnecessary and some modules don't do it, because re-registering doesn't cause any issues. This was confirmed by re-registering manually on the snapshot env.

## Approach
Unregistering logic was removed from `DELETE _tenant`.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
