### PR TITLE
CIRC-1117: Permissions error when checking in items with fees

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Remove redundant override-check-out-by-barcode endpoint (CIRC-1064)
 * Aged to lost process now charges fees for actual cost items if a processing fee is set (CIRC-1115)
+* Added lost-items-fees-policies.collection.get permission to the checkin-by-barcode endpoint (CIRC-1117)
 
 ## 20.1.0 2021-03-30
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -178,8 +178,7 @@
             "circulation.check-in-by-barcode.post"
           ],
           "modulePermissions": [
-            "modperms.circulation.check-in-by-barcode.post",
-            "lost-items-fees-policies.collection.get"
+            "modperms.circulation.check-in-by-barcode.post"
           ]
         },
         {
@@ -1483,6 +1482,7 @@
       "displayName" : "module permissions for one op",
       "description" : "to reduce X-Okapi-Token size",
       "subPermissions": [
+        "lost-items-fees-policies.collection.get",
         "circulation-storage.loans.item.put",
         "circulation-storage.loans.item.get",
         "circulation-storage.loans.collection.get",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -178,7 +178,8 @@
             "circulation.check-in-by-barcode.post"
           ],
           "modulePermissions": [
-            "modperms.circulation.check-in-by-barcode.post"
+            "modperms.circulation.check-in-by-barcode.post",
+            "lost-items-fees-policies.collection.get"
           ]
         },
         {


### PR DESCRIPTION
The checkin-by-barcode endpoint does not have the permission
to access lost item fee policies, which is what was causing the error 
modal to show when checking in items with fees.  I added the 
permission to the checkin endpoint.