### PR TITLE
Release 20.1.0 CIRC-1107

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 20.1.0 IN-PROGRESS
+## 20.1.0 2021-03-30
 
 * Refund/cancel Aged to lost fees/fines when declaring an item lost (CIRC-1077)
 * Lost permissions for /circulation/check-in-by-barcode (CIRC-1099)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>20.1.0-SNAPSHOT</version>
+  <version>20.1.0</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -283,7 +283,7 @@
     <url>https://github.com/folio-org/mod-inventory</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v20.1.0</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>20.1.0</version>
+  <version>20.1.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -283,7 +283,7 @@
     <url>https://github.com/folio-org/mod-inventory</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory.git</developerConnection>
-    <tag>v20.1.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
## Purpose

Release version 20.1.0

## Approach

Minor versions are not usually released from a branch. [CIRC-1077](https://issues.folio.org/browse/CIRC-1077) is considered a bug fix, however it changes the API for the client, which means that it should be included in a minor version release (it would need to be major if the API wasn't a pre-release)