### PR TITLE
CIRC-1114 Add patron notices permission to change due date endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2177,7 +2177,8 @@
         "scheduled-notice-storage.scheduled-notices.collection.delete",
         "scheduled-notice-storage.scheduled-notices.item.post",
         "users.item.get",
-        "pubsub.publish.post"
+        "pubsub.publish.post",
+        "patron-notice.post"
       ],
       "visible": false
     },


### PR DESCRIPTION
Fixes [CIRC-1114 Not receiving change due date notice](https://issues.folio.org/browse/CIRC-1114)

## Purpose
Users are not receiving patron notice when due date is changed manually.

Iris Bugfest logs:

`2021-04-06T12:48:57.973Z 12:48:57 ERROR LogHelper            Failed to send patron notice request: PatronNotice{recipientId='dadff4c5-d0cf-47ac-8d77-e5c5628626ba', templateId='ec9c41b6-122e-4035-ba6f-295ed4993808'}. Cause: [403] Access requires permission: patron-notice.post`

## Approach
Add `patron-notice.post` permission to `modperms.circulation.loans.change-due-date.post`

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
