### PR TITLE
Check more loans for anonymization CIRC-1178

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 22.1.0 IN-PROGRESS
+
+* Increases the number of loans to be checked for scheduled anonymization to 50 000 (CIRC-1178)
+
 ## 22.0.0 2021-06-14
 
 * Due date will be truncated by patron expiration (CIRC-886, CIRC-1159)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2259,15 +2259,13 @@
       ],
       "visible": false
     }
-
-
   ],
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 715827882,
+        "Memory": 1073741824,
         "PortBindings": { "9801/tcp": [ { "HostPort": "%p" } ] }
       }
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2272,6 +2272,10 @@
     "env": [
       { "name": "JAVA_OPTIONS",
         "value": "-XX:MaxRAMPercentage=66.0"
+      },
+      {
+        "name": "SCHEDULED_ANONYMIZATION_NUMBER_OF_LOANS_TO_CHECK",
+        "value": "50000"
       }
     ]
   }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -830,7 +830,7 @@
             "pubsub.publish.post"
           ],
           "unit": "minute",
-          "delay": "1"
+          "delay": "60"
         },
         {
           "methods": [

--- a/src/main/java/org/folio/Environment.java
+++ b/src/main/java/org/folio/Environment.java
@@ -1,10 +1,36 @@
 package org.folio;
 
+import static java.lang.Integer.parseInt;
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+import java.lang.invoke.MethodHandles;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class Environment {
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+
   private Environment() { }
 
   public static int getScheduledAnonymizationNumberOfLoansToCheck() {
-    return Integer.parseInt(System.getenv()
-      .getOrDefault("SCHEDULED_ANONYMIZATION_NUMBER_OF_LOANS_TO_CHECK", "50000"));
+    return getVariable("SCHEDULED_ANONYMIZATION_NUMBER_OF_LOANS_TO_CHECK", 50000);
+  }
+
+  private static int getVariable(String key, int defaultValue) {
+    final var variable = System.getenv().get(key);
+
+    if (isBlank(variable)) {
+      return defaultValue;
+    }
+
+    try {
+      return parseInt(variable);
+    }
+    catch(Exception e) {
+      log.warn("Invalid value for '{}': '{}' ", key, variable);
+
+      return defaultValue;
+    }
   }
 }

--- a/src/main/java/org/folio/Environment.java
+++ b/src/main/java/org/folio/Environment.java
@@ -1,0 +1,10 @@
+package org.folio;
+
+public class Environment {
+  private Environment() { }
+
+  public static int getScheduledAnonymizationNumberOfLoansToCheck() {
+    return Integer.parseInt(System.getenv()
+      .getOrDefault("SCHEDULED_ANONYMIZATION_NUMBER_OF_LOANS_TO_CHECK", "50000"));
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/anonymization/service/LoansForTenantFinder.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/service/LoansForTenantFinder.java
@@ -21,7 +21,7 @@ public class LoansForTenantFinder extends DefaultLoansFinder {
   }
 
   public CompletableFuture<Result<Collection<Loan>>> findLoansToAnonymize() {
-    return loanRepository.findLoansToAnonymize(limit(5000))
+    return loanRepository.findLoansToAnonymize(limit(50000))
       .thenCompose(this::fetchAdditionalLoanInfo);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/anonymization/service/LoansForTenantFinder.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/service/LoansForTenantFinder.java
@@ -12,16 +12,18 @@ import org.folio.circulation.support.results.Result;
 
 public class LoansForTenantFinder extends DefaultLoansFinder {
   private final LoanRepository loanRepository;
+  private final int numberOfLoansToCheck;
 
   public LoansForTenantFinder(LoanRepository loanRepository,
-    AccountRepository accountRepository) {
+    AccountRepository accountRepository, int numberOfLoansToCheck) {
 
     super(accountRepository);
     this.loanRepository = loanRepository;
+    this.numberOfLoansToCheck = numberOfLoansToCheck;
   }
 
   public CompletableFuture<Result<Collection<Loan>>> findLoansToAnonymize() {
-    return loanRepository.findLoansToAnonymize(limit(50000))
+    return loanRepository.findLoansToAnonymize(limit(numberOfLoansToCheck))
       .thenCompose(this::fetchAdditionalLoanInfo);
   }
 }

--- a/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
@@ -6,6 +6,7 @@ import java.lang.invoke.MethodHandles;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.Environment;
 import org.folio.circulation.domain.anonymization.DefaultLoanAnonymizationService;
 import org.folio.circulation.domain.anonymization.service.AnonymizationCheckersService;
 import org.folio.circulation.domain.anonymization.service.LoansForTenantFinder;
@@ -54,7 +55,8 @@ public class ScheduledAnonymizationProcessingResource extends Resource {
     final var anonymizeStorageLoansRepository = new AnonymizeStorageLoansRepository(clients);
     final var eventPublisher = new EventPublisher(clients.pubSubPublishingService());
 
-    final var loansFinder = new LoansForTenantFinder(loanRepository, accountRepository);
+    final var loansFinder = new LoansForTenantFinder(loanRepository, accountRepository,
+      Environment.getScheduledAnonymizationNumberOfLoansToCheck());
 
     log.info("Initializing loan anonymization for current tenant");
 


### PR DESCRIPTION
## Purpose
At the moment, only 5000 closed loans are checked each time scheduled anonymization runs.

For organisations that have many closed loans with outstanding fees / fines, this leads to some loans never being checked as they aren't in the 5000 chosen.

This is a temporary solution for Cornell until more significant changes can be made to how anonymization works.

## Approach
* Increase the number of loans to check to 50 000 (and provide an environment variable for overriding)
* Increase the frequency of runs of scheduled anonymization to every 60 minutes (can be overridden in Okapi)
* Increase the default memory allocation to compensate for fetching more loans

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
