### PR TITLE
Move age to lost processes back to timer CIRC-1144

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
-## 21.0.0 (in-progress)
+## 22.0.0 (in-progress)
 
 * Remove redundant override-check-out-by-barcode endpoint (CIRC-1064)
 * Aged to lost process now charges fees for actual cost items if a processing fee is set (CIRC-1115)
 * Overdue fines not charged if item due before library closes but returned after library has been closed (CIRC-1120)
 * Update version of mod-pubsub-client to fix memory leak (CIRC-1121)
+* Use `_timer` interface to periodically execute age to lost background processes (CIRC-1144)
 
 ## 20.1.0 2021-03-30
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
 Further documentation about this module can be found in the [/doc/](doc) folder:
 
-* [Guide](doc/guide.md) - introduction for developers
+* [Guide](doc/developer-guide.md) - introduction for developers
 * [Operations guide](doc/operations-guide.md) - introduction for operations
 * [Circulationrules](doc/circulationrules.md) - how the circulation rules file and the circulation rules engine work
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 Further documentation about this module can be found in the [/doc/](doc) folder:
 
 * [Guide](doc/guide.md) - introduction for developers
+* [Operations guide](doc/operations-guide.md) - introduction for operations
 * [Circulationrules](doc/circulationrules.md) - how the circulation rules file and the circulation rules engine work
 
 ## Goal

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -589,76 +589,6 @@
       ]
     },
     {
-      "id": "age-to-lost-background-processes",
-      "version": "0.1",
-      "handlers": [
-        {
-          "methods": [
-            "POST"
-          ],
-          "pathPattern": "/circulation/scheduled-age-to-lost",
-          "permissionsRequired": ["circulation.scheduled-age-to-lost.post"],
-          "modulePermissions": [
-            "circulation-storage.loans.item.put",
-            "circulation-storage.loans.item.get",
-            "circulation-storage.loans.collection.get",
-            "circulation-storage.circulation-rules.get",
-            "circulation-storage.patron-notice-policies.collection.get",
-            "circulation-storage.patron-notice-policies.item.get",
-            "inventory-storage.items.item.put",
-            "inventory-storage.items.item.get",
-            "inventory-storage.items.collection.get",
-            "inventory-storage.locations.collection.get",
-            "inventory-storage.locations.item.get",
-            "inventory-storage.holdings.collection.get",
-            "inventory-storage.instances.collection.get",
-            "inventory-storage.material-types.collection.get",
-            "lost-item-fees-policies.item.get",
-            "lost-item-fees-policies.collection.get",
-            "pubsub.publish.post",
-            "users.item.get",
-            "users.collection.get",
-            "scheduled-notice-storage.scheduled-notices.item.post"
-          ]
-        },
-        {
-          "methods": [
-            "POST"
-          ],
-          "pathPattern": "/circulation/scheduled-age-to-lost-fee-charging",
-          "permissionsRequired": ["circulation.scheduled-age-to-lost-fee-charging.post"],
-          "modulePermissions": [
-            "circulation-storage.loans.item.put",
-            "circulation-storage.loans.item.get",
-            "circulation-storage.loans.collection.get",
-            "inventory-storage.items.item.put",
-            "inventory-storage.items.item.get",
-            "inventory-storage.items.collection.get",
-            "inventory-storage.locations.collection.get",
-            "inventory-storage.location-units.libraries.collection.get",
-            "inventory-storage.holdings.collection.get",
-            "inventory-storage.instances.collection.get",
-            "inventory-storage.material-types.collection.get",
-            "lost-item-fees-policies.item.get",
-            "lost-item-fees-policies.collection.get",
-            "owners.collection.get",
-            "feefines.collection.get",
-            "accounts.item.post",
-            "feefineactions.item.post",
-            "pubsub.publish.post",
-            "users.item.get",
-            "users.collection.get",
-            "circulation-storage.circulation-rules.get",
-            "circulation-storage.patron-notice-policies.item.get",
-            "circulation-storage.patron-notice-policies.collection.get",
-            "circulation.rules.notice-policy.get",
-            "inventory-storage.locations.item.get",
-            "scheduled-notice-storage.scheduled-notices.item.post"
-          ]
-        }
-      ]
-    },
-    {
       "id": "_timer",
       "version": "1.0",
       "interfaceType": "system",
@@ -899,6 +829,72 @@
           ],
           "unit": "minute",
           "delay": "1"
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/circulation/scheduled-age-to-lost",
+          "modulePermissions": [
+            "circulation-storage.loans.item.put",
+            "circulation-storage.loans.item.get",
+            "circulation-storage.loans.collection.get",
+            "circulation-storage.circulation-rules.get",
+            "circulation-storage.patron-notice-policies.collection.get",
+            "circulation-storage.patron-notice-policies.item.get",
+            "inventory-storage.items.item.put",
+            "inventory-storage.items.item.get",
+            "inventory-storage.items.collection.get",
+            "inventory-storage.locations.collection.get",
+            "inventory-storage.locations.item.get",
+            "inventory-storage.holdings.collection.get",
+            "inventory-storage.instances.collection.get",
+            "inventory-storage.material-types.collection.get",
+            "lost-item-fees-policies.item.get",
+            "lost-item-fees-policies.collection.get",
+            "pubsub.publish.post",
+            "users.item.get",
+            "users.collection.get",
+            "scheduled-notice-storage.scheduled-notices.item.post"
+          ],
+          "unit": "minute",
+          "delay": "30"
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/circulation/scheduled-age-to-lost-fee-charging",
+          "modulePermissions": [
+            "circulation-storage.loans.item.put",
+            "circulation-storage.loans.item.get",
+            "circulation-storage.loans.collection.get",
+            "inventory-storage.items.item.put",
+            "inventory-storage.items.item.get",
+            "inventory-storage.items.collection.get",
+            "inventory-storage.locations.collection.get",
+            "inventory-storage.location-units.libraries.collection.get",
+            "inventory-storage.holdings.collection.get",
+            "inventory-storage.instances.collection.get",
+            "inventory-storage.material-types.collection.get",
+            "lost-item-fees-policies.item.get",
+            "lost-item-fees-policies.collection.get",
+            "owners.collection.get",
+            "feefines.collection.get",
+            "accounts.item.post",
+            "feefineactions.item.post",
+            "pubsub.publish.post",
+            "users.item.get",
+            "users.collection.get",
+            "circulation-storage.circulation-rules.get",
+            "circulation-storage.patron-notice-policies.item.get",
+            "circulation-storage.patron-notice-policies.collection.get",
+            "circulation.rules.notice-policy.get",
+            "inventory-storage.locations.item.get",
+            "scheduled-notice-storage.scheduled-notices.item.post"
+          ],
+          "unit": "minute",
+          "delay": "35"
         }
       ]
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1254,16 +1254,6 @@
       "description": "end patron action session"
     },
     {
-      "permissionName": "circulation.scheduled-age-to-lost.post",
-      "displayName": "circulation - scheduled age to lost process",
-      "description": "scheduled process to age overdue borrowed items to lost"
-    },
-    {
-      "permissionName": "circulation.scheduled-age-to-lost-fee-charging.post",
-      "displayName": "circulation - scheduled age to lost fee charging process",
-      "description": "scheduled process to issue fees to patrons for aged to lost items"
-    },
-    {
       "permissionName": "circulation.all",
       "displayName": "circulation - all permissions",
       "description": "Entire set of permissions needed to use the circulation",
@@ -1301,9 +1291,7 @@
         "circulation.requests.instances.item.post",
         "circulation.requests.hold-shelf-clearance-report.get",
         "circulation.inventory.items-in-transit-report.get",
-        "circulation.pick-slips.get",
-        "circulation.scheduled-age-to-lost.post",
-        "circulation.scheduled-age-to-lost-fee-charging.post"
+        "circulation.pick-slips.get"
       ]
     },
     {

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -1,12 +1,12 @@
-# Guide
+# Developer Guide
 
 This is a guide meant to help you both use the `mod-circulation` module and
 enable you to contribute to the module.
 
 ## Automated Testing
 
-See [companion document](automated-testing.md) for information on the automated testing approach 
-used in mod-circulation. 
+See [companion document](automated-testing.md) for information on the automated testing approach
+used in mod-circulation.
 
 ## Storage
 

--- a/doc/operations-guide.md
+++ b/doc/operations-guide.md
@@ -1,0 +1,11 @@
+# Operations Guide
+
+## Scheduled Age to Lost Processes
+
+The age to lost processes are made up of two processes:
+* age to lost (the /circulation/scheduled-age-to-lost endpoint)
+* aged to lost fee charging (the /circulation/scheduled-age-to-lost-fee-charging endpoint)
+
+By default, these are scheduled to execute every 30 or 35 minutes respectively. This configuration can be changed via Okapi, by using the [timer management API](https://github.com/folio-org/okapi/blob/master/doc/guide.md#timer-management).
+
+Each execution of these processes can only process a maximum of 1 000 000 loans.


### PR DESCRIPTION
## Purpose

Moves the age to lost processes back to the `_timer` interface.

During 2021 R1, the age to lost processes were moved to a separate interface so they could be scheduled by each organisation as needed.

We received feedback that this approach was too cumbersome for hosting providers / implementors.

In the mean time, additional features (cron scheduling and runtime configuration of schedules) were added to Okapi in version 4.8.0 which allows these to be moved back to to the `_timer` whilst preserving the level of configurability expected.

## Approach
* Move the endpoints back to the `_timer` interface
* Remove the redundant separate interface documentation
* Briefly describe these endpoints in the (new) operations guide

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
