### PR TITLE
Respond with a validation error when evaluating rules and location does not exist CIRC-1170

### DIFF
--- a/src/main/java/org/folio/circulation/rules/CirculationRulesProcessor.java
+++ b/src/main/java/org/folio/circulation/rules/CirculationRulesProcessor.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.rules;
 
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.results.Result.combined;
-import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -13,7 +13,6 @@ import org.folio.circulation.domain.Location;
 import org.folio.circulation.rules.cache.CirculationRulesCache;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FetchSingleRecord;
-import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.results.Result;
 import org.slf4j.Logger;
 
@@ -122,7 +121,7 @@ public class CirculationRulesProcessor {
     return FetchSingleRecord.<Location>forRecord("location")
       .using(locationStorageClient)
       .mapTo(Location::from)
-      .whenNotFound(failed(new ServerErrorFailure("Can`t find location")))
+      .whenNotFound(failedValidation("Cannot find location", "location_id", params.getLocationId()))
       .fetch(params.getLocationId())
       .thenApply(r -> r.map(params::withLocation));
   }

--- a/src/test/java/api/CirculationRulesEngineAPITests.java
+++ b/src/test/java/api/CirculationRulesEngineAPITests.java
@@ -1,7 +1,11 @@
 package api;
 
+import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
+import static api.support.matchers.ValidationErrorMatchers.hasMessage;
+import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
@@ -364,8 +368,9 @@ public class CirculationRulesEngineAPITests extends APITests {
       .attemptToApplyRulesForRequestPolicy(itemType, loanType,
         patronGroup, locationThatDoesNotExist);
 
-    assertThat(response.getStatusCode(), is(500));
-    assertThat(response.getBody(), is("Can`t find location"));
+    assertThat(response.getJson(), hasErrorWith(allOf(
+      hasMessage("Cannot find location"),
+      hasParameter("location_id", locationThatDoesNotExist.id))));
   }
 
   @Test

--- a/src/test/java/api/CirculationRulesEngineAPITests.java
+++ b/src/test/java/api/CirculationRulesEngineAPITests.java
@@ -351,6 +351,24 @@ public class CirculationRulesEngineAPITests extends APITests {
   }
 
   @Test
+  public void rulesEvaluationFailsWhenTheProvidedLocationDoesNotExist() {
+    // The underlying rules are irrelevant
+    setRules(rules1);
+
+    final var itemType = new ItemType(UUID.randomUUID().toString());
+    final var loanType = new LoanType(UUID.randomUUID().toString());
+    final var patronGroup = new PatronGroup(UUID.randomUUID().toString());
+    final var locationThatDoesNotExist = new ItemLocation(UUID.randomUUID().toString());
+
+    final var response = circulationRulesFixture
+      .attemptToApplyRulesForRequestPolicy(itemType, loanType,
+        patronGroup, locationThatDoesNotExist);
+
+    assertThat(response.getStatusCode(), is(500));
+    assertThat(response.getBody(), is("Can`t find location"));
+  }
+
+  @Test
   public void setRulesInvalidatesCache() {
     setRules(rulesFallback);
     assertThat(applyRulesForLoanPolicy(m1, t1, g1, s1), is(lp6));

--- a/src/test/java/api/support/RestAssuredClient.java
+++ b/src/test/java/api/support/RestAssuredClient.java
@@ -7,6 +7,8 @@ import static api.support.RestAssuredConfiguration.timeoutConfig;
 import static api.support.RestAssuredResponseConversion.toResponse;
 import static io.restassured.RestAssured.given;
 import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 
 import java.net.URL;
@@ -76,6 +78,17 @@ public class RestAssuredClient {
   public Response get(URL url, Collection<QueryStringParameter> parameters,
       int expectedStatusCode, String requestId) {
 
+    final var response = get(url, parameters, requestId);
+
+    assertThat("Unexpected status code",
+      response.getStatusCode(), is(expectedStatusCode));
+
+    return response;
+  }
+
+  public Response get(URL url, Collection<QueryStringParameter> parameters,
+    String requestId) {
+
     return toResponse(given()
       .config(config)
       .log().ifValidationFails()
@@ -84,8 +97,6 @@ public class RestAssuredClient {
       .spec(timeoutConfig())
       .when().get(url)
       .then()
-      .log().ifValidationFails()
-      .statusCode(expectedStatusCode)
       .extract().response());
   }
 

--- a/src/test/java/api/support/fixtures/CirculationRulesFixture.java
+++ b/src/test/java/api/support/fixtures/CirculationRulesFixture.java
@@ -14,8 +14,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.folio.circulation.rules.ItemLocation;
 import org.folio.circulation.rules.ItemType;
@@ -153,6 +151,15 @@ public class CirculationRulesFixture {
     assertThat(requestPolicyId, is(not(nullValue())));
 
     return new Policy(requestPolicyId);
+  }
+
+  public Response attemptToApplyRulesForRequestPolicy(ItemType itemType,
+    LoanType loanType, PatronGroup patronGroup, ItemLocation location) {
+
+    return restAssuredClient.get(
+      circulationRulesUrl("/request-policy"),
+      getApplyParameters(itemType, loanType, patronGroup, location),
+      "apply-rules-to-get-request-policy");
   }
 
   public JsonArray applyAllRulesForRequestPolicy(ItemType itemType,


### PR DESCRIPTION
## Purpose

It has been [requested](https://issues.folio.org/browse/CIRC-1170) that the circulation rules endpoints should respond with a validation error rather than a server error when a location that does not exist is used to evaluate them.

## Approach
* Wrote a test to demonstrate the server error
* Change the test to expect a validation error
* Change the implementation to make the test pass

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
