### PR TITLE
reverting permissions changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,6 @@
 
 * Remove redundant override-check-out-by-barcode endpoint (CIRC-1064)
 * Aged to lost process now charges fees for actual cost items if a processing fee is set (CIRC-1115)
-* Added lost-item-fees-policies.collection.get permission to the checkin-by-barcode endpoint (CIRC-1117)
 * Overdue fines not charged if item due before library closes but returned after library has been closed (CIRC-1120)
 
 ## 20.1.0 2021-03-30

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1482,7 +1482,6 @@
       "displayName" : "module permissions for one op",
       "description" : "to reduce X-Okapi-Token size",
       "subPermissions": [
-        "lost-item-fees-policies.collection.get",
         "circulation-storage.loans.item.put",
         "circulation-storage.loans.item.get",
         "circulation-storage.loans.collection.get",


### PR DESCRIPTION
Reverting permissions added as part of CIRC-1117.  It was determined that these 
were front-end permissions.