### PR TITLE
CIRC-1126 - Errors when filtering on recall requested

### DIFF
--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticeService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticeService.java
@@ -3,7 +3,6 @@ package org.folio.circulation.domain.notice;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.groupingBy;
 import static org.apache.http.HttpStatus.SC_OK;
-import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE;
 import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.support.logging.PatronNoticeLogHelper.logResponse;
 import static org.folio.circulation.support.results.Result.succeeded;
@@ -33,7 +32,6 @@ import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.http.client.ResponseInterpreter;
 
 import io.vertx.core.json.JsonObject;
-import org.joda.time.DateTime;
 
 public class PatronNoticeService {
   public static PatronNoticeService using(Clients clients) {
@@ -174,7 +172,7 @@ public class PatronNoticeService {
   }
 
   private CompletableFuture<Result<Void>> publishAuditLogEvent(NoticeLogContext noticeLogContext) {
-    return eventPublisher.publishLogRecord(noticeLogContext.withDate(DateTime.now()).asJson(), NOTICE);
+    return eventPublisher.publishNoticeEvent(noticeLogContext);
   }
 
   private static class NoticeEventGroupDefinition {

--- a/src/test/java/api/queue/RequestQueueResourceTest.java
+++ b/src/test/java/api/queue/RequestQueueResourceTest.java
@@ -245,7 +245,7 @@ public class RequestQueueResourceTest extends APITests {
 
     final var publishedEvents = Awaitility.await()
       .atMost(1, TimeUnit.SECONDS)
-      .until(FakePubSub::getPublishedEvents, hasSize(17));
+      .until(FakePubSub::getPublishedEvents, hasSize(15));
 
     final var reorderedLogEvents = publishedEvents.filterToList(
       byLogEventType(REQUEST_REORDERED.value()));

--- a/src/test/java/api/requests/RequestsAPIUpdatingTests.java
+++ b/src/test/java/api/requests/RequestsAPIUpdatingTests.java
@@ -754,12 +754,12 @@ public class RequestsAPIUpdatingTests extends APITests {
     Response response = loansClient.getById(loan.getId());
     JsonObject updatedLoan = response.getJson();
 
-    // There should be ten events published - for "check out", for "log event: check out",
+    // There should be seven events published - for "check out", for "log event: check out",
     // for "log event: request created", for "log event: request updated" for "recall" and for "replace"
-    // and three log events for loans
+    // and one log events for loans
     final var publishedEvents = Awaitility.await()
       .atMost(1, SECONDS)
-      .until(FakePubSub::getPublishedEvents, hasSize(9));
+      .until(FakePubSub::getPublishedEvents, hasSize(7));
 
     final var requestCreatedLogEvent = publishedEvents.findFirst(byLogEventType(REQUEST_CREATED.value()));
     final var requestUpdatedLogEvent = publishedEvents.findFirst(byLogEventType(REQUEST_UPDATED.value()));

--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -1025,7 +1025,7 @@ public class MoveRequestTests extends APITests {
     // There should be four events published - for "check out", for "log event", for "hold" and for "move"
     final var publishedEvents = Awaitility.await()
       .atMost(1, TimeUnit.SECONDS)
-      .until(FakePubSub::getPublishedEvents, hasSize(11));
+      .until(FakePubSub::getPublishedEvents, hasSize(10));
 
     Map<String, List<JsonObject>> events = publishedEvents.stream().collect(groupingBy(o -> o.getString("eventType")));
 


### PR DESCRIPTION
[CIRC-1126](https://issues.folio.org/browse/CIRC-1126) - Errors when filtering on recall requested

## Purpose
Fixing loan log records duplication, invalid source name.

## Approach
Removing unnecessary log record event publishing.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
