### PR TITLE
CIRC-1053: Upgrade to vert.x 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <antlr4.version>4.7.2</antlr4.version>
     <drools.version>7.53.0.Final</drools.version>
     <rmb.version>31.1.0</rmb.version>
-    <vertx.version>3.9.1</vertx.version>
+    <vertx.version>4.1.1</vertx.version>
     <log4j2.version>2.13.3</log4j2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -346,6 +346,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
+         <showDeprecation>true</showDeprecation>
           <release>11</release>
           <encoding>UTF-8</encoding>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-         <showDeprecation>true</showDeprecation>
           <release>11</release>
           <encoding>UTF-8</encoding>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -66,11 +66,6 @@
       <version>${log4j2.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j2.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
     </dependency>

--- a/src/main/java/org/folio/circulation/CirculationVerticle.java
+++ b/src/main/java/org/folio/circulation/CirculationVerticle.java
@@ -36,8 +36,8 @@ import org.folio.circulation.resources.handlers.LoanRelatedFeeFineClosedHandlerR
 import org.folio.circulation.resources.renewal.RenewByBarcodeResource;
 import org.folio.circulation.resources.renewal.RenewByIdResource;
 import org.folio.circulation.support.logging.Logging;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
@@ -53,7 +53,7 @@ public class CirculationVerticle extends AbstractVerticle {
   public void start(Promise<Void> startFuture) {
     Logging.initialiseFormat();
 
-    final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
     log.info("Starting circulation module");
 
@@ -139,7 +139,7 @@ public class CirculationVerticle extends AbstractVerticle {
 
   @Override
   public void stop(Promise<Void> stopFuture) {
-    final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
     log.info("Stopping circulation module");
 

--- a/src/main/java/org/folio/circulation/Launcher.java
+++ b/src/main/java/org/folio/circulation/Launcher.java
@@ -10,8 +10,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
 public class Launcher {
@@ -23,7 +23,7 @@ public class Launcher {
     Logging.initialiseFormat();
 
     this.vertxAssistant = vertxAssistant;
-    this.log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    this.log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   }
 
   public static void main(String[] args) throws

--- a/src/main/java/org/folio/circulation/Launcher.java
+++ b/src/main/java/org/folio/circulation/Launcher.java
@@ -1,7 +1,6 @@
 package org.folio.circulation;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
 import org.folio.circulation.support.VertxAssistant;
 import org.folio.circulation.support.logging.Logging;
 
@@ -11,7 +10,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static io.vertx.core.logging.LoggerFactory.getLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
 public class Launcher {
@@ -23,7 +23,7 @@ public class Launcher {
     Logging.initialiseFormat();
 
     this.vertxAssistant = vertxAssistant;
-    this.log = getLogger(MethodHandles.lookup().lookupClass());
+    this.log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   }
 
   public static void main(String[] args) throws

--- a/src/main/java/org/folio/circulation/domain/ConfigurationService.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationService.java
@@ -7,13 +7,13 @@ import java.util.Collection;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTimeZone;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 
 public class ConfigurationService {
-  private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final int DEFAULT_SCHEDULED_NOTICES_PROCESSING_LIMIT = 100;
   private static final int DEFAULT_CHECKOUT_TIMEOUT_DURATION_IN_MINUTES = 3;

--- a/src/main/java/org/folio/circulation/domain/LoanRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepresentation.java
@@ -14,13 +14,13 @@ import org.folio.circulation.domain.policy.Policy;
 import org.folio.circulation.domain.representations.ItemSummaryRepresentation;
 import org.folio.circulation.domain.representations.LoanProperties;
 import org.folio.circulation.resources.context.RenewalContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 
 public class LoanRepresentation {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   public JsonObject extendedLoan(Loan loan) {
     if(loan == null) {

--- a/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
@@ -11,14 +11,14 @@ import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import java.lang.invoke.MethodHandles;
 
 import org.joda.time.format.ISODateTimeFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class RequestRepresentation {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final String PICKUP_SERVICE_POINT = "pickupServicePoint";
 

--- a/src/main/java/org/folio/circulation/domain/StoredRequestRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/StoredRequestRepresentation.java
@@ -5,13 +5,13 @@ import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
 import java.lang.invoke.MethodHandles;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 
 public class StoredRequestRepresentation {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   public JsonObject storedRequest(Request request) {
     final JsonObject representation = request.asJson();

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -23,11 +23,11 @@ import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.utils.DateTimeUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class UpdateRequestQueue {
-  private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private final RequestQueueRepository requestQueueRepository;
   private final RequestRepository requestRepository;

--- a/src/main/java/org/folio/circulation/domain/anonymization/LoanAnonymization.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/LoanAnonymization.java
@@ -16,11 +16,11 @@ import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.http.client.PageLimit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class LoanAnonymization {
-  private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   public static final PageLimit FETCH_LOANS_PAGE_LIMIT = limit(5000);
 

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/DueDateNotRealTimeScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/DueDateNotRealTimeScheduledNoticeHandler.java
@@ -23,8 +23,8 @@ import org.folio.circulation.infrastructure.storage.notices.PatronNoticePolicyRe
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -32,7 +32,7 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public class DueDateNotRealTimeScheduledNoticeHandler {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   public static DueDateNotRealTimeScheduledNoticeHandler using(Clients clients, DateTime systemTime) {
     return new DueDateNotRealTimeScheduledNoticeHandler(

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
@@ -27,8 +27,8 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 import lombok.AllArgsConstructor;
@@ -36,7 +36,7 @@ import lombok.Getter;
 import lombok.With;
 
 public class FeeFineScheduledNoticeHandler {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private final PatronNoticeService patronNoticeService;
   private final ScheduledNoticesRepository scheduledNoticesRepository;

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
@@ -44,8 +44,8 @@ import org.folio.circulation.support.RecordNotFoundFailure;
 import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 import lombok.AccessLevel;
@@ -54,7 +54,7 @@ import lombok.Getter;
 
 @AllArgsConstructor
 public class LoanScheduledNoticeHandler {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private static final String ERROR_MESSAGE_TEMPLATE = "Sending scheduled notice {} failed: {}";
 
   public static LoanScheduledNoticeHandler using(Clients clients, DateTime systemTime) {

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
@@ -26,13 +26,13 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 
 public class RequestScheduledNoticeHandler {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   public static RequestScheduledNoticeHandler using(Clients clients) {
     return new RequestScheduledNoticeHandler(

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionService.java
@@ -39,11 +39,11 @@ import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.http.client.PageLimit;
 
 import io.vertx.core.json.JsonObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class PatronActionSessionService {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private static final PageLimit DEFAULT_SESSION_SIZE_PAGE_LIMIT = limit(200);
 
   private static EnumMap<PatronActionType, NoticeEventType> actionToEventMap;

--- a/src/main/java/org/folio/circulation/domain/policy/DueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/DueDateStrategy.java
@@ -7,11 +7,11 @@ import org.folio.circulation.domain.Loan;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public abstract class DueDateStrategy {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private final String loanPolicyId;
   private final String loanPolicyName;

--- a/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
@@ -12,13 +12,13 @@ import java.util.Objects;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.ServicePoint;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 
 public class ItemSummaryRepresentation {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   public JsonObject createItemSummary(Item item) {
     if(item == null || item.isNotFound()) {

--- a/src/main/java/org/folio/circulation/domain/validation/ServicePointPickupLocationValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ServicePointPickupLocationValidator.java
@@ -9,11 +9,11 @@ import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestAndRelatedRecords;
 import org.folio.circulation.domain.RequestFulfilmentPreference;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ServicePointPickupLocationValidator {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   public Result<RequestAndRelatedRecords> refuseInvalidPickupServicePoint(
     RequestAndRelatedRecords requestAndRelatedRecords) {

--- a/src/main/java/org/folio/circulation/infrastructure/storage/CirculationPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/CirculationPolicyRepository.java
@@ -19,14 +19,14 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.SingleRecordFetcher;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 
 public abstract class CirculationPolicyRepository<T> {
   public static final String LOCATION_ID_NAME = "location_id";
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   protected final CollectionResourceClient policyStorageClient;
   protected final CirculationRulesProcessor circulationRulesProcessor;

--- a/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
@@ -24,11 +24,11 @@ import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FetchSingleRecord;
 import org.folio.circulation.support.FindWithMultipleCqlIndexValues;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ServicePointRepository {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private final CollectionResourceClient servicePointsStorageClient;
 

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -42,15 +42,15 @@ import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.results.CommonFailures;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 public class ItemRepository {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private final CollectionResourceClient itemsClient;
   private final CollectionResourceClient holdingsClient;

--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
@@ -59,8 +59,8 @@ import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.client.ResponseInterpreter;
 import org.folio.circulation.support.results.CommonFailures;
 import org.folio.circulation.support.utils.CollectionUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 
@@ -70,7 +70,7 @@ public class LoanRepository implements GetManyRecordsRepository<Loan> {
   private final CollectionResourceClient loansStorageClient;
   private final ItemRepository itemRepository;
   private final UserRepository userRepository;
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private static final String ITEM_STATUS = "itemStatus";
   private static final String ITEM_ID = "itemId";
   private static final String USER_ID = "userId";

--- a/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestPolicyRepository.java
@@ -21,13 +21,13 @@ import org.folio.circulation.support.ForwardOnFailure;
 import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.SingleRecordFetcher;
 import org.folio.circulation.support.http.client.Response;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 
 public class RequestPolicyRepository {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private final CirculationRulesClient circulationRequestRulesClient;
   private final CollectionResourceClient requestPoliciesStorageClient;

--- a/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestQueueRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestQueueRepository.java
@@ -21,11 +21,11 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.http.client.PageLimit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class RequestQueueRepository {
-  private static final Logger LOG = LoggerFactory.getLogger(RequestQueueRepository.class);
+  private static final Logger LOG = LogManager.getLogger(RequestQueueRepository.class);
 
   private static final PageLimit MAXIMUM_SUPPORTED_REQUEST_QUEUE_SIZE = oneThousand();
   private final RequestRepository requestRepository;

--- a/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
@@ -50,14 +50,14 @@ import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.client.ResponseInterpreter;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 
 public class PatronActionSessionRepository {
 
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private final CollectionResourceClient patronActionSessionsStorageClient;
   private final LoanRepository loanRepository;
   private final LoanPolicyRepository loanPolicyRepository;

--- a/src/main/java/org/folio/circulation/infrastructure/storage/users/UserRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/users/UserRepository.java
@@ -32,11 +32,11 @@ import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.client.Response;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class UserRepository {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private static final String USERS_RECORD_PROPERTY = "users";
 
   private final CollectionResourceClient usersStorageClient;

--- a/src/main/java/org/folio/circulation/resources/AbstractCirculationRulesEngineResource.java
+++ b/src/main/java/org/folio/circulation/resources/AbstractCirculationRulesEngineResource.java
@@ -16,8 +16,8 @@ import org.folio.circulation.support.http.server.ClientErrorResponse;
 import org.folio.circulation.support.http.server.JsonHttpResponse;
 import org.folio.circulation.support.http.server.WebContext;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpServerRequest;
@@ -32,7 +32,7 @@ import lombok.val;
  * item type, loan type, patron type and location.
  */
 public abstract class AbstractCirculationRulesEngineResource extends Resource {
-  protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  protected static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   public static final String ITEM_TYPE_ID_NAME = "item_type_id";
   public static final String PATRON_TYPE_ID_NAME = "patron_type_id";

--- a/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
@@ -42,11 +42,11 @@ import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.support.RecordNotFoundFailure;
 import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.http.server.WebContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 class CheckInProcessAdapter {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private final ItemByBarcodeInStorageFinder itemFinder;
   private final SingleOpenLoanForItemInStorageFinder singleOpenLoanFinder;
   private final LoanCheckInService loanCheckInService;

--- a/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
+++ b/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
@@ -35,8 +35,8 @@ import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.server.ForwardResponse;
 import org.folio.circulation.support.http.server.WebContext;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpServerResponse;
@@ -50,7 +50,7 @@ import io.vertx.ext.web.handler.BodyHandler;
  * Write and read the circulation rules.
  */
 public class CirculationRulesResource extends Resource {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private static final int FIRST_ELEMENT_OF_LIST = 0;
   private static final int POLICY_ID_POSITION_NUMBER = 1;
   private static final PageLimit POLICY_PAGE_LIMIT = PageLimit.limit(1000);

--- a/src/main/java/org/folio/circulation/resources/LoanNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/LoanNoticeSender.java
@@ -20,8 +20,8 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 
 import io.vertx.core.json.JsonObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class LoanNoticeSender {
 
@@ -31,7 +31,7 @@ public class LoanNoticeSender {
       new LoanPolicyRepository(clients));
   }
 
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private final PatronNoticeService patronNoticeService;
   private final LoanPolicyRepository loanPolicyRepository;
 

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -69,8 +69,8 @@ import org.folio.circulation.support.http.server.WebContext;
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonObject;
@@ -83,7 +83,7 @@ public class RequestByInstanceIdResource extends Resource {
 
   public RequestByInstanceIdResource(HttpClient client) {
     super(client);
-    log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/resources/handlers/LoanRelatedFeeFineClosedHandlerResource.java
+++ b/src/main/java/org/folio/circulation/resources/handlers/LoanRelatedFeeFineClosedHandlerResource.java
@@ -28,15 +28,15 @@ import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.http.server.WebContext;
 import org.folio.circulation.support.results.CommonFailures;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
 public class LoanRelatedFeeFineClosedHandlerResource extends Resource {
-  private static final Logger log = LoggerFactory.getLogger(
+  private static final Logger log = LogManager.getLogger(
     LoanRelatedFeeFineClosedHandlerResource.class);
 
   public LoanRelatedFeeFineClosedHandlerResource(HttpClient client) {

--- a/src/main/java/org/folio/circulation/resources/handlers/error/DeferFailureErrorHandler.java
+++ b/src/main/java/org/folio/circulation/resources/handlers/error/DeferFailureErrorHandler.java
@@ -13,11 +13,11 @@ import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class DeferFailureErrorHandler extends CirculationErrorHandler {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   public DeferFailureErrorHandler() {
     super(new LinkedHashMap<>());

--- a/src/main/java/org/folio/circulation/rules/CirculationRulesProcessor.java
+++ b/src/main/java/org/folio/circulation/rules/CirculationRulesProcessor.java
@@ -4,7 +4,8 @@ import static org.folio.circulation.support.results.Result.combined;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
@@ -15,13 +16,12 @@ import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FetchSingleRecord;
 import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
 
 import io.vertx.core.json.JsonArray;
 import lombok.val;
 
 public class CirculationRulesProcessor {
-  private static final Logger log = getLogger(CirculationRulesProcessor.class);
+  private static final Logger log = LogManager.getLogger(CirculationRulesProcessor.class);
 
   private final String tenantId;
   private final CollectionResourceClient circulationRulesStorage;

--- a/src/main/java/org/folio/circulation/rules/ExecutableRules.java
+++ b/src/main/java/org/folio/circulation/rules/ExecutableRules.java
@@ -3,7 +3,8 @@ package org.folio.circulation.rules;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.folio.circulation.support.results.Result.of;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.lang.invoke.MethodHandles;
 import java.util.function.BiFunction;
@@ -13,13 +14,12 @@ import org.folio.circulation.domain.Location;
 import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
 
 import io.vertx.core.MultiMap;
 import lombok.Getter;
 
 public class ExecutableRules {
-  private static final Logger log = getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   @Getter()
   private final String text;

--- a/src/main/java/org/folio/circulation/rules/cache/CirculationRulesCache.java
+++ b/src/main/java/org/folio/circulation/rules/cache/CirculationRulesCache.java
@@ -5,7 +5,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
@@ -18,12 +19,12 @@ import org.folio.circulation.rules.Text2Drools;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
+
 
 import io.vertx.core.json.JsonObject;
 
 public final class CirculationRulesCache {
-  private static final Logger log = getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final CirculationRulesCache instance = new CirculationRulesCache();
   /** after this time the rules get loaded before executing the circulation rules engine */

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -25,8 +25,8 @@ import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.folio.circulation.support.results.Result.succeeded;
 
 import io.vertx.core.json.JsonObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import io.vertx.ext.web.RoutingContext;
 import org.folio.circulation.domain.CheckInContext;
 import org.folio.circulation.domain.EventType;
@@ -52,7 +52,7 @@ import org.joda.time.format.DateTimeFormatter;
 import java.util.concurrent.CompletableFuture;
 
 public class EventPublisher {
-  private static final Logger logger = LoggerFactory.getLogger(EventPublisher.class);
+  private static final Logger logger = LogManager.getLogger(EventPublisher.class);
 
   public static final String USER_ID_FIELD = "userId";
   public static final String LOAN_ID_FIELD = "loanId";

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -25,8 +25,8 @@ import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.folio.circulation.support.results.Result.succeeded;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
 import org.folio.circulation.domain.CheckInContext;
 import org.folio.circulation.domain.EventType;

--- a/src/main/java/org/folio/circulation/services/FeeFineFacade.java
+++ b/src/main/java/org/folio/circulation/services/FeeFineFacade.java
@@ -5,7 +5,8 @@ import static org.folio.circulation.domain.representations.StoredFeeFineAction.S
 import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.List;
@@ -30,10 +31,9 @@ import org.folio.circulation.services.support.CreateAccountCommand;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.CommonFailures;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
 
 public class FeeFineFacade {
-  private static final Logger log = getLogger(FeeFineFacade.class);
+  private static final Logger log = LogManager.getLogger(FeeFineFacade.class);
 
   private final AccountRepository accountRepository;
   private final FeeFineActionRepository feeFineActionRepository;

--- a/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
@@ -35,11 +35,11 @@ import org.folio.circulation.services.feefine.FeeFineService;
 import org.folio.circulation.services.support.CreateAccountCommand;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class LostItemFeeChargingService {
-  private static final Logger log = LoggerFactory.getLogger(LostItemFeeChargingService.class);
+  private static final Logger log = LogManager.getLogger(LostItemFeeChargingService.class);
 
   private final LostItemPolicyRepository lostItemPolicyRepository;
   private final FeeFineOwnerRepository feeFineOwnerRepository;

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
@@ -38,11 +38,11 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.results.CommonFailures;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class LostItemFeeRefundService {
-  private static final Logger log = LoggerFactory.getLogger(LostItemFeeRefundService.class);
+  private static final Logger log = LogManager.getLogger(LostItemFeeRefundService.class);
 
   private final LostItemPolicyRepository lostItemPolicyRepository;
   private final FeeFineFacade feeFineFacade;

--- a/src/main/java/org/folio/circulation/services/PubSubPublishingService.java
+++ b/src/main/java/org/folio/circulation/services/PubSubPublishingService.java
@@ -16,12 +16,12 @@ import org.folio.util.pubsub.PubSubClientUtils;
 
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import io.vertx.ext.web.RoutingContext;
 
 public class PubSubPublishingService {
-  private static final Logger logger = LoggerFactory.getLogger(PubSubPublishingService.class);
+  private static final Logger logger = LogManager.getLogger(PubSubPublishingService.class);
 
   private final Map<String, String> okapiHeaders;
   private final Context vertxContext;

--- a/src/main/java/org/folio/circulation/services/PubSubPublishingService.java
+++ b/src/main/java/org/folio/circulation/services/PubSubPublishingService.java
@@ -16,8 +16,8 @@ import org.folio.util.pubsub.PubSubClientUtils;
 
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
 
 public class PubSubPublishingService {

--- a/src/main/java/org/folio/circulation/services/PubSubRegistrationService.java
+++ b/src/main/java/org/folio/circulation/services/PubSubRegistrationService.java
@@ -7,11 +7,11 @@ import org.folio.rest.util.OkapiConnectionParams;
 import org.folio.util.pubsub.PubSubClientUtils;
 
 import io.vertx.core.Vertx;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class PubSubRegistrationService {
-  private static final Logger logger = LoggerFactory.getLogger(PubSubRegistrationService.class);
+  private static final Logger logger = LogManager.getLogger(PubSubRegistrationService.class);
 
   private PubSubRegistrationService() {
     throw new IllegalStateException();

--- a/src/main/java/org/folio/circulation/services/PubSubRegistrationService.java
+++ b/src/main/java/org/folio/circulation/services/PubSubRegistrationService.java
@@ -7,8 +7,8 @@ import org.folio.rest.util.OkapiConnectionParams;
 import org.folio.util.pubsub.PubSubClientUtils;
 
 import io.vertx.core.Vertx;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PubSubRegistrationService {
   private static final Logger logger = LoggerFactory.getLogger(PubSubRegistrationService.class);

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -52,13 +52,13 @@ import org.folio.circulation.support.fetching.PageableFetcher;
 import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import lombok.val;
 
 public class ChargeLostFeesWhenAgedToLostService {
-  private static final Logger log = LoggerFactory.getLogger(ChargeLostFeesWhenAgedToLostService.class);
+  private static final Logger log = LogManager.getLogger(ChargeLostFeesWhenAgedToLostService.class);
 
   private final LostItemPolicyRepository lostItemPolicyRepository;
   private final FeeFineOwnerRepository feeFineOwnerRepository;

--- a/src/main/java/org/folio/circulation/services/agedtolost/MarkOverdueLoansAsAgedLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/MarkOverdueLoansAsAgedLostService.java
@@ -11,7 +11,8 @@ import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
 import static org.folio.circulation.support.http.client.CqlQuery.lessThan;
 import static org.folio.circulation.support.http.client.CqlQuery.notEqual;
 import static org.folio.circulation.support.results.Result.ofAsync;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -31,10 +32,9 @@ import org.folio.circulation.support.fetching.PageableFetcher;
 import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
 
 public class MarkOverdueLoansAsAgedLostService {
-  private static final Logger log = getLogger(MarkOverdueLoansAsAgedLostService.class);
+  private static final Logger log = LogManager.getLogger(MarkOverdueLoansAsAgedLostService.class);
 
   private final LostItemPolicyRepository lostItemPolicyRepository;
   private final ItemRepository itemRepository;

--- a/src/main/java/org/folio/circulation/services/feefine/FeeFineService.java
+++ b/src/main/java/org/folio/circulation/services/feefine/FeeFineService.java
@@ -3,7 +3,8 @@ package org.folio.circulation.services.feefine;
 import static org.folio.circulation.support.http.ResponseMapping.forwardOnFailure;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -11,10 +12,9 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.http.client.ResponseInterpreter;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
 
 public class FeeFineService {
-  private static final Logger log = getLogger(FeeFineService.class);
+  private static final Logger log = LogManager.getLogger(FeeFineService.class);
 
   private final CollectionResourceClient accountRefundClient;
   private final CollectionResourceClient accountCancelClient;

--- a/src/main/java/org/folio/circulation/support/SingleRecordFetcher.java
+++ b/src/main/java/org/folio/circulation/support/SingleRecordFetcher.java
@@ -16,13 +16,13 @@ import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.client.ResponseInterpreter;
 import org.folio.circulation.support.results.CommonFailures;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 
 public class SingleRecordFetcher<T> {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private final CollectionResourceClient client;
   private final String recordType;

--- a/src/main/java/org/folio/circulation/support/ValidationErrorFailure.java
+++ b/src/main/java/org/folio/circulation/support/ValidationErrorFailure.java
@@ -11,15 +11,15 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class ValidationErrorFailure implements HttpFailure {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private final Collection<ValidationError> errors = new ArrayList<>();
 

--- a/src/main/java/org/folio/circulation/support/VertxAssistant.java
+++ b/src/main/java/org/folio/circulation/support/VertxAssistant.java
@@ -3,15 +3,15 @@ package org.folio.circulation.support;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 public class VertxAssistant {
-  private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private Vertx vertx;
 

--- a/src/main/java/org/folio/circulation/support/fetching/PageableFetcher.java
+++ b/src/main/java/org/folio/circulation/support/fetching/PageableFetcher.java
@@ -4,7 +4,8 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.support.http.client.Offset.zeroOffset;
 import static org.folio.circulation.support.http.client.PageLimit.limit;
 import static org.folio.circulation.support.results.Result.failed;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -14,13 +15,12 @@ import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.http.client.Offset;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
 
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public final class PageableFetcher<T> {
-  private static final Logger log = getLogger(PageableFetcher.class);
+  private static final Logger log = LogManager.getLogger(PageableFetcher.class);
 
   // This limit needed to prevent stack overflow for recursive fetch
   private static final int DEFAULT_MAX_ALLOWED_RECORDS_LIMIT = 1_000_000;

--- a/src/main/java/org/folio/circulation/support/http/client/CqlQuery.java
+++ b/src/main/java/org/folio/circulation/support/http/client/CqlQuery.java
@@ -18,11 +18,11 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.support.CqlSortBy;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class CqlQuery implements QueryParameter {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private final String query;
   private final CqlSortBy sortBy;

--- a/src/main/java/org/folio/circulation/support/http/client/ResponseInterpreter.java
+++ b/src/main/java/org/folio/circulation/support/http/client/ResponseInterpreter.java
@@ -8,11 +8,11 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ResponseInterpreter<T> {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private final Map<Integer, Function<Response, Result<T>>> responseMappers;
   private final Function<Response, Result<T>> unexpectedResponseMapper;

--- a/src/main/java/org/folio/circulation/support/http/client/VertxWebClientOkapiHttpClient.java
+++ b/src/main/java/org/folio/circulation/support/http/client/VertxWebClientOkapiHttpClient.java
@@ -26,6 +26,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import io.vertx.core.http.HttpMethod;
 
 public class VertxWebClientOkapiHttpClient implements OkapiHttpClient {
   private static final Duration DEFAULT_TIMEOUT = Duration.of(20, SECONDS);
@@ -73,7 +74,7 @@ public class VertxWebClientOkapiHttpClient implements OkapiHttpClient {
       = new CompletableFuture<>();
 
     final HttpRequest<Buffer> request = withStandardHeaders(
-      webClient.postAbs(url));
+      webClient.requestAbs(HttpMethod.POST, url));
 
     request
       .timeout(timeout.toMillis())
@@ -91,7 +92,7 @@ public class VertxWebClientOkapiHttpClient implements OkapiHttpClient {
       = new CompletableFuture<>();
 
     final HttpRequest<Buffer> request = withStandardHeaders(
-      webClient.getAbs(url));
+      webClient.requestAbs(HttpMethod.GET, url));
 
     Stream.of(queryParameters)
       .forEach(parameter -> parameter.consume(request::addQueryParam));
@@ -136,7 +137,7 @@ public class VertxWebClientOkapiHttpClient implements OkapiHttpClient {
       = new CompletableFuture<>();
 
     final HttpRequest<Buffer> request = withStandardHeaders(
-      webClient.putAbs(url));
+      webClient.requestAbs(HttpMethod.PUT, url));
 
     request
       .timeout(timeout.toMillis())
@@ -168,7 +169,7 @@ public class VertxWebClientOkapiHttpClient implements OkapiHttpClient {
       = new CompletableFuture<>();
 
     final HttpRequest<Buffer> request = withStandardHeaders(
-      webClient.deleteAbs(url));
+      webClient.requestAbs(HttpMethod.DELETE, url));
 
     Stream.of(queryParameters)
       .forEach(parameter -> parameter.consume(request::addQueryParam));

--- a/src/main/java/org/folio/circulation/support/logging/LogHelper.java
+++ b/src/main/java/org/folio/circulation/support/logging/LogHelper.java
@@ -4,11 +4,11 @@ import java.lang.invoke.MethodHandles;
 
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class LogHelper {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private LogHelper() {
     throw new UnsupportedOperationException("Do not instantiate");

--- a/src/test/java/api/requests/scenarios/RequestsServicePointsTests.java
+++ b/src/test/java/api/requests/scenarios/RequestsServicePointsTests.java
@@ -12,8 +12,8 @@ import api.support.http.IndividualResource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import api.requests.RequestsAPICreationTests;
 import api.support.APITests;
@@ -22,7 +22,7 @@ import io.vertx.core.json.JsonObject;
 
 public class RequestsServicePointsTests extends APITests {
 
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   @Test
   public void pagedRequestCheckedInAtIntendedServicePointTest() {

--- a/src/test/java/api/support/APITestContext.java
+++ b/src/test/java/api/support/APITestContext.java
@@ -18,8 +18,8 @@ import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.client.VertxWebClientOkapiHttpClient;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import api.support.fakes.FakeOkapi;
 import api.support.fakes.FakeStorageModule;
@@ -28,7 +28,7 @@ import api.support.http.URLHelper;
 import io.vertx.core.Vertx;
 
 public class APITestContext {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final String TENANT_ID = "test_tenant";
   private static String USER_ID = "79ff2a8b-d9c3-5b39-ad4a-0a84025ab085";

--- a/src/test/java/api/support/fakes/FakeCQLToJSONInterpreter.java
+++ b/src/test/java/api/support/fakes/FakeCQLToJSONInterpreter.java
@@ -12,13 +12,13 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 
 public class FakeCQLToJSONInterpreter {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   public List<JsonObject> execute(Collection<JsonObject> records, String query) {
     final var queryAndSort = splitQueryAndSort(query);

--- a/src/test/java/api/support/fakes/FakeCalendarOkapi.java
+++ b/src/test/java/api/support/fakes/FakeCalendarOkapi.java
@@ -9,15 +9,15 @@ import static api.support.fixtures.LibraryHoursExamples.getLibraryHoursById;
 
 import java.lang.invoke.MethodHandles;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import api.support.fixtures.OpeningPeriodsExamples;
 import io.vertx.core.MultiMap;
 import io.vertx.ext.web.Router;
 
 public class FakeCalendarOkapi {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   public static void registerOpeningHours(Router router) {
     router.get("/calendar/periods")

--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -26,8 +26,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.results.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
@@ -38,7 +38,7 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
 public class FakeOkapi extends AbstractVerticle {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final int PORT_TO_USE = nextFreePort();
   private static final String address =

--- a/src/test/java/api/support/fakes/FakePubSub.java
+++ b/src/test/java/api/support/fakes/FakePubSub.java
@@ -42,8 +42,8 @@ public class FakePubSub {
             .setStatusCode(HTTP_BAD_REQUEST.toInt())
             .putHeader("content-type", "text/plain; charset=utf-8")
             .putHeader("content-length", Integer.toString(buffer.length()))
-            .write(buffer)
-            .end();
+            .write(buffer);
+          routingContext.response().end();
         }
         else {
           publishedEvents.add(routingContext.getBodyAsJson());
@@ -84,8 +84,8 @@ public class FakePubSub {
         .setStatusCode(HTTP_CREATED.toInt())
         .putHeader("content-type", "application/json; charset=utf-8")
         .putHeader("content-length", Integer.toString(buffer.length()))
-        .write(buffer)
-        .end();
+        .write(buffer);
+      routingContext.response().end();
     }
   }
 

--- a/src/test/java/api/support/fakes/FakeStorageModule.java
+++ b/src/test/java/api/support/fakes/FakeStorageModule.java
@@ -33,8 +33,8 @@ import org.folio.circulation.support.http.server.WebContext;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import api.support.APITestContext;
 import io.vertx.core.AbstractVerticle;
@@ -48,7 +48,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 
 public class FakeStorageModule extends AbstractVerticle {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private static final Set<String> queries = Collections.synchronizedSet(new HashSet<>());
 
   private final String rootPath;

--- a/src/test/java/api/support/fixtures/policies/PoliciesActivationFixture.java
+++ b/src/test/java/api/support/fixtures/policies/PoliciesActivationFixture.java
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import api.support.RestAssuredClient;
 import api.support.builders.LoanPolicyBuilder;
@@ -39,7 +39,7 @@ import lombok.val;
 // It is delegated by lombok in APITests class
 @SuppressWarnings("unused")
 public final class PoliciesActivationFixture {
-  private static final Logger log = LoggerFactory.getLogger(PoliciesActivationFixture.class);
+  private static final Logger log = LogManager.getLogger(PoliciesActivationFixture.class);
 
   private final RestAssuredClient restAssuredClient;
   private final LoanPoliciesFixture loanPoliciesFixture;

--- a/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
+++ b/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
@@ -21,15 +21,15 @@ import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import api.support.builders.LocationBuilder;
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonArray;
 
 public class Text2DroolsTest {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final String HEADER = "priority: last-line\nfallback-policy: l no-loan r no-hold n basic-notice o overdue i lost-item\n";
   private static final String FIRST_INSTITUTION_ID = "3d22d91c-cf1d-11e9-bb65-2a2ae2dbcce4";

--- a/src/test/java/org/folio/circulation/support/http/client/VertxWebClientOkapiHttpClientTests.java
+++ b/src/test/java/org/folio/circulation/support/http/client/VertxWebClientOkapiHttpClientTests.java
@@ -42,6 +42,8 @@ import org.junit.Test;
 
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -50,7 +52,7 @@ public class VertxWebClientOkapiHttpClientTests {
   private static VertxAssistant vertxAssistant;
 
   @Rule
-  public WireMockRule fakeWebServer = new WireMockRule();
+  public WireMockRule fakeWebServer = new WireMockRule(options().port(8081));
   private final URL okapiUrl = new URL("http://okapi.com");
   private final String tenantId = "test-tenant";
   private final String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkaWt1X2FkbWluIiwidXNlcl9pZCI6ImFhMjZjYjg4LTc2YjEtNTQ1OS1hMjM1LWZjYTRmZDI3MGMyMyIsImlhdCI6MTU3NjAxMzY3MiwidGVuYW50IjoiZGlrdSJ9.oGCb0gDIdkXGlCiECvJHgQMXD3QKKW2vTh7PPCrpds8";


### PR DESCRIPTION
Procedure I followed:

* Visit vertx site to find out what version of 4.x to use (looks like 4.1.1)
* Change vertx version in pomfile
* run build and tests to see what breaks
* fix all obvious breaking issues
* Check vertx upgrade docs for any other potential issues
* Do searches for anything that looks like it might not be a breaking 
change, but would need to be updated

After doing all of that, there wasn't too much that actually needed to 
be changed.  Some webclients were still using outdated methods
like postAbs, and there were some use of deprecated logging libraries.
I changed some calls that were trying to call the end() method after 
the write() method-those won't compile anymore because write() is
no longer fluent.

I also had problems with VertxWebClientOkapiHttpClientTests, the 
mock server was binding to a port that was already in use, which 
was causing the test to crash.  I changed it to bind to a different port.