### PR TITLE
CIRC-1165 - Circ log filter for renewed doesn't work

### DIFF
--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -12,6 +12,7 @@ import static org.folio.circulation.domain.EventType.LOG_RECORD;
 import static org.folio.circulation.domain.LoanAction.CHECKED_IN;
 import static org.folio.circulation.domain.LoanAction.DUE_DATE_CHANGED;
 import static org.folio.circulation.domain.LoanAction.RECALLREQUESTED;
+import static org.folio.circulation.domain.LoanAction.RENEWED;
 import static org.folio.circulation.domain.representations.logs.LogEventPayloadField.LOG_EVENT_TYPE;
 import static org.folio.circulation.domain.representations.logs.CirculationCheckInCheckOutLogEventMapper.mapToCheckInLogEventContent;
 import static org.folio.circulation.domain.representations.logs.CirculationCheckInCheckOutLogEventMapper.mapToCheckOutLogEventContent;
@@ -153,10 +154,10 @@ public class EventPublisher {
   }
 
   private CompletableFuture<Result<Loan>> publishDueDateChangedEvent(Loan loan, RequestAndRelatedRecords records) {
-    return publishDueDateChangedEvent(loan, records.getRequest().getRequester());
+    return publishDueDateChangedEvent(loan, records.getRequest().getRequester(), false);
   }
 
-  private CompletableFuture<Result<Loan>> publishDueDateChangedEvent(Loan loan, User user) {
+  private CompletableFuture<Result<Loan>> publishDueDateChangedEvent(Loan loan, User user, boolean renewalContext) {
     if (loan != null) {
       JsonObject payloadJsonObject = new JsonObject();
       write(payloadJsonObject, USER_ID_FIELD, loan.getUserId());
@@ -165,6 +166,9 @@ public class EventPublisher {
       write(payloadJsonObject, DUE_DATE_CHANGED_BY_RECALL_FIELD, loan.wasDueDateChangedByRecall());
 
       runAsync(() -> publishDueDateLogEvent(loan.copy().withUser(user)));
+      if (renewalContext) {
+        runAsync(() -> publishRenewedEvent(loan.copy().withUser(user)));
+      }
 
       return pubSubPublishingService.publishEvent(LOAN_DUE_DATE_CHANGED.name(),
         payloadJsonObject.encode())
@@ -182,7 +186,7 @@ public class EventPublisher {
 
     if (loanAndRelatedRecords.getLoan() != null) {
       Loan loan = loanAndRelatedRecords.getLoan();
-      publishDueDateChangedEvent(loan, loan.getUser());
+      publishDueDateChangedEvent(loan, loan.getUser(), false);
     }
 
     return completedFuture(succeeded(loanAndRelatedRecords));
@@ -193,7 +197,7 @@ public class EventPublisher {
 
     var loan = renewalContext.getLoan();
 
-    publishDueDateChangedEvent(loan, loan.getUser());
+    publishDueDateChangedEvent(loan, loan.getUser(), true);
 
     return completedFuture(succeeded(renewalContext));
   }
@@ -247,6 +251,10 @@ public class EventPublisher {
     return publishLogRecord(LoanLogContext.from(loan)
       .withAction(LogContextActionResolver.resolveAction(DUE_DATE_CHANGED.getValue()))
       .withDescription(String.format("New due date: %s (from %s)", formatDateTime(loan.getDueDate()), formatDateTime(loan.getPreviousDueDate()))).asJson(), LOAN);
+  }
+
+  public CompletableFuture<Result<Void>> publishRenewedEvent(Loan loan) {
+    return publishLogRecord(LoanLogContext.from(loan).withAction(LogContextActionResolver.resolveAction(RENEWED.getValue())).asJson(), LOAN);
   }
 
   public CompletableFuture<Result<Void>> publishNoticeEvent(NoticeLogContext noticeLogContext) {

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -6,8 +6,9 @@ import static api.support.builders.FixedDueDateSchedule.forDay;
 import static api.support.builders.FixedDueDateSchedule.todayOnly;
 import static api.support.builders.FixedDueDateSchedule.wholeMonth;
 import static api.support.builders.ItemBuilder.CHECKED_OUT;
-import static api.support.fakes.PublishedEvents.byEventType;
 import static api.support.fakes.PublishedEvents.byLogEventType;
+import static api.support.fakes.PublishedEvents.byLogAction;
+import static api.support.fakes.PublishedEvents.byEventType;
 import static api.support.fixtures.AutomatedPatronBlocksFixture.MAX_NUMBER_OF_ITEMS_CHARGED_OUT_MESSAGE;
 import static api.support.fixtures.AutomatedPatronBlocksFixture.MAX_OUTSTANDING_FEE_FINE_BALANCE_MESSAGE;
 import static api.support.fixtures.CalendarExamples.CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN;
@@ -22,7 +23,9 @@ import static api.support.fixtures.CalendarExamples.MONDAY_DATE;
 import static api.support.fixtures.CalendarExamples.START_TIME_FIRST_PERIOD;
 import static api.support.fixtures.CalendarExamples.START_TIME_SECOND_PERIOD;
 import static api.support.fixtures.CalendarExamples.WEDNESDAY_DATE;
+import static api.support.matchers.EventActionMatchers.ITEM_RENEWED;
 import static api.support.matchers.EventMatchers.isValidLoanDueDateChangedEvent;
+import static api.support.matchers.EventMatchers.isValidRenewedEvent;
 import static api.support.matchers.EventTypeMatchers.LOAN_DUE_DATE_CHANGED;
 import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
 import static api.support.matchers.PatronNoticeMatcher.hasEmailNoticeProperties;
@@ -1489,12 +1492,14 @@ public abstract class RenewalAPITests extends APITests {
       .atMost(1, TimeUnit.SECONDS)
       .until(FakePubSub::getPublishedEvents, hasSize(5));
 
-    assertThat(renewedLoan.getString("action"), is(RENEWED));
-
     final var event = publishedEvents.findFirst(byEventType(LOAN_DUE_DATE_CHANGED));
 
     assertThat(event, isValidLoanDueDateChangedEvent(renewedLoan));
     assertThatPublishedLoanLogRecordEventsAreValid(renewedLoan);
+
+    final var renewedEvent = publishedEvents.findFirst(byLogAction(ITEM_RENEWED));
+
+    assertThat(renewedEvent, isValidRenewedEvent(renewedLoan));
   }
 
   @Test

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -1486,7 +1486,7 @@ public abstract class RenewalAPITests extends APITests {
     // and one "log record"
     final var publishedEvents = Awaitility.await()
       .atMost(1, TimeUnit.SECONDS)
-      .until(FakePubSub::getPublishedEvents, hasSize(4));
+      .until(FakePubSub::getPublishedEvents, hasSize(5));
 
     final var event = publishedEvents.findFirst(byEventType(LOAN_DUE_DATE_CHANGED));
 

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -115,6 +115,7 @@ public abstract class RenewalAPITests extends APITests {
     "circulation.override-item-limit-block";
   private static final String RENEWED_THROUGH_OVERRIDE = "renewedThroughOverride";
   private static final String PATRON_WAS_BLOCKED_MESSAGE = "Patron blocked from renewing";
+  private static final String RENEWED = "renewed";
 
   abstract Response attemptRenewal(IndividualResource user, IndividualResource item);
 
@@ -1481,12 +1482,14 @@ public abstract class RenewalAPITests extends APITests {
 
     final JsonObject renewedLoan = renew(smallAngryPlanet, jessica).getJson();
 
-    // There should be six events published - first for "check out",
-    // second one for log event, third for "change due date"
-    // and one "log record"
+    // There should be five events published - first for "check out",
+    // second one for log event, third for "change due date",
+    // fourth one for "log record", and fifth one for "renewed".
     final var publishedEvents = Awaitility.await()
       .atMost(1, TimeUnit.SECONDS)
       .until(FakePubSub::getPublishedEvents, hasSize(5));
+
+    assertThat(renewedLoan.getString("action"), is(RENEWED));
 
     final var event = publishedEvents.findFirst(byEventType(LOAN_DUE_DATE_CHANGED));
 

--- a/src/test/java/api/support/matchers/EventActionMatchers.java
+++ b/src/test/java/api/support/matchers/EventActionMatchers.java
@@ -1,0 +1,23 @@
+package api.support.matchers;
+
+import io.vertx.core.json.JsonObject;
+import org.hamcrest.Matcher;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.core.Is.is;
+
+public class EventActionMatchers {
+  public static final String ITEM_RENEWED = "Renewed";
+
+  public static Matcher<JsonObject> isItemRenewedEventAction() {
+    return isEventOfAction(ITEM_RENEWED);
+  }
+
+  private static Matcher<JsonObject> isEventOfAction(String eventAction) {
+    return JsonObjectMatcher.allOfPaths(
+      hasJsonPath("eventPayload", allOf(
+        hasJsonPath("payload", allOf(
+          hasJsonPath("action", is(eventAction)))))));
+  }
+}

--- a/src/test/java/api/support/matchers/EventMatchers.java
+++ b/src/test/java/api/support/matchers/EventMatchers.java
@@ -1,5 +1,6 @@
 package api.support.matchers;
 
+import static api.support.matchers.EventActionMatchers.isItemRenewedEventAction;
 import static api.support.matchers.EventTypeMatchers.isItemAgedToLostEventType;
 import static api.support.matchers.EventTypeMatchers.isItemCheckedInEventType;
 import static api.support.matchers.EventTypeMatchers.isItemCheckedOutEventType;
@@ -114,6 +115,16 @@ public class EventMatchers {
           is(getBooleanProperty(loan, "dueDateChangedByRecall")))
       ))),
       isLoanDueDateChangedEventType());
+  }
+
+  public static Matcher<JsonObject> isValidRenewedEvent(JsonObject loan) {
+    return allOf(JsonObjectMatcher.allOfPaths(
+      hasJsonPath("eventPayload", allOf(
+        hasJsonPath("payload", allOf(
+          hasJsonPath("userId", is(loan.getString("userId"))),
+          hasJsonPath("loanId", is(loan.getString("id")))
+        ))))),
+      isItemRenewedEventAction());
   }
 
   public static Matcher<JsonObject> isValidLoanLogRecordEvent(JsonObject loanCtx) {


### PR DESCRIPTION
[CIRC-1165](https://issues.folio.org/browse/CIRC-1165) - Circ log filter for renewed doesn't work

## Purpose
To show a row with the item just renewed in circulation logs.

## Approach
Add option to publish event with Renewed action when context is renewal.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  