### PR TITLE
CIRC-1115: Aged to lost process need to process ACTUAL COST items if there is a LOST ITEM PROCESSING FEE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 21.0.0 (in-progress)
 
 * Remove redundant override-check-out-by-barcode endpoint (CIRC-1064)
+* Aged to lost process now charges fees for actual cost items if a processing fee is set (CIRC-1115)
 
 ## 20.1.0 2021-03-30
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,8 @@
     <antlr4.version>4.7.2</antlr4.version>
     <drools.version>7.0.0.Final</drools.version>
     <rmb.version>31.1.0</rmb.version>
-    <vertx.version>3.9.1</vertx.version>
+    <vertx.version>4.0.0</vertx.version>
+    <raml-module-builder-version>32.2.0</raml-module-builder-version>
     <log4j2.version>2.13.3</log4j2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -125,6 +126,12 @@
       <groupId>org.drools</groupId>
       <artifactId>drools-compiler</artifactId>
       <version>${drools.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>postgres-testing</artifactId>
+      <version>${raml-module-builder-version}</version>
+      <scope>test</scope>
     </dependency>
     <!--
     Remove xstream dependency after drools has upgraded its

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,7 @@
     <antlr4.version>4.7.2</antlr4.version>
     <drools.version>7.0.0.Final</drools.version>
     <rmb.version>31.1.0</rmb.version>
-    <vertx.version>4.0.0</vertx.version>
-    <raml-module-builder-version>32.2.0</raml-module-builder-version>
+    <vertx.version>3.9.1</vertx.version>
     <log4j2.version>2.13.3</log4j2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -126,12 +125,6 @@
       <groupId>org.drools</groupId>
       <artifactId>drools-compiler</artifactId>
       <version>${drools.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>postgres-testing</artifactId>
-      <version>${raml-module-builder-version}</version>
-      <scope>test</scope>
     </dependency>
     <!--
     Remove xstream dependency after drools has upgraded its

--- a/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
@@ -153,7 +153,7 @@ public class LostItemPolicy extends Policy {
   }
 
   public boolean canAgeLoanToLost(boolean isRecalled, DateTime loanDueDate) {
-    if (actualCostFee.isChargeable()) {
+    if (actualCostFee.isChargeable() && !ageToLostProcessingFee.isChargeable()) {
       // actual cost is not supported now
       return false;
     }

--- a/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
@@ -153,7 +153,7 @@ public class LostItemPolicy extends Policy {
   }
 
   public boolean canAgeLoanToLost(boolean isRecalled, DateTime loanDueDate) {
-    if (actualCostFee.isChargeable() && !ageToLostProcessingFee.isChargeable()) {
+    if (actualCostFee.isChargeable()) {
       // actual cost is not supported now
       return false;
     }

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
@@ -55,11 +55,8 @@ import api.support.matchers.LoanMatchers;
 import api.support.spring.SpringApiTest;
 import io.vertx.core.json.JsonObject;
 import lombok.val;
-import org.slf4j.Logger;
-import static org.slf4j.LoggerFactory.getLogger;
 
 public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
-  private static final Logger log = getLogger(ScheduledAgeToLostFeeChargingApiTest.class);
 
   public ScheduledAgeToLostFeeChargingApiTest() {
     super(true, true);

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
@@ -368,8 +368,6 @@ public class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
         .billPatronImmediatelyWhenAgedToLost()
         .chargeProcessingFeeWhenAgedToLost(agedToLostLostProcessingFee));
 
-    log.info("policies:" + lostItemPolicy.getJson().toString());
-
     useLostItemPolicy(lostItemPolicy.getId());
     
     final ItemResource item = itemsFixture.basedUponNod();


### PR DESCRIPTION
The fix for this was very simple: I added a condition to the 
code that checks for actual cost items so that it does not trigger
if the item has both an actual cost set and a chargeable lost item
processing fee.  This causes actual cost items to get processed if
they have a lost item processing fee set.

I also wrote a test for this behavior.

refs: https://issues.folio.org/browse/CIRC-1115