### PR TITLE
CIRC-1095: Missing module permissions for request endpoints

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2203,7 +2203,8 @@
         "scheduled-notice-storage.scheduled-notices.collection.delete",
         "scheduled-notice-storage.scheduled-notices.item.post",
         "manualblocks.collection.get",
-        "automated-patron-blocks.collection.get"
+        "automated-patron-blocks.collection.get",
+        "pubsub.publish.post"
       ],
       "visible": false
     },


### PR DESCRIPTION
## Purpose
The pubsub.publish.post was missing from the modperms.circulation.requests.instances.item.post set so any instance-level request event is not published and subsequently does not show up in mod-circulation-log.  The JIRA stated 2 endpoints ( which equates to 2 permissions set not having this permission, but it turns out that this permission already existed in modperms.circulation.requests.item.post, which is used by item-level requests.

## Approach
Add pubsub.publish.post to the modperms.circulation.requests.instances.item.post set.

#### TODOS and Open Questions

## Learning
Any new permissions added to modperms.circulation.requests.item.post for the /circulation/requests API must be added to modperms.circulation.requests.instances.item.post for the /circulation/requests/instances API as well

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
