### PR TITLE
Update minor version CIRC-1107

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 
-## 20.1.0 (in-progress)
+## 20.2.0 (in-progress)
+
 * Refund/cancel Aged to lost fees/fines when declaring an item lost (CIRC-1077)
 * Provides `declare-item-lost 0.3` (CIRC-1077)
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>20.1.0-SNAPSHOT</version>
+  <version>20.2.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>


### PR DESCRIPTION
## Purpose
In order to create space to release `20.1.0` from a branch based upon the bug fix branch for 20.0.x, the version on the mainline needs to change to `20.2.0` for the next mainline release.

This is due to a bug fix, [CIRC-1077](https://issues.folio.org/browse/CIRC-1077), containing an API change which means a minor release is needed.