### PR TITLE
CIRC-966: Stage 3, For CU & DTU, implement and refactor now() and similar.

### DIFF
--- a/src/main/java/org/folio/circulation/domain/LoanService.java
+++ b/src/main/java/org/folio/circulation/domain/LoanService.java
@@ -10,8 +10,7 @@ import org.folio.circulation.domain.policy.LoanPolicy;
 import org.folio.circulation.domain.policy.library.ClosedLibraryStrategyService;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.folio.circulation.support.utils.ClockUtil;
 
 public class LoanService {
 
@@ -19,7 +18,7 @@ public class LoanService {
 
   public LoanService(Clients clients) {
     closedLibraryStrategyService = ClosedLibraryStrategyService.using(clients,
-      DateTime.now(DateTimeZone.UTC), false);
+      ClockUtil.getDateTime(), false);
   }
 
   public CompletableFuture<Result<LoanAndRelatedRecords>> truncateLoanWhenItemRecalled(

--- a/src/main/java/org/folio/circulation/domain/ProxyRelationship.java
+++ b/src/main/java/org/folio/circulation/domain/ProxyRelationship.java
@@ -2,6 +2,7 @@ package org.folio.circulation.domain;
 
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTimeProperty;
@@ -51,7 +52,7 @@ public class ProxyRelationship {
 
   public boolean isActive() {
       boolean expired = expirationDate != null
-        && expirationDate.isBefore(DateTime.now());
+        && expirationDate.isBefore(ClockUtil.getDateTime());
 
       return active && !expired;
   }

--- a/src/main/java/org/folio/circulation/domain/UpdateLoan.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateLoan.java
@@ -8,13 +8,12 @@ import java.util.concurrent.CompletableFuture;
 
 import org.folio.circulation.domain.notice.schedule.LoanScheduledNoticeService;
 import org.folio.circulation.domain.policy.LoanPolicy;
-import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
 import org.folio.circulation.domain.policy.library.ClosedLibraryStrategyService;
+import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.folio.circulation.support.utils.ClockUtil;
 
 public class UpdateLoan {
   private final ClosedLibraryStrategyService closedLibraryStrategyService;
@@ -26,7 +25,7 @@ public class UpdateLoan {
       LoanRepository loanRepository,
       LoanPolicyRepository loanPolicyRepository) {
     closedLibraryStrategyService = ClosedLibraryStrategyService.using(clients,
-        DateTime.now(DateTimeZone.UTC), false);
+      ClockUtil.getDateTime(), false);
     this.loanPolicyRepository = loanPolicyRepository;
     this.loanRepository = loanRepository;
     this.scheduledNoticeService = LoanScheduledNoticeService.using(clients);

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -6,16 +6,17 @@ import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
 
 import java.lang.invoke.MethodHandles;
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.ServicePointRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestQueueRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
-import org.folio.circulation.infrastructure.storage.ServicePointRepository;
 import org.folio.circulation.resources.context.ReorderRequestContext;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
@@ -23,8 +24,6 @@ import org.folio.circulation.support.utils.ClockUtil;
 import org.folio.circulation.support.utils.DateTimeUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class UpdateRequestQueue {
   private final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
@@ -293,8 +292,8 @@ public class UpdateRequestQueue {
   private ZonedDateTime calculateHoldShelfExpirationDate(
     TimePeriod holdShelfExpiryPeriod, DateTimeZone tenantTimeZone) {
 
-    ZonedDateTime now = Instant.now(ClockUtil.getClock())
-      .atZone(tenantTimeZone.toTimeZone().toZoneId());
+    ZonedDateTime now = ClockUtil.getZonedDateTime()
+      .withZoneSameInstant(tenantTimeZone.toTimeZone().toZoneId());
 
     ZonedDateTime holdShelfExpirationDate = holdShelfExpiryPeriod.getInterval()
       .addTo(now, holdShelfExpiryPeriod.getDuration());

--- a/src/main/java/org/folio/circulation/domain/User.java
+++ b/src/main/java/org/folio/circulation/domain/User.java
@@ -10,6 +10,7 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty
 
 import java.util.Objects;
 
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 
 import io.vertx.core.json.JsonObject;
@@ -55,7 +56,7 @@ public class User {
       return false;
     }
     else {
-      return expirationDate.isBefore(DateTime.now());
+      return expirationDate.isBefore(ClockUtil.getDateTime());
     }
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -22,8 +22,7 @@ import org.folio.circulation.domain.RequestType;
 import org.folio.circulation.domain.ServicePoint;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.policy.LoanPolicy;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.folio.circulation.support.utils.ClockUtil;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -86,7 +85,7 @@ public class TemplateContextUtil {
     JsonObject itemContext = staffSlipContext.getJsonObject(ITEM);
 
     if (ObjectUtils.allNotNull(item, itemContext)) {
-      write(itemContext, "lastCheckedInDateTime", DateTime.now(DateTimeZone.UTC));
+      write(itemContext, "lastCheckedInDateTime", ClockUtil.getDateTime());
       if (item.getInTransitDestinationServicePoint() != null) {
         itemContext.put("fromServicePoint", context.getCheckInServicePoint().getName());
         itemContext.put("toServicePoint", item.getInTransitDestinationServicePoint().getName());

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
@@ -17,8 +17,8 @@ import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.rules.CirculationRuleMatch;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import io.vertx.core.json.JsonObject;
 
@@ -125,7 +125,7 @@ public class RequestScheduledNoticeHandler extends ScheduledNoticeHandler {
   }
 
   private static ScheduledNotice updateNoticeNextRunTime(ScheduledNotice notice) {
-    final DateTime systemTime = DateTime.now(DateTimeZone.UTC);
+    final DateTime systemTime = ClockUtil.getDateTime();
     ScheduledNoticeConfig noticeConfig = notice.getConfiguration();
 
     DateTime recurringNoticeNextRunTime = notice.getNextRunTime()

--- a/src/main/java/org/folio/circulation/domain/representations/logs/LoanLogContext.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/LoanLogContext.java
@@ -16,14 +16,16 @@ import static org.folio.circulation.domain.representations.logs.LogEventPayloadF
 import static org.folio.circulation.domain.representations.logs.LogEventPayloadField.USER_ID;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
+import org.folio.circulation.domain.Item;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.User;
+import org.folio.circulation.support.utils.ClockUtil;
+import org.joda.time.DateTime;
+
 import io.vertx.core.json.JsonObject;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.With;
-import org.folio.circulation.domain.Item;
-import org.folio.circulation.domain.Loan;
-import org.folio.circulation.domain.User;
-import org.joda.time.DateTime;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -50,7 +52,7 @@ public class LoanLogContext {
       .withItem(ofNullable(loan.getItem())
         .orElse(itemFromRepresentation(loan)))
       .withAction(LogContextActionResolver.resolveAction(loan.getAction()))
-      .withDate(DateTime.now())
+      .withDate(ClockUtil.getDateTime())
       .withServicePointId(ofNullable(loan.getCheckInServicePointId())
         .orElse(loan.getCheckoutServicePointId()))
       .withLoanId(loan.getId())

--- a/src/main/java/org/folio/circulation/resources/DueDateNotRealTimeScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/DueDateNotRealTimeScheduledNoticeProcessingResource.java
@@ -94,7 +94,7 @@ public class DueDateNotRealTimeScheduledNoticeProcessingResource extends Schedul
       .map(Map.Entry::getValue)
       .collect(Collectors.toList());
 
-    return new GroupedLoanScheduledNoticeHandler(clients, DateTime.now(DateTimeZone.UTC))
+    return new GroupedLoanScheduledNoticeHandler(clients, ClockUtil.getDateTime())
       .handleNotices(noticeGroups)
       .thenApply(mapResult(v -> notices));
   }

--- a/src/main/java/org/folio/circulation/resources/LoanScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanScheduledNoticeProcessingResource.java
@@ -16,8 +16,7 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CqlSortBy;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.results.Result;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.folio.circulation.support.utils.ClockUtil;
 
 import io.vertx.core.http.HttpClient;
 
@@ -33,7 +32,7 @@ public class LoanScheduledNoticeProcessingResource extends ScheduledNoticeProces
     ScheduledNoticesRepository scheduledNoticesRepository, PageLimit pageLimit) {
 
     return scheduledNoticesRepository.findNotices(
-      DateTime.now(DateTimeZone.UTC), true,
+      ClockUtil.getDateTime(), true,
       List.of(DUE_DATE, AGED_TO_LOST),
       CqlSortBy.ascending("nextRunTime"), pageLimit);
   }
@@ -42,7 +41,7 @@ public class LoanScheduledNoticeProcessingResource extends ScheduledNoticeProces
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> handleNotices(
     Clients clients, MultipleRecords<ScheduledNotice> noticesResult) {
 
-    return new LoanScheduledNoticeHandler(clients, DateTime.now(DateTimeZone.UTC))
+    return new LoanScheduledNoticeHandler(clients, ClockUtil.getDateTime())
       .handleNotices(noticesResult.getRecords())
       .thenApply(mapResult(v -> noticesResult));
   }

--- a/src/main/java/org/folio/circulation/resources/RequestScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestScheduledNoticeProcessingResource.java
@@ -8,15 +8,14 @@ import java.util.concurrent.CompletableFuture;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.notice.schedule.RequestScheduledNoticeHandler;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
+import org.folio.circulation.domain.notice.schedule.TriggeringEvent;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
-import org.folio.circulation.domain.notice.schedule.TriggeringEvent;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CqlSortBy;
-import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.http.client.PageLimit;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.ClockUtil;
 
 import io.vertx.core.http.HttpClient;
 
@@ -32,7 +31,7 @@ public class RequestScheduledNoticeProcessingResource extends ScheduledNoticePro
     ScheduledNoticesRepository scheduledNoticesRepository, PageLimit pageLimit) {
 
     return scheduledNoticesRepository.findNotices(
-      DateTime.now(DateTimeZone.UTC), true,
+      ClockUtil.getDateTime(), true,
       Arrays.asList(TriggeringEvent.HOLD_EXPIRATION, TriggeringEvent.REQUEST_EXPIRATION),
       CqlSortBy.ascending("nextRunTime"), pageLimit);
   }

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -89,8 +89,8 @@ import org.folio.circulation.support.http.server.JsonHttpResponse;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.http.server.WebContext;
 import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonObject;
@@ -288,7 +288,7 @@ public abstract class RenewalResource extends Resource {
         .thenApply(r -> errorHandler.handleValidationResult(r, RENEWAL_VALIDATION_ERROR,
           renewalContext));
     }
-    DateTime systemTime = DateTime.now(DateTimeZone.UTC);
+    DateTime systemTime = ClockUtil.getDateTime();
     final ClosedLibraryStrategyService strategyService = ClosedLibraryStrategyService.using(
       clients, systemTime, true);
 
@@ -363,7 +363,7 @@ public abstract class RenewalResource extends Resource {
         .map(r -> r.getRequestType() == RequestType.RECALL)
         .orElse(false);
 
-    return completedFuture(overrideRenewal(loan, DateTime.now(DateTimeZone.UTC),
+    return completedFuture(overrideRenewal(loan, ClockUtil.getDateTime(),
       overrideDueDate, comment, hasRecallRequest))
       .thenApply(mapResult(context::withLoan));
   }

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -14,27 +14,28 @@ import static org.folio.circulation.domain.EventType.LOG_RECORD;
 import static org.folio.circulation.domain.LoanAction.CHECKED_IN;
 import static org.folio.circulation.domain.LoanAction.DUE_DATE_CHANGED;
 import static org.folio.circulation.domain.LoanAction.RECALLREQUESTED;
-import static org.folio.circulation.domain.representations.logs.LogEventPayloadField.LOG_EVENT_TYPE;
 import static org.folio.circulation.domain.representations.logs.CirculationCheckInCheckOutLogEventMapper.mapToCheckInLogEventContent;
 import static org.folio.circulation.domain.representations.logs.CirculationCheckInCheckOutLogEventMapper.mapToCheckOutLogEventContent;
+import static org.folio.circulation.domain.representations.logs.LogEventPayloadField.LOG_EVENT_TYPE;
 import static org.folio.circulation.domain.representations.logs.LogEventPayloadField.PAYLOAD;
 import static org.folio.circulation.domain.representations.logs.LogEventType.LOAN;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE_ERROR;
-import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.domain.representations.logs.RequestUpdateLogEventMapper.mapToRequestLogEventJson;
+import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
 
-import io.vertx.core.json.JsonObject;
+import java.util.concurrent.CompletableFuture;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import io.vertx.ext.web.RoutingContext;
 import org.folio.circulation.domain.CheckInContext;
 import org.folio.circulation.domain.EventType;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
+import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestAndRelatedRecords;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.anonymization.LoanAnonymizationRecords;
@@ -43,7 +44,6 @@ import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.domain.representations.logs.LoanLogContext;
 import org.folio.circulation.domain.representations.logs.LogContextActionResolver;
 import org.folio.circulation.domain.representations.logs.LogEventType;
-import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
@@ -51,11 +51,13 @@ import org.folio.circulation.resources.context.RenewalContext;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-import java.util.concurrent.CompletableFuture;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
 
 public class EventPublisher {
   private static final Logger logger = LogManager.getLogger(EventPublisher.class);
@@ -309,7 +311,7 @@ public class EventPublisher {
   public CompletableFuture<Result<Void>> publishNoticeLogEvent(NoticeLogContext noticeLogContext,
     LogEventType eventType) {
 
-    return publishLogRecord(noticeLogContext.withDate(DateTime.now()).asJson(), eventType);
+    return publishLogRecord(noticeLogContext.withDate(ClockUtil.getDateTime()).asJson(), eventType);
   }
 
   public CompletableFuture<Result<Void>> publishNoticeErrorLogEvent(

--- a/src/main/java/org/folio/circulation/services/PubSubPublishingService.java
+++ b/src/main/java/org/folio/circulation/services/PubSubPublishingService.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.circulation.support.http.server.WebContext;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventMetadata;
@@ -16,8 +18,6 @@ import org.folio.util.pubsub.PubSubClientUtils;
 
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.vertx.ext.web.RoutingContext;
 
 public class PubSubPublishingService {

--- a/src/test/java/api/item/ItemLastCheckInTests.java
+++ b/src/test/java/api/item/ItemLastCheckInTests.java
@@ -48,7 +48,7 @@ class ItemLastCheckInTests extends APITests {
     UUID servicePointId = servicePointsFixture.cd1().getId();
 
     checkOutFixture.checkOutByBarcode(item, user);
-    checkInFixture.checkInByBarcode(item, DateTime.now(UTC), servicePointId);
+    checkInFixture.checkInByBarcode(item, ClockUtil.getDateTime(), servicePointId);
     JsonObject lastCheckIn = itemsClient.get(item.getId()).getJson()
       .getJsonObject("lastCheckIn");
 
@@ -135,7 +135,7 @@ class ItemLastCheckInTests extends APITests {
 
     IndividualResource item = itemsFixture.basedUponSmallAngryPlanet();
     UUID servicePointId = servicePointsFixture.cd1().getId();
-    DateTime firstCheckInDateTime = DateTime.now(UTC);
+    DateTime firstCheckInDateTime = ClockUtil.getDateTime();
 
     checkInFixture.checkInByBarcode(item, firstCheckInDateTime, servicePointId);
     JsonObject lastCheckIn = itemsClient.get(item.getId()).getJson()

--- a/src/test/java/api/item/ItemStatusApiTests.java
+++ b/src/test/java/api/item/ItemStatusApiTests.java
@@ -3,15 +3,16 @@ package api.item;
 import static api.support.matchers.TextDateTimeMatcher.withinSecondsAfter;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.joda.time.Seconds.seconds;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.joda.time.Seconds.seconds;
 
-import api.support.http.IndividualResource;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
 
 import api.support.APITests;
+import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonObject;
 
 class ItemStatusApiTests extends APITests {
@@ -24,7 +25,7 @@ class ItemStatusApiTests extends APITests {
 
     IndividualResource item = itemsFixture.basedUponSmallAngryPlanet();
     IndividualResource user = usersFixture.jessica();
-    final DateTime beforeCheckOutDatetime = DateTime.now(DateTimeZone.UTC);
+    final DateTime beforeCheckOutDatetime = ClockUtil.getDateTime();
 
     checkOutFixture.checkOutByBarcode(item, user, new DateTime(DateTimeZone.UTC));
 

--- a/src/test/java/api/loans/AgedToLostScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/AgedToLostScheduledNoticesProcessingTests.java
@@ -31,7 +31,6 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.iterableWithSize;
-import static org.joda.time.DateTime.now;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,6 +43,7 @@ import java.util.stream.Stream;
 import org.awaitility.Awaitility;
 import org.folio.circulation.domain.Account;
 import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -248,7 +248,7 @@ class AgedToLostScheduledNoticesProcessingTests extends APITests {
 
     claimItemReturnedFixture.claimItemReturned(new ClaimItemReturnedRequestBuilder()
       .forLoan(agedToLostLoan.getLoanId().toString())
-      .withItemClaimedReturnedDate(now()));
+      .withItemClaimedReturnedDate(ClockUtil.getDateTime()));
     final DateTime firstRunTime = getAgedToLostDate(agedToLostLoan).plus(
       TIMING_PERIOD.timePeriod());
     scheduledNoticeProcessingClient.runLoanNoticesProcessing(

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -66,6 +66,7 @@ import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 import org.joda.time.Seconds;
@@ -113,7 +114,7 @@ class CheckInByBarcodeTests extends APITests {
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(nod, james,
       new DateTime(2018, 3, 1, 13, 25, 46, UTC));
 
-    DateTime expectedSystemReturnDate = DateTime.now(UTC);
+    DateTime expectedSystemReturnDate = ClockUtil.getDateTime();
 
     final CheckInByBarcodeResponse checkInResponse = checkInFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
@@ -295,7 +296,7 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
     final Response response = checkInFixture.attemptCheckInByBarcode(
       new CheckInByBarcodeRequestBuilder()
         .withItemBarcode("543593485458")
-        .on(DateTime.now())
+        .on(ClockUtil.getDateTime())
         .at(UUID.randomUUID()));
 
     assertThat(response, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
@@ -316,7 +317,7 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
     final Response response = checkInFixture.attemptCheckInByBarcode(
       new CheckInByBarcodeRequestBuilder()
         .forItem(nod)
-        .on(DateTime.now())
+        .on(ClockUtil.getDateTime())
         .atNoServicePoint());
 
     assertThat(response, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
@@ -337,7 +338,7 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
     final Response response = checkInFixture.attemptCheckInByBarcode(
       new CheckInByBarcodeRequestBuilder()
         .noItem()
-        .on(DateTime.now())
+        .on(ClockUtil.getDateTime())
         .at(UUID.randomUUID()));
 
     assertThat(response, hasStatus(HTTP_UNPROCESSABLE_ENTITY));

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -40,7 +40,6 @@ import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static api.support.matchers.ValidationErrorMatchers.hasUUIDParameter;
 import static api.support.utl.BlockOverridesUtils.getMissingPermissions;
-import static api.support.utl.DateTimeUtils.executeWithFixedDateTime;
 import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
 import static org.folio.circulation.domain.EventType.ITEM_CHECKED_OUT;
 import static org.folio.circulation.domain.policy.DueDateManagement.KEEP_THE_CURRENT_DUE_DATE;
@@ -75,6 +74,7 @@ import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.domain.representations.logs.LogEventType;
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalTime;
@@ -268,7 +268,7 @@ class CheckOutByBarcodeTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    final DateTime loanDate = DateTime.now(UTC)
+    final DateTime loanDate = ClockUtil.getDateTime()
       .withMonthOfYear(3)
       .withDayOfMonth(18)
       .withHourOfDay(11)
@@ -372,7 +372,7 @@ class CheckOutByBarcodeTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    final DateTime requestDate = DateTime.now();
+    final DateTime requestDate = ClockUtil.getDateTime();
 
     final IndividualResource response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -1330,7 +1330,7 @@ class CheckOutByBarcodeTests extends APITests {
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
         .to(steve)
-        .on(DateTime.now(UTC))
+        .on(ClockUtil.getDateTime())
         .at(UUID.randomUUID()));
 
     final JsonObject loan = response.getJson();
@@ -1376,7 +1376,7 @@ class CheckOutByBarcodeTests extends APITests {
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
         .to(steve)
-        .on(DateTime.now(UTC))
+        .on(ClockUtil.getDateTime())
         .at(UUID.randomUUID()));
 
     final JsonObject loan = response.getJson();
@@ -1421,7 +1421,7 @@ class CheckOutByBarcodeTests extends APITests {
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
         .to(steve)
-        .on(DateTime.now(UTC))
+        .on(ClockUtil.getDateTime())
         .at(UUID.randomUUID()));
 
     assertThat(response.getBody(), containsString(
@@ -1443,7 +1443,7 @@ class CheckOutByBarcodeTests extends APITests {
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
         .to(steve)
-        .on(DateTime.now(UTC))
+        .on(ClockUtil.getDateTime())
         .at(UUID.randomUUID()));
 
     usersFixture.remove(steve);
@@ -1990,12 +1990,14 @@ class CheckOutByBarcodeTests extends APITests {
     DateTime patronExpirationDate = loanDate.plusHours(2);
     IndividualResource steve = usersFixture.steve(user -> user.expires(patronExpirationDate));
 
-    JsonObject response = executeWithFixedDateTime(() -> checkOutFixture.checkOutByBarcode(
+    mockClockManagerToReturnFixedDateTime(loanDate);
+    JsonObject response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(item)
         .to(steve)
         .on(loanDate)
-        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_CLOSED)).getJson(), loanDate);
+        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_CLOSED)).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat(DateTime.parse(response.getString("dueDate")).toDateTime(),
       is(FIRST_DAY_OPEN.toDateTime(LocalTime.MIDNIGHT.minusSeconds(1), UTC)));
@@ -2010,12 +2012,14 @@ class CheckOutByBarcodeTests extends APITests {
     DateTime patronExpirationDate = loanDate.plusHours(1);
     IndividualResource steve = usersFixture.steve(user -> user.expires(patronExpirationDate));
 
-    JsonObject response = executeWithFixedDateTime(() -> checkOutFixture.checkOutByBarcode(
+    mockClockManagerToReturnFixedDateTime(loanDate);
+    JsonObject response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(item)
         .to(steve)
         .on(loanDate)
-        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN)).getJson(), loanDate);
+        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN)).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat(DateTime.parse(response.getString("dueDate")).toDateTime(),
       is(FIRST_DAY_OPEN.toDateTime(LocalTime.MIDNIGHT.minusSeconds(1), UTC)));
@@ -2030,12 +2034,14 @@ class CheckOutByBarcodeTests extends APITests {
     DateTime patronExpirationDate = loanDate.plusHours(1);
     IndividualResource steve = usersFixture.steve(user -> user.expires(patronExpirationDate));
 
-    JsonObject response = executeWithFixedDateTime(() -> checkOutFixture.checkOutByBarcode(
+    mockClockManagerToReturnFixedDateTime(loanDate);
+    JsonObject response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(item)
         .to(steve)
         .on(loanDate)
-        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN)).getJson(), loanDate);
+        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN)).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat(DateTime.parse(response.getString("dueDate")).toDateTime(),
       is(patronExpirationDate));
@@ -2049,12 +2055,14 @@ class CheckOutByBarcodeTests extends APITests {
     DateTime patronExpirationDate = loanDate.plusHours(1);
     IndividualResource steve = usersFixture.steve(user -> user.expires(patronExpirationDate));
 
-    JsonObject response = executeWithFixedDateTime(() -> checkOutFixture.checkOutByBarcode(
+    mockClockManagerToReturnFixedDateTime(loanDate);
+    JsonObject response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(item)
         .to(steve)
         .on(loanDate)
-        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN)).getJson(), loanDate);
+        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN)).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat(DateTime.parse(response.getString("dueDate")).toDateTime(), is(patronExpirationDate));
   }
@@ -2069,12 +2077,14 @@ class CheckOutByBarcodeTests extends APITests {
     DateTime patronExpirationDate = loanDate.plusHours(12);
     IndividualResource steve = usersFixture.steve(user -> user.expires(patronExpirationDate));
 
-    JsonObject response = executeWithFixedDateTime(() -> checkOutFixture.checkOutByBarcode(
+    mockClockManagerToReturnFixedDateTime(loanDate);
+    JsonObject response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(item)
         .to(steve)
         .on(loanDate)
-        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN)).getJson(), loanDate);
+        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN)).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat(DateTime.parse(response.getString("dueDate")).toDateTime(),
       is(FIRST_DAY_OPEN.toDateTime(END_TIME_SECOND_PERIOD, UTC)));
@@ -2090,12 +2100,14 @@ class CheckOutByBarcodeTests extends APITests {
     DateTime patronExpirationDate = loanDate.plusHours(12);
     IndividualResource steve = usersFixture.steve(user -> user.expires(patronExpirationDate));
 
-    JsonObject response = executeWithFixedDateTime(() -> checkOutFixture.checkOutByBarcode(
+    mockClockManagerToReturnFixedDateTime(loanDate);
+    JsonObject response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(item)
         .to(steve)
         .on(loanDate)
-        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN)).getJson(), loanDate);
+        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN)).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat(DateTime.parse(response.getString("dueDate")).toDateTime(),
       is(FIRST_DAY_OPEN.toDateTime(END_TIME_SECOND_PERIOD, UTC)));
@@ -2111,12 +2123,14 @@ class CheckOutByBarcodeTests extends APITests {
     DateTime patronExpirationDate = loanDate.plusDays(1);
     IndividualResource steve = usersFixture.steve(user -> user.expires(patronExpirationDate));
 
-    JsonObject response = executeWithFixedDateTime(() -> checkOutFixture.checkOutByBarcode(
+    mockClockManagerToReturnFixedDateTime(loanDate);
+    JsonObject response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(item)
         .to(steve)
         .on(loanDate)
-        .at(CASE_MON_WED_FRI_OPEN_TUE_THU_CLOSED)).getJson(), loanDate);
+        .at(CASE_MON_WED_FRI_OPEN_TUE_THU_CLOSED)).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat(DateTime.parse(response.getString("dueDate")).toDateTime(),
       is(MONDAY_DATE.toDateTime(LocalTime.MIDNIGHT.minusSeconds(1), UTC)));
@@ -2132,12 +2146,14 @@ class CheckOutByBarcodeTests extends APITests {
     DateTime patronExpirationDate = loanDate.plusDays(1);
     IndividualResource steve = usersFixture.steve(user -> user.expires(patronExpirationDate));
 
-    JsonObject response = executeWithFixedDateTime(() -> checkOutFixture.checkOutByBarcode(
+    mockClockManagerToReturnFixedDateTime(loanDate);
+    JsonObject response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(item)
         .to(steve)
         .on(loanDate)
-        .at(CASE_MON_WED_FRI_OPEN_TUE_THU_CLOSED)).getJson(), loanDate);
+        .at(CASE_MON_WED_FRI_OPEN_TUE_THU_CLOSED)).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat(DateTime.parse(response.getString("dueDate")).toDateTime(),
       is(MONDAY_DATE.toDateTime(LocalTime.MIDNIGHT.minusSeconds(1), UTC)));

--- a/src/test/java/api/loans/CheckOutCalculateDueDateShortTermTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateDueDateShortTermTests.java
@@ -19,10 +19,8 @@ import java.util.concurrent.TimeoutException;
 
 import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.Period;
-import api.support.http.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalTime;
 import org.junit.jupiter.api.Test;
@@ -31,6 +29,7 @@ import api.support.APITests;
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
 import api.support.builders.LoanPolicyBuilder;
 import api.support.fixtures.ConfigurationExample;
+import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -186,14 +185,14 @@ class CheckOutCalculateDueDateShortTermTests extends APITests {
     useFallbackPolicies(loanPolicy.getId(), requestPolicyId, noticePolicyId,
       overdueFinePolicy.getId(), lostItemFeePolicy.getId());
 
-    DateTimeUtils.setCurrentMillisFixed(loanDate.getMillis());
+    mockClockManagerToReturnFixedDateTime(loanDate);
     final IndividualResource response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
         .to(steve)
         .on(loanDate)
         .at(checkoutServicePointId));
-    DateTimeUtils.setCurrentMillisSystem();
+    mockClockManagerToReturnDefaultDateTime();
 
     final JsonObject loan = response.getJson();
 

--- a/src/test/java/api/loans/CheckOutCalculateDueDateTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateDueDateTests.java
@@ -46,6 +46,7 @@ import org.folio.circulation.domain.OpeningHour;
 import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
@@ -872,7 +873,7 @@ class CheckOutCalculateDueDateTests extends APITests {
   private DateTime currentYearDateTime(int month, int day, int hour, int minute,
     int second, DateTimeZone zone) {
 
-    return DateTime.now(zone)
+    return ClockUtil.getDateTime().withZone(zone)
       .withMonthOfYear(month)
       .withDayOfMonth(day)
       .withHourOfDay(hour)

--- a/src/test/java/api/loans/ClaimItemReturnedAPITests.java
+++ b/src/test/java/api/loans/ClaimItemReturnedAPITests.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +52,7 @@ class ClaimItemReturnedAPITests extends APITests {
   @Test
   void canClaimItemReturnedWithComment() {
     final String comment = "testing";
-    final DateTime dateTime = DateTime.now();
+    final DateTime dateTime = ClockUtil.getDateTime();
 
     final Response response = claimItemReturnedFixture
       .claimItemReturned(new ClaimItemReturnedRequestBuilder()
@@ -64,7 +65,7 @@ class ClaimItemReturnedAPITests extends APITests {
 
   @Test
   void canClaimItemReturnedWithoutComment() {
-    final DateTime dateTime = DateTime.now();
+    final DateTime dateTime = ClockUtil.getDateTime();
 
     final Response response = claimItemReturnedFixture
       .claimItemReturned(new ClaimItemReturnedRequestBuilder()
@@ -76,7 +77,7 @@ class ClaimItemReturnedAPITests extends APITests {
 
   @Test
   void cannotClaimItemReturnedWhenLoanIsClosed() {
-    final DateTime dateTime = DateTime.now();
+    final DateTime dateTime = ClockUtil.getDateTime();
 
     checkInFixture.checkInByBarcode(item);
 
@@ -117,7 +118,7 @@ class ClaimItemReturnedAPITests extends APITests {
 
   @Test
   void itemClaimedReturnedEventIsPublished() {
-    final DateTime dateTime = DateTime.now();
+    final DateTime dateTime = ClockUtil.getDateTime();
 
     final Response response = claimItemReturnedFixture
       .claimItemReturned(new ClaimItemReturnedRequestBuilder()

--- a/src/test/java/api/loans/DeclareClaimedReturnedItemAsMissingApiTests.java
+++ b/src/test/java/api/loans/DeclareClaimedReturnedItemAsMissingApiTests.java
@@ -1,12 +1,12 @@
 package api.loans;
 
+import static api.support.PubsubPublisherTestUtils.assertThatPublishedLoanLogRecordEventsAreValid;
 import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
 import static api.support.matchers.LoanMatchers.hasLoanProperty;
 import static api.support.matchers.LoanMatchers.isClosed;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
-import static api.support.PubsubPublisherTestUtils.assertThatPublishedLoanLogRecordEventsAreValid;
 import static org.folio.circulation.domain.representations.LoanProperties.ACTION;
 import static org.folio.circulation.domain.representations.LoanProperties.ACTION_COMMENT;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.folio.circulation.support.http.client.Response;
-import org.joda.time.DateTime;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +44,7 @@ class DeclareClaimedReturnedItemAsMissingApiTests extends APITests {
   void canDeclareItemMissingWhenClaimedReturned() {
     claimItemReturnedFixture.claimItemReturned(new ClaimItemReturnedRequestBuilder()
       .forLoan(loanId)
-      .withItemClaimedReturnedDate(DateTime.now()));
+      .withItemClaimedReturnedDate(ClockUtil.getDateTime()));
 
     claimItemReturnedFixture.declareClaimedReturnedItemAsMissing(
       new DeclareClaimedReturnedItemAsMissingRequestBuilder()

--- a/src/test/java/api/loans/DeclareLostAPITests.java
+++ b/src/test/java/api/loans/DeclareLostAPITests.java
@@ -35,8 +35,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTimeZone.UTC;
 import static org.joda.time.Seconds.seconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -48,6 +46,7 @@ import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
 import org.folio.circulation.domain.EventType;
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,7 +86,7 @@ class DeclareLostAPITests extends APITests {
       .checkOutByBarcode(itemsFixture.basedUponNod(), usersFixture.jessica());
 
     String comment = "testing";
-    DateTime dateTime = DateTime.now();
+    DateTime dateTime = ClockUtil.getDateTime();
 
     final DeclareItemLostRequestBuilder builder = new DeclareItemLostRequestBuilder()
       .forLoanId(checkOut.getId()).on(dateTime)
@@ -113,7 +112,7 @@ class DeclareLostAPITests extends APITests {
     final IndividualResource checkOut = checkOutFixture
       .checkOutByBarcode(itemsFixture.basedUponNod(), usersFixture.jessica());
 
-    DateTime dateTime = DateTime.now();
+    DateTime dateTime = ClockUtil.getDateTime();
 
     final DeclareItemLostRequestBuilder builder = new DeclareItemLostRequestBuilder()
       .forLoanId(checkOut.getId()).on(dateTime)
@@ -166,7 +165,7 @@ class DeclareLostAPITests extends APITests {
     final DeclareItemLostRequestBuilder builder = new DeclareItemLostRequestBuilder()
       .forLoanId(loanId)
       .withServicePointId(servicePointId)
-      .on(DateTime.now()).withNoComment();
+      .on(ClockUtil.getDateTime()).withNoComment();
 
     Response response = declareLostFixtures.attemptDeclareItemLost(builder);
 
@@ -478,7 +477,7 @@ class DeclareLostAPITests extends APITests {
 
     final DeclareItemLostRequestBuilder builder = new DeclareItemLostRequestBuilder()
       .forLoanId(loanIndividualResource.getId())
-      .on(DateTime.now())
+      .on(ClockUtil.getDateTime())
       .withServicePointId(servicePointId)
       .withNoComment();
     declareLostFixtures.declareItemLost(builder);
@@ -548,7 +547,7 @@ class DeclareLostAPITests extends APITests {
     assertThat(itemFee, hasJsonPath("amount", expectedItemFee));
     assertThat(itemProcessingFee, hasJsonPath("amount", expectedProcessingFee));
 
-    final DateTime declareLostDate = now(UTC).plusWeeks(1);
+    final DateTime declareLostDate = ClockUtil.getDateTime().plusWeeks(1);
     mockClockManagerToReturnFixedDateTime(declareLostDate);
 
     final DeclareItemLostRequestBuilder builder = new DeclareItemLostRequestBuilder()
@@ -615,7 +614,7 @@ class DeclareLostAPITests extends APITests {
     Double amountRemaining = transferredAndPaidLoan.getJsonObject("feesAndFines").getDouble("amountRemainingToPay");
     assertEquals(amountRemaining, 10.0, 0.01);
 
-    final DateTime declareLostDate = now(UTC).plusWeeks(1);
+    final DateTime declareLostDate = ClockUtil.getDateTime().plusWeeks(1);
     mockClockManagerToReturnFixedDateTime(declareLostDate);
 
     final DeclareItemLostRequestBuilder builder = new DeclareItemLostRequestBuilder()
@@ -667,7 +666,7 @@ class DeclareLostAPITests extends APITests {
 
 	  assertThat(itemFee, hasJsonPath("amount", lostItemProcessingFee));
 
-	  final DateTime declareLostDate = now(UTC).plusWeeks(1);
+	  final DateTime declareLostDate = ClockUtil.getDateTime().plusWeeks(1);
 	  mockClockManagerToReturnFixedDateTime(declareLostDate);
 
 	  final DeclareItemLostRequestBuilder builder = new DeclareItemLostRequestBuilder()
@@ -713,7 +712,7 @@ class DeclareLostAPITests extends APITests {
       .checkOutByBarcode(item, usersFixture.jessica());
 
     // advance system time by five weeks to accrue fines before declared lost
-    final DateTime declareLostDate = now(UTC).plusWeeks(5);
+    final DateTime declareLostDate = ClockUtil.getDateTime().plusWeeks(5);
     mockClockManagerToReturnFixedDateTime(declareLostDate);
 
     final DeclareItemLostRequestBuilder builder = new DeclareItemLostRequestBuilder()
@@ -723,7 +722,7 @@ class DeclareLostAPITests extends APITests {
       .withNoComment();
     declareLostFixtures.declareItemLost(builder);
 
-    final DateTime checkInDate = now(UTC).plusWeeks(6);
+    final DateTime checkInDate = ClockUtil.getDateTime().plusWeeks(6);
     mockClockManagerToReturnFixedDateTime(checkInDate);
     checkInFixture.checkInByBarcode(item, checkInDate);
 
@@ -743,9 +742,9 @@ class DeclareLostAPITests extends APITests {
 
     claimItemReturnedFixture.claimItemReturned(new ClaimItemReturnedRequestBuilder()
       .forLoan(loanId)
-      .withItemClaimedReturnedDate(DateTime.now()));
+      .withItemClaimedReturnedDate(ClockUtil.getDateTime()));
 
-    DateTime dateTime = DateTime.now();
+    DateTime dateTime = ClockUtil.getDateTime();
 
     JsonObject updatedLoan = loansClient.get(loanId).getJson();
     assertThat(updatedLoan.getJsonObject("item"), hasStatus("Claimed returned"));
@@ -768,7 +767,7 @@ class DeclareLostAPITests extends APITests {
     UUID loanId = checkOutFixture.checkOutByBarcode(item, usersFixture.charlotte())
       .getId();
 
-    DateTime dateTime = DateTime.now();
+    DateTime dateTime = ClockUtil.getDateTime();
 
     final DeclareItemLostRequestBuilder builder = new DeclareItemLostRequestBuilder()
       .forLoanId(loanId).on(dateTime)

--- a/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
@@ -236,7 +237,7 @@ class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests {
 
     //Should fetch 10 notices, when total records is 12
     //So that notices for one of the users should not be processed
-    final DateTime runTime = DateTime.now(DateTimeZone.UTC).plusDays(15);
+    final DateTime runTime = ClockUtil.getDateTime().plusDays(15);
     mockClockManagerToReturnFixedDateTime(runTime);
 
     scheduledNoticeProcessingClient.runDueDateNotRealTimeNoticesProcessing(runTime);
@@ -523,7 +524,7 @@ class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests {
       .withLoanNotices(Collections.singletonList(afterDueDateNoticeConfig));
     use(noticePolicy);
 
-    DateTime loanDate = DateTime.now().minusMonths(1);
+    DateTime loanDate = ClockUtil.getDateTime().minusMonths(1);
 
     IndividualResource steve = usersFixture.steve();
     ItemResource dunkirk = itemsFixture.basedUponDunkirk();

--- a/src/test/java/api/loans/DueDateScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/DueDateScheduledNoticesProcessingTests.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -206,7 +207,7 @@ class DueDateScheduledNoticesProcessingTests extends APITests {
   void processingTakesNoticesInThePastLimitedAndOrdered() {
     generateLoanAndScheduledNotices();
 
-    DateTime systemTime = DateTime.now(UTC);
+    DateTime systemTime = ClockUtil.getDateTime();
     int expectedNumberOfUnprocessedNoticesInThePast = 10;
     int numberOfNoticesInThePast =
       SCHEDULED_NOTICES_PROCESSING_LIMIT + expectedNumberOfUnprocessedNoticesInThePast;
@@ -592,7 +593,7 @@ class DueDateScheduledNoticesProcessingTests extends APITests {
   }
 
   private void createNotices(int numberOfNotices) {
-    DateTime systemTime = DateTime.now(UTC);
+    DateTime systemTime = ClockUtil.getDateTime();
     List<JsonObject> notices = createNoticesOverTime(systemTime::minusHours, numberOfNotices);
     for (JsonObject notice : notices) {
       scheduledNoticesClient.create(notice);

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -31,7 +31,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.joda.time.DateTime.now;
 import static org.joda.time.DateTimeConstants.APRIL;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.joda.time.Seconds.seconds;
@@ -44,6 +43,7 @@ import java.util.UUID;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.server.ValidationError;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeConstants;
@@ -218,7 +218,7 @@ class OverrideRenewByBarcodeTests extends APITests {
 
     loansFixture.attemptRenewal(422, smallAngryPlanet, jessica);
 
-    DateTime newDueDate = DateTime.now().plusWeeks(2);
+    DateTime newDueDate = ClockUtil.getDateTime().plusWeeks(2);
 
     final OkapiHeaders okapiHeaders = buildOkapiHeadersWithPermissions(OVERRIDE_RENEWAL_PERMISSION);
     JsonObject renewedLoan =
@@ -302,7 +302,7 @@ class OverrideRenewByBarcodeTests extends APITests {
     loansFixture.attemptRenewal(422, smallAngryPlanet, jessica);
 
     final OkapiHeaders okapiHeaders = buildOkapiHeadersWithPermissions(OVERRIDE_RENEWAL_PERMISSION);
-    DateTime newDueDate = DateTime.now().plusWeeks(1);
+    DateTime newDueDate = ClockUtil.getDateTime().plusWeeks(1);
     final JsonObject renewedLoan = loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica,
         OVERRIDE_COMMENT, newDueDate.toString(), okapiHeaders).getJson();
 
@@ -328,7 +328,7 @@ class OverrideRenewByBarcodeTests extends APITests {
 
   @Test
   void canOverrideRenewalWhenDateFallsOutsideOfTheDateRangesInTheRollingLoanPolicy() {
-    final DateTime renewalDate = DateTime.now();
+    final DateTime renewalDate = ClockUtil.getDateTime();
 
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource jessica = usersFixture.jessica();
@@ -393,7 +393,7 @@ class OverrideRenewByBarcodeTests extends APITests {
 
     use(limitedRenewalsPolicy);
 
-    DateTime loanDate = DateTime.now(UTC);
+    DateTime loanDate = ClockUtil.getDateTime();
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica, loanDate).getJson();
 
     loansFixture.renewLoan(smallAngryPlanet, jessica);
@@ -430,7 +430,7 @@ class OverrideRenewByBarcodeTests extends APITests {
       // Have to charge a fine otherwise the loan is closed when item is declared lost
       .lostItemPolicy(lostItemFeePoliciesFixture.chargeFee()));
 
-    final DateTime loanDate = DateTime.now(UTC).minusWeeks(1);
+    final DateTime loanDate = ClockUtil.getDateTime().minusWeeks(1);
 
     final JsonObject loanJson = checkOutFixture.checkOutByBarcode(smallAngryPlanet,
       usersFixture.jessica(), loanDate).getJson();
@@ -474,7 +474,7 @@ class OverrideRenewByBarcodeTests extends APITests {
 
   @Test
   void canOverrideRenewalWhenItemIsAgedToLost() {
-    final DateTime approximateRenewalDate = DateTime.now(UTC).plusWeeks(3);
+    final DateTime approximateRenewalDate = ClockUtil.getDateTime().plusWeeks(3);
     val result = ageToLostFixture.createAgedToLostLoan();
 
     final OkapiHeaders okapiHeaders = buildOkapiHeadersWithPermissions(OVERRIDE_RENEWAL_PERMISSION);
@@ -537,7 +537,7 @@ class OverrideRenewByBarcodeTests extends APITests {
 
     loansFixture.attemptRenewal(422, smallAngryPlanet, jessica);
 
-    DateTime newDueDate = DateTime.now().plusWeeks(2);
+    DateTime newDueDate = ClockUtil.getDateTime().plusWeeks(2);
 
     final OkapiHeaders okapiHeaders = buildOkapiHeadersWithPermissions(OVERRIDE_RENEWAL_PERMISSION);
     JsonObject loanAfterOverride = loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica,
@@ -570,7 +570,7 @@ class OverrideRenewByBarcodeTests extends APITests {
 
     loansFixture.attemptRenewal(422, smallAngryPlanet, jessica);
 
-    DateTime newDueDate = DateTime.now().plusWeeks(2);
+    DateTime newDueDate = ClockUtil.getDateTime().plusWeeks(2);
 
     final OkapiHeaders okapiHeaders = buildOkapiHeadersWithPermissions(OVERRIDE_RENEWAL_PERMISSION);
     JsonObject loanAfterOverride = loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica,
@@ -627,7 +627,7 @@ class OverrideRenewByBarcodeTests extends APITests {
     assertThat(renewalResponse, hasErrorWith(allOf(
       hasMessage(ITEM_IS_NOT_LOANABLE_MESSAGE))));
 
-    DateTime newDueDate = DateTime.now().plusWeeks(2);
+    DateTime newDueDate = ClockUtil.getDateTime().plusWeeks(2);
 
     final OkapiHeaders okapiHeaders = buildOkapiHeadersWithPermissions(OVERRIDE_RENEWAL_PERMISSION);
     JsonObject renewedLoan = loansFixture.overrideRenewalByBarcode(smallAngryPlanet, jessica,
@@ -648,7 +648,7 @@ class OverrideRenewByBarcodeTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource jessica = usersFixture.jessica();
 
-    checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica, DateTime.now());
+    checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica, ClockUtil.getDateTime());
 
     LoanPolicyBuilder loanablePolicy = new LoanPolicyBuilder()
       .withName("Loanable Policy")
@@ -658,7 +658,7 @@ class OverrideRenewByBarcodeTests extends APITests {
       .renewFromSystemDate();
     createLoanPolicyAndSetAsFallback(loanablePolicy);
 
-    DateTime newDueDate = DateTime.now().plusDays(3);
+    DateTime newDueDate = ClockUtil.getDateTime().plusDays(3);
 
     Response response = loansFixture.attemptOverride(smallAngryPlanet, jessica,
         OVERRIDE_COMMENT, newDueDate.toString());
@@ -742,7 +742,7 @@ class OverrideRenewByBarcodeTests extends APITests {
     IndividualResource item = result.getItem();
     IndividualResource user = result.getUser();
 
-    final DateTime renewalDate = now(UTC).plusWeeks(9);
+    final DateTime renewalDate = ClockUtil.getDateTime().plusWeeks(9);
     mockClockManagerToReturnFixedDateTime(renewalDate);
 
     final OkapiHeaders okapiHeaders = buildOkapiHeadersWithPermissions(OVERRIDE_RENEWAL_PERMISSION);
@@ -769,7 +769,7 @@ class OverrideRenewByBarcodeTests extends APITests {
     IndividualResource loan = checkOutFixture.checkOutByBarcode(item, user);
 
     // advance system time by five weeks to accrue fines before declared lost
-    final DateTime declareLostDate = now(UTC).plusWeeks(5);
+    final DateTime declareLostDate = ClockUtil.getDateTime().plusWeeks(5);
     mockClockManagerToReturnFixedDateTime(declareLostDate);
 
     final DeclareItemLostRequestBuilder builder = new DeclareItemLostRequestBuilder()
@@ -779,7 +779,7 @@ class OverrideRenewByBarcodeTests extends APITests {
       .withServicePointId(servicePointId);
     declareLostFixtures.declareItemLost(builder);
 
-    final DateTime renewalDate = now(UTC).plusWeeks(6);
+    final DateTime renewalDate = ClockUtil.getDateTime().plusWeeks(6);
     mockClockManagerToReturnFixedDateTime(renewalDate);
 
     final OkapiHeaders okapiHeaders = buildOkapiHeadersWithPermissions(OVERRIDE_RENEWAL_PERMISSION);
@@ -791,7 +791,7 @@ class OverrideRenewByBarcodeTests extends APITests {
 
   @Test
   void canOverrideRenewalWhenItemIsAgedToLostAndPatronIsBlockedAutomatically() {
-    final DateTime approximateRenewalDate = DateTime.now(UTC).plusWeeks(3);
+    final DateTime approximateRenewalDate = ClockUtil.getDateTime().plusWeeks(3);
     val result = ageToLostFixture.createAgedToLostLoan();
 
     automatedPatronBlocksFixture.blockAction(result.getUser().getId().toString(),
@@ -842,7 +842,7 @@ class OverrideRenewByBarcodeTests extends APITests {
 
   @Test
   void canOverrideRenewalWhenItemIsAgedToLostAndPatronIsBlockedManually() {
-    final DateTime approximateRenewalDate = DateTime.now(UTC).plusWeeks(3);
+    final DateTime approximateRenewalDate = ClockUtil.getDateTime().plusWeeks(3);
     val result = ageToLostFixture.createAgedToLostLoan();
 
     userManualBlocksFixture.createRenewalsManualPatronBlockForUser(result.getUser().getId());

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -39,7 +39,6 @@ import static api.support.matchers.ValidationErrorMatchers.isBlockRelatedError;
 import static api.support.utl.BlockOverridesUtils.buildOkapiHeadersWithPermissions;
 import static api.support.utl.BlockOverridesUtils.getMissingPermissions;
 import static api.support.utl.BlockOverridesUtils.getOverridableBlockNames;
-import static api.support.utl.DateTimeUtils.executeWithFixedDateTime;
 import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfPublishedEvents;
 import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfSentNotices;
 import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
@@ -75,11 +74,11 @@ import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.server.ValidationError;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.Is;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeConstants;
-import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalTime;
 import org.joda.time.Seconds;
@@ -144,7 +143,7 @@ public abstract class RenewalAPITests extends APITests {
 
     //TODO: Renewal based upon system date,
     // needs to be approximated, at least until we introduce a calendar and clock
-    DateTime approximateRenewalDate = DateTime.now(DateTimeZone.UTC);
+    DateTime approximateRenewalDate = ClockUtil.getDateTime();
 
     final JsonObject renewedLoan = renew(smallAngryPlanet, jessica).getJson();
 
@@ -410,7 +409,7 @@ public abstract class RenewalAPITests extends APITests {
   @Test
   void canCheckOutUsingFixedDueDateLoanPolicy() {
     //TODO: Need to be able to inject system date here
-    final DateTime renewalDate = DateTime.now(DateTimeZone.UTC);
+    final DateTime renewalDate = ClockUtil.getDateTime();
     //e.g. Clock.freeze(renewalDate)
 
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
@@ -520,7 +519,7 @@ public abstract class RenewalAPITests extends APITests {
 
     //TODO: Renewal based upon system date,
     // needs to be approximated, at least until we introduce a calendar and clock
-    DateTime approximateRenewalDate = DateTime.now(DateTimeZone.UTC);
+    DateTime approximateRenewalDate = ClockUtil.getDateTime();
 
     final IndividualResource response = renew(smallAngryPlanet, jessica);
 
@@ -724,7 +723,7 @@ public abstract class RenewalAPITests extends APITests {
     use(limitedRenewalsPolicy);
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      DateTime.now(DateTimeZone.UTC).minusDays(1)).getJson();
+      ClockUtil.getDateTime().minusDays(1)).getJson();
 
     renew(smallAngryPlanet, jessica);
 
@@ -792,7 +791,7 @@ public abstract class RenewalAPITests extends APITests {
     use(limitedRenewalsPolicy);
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      DateTime.now(DateTimeZone.UTC));
+      ClockUtil.getDateTime());
 
     final Response response = attemptRenewal(smallAngryPlanet, jessica);
 
@@ -868,7 +867,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource jessica = usersFixture.jessica();
     final String comment = "testing";
-    final DateTime dateTime = DateTime.now();
+    final DateTime dateTime = ClockUtil.getDateTime();
 
     final JsonObject loanJson = checkOutFixture.checkOutByBarcode(smallAngryPlanet,
       usersFixture.jessica())
@@ -1115,9 +1114,9 @@ public abstract class RenewalAPITests extends APITests {
 
     use(renewPolicy);
 
-    DateTimeUtils.setCurrentMillisFixed(loanDate.plusHours(1).getMillis());
+    mockClockManagerToReturnFixedDateTime(loanDate.plusHours(1));
     JsonObject renewedLoan = renew(smallAngryPlanet, jessica).getJson();
-    DateTimeUtils.setCurrentMillisSystem();
+    mockClockManagerToReturnDefaultDateTime();
 
     DateTime expectedDate =
       WEDNESDAY_DATE
@@ -1209,7 +1208,7 @@ public abstract class RenewalAPITests extends APITests {
       .addSchedule(wholeMonth(2019, DateTimeConstants.MARCH))
       .addSchedule(todayOnly());
 
-    DateTime expectedDueDate = DateTime.now(DateTimeZone.UTC)
+    DateTime expectedDueDate = ClockUtil.getDateTime()
       .withTimeAtStartOfDay()
       .withHourOfDay(23)
       .withMinuteOfHour(59)
@@ -1232,7 +1231,7 @@ public abstract class RenewalAPITests extends APITests {
 
   @Test
   void cannotRenewWhenCurrentDueDateDoesNotFallWithinLimitingDueDateSchedule() {
-    DateTime futureDateTime = DateTime.now(DateTimeZone.UTC).plusMonths(1);
+    DateTime futureDateTime = ClockUtil.getDateTime().plusMonths(1);
 
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
       .withName("Fixed Due Date Schedule in the Future")
@@ -1295,7 +1294,7 @@ public abstract class RenewalAPITests extends APITests {
       .addSchedule(wholeMonth(2019, DateTimeConstants.MARCH))
       .addSchedule(todayOnly());
 
-    DateTime expectedDueDate = DateTime.now(DateTimeZone.UTC)
+    DateTime expectedDueDate = ClockUtil.getDateTime()
       .withTimeAtStartOfDay()
       .withHourOfDay(23)
       .withMinuteOfHour(59)
@@ -1802,8 +1801,9 @@ public abstract class RenewalAPITests extends APITests {
     checkOutItem(loanDate, item, MONDAY_DATE.toDateTime(END_OF_A_DAY, UTC), steve,
       CASE_MON_WED_FRI_OPEN_TUE_THU_CLOSED);
 
-    JsonObject renewedLoan = executeWithFixedDateTime(() -> loansFixture.renewLoan(item, steve).getJson(),
-      loanDate.plusDays(1));
+    mockClockManagerToReturnFixedDateTime(loanDate.plusDays(1));
+    JsonObject renewedLoan = loansFixture.renewLoan(item, steve).getJson();
+    mockClockManagerToReturnDefaultDateTime();
     DateTime expectedDate = MONDAY_DATE.toDateTime(END_OF_A_DAY, DateTimeZone.UTC);
 
     assertThat("due date should be " + expectedDate, renewedLoan.getString("dueDate"),
@@ -1822,8 +1822,9 @@ public abstract class RenewalAPITests extends APITests {
     checkOutItem(loanDate, item, MONDAY_DATE.toDateTime(END_OF_A_DAY, UTC), steve,
       CASE_MON_WED_FRI_OPEN_TUE_THU_CLOSED);
 
-    JsonObject renewedLoan = executeWithFixedDateTime(() -> loansFixture.renewLoan(item, steve).getJson(),
-      loanDate.plusDays(1));
+    mockClockManagerToReturnFixedDateTime(loanDate.plusDays(1));
+    JsonObject renewedLoan = loansFixture.renewLoan(item, steve).getJson();
+    mockClockManagerToReturnDefaultDateTime();
     DateTime expectedDate = MONDAY_DATE.toDateTime(END_OF_A_DAY, DateTimeZone.UTC);
 
     assertThat("due date should be " + expectedDate, renewedLoan.getString("dueDate"),
@@ -1841,8 +1842,9 @@ public abstract class RenewalAPITests extends APITests {
 
     checkOutItem(loanDate, item, patronExpirationDate, steve, CASE_MON_WED_FRI_OPEN_TUE_THU_CLOSED);
 
-    JsonObject renewedLoan = executeWithFixedDateTime(() -> loansFixture.renewLoan(item, steve).getJson(),
-      loanDate.plusDays(1));
+    mockClockManagerToReturnFixedDateTime(loanDate.plusDays(1));
+    JsonObject renewedLoan = loansFixture.renewLoan(item, steve).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat("due date should be " + patronExpirationDate, renewedLoan.getString("dueDate"),
       isEquivalentTo(patronExpirationDate));
@@ -1858,8 +1860,9 @@ public abstract class RenewalAPITests extends APITests {
 
     checkOutItem(loanDate, item, patronExpirationDate, steve, CASE_MON_WED_FRI_OPEN_TUE_THU_CLOSED);
 
-    JsonObject renewedLoan = executeWithFixedDateTime(() -> loansFixture.renewLoan(item, steve).getJson(),
-      loanDate.plusHours(10));
+    mockClockManagerToReturnFixedDateTime(loanDate.plusHours(10));
+    JsonObject renewedLoan = loansFixture.renewLoan(item, steve).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat("due date should be " + patronExpirationDate, renewedLoan.getString("dueDate"),
       isEquivalentTo(patronExpirationDate));
@@ -1878,8 +1881,9 @@ public abstract class RenewalAPITests extends APITests {
     checkOutItem(loanDate, item, FIRST_DAY_OPEN.toDateTime(END_TIME_SECOND_PERIOD, UTC), steve,
       CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN);
 
-    JsonObject renewedLoan = executeWithFixedDateTime(() -> loansFixture.renewLoan(item, steve).getJson(),
-      loanDate.plusHours(11));
+    mockClockManagerToReturnFixedDateTime(loanDate.plusHours(11));
+    JsonObject renewedLoan = loansFixture.renewLoan(item, steve).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat("due date should be " + FIRST_DAY_OPEN.toDateTime(END_TIME_SECOND_PERIOD, UTC),
       renewedLoan.getString("dueDate"), isEquivalentTo(FIRST_DAY_OPEN.toDateTime(
@@ -1899,8 +1903,9 @@ public abstract class RenewalAPITests extends APITests {
     checkOutItem(loanDate, item, FIRST_DAY_OPEN.toDateTime(END_TIME_SECOND_PERIOD, UTC), steve,
       CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN);
 
-    JsonObject renewedLoan = executeWithFixedDateTime(() -> loansFixture.renewLoan(item, steve).getJson(),
-      loanDate.plusHours(11));
+    mockClockManagerToReturnFixedDateTime(loanDate.plusHours(11));
+    JsonObject renewedLoan = loansFixture.renewLoan(item, steve).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat("due date should be " + FIRST_DAY_OPEN.toDateTime(END_TIME_SECOND_PERIOD, UTC),
       renewedLoan.getString("dueDate"), isEquivalentTo(FIRST_DAY_OPEN.toDateTime(
@@ -1910,12 +1915,14 @@ public abstract class RenewalAPITests extends APITests {
   private void checkOutItem(DateTime loanDate, IndividualResource item, DateTime expectedDueDate,
     IndividualResource steve, String servicePointId) {
 
-    JsonObject response = executeWithFixedDateTime(() -> checkOutFixture.checkOutByBarcode(
+    mockClockManagerToReturnFixedDateTime(loanDate);
+    JsonObject response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(item)
         .to(steve)
         .on(loanDate)
-        .at(servicePointId)).getJson(), loanDate);
+        .at(servicePointId)).getJson();
+    mockClockManagerToReturnDefaultDateTime();
 
     assertThat(DateTime.parse(response.getString("dueDate")).toDateTime(), is(expectedDueDate));
   }

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostApiTest.java
@@ -1,5 +1,6 @@
 package api.loans.agetolost;
 
+import static api.support.PubsubPublisherTestUtils.assertThatPublishedLoanLogRecordEventsAreValid;
 import static api.support.fakes.FakePubSub.getPublishedEvents;
 import static api.support.fakes.PublishedEvents.byEventType;
 import static api.support.http.CqlQuery.queryFromTemplate;
@@ -10,7 +11,6 @@ import static api.support.matchers.ItemMatchers.isCheckedOut;
 import static api.support.matchers.ItemMatchers.isClaimedReturned;
 import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
-import static api.support.PubsubPublisherTestUtils.assertThatPublishedLoanLogRecordEventsAreValid;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTimePropertyByPath;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -19,8 +19,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.not;
-import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTimeZone.UTC;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -28,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import api.support.PubsubPublisherTestUtils;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import api.support.MultipleJsonRecords;
+import api.support.PubsubPublisherTestUtils;
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
 import api.support.builders.ItemBuilder;
 import api.support.http.IndividualResource;
@@ -130,7 +129,7 @@ class ScheduledAgeToLostApiTest extends SpringApiTest {
         .forItem(overdueItem)
         .at(servicePointsFixture.cd1())
         .to(usersFixture.james())
-        .on(now(UTC)));
+        .on(ClockUtil.getDateTime()));
 
     scheduledAgeToLostClient.triggerJob();
 
@@ -146,7 +145,7 @@ class ScheduledAgeToLostApiTest extends SpringApiTest {
     checkOutItem();
     scheduledAgeToLostClient.triggerJob();
 
-    mockClockManagerToReturnFixedDateTime(DateTime.now(UTC).plusMinutes(30));
+    mockClockManagerToReturnFixedDateTime(ClockUtil.getDateTime().plusMinutes(30));
     scheduledAgeToLostClient.triggerJob();
     mockClockManagerToReturnDefaultDateTime();
 
@@ -163,7 +162,7 @@ class ScheduledAgeToLostApiTest extends SpringApiTest {
   }
 
   private DateTime getLoanOverdueDate() {
-    return now(UTC).minusWeeks(3);
+    return ClockUtil.getDateTime().minusWeeks(3);
   }
 
   private void checkOutItem() {

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
@@ -15,8 +15,8 @@ import static api.support.matchers.LoanAccountMatcher.hasLostItemFees;
 import static api.support.matchers.LoanAccountMatcher.hasLostItemProcessingFee;
 import static api.support.matchers.LoanAccountMatcher.hasNoLostItemFee;
 import static api.support.matchers.LoanAccountMatcher.hasNoLostItemProcessingFee;
-import static api.support.matchers.LoanHistoryMatcher.hasLoanHistoryInOrder;
 import static api.support.matchers.LoanAccountMatcher.hasNoOverdueFine;
+import static api.support.matchers.LoanHistoryMatcher.hasLoanHistoryInOrder;
 import static api.support.matchers.LoanMatchers.isClosed;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
@@ -27,9 +27,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 
-import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTimeZone.UTC;
-
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +34,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -347,7 +345,7 @@ class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
     // the creation function ages the loan eight weeks into the future.
     // it must be checked in after that timeframe to properly examine the
     // overdue charges
-    final DateTime checkInDate = now(UTC).plusWeeks(9);
+    final DateTime checkInDate = ClockUtil.getDateTime().plusWeeks(9);
     mockClockManagerToReturnFixedDateTime(checkInDate);
     checkInFixture.checkInByBarcode(result.getItem(), checkInDate);
     assertThat(loansFixture.getLoanById(loanId), hasNoOverdueFine());

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansAfterXIntervalTests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansAfterXIntervalTests.java
@@ -10,12 +10,11 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTimeZone.UTC;
 
 import java.util.UUID;
 
 import org.folio.circulation.domain.representations.anonymization.LoanAnonymizationAPIResponse;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
@@ -55,7 +54,7 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
     UUID loanID = loanResource.getId();
 
     createClosedAccountWithFeeFines(loanResource,
-      now(UTC).minusMinutes(1));
+      ClockUtil.getDateTime().minusMinutes(1));
 
     anonymizeLoansInTenant();
 
@@ -88,12 +87,12 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
     UUID loanID = loanResource.getId();
 
     createClosedAccountWithFeeFines(loanResource,
-      now(UTC).minusMinutes(1));
+      ClockUtil.getDateTime().minusMinutes(1));
 
     assertThat(loanResource.getJson(), isOpen());
 
     mockClockManagerToReturnFixedDateTime(
-      now(UTC).plus(ONE_MINUTE_AND_ONE));
+      ClockUtil.getDateTime().plus(ONE_MINUTE_AND_ONE));
 
     anonymizeLoansInTenant();
 
@@ -125,7 +124,7 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, now());
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
 
     checkInFixture.checkInByBarcode(item1);
 
@@ -161,7 +160,7 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, now(UTC));
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
 
     checkInFixture.checkInByBarcode(item1);
 
@@ -195,10 +194,10 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, now(UTC));
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
 
     mockClockManagerToReturnFixedDateTime(
-      now(UTC).plus(20 * ONE_MINUTE_AND_ONE));
+      ClockUtil.getDateTime().plus(20 * ONE_MINUTE_AND_ONE));
     anonymizeLoansInTenant();
 
     assertThat(loansStorageClient.getById(loanID)
@@ -230,13 +229,13 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, now());
-    createClosedAccountWithFeeFines(loanResource, now());
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
 
     checkInFixture.checkInByBarcode(item1);
 
     mockClockManagerToReturnFixedDateTime(
-      now(UTC).plus(20 * ONE_MINUTE_AND_ONE));
+      ClockUtil.getDateTime().plus(20 * ONE_MINUTE_AND_ONE));
 
     anonymizeLoansInTenant();
 
@@ -270,7 +269,7 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, now(UTC));
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
 
     checkInFixture.checkInByBarcode(item1);
 
@@ -304,11 +303,11 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, now(UTC));
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
 
     checkInFixture.checkInByBarcode(item1);
 
-    mockClockManagerToReturnFixedDateTime(now(UTC).plus(ONE_MINUTE_AND_ONE));
+    mockClockManagerToReturnFixedDateTime(ClockUtil.getDateTime().plus(ONE_MINUTE_AND_ONE));
 
     anonymizeLoansInTenant();
 
@@ -340,7 +339,7 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, now());
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
 
     checkInFixture.checkInByBarcode(item1);
 
@@ -369,7 +368,7 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
 
     checkInFixture.checkInByBarcode(item1);
 
-    mockClockManagerToReturnFixedDateTime(now(UTC).plus(ONE_MINUTE_AND_ONE));
+    mockClockManagerToReturnFixedDateTime(ClockUtil.getDateTime().plus(ONE_MINUTE_AND_ONE));
     anonymizeLoansInTenant();
 
     assertThat(loansStorageClient.getById(loanID)
@@ -480,7 +479,7 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
     UUID loanID = loanResource.getId();
 
 
-    createClosedAccountWithFeeFines(loanResource, now());
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
     checkInFixture.checkInByBarcode(item1);
 
     anonymizeLoansInTenant();
@@ -504,7 +503,7 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
 
     createOpenAccountWithFeeFines(loanResource);
 
-    mockClockManagerToReturnFixedDateTime(now(UTC).plus(ONE_MINUTE_AND_ONE));
+    mockClockManagerToReturnFixedDateTime(ClockUtil.getDateTime().plus(ONE_MINUTE_AND_ONE));
 
     checkInFixture.checkInByBarcode(item1);
 
@@ -521,7 +520,7 @@ class AnonymizeLoansAfterXIntervalTests extends LoanAnonymizationTests {
 
   private void setNextAnonymizationDateTime(long anonymizationInterval) {
     lastAnonymizationDateTime = lastAnonymizationDateTime == null
-      ? now(UTC).plus(anonymizationInterval)
+      ? ClockUtil.getDateTime().plus(anonymizationInterval)
       : lastAnonymizationDateTime.plus(anonymizationInterval);
 
     mockClockManagerToReturnFixedDateTime(lastAnonymizationDateTime);

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansByUserIdAPITests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansByUserIdAPITests.java
@@ -1,18 +1,18 @@
 package api.loans.anonymization;
 
-import static api.support.matchers.LoanMatchers.isOpen;
 import static api.support.matchers.LoanMatchers.isAnonymized;
-import static org.hamcrest.Matchers.not;
+import static api.support.matchers.LoanMatchers.isOpen;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
 
 import java.util.UUID;
 
-import api.support.http.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
-import org.joda.time.DateTime;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.Test;
 
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
+import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
 import io.vertx.core.json.JsonObject;
 
@@ -93,7 +93,7 @@ public class AnonymizeLoansByUserIdAPITests extends LoanAnonymizationTests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, DateTime.now());
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
 
     checkInFixture.checkInByBarcode(item1);
 

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansImmediatelyAPITests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansImmediatelyAPITests.java
@@ -2,18 +2,17 @@ package api.loans.anonymization;
 
 import static api.support.PubsubPublisherTestUtils.assertThatPublishedAnonymizeLoanLogRecordEventsAreValid;
 import static api.support.matchers.LoanMatchers.isAnonymized;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
 
 import java.util.UUID;
 
-import api.support.http.IndividualResource;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.Test;
 
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
 import api.support.builders.LoanHistoryConfigurationBuilder;
+import api.support.http.IndividualResource;
 
 class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
 
@@ -68,8 +67,7 @@ class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource,
-      DateTime.now(DateTimeZone.UTC));
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
 
     checkInFixture.checkInByBarcode(item1);
 
@@ -133,7 +131,7 @@ class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
     UUID loanID = loanResource.getId();
 
     createClosedAccountWithFeeFines(loanResource,
-      DateTime.now(DateTimeZone.UTC));
+      ClockUtil.getDateTime());
 
     anonymizeLoansInTenant();
 
@@ -162,7 +160,7 @@ class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, DateTime.now(DateTimeZone.UTC));
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
 
     checkInFixture.checkInByBarcode(item1);
 
@@ -194,12 +192,12 @@ class AnonymizeLoansImmediatelyAPITests extends LoanAnonymizationTests {
       .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, DateTime.now(DateTimeZone.UTC));
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime());
 
     checkInFixture.checkInByBarcode(item1);
 
     mockClockManagerToReturnFixedDateTime(
-      DateTime.now(DateTimeZone.UTC).plus(ONE_MINUTE_AND_ONE));
+      ClockUtil.getDateTime().plus(ONE_MINUTE_AND_ONE));
 
     anonymizeLoansInTenant();
 

--- a/src/test/java/api/loans/anonymization/AnonymizeLoansNeverTests.java
+++ b/src/test/java/api/loans/anonymization/AnonymizeLoansNeverTests.java
@@ -6,13 +6,12 @@ import static org.hamcrest.Matchers.not;
 
 import java.util.UUID;
 
-import api.support.http.IndividualResource;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.Test;
 
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
 import api.support.builders.LoanHistoryConfigurationBuilder;
+import api.support.http.IndividualResource;
 
 class AnonymizeLoansNeverTests extends LoanAnonymizationTests {
 
@@ -73,7 +72,7 @@ class AnonymizeLoansNeverTests extends LoanAnonymizationTests {
         .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, DateTime.now().minusMinutes(1));
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime().minusMinutes(1));
     checkInFixture.checkInByBarcode(item1);
 
     anonymizeLoansInTenant();
@@ -139,7 +138,7 @@ class AnonymizeLoansNeverTests extends LoanAnonymizationTests {
         .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, DateTime.now().minusMinutes(1));
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime().minusMinutes(1));
     checkInFixture.checkInByBarcode(item1);
 
     anonymizeLoansInTenant();
@@ -205,7 +204,7 @@ class AnonymizeLoansNeverTests extends LoanAnonymizationTests {
         .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, DateTime.now().minusMinutes(1));
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime().minusMinutes(1));
     checkInFixture.checkInByBarcode(item1);
 
     anonymizeLoansInTenant();
@@ -274,11 +273,11 @@ class AnonymizeLoansNeverTests extends LoanAnonymizationTests {
         .at(servicePoint.getId()));
     UUID loanID = loanResource.getId();
 
-    createClosedAccountWithFeeFines(loanResource, DateTime.now().minusMinutes(1));
+    createClosedAccountWithFeeFines(loanResource, ClockUtil.getDateTime().minusMinutes(1));
     checkInFixture.checkInByBarcode(item1);
 
     mockClockManagerToReturnFixedDateTime(
-      DateTime.now(DateTimeZone.UTC).plus(20 * ONE_MINUTE_AND_ONE));
+      ClockUtil.getDateTime().plus(20 * ONE_MINUTE_AND_ONE));
 
     anonymizeLoansInTenant();
 

--- a/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
@@ -12,11 +12,10 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.joda.time.DateTime.now;
 
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
 
 import api.support.builders.CheckInByBarcodeRequestBuilder;
@@ -49,7 +48,8 @@ class CheckInDeclaredLostItemTest extends RefundDeclaredLostFeesTestBase {
     useChargeableRefundableLostItemFee(firstFee, 0.0);
 
     final IndividualResource firstLoan = declareItemLost();
-    mockClockManagerToReturnFixedDateTime(now(DateTimeZone.UTC).plusMinutes(2));
+    mockClockManagerToReturnFixedDateTime(ClockUtil.getDateTime()
+      .plusMinutes(2));
     // Item fee won't be cancelled, because refund period is exceeded
     checkInFixture.checkInByBarcode(item);
     assertThat(itemsClient.getById(item.getId()).getJson(), isAvailable());

--- a/src/test/java/api/loans/scenarios/InTransitToHomeLocationTests.java
+++ b/src/test/java/api/loans/scenarios/InTransitToHomeLocationTests.java
@@ -11,15 +11,14 @@ import static org.hamcrest.core.IsNull.nullValue;
 import java.util.HashMap;
 import java.util.Map;
 
-import api.support.http.IndividualResource;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
 
 import api.support.APITests;
 import api.support.CheckInByBarcodeResponse;
 import api.support.builders.CheckInByBarcodeRequestBuilder;
+import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
 import api.support.matchers.JsonObjectMatcher;
 import io.vertx.core.json.JsonObject;
@@ -528,7 +527,7 @@ class InTransitToHomeLocationTests extends APITests {
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(nod, james);
 
     requestsFixture.placeHoldShelfRequest(
-      nod, jessica, DateTime.now(DateTimeZone.UTC), otherServicePoint.getId());
+      nod, jessica, ClockUtil.getDateTime(), otherServicePoint.getId());
 
     final CheckInByBarcodeResponse checkInResponse = checkInFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()

--- a/src/test/java/api/loans/scenarios/RefundAgedToLostFeesTestBase.java
+++ b/src/test/java/api/loans/scenarios/RefundAgedToLostFeesTestBase.java
@@ -16,9 +16,8 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTime
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
-import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTimeZone.UTC;
 
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,7 +89,7 @@ public abstract class RefundAgedToLostFeesTestBase extends SpringApiTest {
 
     feeFineAccountFixture.payLostItemProcessingFee(result.getLoanId());
 
-    performActionThatRequiresRefund(result, now(UTC).plusMonths(8));
+    performActionThatRequiresRefund(result, ClockUtil.getDateTime().plusMonths(8));
 
     final IndividualResource loan = result.getLoan();
     assertThat(loan, hasLostItemProcessingFee(isRefundedFully(processingFee)));
@@ -110,7 +109,7 @@ public abstract class RefundAgedToLostFeesTestBase extends SpringApiTest {
 
     val result = ageToLostFixture.createAgedToLostLoan(policy);
 
-    performActionThatRequiresRefund(result, now(UTC).plusMonths(8));
+    performActionThatRequiresRefund(result, ClockUtil.getDateTime().plusMonths(8));
 
     final IndividualResource loan = result.getLoan();
     assertThat(loan, hasOverdueFine());
@@ -186,6 +185,6 @@ public abstract class RefundAgedToLostFeesTestBase extends SpringApiTest {
   }
 
   private void performActionThatRequiresRefund(AgeToLostFixture.AgeToLostResult result) {
-    performActionThatRequiresRefund(result, now(UTC));
+    performActionThatRequiresRefund(result, ClockUtil.getDateTime());
   }
 }

--- a/src/test/java/api/loans/scenarios/RefundDeclaredLostFeesTestBase.java
+++ b/src/test/java/api/loans/scenarios/RefundDeclaredLostFeesTestBase.java
@@ -11,9 +11,8 @@ import static api.support.matchers.LoanAccountMatcher.hasNoOverdueFine;
 import static api.support.matchers.LoanAccountMatcher.hasOverdueFine;
 import static api.support.matchers.LoanMatchers.isClosed;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTimeZone.UTC;
 
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +34,7 @@ public abstract class RefundDeclaredLostFeesTestBase extends SpringApiTest {
   }
 
   protected void performActionThatRequiresRefund() {
-    performActionThatRequiresRefund(DateTime.now(UTC));
+    performActionThatRequiresRefund(ClockUtil.getDateTime());
   }
 
   protected abstract void performActionThatRequiresRefund(DateTime actionDate);
@@ -111,7 +110,7 @@ public abstract class RefundDeclaredLostFeesTestBase extends SpringApiTest {
     feeFineAccountFixture.transferLostItemFee(loan.getId());
     feeFineAccountFixture.payLostItemProcessingFee(loan.getId());
 
-    performActionThatRequiresRefund(now(UTC).plusMinutes(2));
+    performActionThatRequiresRefund(ClockUtil.getDateTime().plusMinutes(2));
 
     assertThat(loan, hasLostItemFee(isTransferredFully(setCostFee)));
     assertThat(loan, hasLostItemProcessingFee(isPaidFully(processingFee)));
@@ -244,7 +243,7 @@ public abstract class RefundDeclaredLostFeesTestBase extends SpringApiTest {
 
     declareItemLost();
 
-    performActionThatRequiresRefund(now().plusMonths(2));
+    performActionThatRequiresRefund(ClockUtil.getDateTime().plusMonths(2));
 
     assertThat(loan, hasLostItemProcessingFee(isClosedCancelled(processingFee)));
     assertThat(loan, hasOverdueFine());
@@ -266,7 +265,7 @@ public abstract class RefundDeclaredLostFeesTestBase extends SpringApiTest {
 
     declareItemLost();
 
-    performActionThatRequiresRefund(now().plusMonths(2));
+    performActionThatRequiresRefund(ClockUtil.getDateTime().plusMonths(2));
 
     assertThat(loan, hasLostItemProcessingFee(isClosedCancelled(processingFee)));
     assertThat(loan, hasNoOverdueFine());
@@ -288,7 +287,7 @@ public abstract class RefundDeclaredLostFeesTestBase extends SpringApiTest {
 
     declareItemLost();
 
-    performActionThatRequiresRefund(DateTime.now(UTC).plusMinutes(2));
+    performActionThatRequiresRefund(ClockUtil.getDateTime().plusMinutes(2));
 
     assertThat(loan, hasLostItemFee(isOpen(itemFee)));
     assertThat(loan, hasNoOverdueFine());

--- a/src/test/java/api/loans/scenarios/ServicePointCheckInTests.java
+++ b/src/test/java/api/loans/scenarios/ServicePointCheckInTests.java
@@ -17,9 +17,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.Seconds;
 import org.junit.jupiter.api.Test;
 
@@ -54,7 +54,7 @@ class ServicePointCheckInTests extends APITests {
         .withRequestDate(new DateTime(2019, 7, 5, 10, 0))
         .withRequestExpiration(LocalDate.of(2019, 7, 11)));
 
-    final DateTime beforeCheckIn = DateTime.now(DateTimeZone.UTC);
+    final DateTime beforeCheckIn = ClockUtil.getDateTime();
 
     final CheckInByBarcodeResponse checkInResponse = checkInFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
@@ -141,9 +141,9 @@ class ServicePointCheckInTests extends APITests {
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(nod, james);
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
-        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId());
+      ClockUtil.getDateTime(), requestServicePoint.getId());
 
-    final DateTime beforeCheckIn = DateTime.now(DateTimeZone.UTC);
+    final DateTime beforeCheckIn = ClockUtil.getDateTime();
 
     final CheckInByBarcodeResponse checkInResponse = checkInFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()

--- a/src/test/java/api/loans/scenarios/ServicePointCheckOutTests.java
+++ b/src/test/java/api/loans/scenarios/ServicePointCheckOutTests.java
@@ -8,9 +8,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.MatcherAssert;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
 
 import api.support.APITests;
@@ -42,7 +41,7 @@ class ServicePointCheckOutTests extends APITests {
     checkOutFixture.checkOutByBarcode(nod, james);
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
-        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId());
+      ClockUtil.getDateTime(), requestServicePoint.getId());
 
     final CheckInByBarcodeResponse checkInResponse = checkInFixture.checkInByBarcode(
         new CheckInByBarcodeRequestBuilder()

--- a/src/test/java/api/requests/HoldShelfClearanceReportTests.java
+++ b/src/test/java/api/requests/HoldShelfClearanceReportTests.java
@@ -12,8 +12,7 @@ import java.util.UUID;
 
 import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.support.http.client.Response;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.Test;
 
 import api.support.APITests;
@@ -397,7 +396,7 @@ class HoldShelfClearanceReportTests extends APITests {
     // #7 check-in item in SP2
     checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
       .forItem(smallAngryPlanet)
-      .on(DateTime.now(DateTimeZone.UTC))
+      .on(ClockUtil.getDateTime())
       .at(secondServicePointId));
 
     // #8 Check that hold shelf expiration report doesn't contain data when the item has the status `Awaiting pickup`,
@@ -477,7 +476,7 @@ class HoldShelfClearanceReportTests extends APITests {
     // #7 check-in item in SP2
     checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
       .forItem(smallAngryPlanet)
-      .on(DateTime.now(DateTimeZone.UTC))
+      .on(ClockUtil.getDateTime())
       .at(secondServicePointId));
 
     // #8 get hold shelf expiration report in SP1 >>> empty
@@ -530,7 +529,7 @@ class HoldShelfClearanceReportTests extends APITests {
     // #7 check-in item in SP2
     checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
       .forItem(nod)
-      .on(DateTime.now(DateTimeZone.UTC))
+      .on(ClockUtil.getDateTime())
       .at(secondServicePointId));
 
     // #8 get hold shelf expiration report in SP1 >>> empty

--- a/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
+++ b/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
@@ -9,7 +9,6 @@ import static org.folio.HttpStatus.HTTP_CREATED;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.joda.time.DateTime.now;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -22,6 +21,7 @@ import java.util.UUID;
 import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.RequestType;
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
@@ -332,8 +332,8 @@ class InstanceRequestsAPICreationTests extends APITests {
       itemsFixture.basedUponDunkirkWithCustomHoldingAndLocation(holdings.getId(),
         locationsResource.getId());
 
-    loansFixture.createLoan(item1, usersFixture.charlotte(), now().plusDays(2));
-    loansFixture.createLoan(item2, usersFixture.charlotte(), now());
+    loansFixture.createLoan(item1, usersFixture.charlotte(), ClockUtil.getDateTime().plusDays(2));
+    loansFixture.createLoan(item2, usersFixture.charlotte(), ClockUtil.getDateTime());
 
     //Set up request queues. Item1 has requests (1 queued request), Item2 is requests (1 queued), either should be satisfied.
     placeHoldRequest(item1, pickupServicePointId, usersFixture.jessica(),
@@ -498,8 +498,8 @@ class InstanceRequestsAPICreationTests extends APITests {
       itemsFixture.basedUponDunkirkWithCustomHoldingAndLocation(holdings.getId(),
         locationsResource.getId());
 
-    loansFixture.createLoan(item1, usersFixture.james(),  now());
-    loansFixture.createLoan(item2, usersFixture.rebecca(), now().plusDays(5));
+    loansFixture.createLoan(item1, usersFixture.james(),  ClockUtil.getDateTime());
+    loansFixture.createLoan(item2, usersFixture.rebecca(), ClockUtil.getDateTime().plusDays(5));
 
     IndividualResource instanceRequester = usersFixture.charlotte();
 
@@ -555,9 +555,9 @@ class InstanceRequestsAPICreationTests extends APITests {
       itemsFixture.basedUponDunkirkWithCustomHoldingAndLocation(holdings.getId(),
         locationsResource.getId());
 
-    loansFixture.createLoan(item1, usersFixture.james(),  now().plusDays(5));
-    loansFixture.createLoan(item2, usersFixture.rebecca(), now().plusDays(3));
-    loansFixture.createLoan(item3, usersFixture.steve(), now().plusDays(10));
+    loansFixture.createLoan(item1, usersFixture.james(),  ClockUtil.getDateTime().plusDays(5));
+    loansFixture.createLoan(item2, usersFixture.rebecca(), ClockUtil.getDateTime().plusDays(3));
+    loansFixture.createLoan(item3, usersFixture.steve(), ClockUtil.getDateTime().plusDays(10));
 
     IndividualResource instanceRequester = usersFixture.charlotte();
 
@@ -612,8 +612,8 @@ class InstanceRequestsAPICreationTests extends APITests {
       itemsFixture.basedUponDunkirkWithCustomHoldingAndLocation(holdings.getId(),
         locationsResource.getId());
 
-    loansFixture.createLoan(item1, usersFixture.james(),  now().plusDays(21));
-    loansFixture.createLoan(item2, usersFixture.rebecca(), now().plusDays(5));
+    loansFixture.createLoan(item1, usersFixture.james(),  ClockUtil.getDateTime().plusDays(21));
+    loansFixture.createLoan(item2, usersFixture.rebecca(), ClockUtil.getDateTime().plusDays(5));
 
     //Set up request queues. Item1 has requests (1 queued request), Item2 is requests (1 queued), either should be satisfied
     //but only item2 should a request be placed on because its due date is nearest.
@@ -684,7 +684,7 @@ class InstanceRequestsAPICreationTests extends APITests {
         cd4Location.getId());
 
     //All of these items are checked out, have the same queue length, and due dates
-    DateTime sameCheckoutDate = now();
+    DateTime sameCheckoutDate = ClockUtil.getDateTime();
     loansFixture.createLoan(item1, usersFixture.steve(), sameCheckoutDate );
     loansFixture.createLoan(item2, usersFixture.jessica(), sameCheckoutDate );
     loansFixture.createLoan(item3, usersFixture.james(), sameCheckoutDate );
@@ -728,7 +728,7 @@ class InstanceRequestsAPICreationTests extends APITests {
 
     //For simplicity and by default, these items' request queue lengths are 0.
     //One item is "Checked out", the other item is  "In process"
-    loansFixture.createLoan(item2, usersFixture.steve(), now());
+    loansFixture.createLoan(item2, usersFixture.steve(), ClockUtil.getDateTime());
 
     JsonObject requestBody = createInstanceRequestObject(
       instanceMultipleCopies.getId(),

--- a/src/test/java/api/requests/ItemsInTransitReportTests.java
+++ b/src/test/java/api/requests/ItemsInTransitReportTests.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 
 import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.support.json.JsonPropertyFetcher;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -460,7 +461,7 @@ class ItemsInTransitReportTests extends APITests {
 
       checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
         .forItem(item)
-        .on(DateTime.now())
+        .on(ClockUtil.getDateTime())
         .at(firstServicePointId));
     }
 

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -7,7 +7,6 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTime
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -29,6 +28,7 @@ import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
@@ -143,7 +143,7 @@ class PickSlipsTests extends APITests {
         .withMaterialType(materialTypeResource.getId())
         .withPermanentLoanType(loanTypeResource.getId()));
 
-    DateTime now = DateTime.now(UTC);
+    DateTime now = ClockUtil.getDateTime();
     checkOutFixture.checkOutByBarcode(itemResource, requesterResource);
     checkInFixture.checkInByBarcode(itemResource, now, servicePointId);
     JsonObject lastCheckIn = itemsClient.get(itemResource.getId())

--- a/src/test/java/api/requests/RequestScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/requests/RequestScheduledNoticesProcessingTests.java
@@ -18,7 +18,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.joda.time.DateTimeZone.UTC;
 
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -88,12 +87,15 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .create();
     setupNoticePolicyWithRequestNotice(noticeConfiguration);
 
-    final var requestExpiration = LocalDate.now(ClockUtil.getClock()).minusDays(1);
+    final org.joda.time.LocalDate localDate = ClockUtil.getLocalDate()
+      .minusDays(1);
+    final var requestExpiration = LocalDate.of(localDate.getYear(),
+      localDate.getMonthOfYear(), localDate.getDayOfMonth());
 
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration));
@@ -127,19 +129,22 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .create();
     setupNoticePolicyWithRequestNotice(noticeConfiguration);
 
-    final var requestExpiration = LocalDate.now(ClockUtil.getClock()).minusDays(1);
+    final org.joda.time.LocalDate localDate = ClockUtil.getLocalDate()
+      .minusDays(1);
+    final var requestExpiration = LocalDate.of(localDate.getYear(),
+      localDate.getMonthOfYear(), localDate.getDayOfMonth());
 
     requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration));
 
     verifyNumberOfScheduledNotices(1);
 
-    scheduledNoticeProcessingClient.runRequestNoticesProcessing(DateTime.now().plusMonths(2));
+    scheduledNoticeProcessingClient.runRequestNoticesProcessing(ClockUtil.getDateTime().plusMonths(2));
 
     verifyNumberOfScheduledNotices(1);
     verifyNumberOfSentNotices(0);
@@ -163,7 +168,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint));
 
@@ -180,7 +185,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       request.getJson().put("status", "Closed - Pickup expired"));
 
     scheduledNoticeProcessingClient.runRequestNoticesProcessing(
-      org.joda.time.LocalDate.now(UTC).plusDays(31).toDateTimeAtStartOfDay());
+      ClockUtil.getLocalDate().plusDays(31).toDateTimeAtStartOfDay());
 
     verifyNumberOfScheduledNotices(0);
     verifyNumberOfSentNotices(1);
@@ -201,7 +206,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint));
 
@@ -214,7 +219,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     verifyNumberOfScheduledNotices(1);
 
     scheduledNoticeProcessingClient.runRequestNoticesProcessing(
-      org.joda.time.LocalDate.now(UTC).plusDays(31).toDateTimeAtStartOfDay());
+      ClockUtil.getLocalDate().plusDays(31).toDateTimeAtStartOfDay());
 
     verifyNumberOfScheduledNotices(1);
     verifyNumberOfSentNotices(0);
@@ -235,7 +240,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint));
 
@@ -256,7 +261,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
         equalTo("Closed - Filled"));
 
     scheduledNoticeProcessingClient.runRequestNoticesProcessing(
-      org.joda.time.LocalDate.now(UTC).plusDays(100).toDateTimeAtStartOfDay());
+      ClockUtil.getLocalDate().plusDays(100).toDateTimeAtStartOfDay());
 
     verifyNumberOfScheduledNotices(0);
     verifyNumberOfSentNotices(0);
@@ -274,12 +279,15 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .create();
     setupNoticePolicyWithRequestNotice(noticeConfiguration);
 
-    final var requestExpiration = LocalDate.now(ClockUtil.getClock()).plusDays(4);
+    final org.joda.time.LocalDate localDate = ClockUtil.getLocalDate()
+      .plusDays(4);
+    final var requestExpiration = LocalDate.of(localDate.getYear(),
+      localDate.getMonthOfYear(), localDate.getDayOfMonth());
 
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration));
@@ -307,12 +315,15 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .create();
     setupNoticePolicyWithRequestNotice(noticeConfiguration);
 
-    final var requestExpiration = LocalDate.now(ClockUtil.getClock()).plusDays(2);
+    final org.joda.time.LocalDate localDate = ClockUtil.getLocalDate()
+      .plusDays(2);
+    final var requestExpiration = LocalDate.of(localDate.getYear(),
+      localDate.getMonthOfYear(), localDate.getDayOfMonth());
 
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration));
@@ -347,12 +358,15 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .create();
     setupNoticePolicyWithRequestNotice(noticeConfiguration);
 
-    final var requestExpiration = LocalDate.now(ClockUtil.getClock()).plusMonths(3);
+    final org.joda.time.LocalDate localDate = ClockUtil.getLocalDate()
+      .plusMonths(3);
+    final var requestExpiration = LocalDate.of(localDate.getYear(),
+      localDate.getMonthOfYear(), localDate.getDayOfMonth());
 
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration));
@@ -366,7 +380,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
    verifyNumberOfScheduledNotices(1);
 
     scheduledNoticeProcessingClient.runRequestNoticesProcessing(
-      org.joda.time.LocalDate.now(UTC).plusDays(28).toDateTimeAtStartOfDay());
+      ClockUtil.getLocalDate().plusDays(28).toDateTimeAtStartOfDay());
 
     verifyNumberOfSentNotices(1);
     assertThat(FakeModNotify.getFirstSentPatronNotice(),
@@ -392,7 +406,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withNoRequestExpiration());
@@ -427,7 +441,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint);
     IndividualResource request = requestsFixture.place(requestBuilder);
@@ -443,7 +457,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .withStatus(CLOSED_PICKUP_EXPIRED));
 
     scheduledNoticeProcessingClient.runRequestNoticesProcessing(
-      org.joda.time.LocalDate.now(UTC).plusDays(35).toDateTimeAtStartOfDay());
+      ClockUtil.getLocalDate().plusDays(35).toDateTimeAtStartOfDay());
 
     verifyNumberOfScheduledNotices(0);
     verifyNumberOfSentNotices(1);
@@ -457,7 +471,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
 
     templateFixture.delete(templateId);
 
-    scheduledNoticeProcessingClient.runRequestNoticesProcessing(DateTime.now().plusMonths(2));
+    scheduledNoticeProcessingClient.runRequestNoticesProcessing(ClockUtil.getDateTime().plusMonths(2));
 
     verifyNumberOfSentNotices(0);
     verifyNumberOfScheduledNotices(0);
@@ -471,7 +485,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
 
     requestsStorageClient.delete(request);
 
-    scheduledNoticeProcessingClient.runRequestNoticesProcessing(DateTime.now().plusMonths(2));
+    scheduledNoticeProcessingClient.runRequestNoticesProcessing(ClockUtil.getDateTime().plusMonths(2));
 
     verifyNumberOfSentNotices(0);
     verifyNumberOfScheduledNotices(0);
@@ -485,7 +499,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
 
     usersFixture.remove(requester);
 
-    scheduledNoticeProcessingClient.runRequestNoticesProcessing(DateTime.now().plusMonths(2));
+    scheduledNoticeProcessingClient.runRequestNoticesProcessing(ClockUtil.getDateTime().plusMonths(2));
 
     verifyNumberOfSentNotices(0);
     verifyNumberOfScheduledNotices(0);
@@ -499,7 +513,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
 
     itemsClient.delete(item);
 
-    scheduledNoticeProcessingClient.runRequestNoticesProcessing(DateTime.now().plusMonths(2));
+    scheduledNoticeProcessingClient.runRequestNoticesProcessing(ClockUtil.getDateTime().plusMonths(2));
 
     verifyNumberOfSentNotices(0);
     verifyNumberOfScheduledNotices(0);
@@ -513,7 +527,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
 
     FakeModNotify.setFailPatronNoticesWithBadRequest(true);
 
-    scheduledNoticeProcessingClient.runRequestNoticesProcessing(DateTime.now().plusMonths(2));
+    scheduledNoticeProcessingClient.runRequestNoticesProcessing(ClockUtil.getDateTime().plusMonths(2));
 
     verifyNumberOfSentNotices(0);
     verifyNumberOfScheduledNotices(1);
@@ -531,13 +545,17 @@ class RequestScheduledNoticesProcessingTests extends APITests {
         .create()
     );
 
+    final org.joda.time.LocalDate localDate = ClockUtil.getLocalDate();
+    final var requestExpiration = LocalDate.of(localDate.getYear(),
+      localDate.getMonthOfYear(), localDate.getDayOfMonth());
+
     IndividualResource request = requestsFixture.place(
       new RequestBuilder()
         .page()
         .forItem(item)
         .withRequesterId(requester.getId())
-        .withRequestDate(DateTime.now())
-        .withRequestExpiration(LocalDate.now())
+        .withRequestDate(ClockUtil.getDateTime())
+        .withRequestExpiration(requestExpiration)
         .withStatus(OPEN_NOT_YET_FILLED)
         .withPickupServicePoint(pickupServicePoint)
     );

--- a/src/test/java/api/requests/RequestScheduledNoticesTests.java
+++ b/src/test/java/api/requests/RequestScheduledNoticesTests.java
@@ -2,14 +2,12 @@ package api.requests;
 
 import static api.support.builders.RequestBuilder.OPEN_NOT_YET_FILLED;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
-import static java.time.ZoneOffset.UTC;
 import static org.folio.circulation.domain.representations.RequestProperties.HOLD_SHELF_EXPIRATION_DATE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -20,7 +18,7 @@ import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.utils.ClockUtil;
-import org.joda.time.DateTime;
+import org.folio.circulation.support.utils.DateTimeUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -73,12 +71,12 @@ class RequestScheduledNoticesTests extends APITests {
 
     useDefaultRollingPoliciesAndOnlyAllowPageRequests(noticePolicyBuilder);
 
-    final var requestExpiration = java.time.LocalDate.now(ClockUtil.getClock()).plusMonths(3);
+    final java.time.LocalDate requestExpiration = ClockUtil.getZonedDateTime().toLocalDate().plusMonths(3);
 
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration));
@@ -96,7 +94,7 @@ class RequestScheduledNoticesTests extends APITests {
     assertThat(scheduledNotice.getString("requestId"), is(request.getId().toString()));
     assertThat(scheduledNotice.getString("triggeringEvent"), is("Request expiration"));
     assertThat(scheduledNotice.getString("nextRunTime"),
-      isEquivalentTo(ZonedDateTime.of(requestExpiration.atTime(23, 59, 59), UTC)));
+      isEquivalentTo(DateTimeUtil.atEndOfTheDay(requestExpiration)));
     assertThat(noticeConfig.getString("timing"), is("Upon At"));
     assertThat(noticeConfig.getString("templateId"), is(templateId.toString()));
     assertThat(noticeConfig.getString("format"), is("Email"));
@@ -121,7 +119,7 @@ class RequestScheduledNoticesTests extends APITests {
     requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint));
 
@@ -150,7 +148,7 @@ class RequestScheduledNoticesTests extends APITests {
     requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withNoRequestExpiration());
@@ -176,12 +174,12 @@ class RequestScheduledNoticesTests extends APITests {
 
     useDefaultRollingPoliciesAndOnlyAllowPageRequests(noticePolicyBuilder);
 
-    final var requestExpiration = java.time.LocalDate.now(ClockUtil.getClock()).plusMonths(3);
+    final var requestExpiration = ClockUtil.getZonedDateTime().toLocalDate().plusMonths(3);
 
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration));
@@ -198,8 +196,8 @@ class RequestScheduledNoticesTests extends APITests {
 
     assertThat(scheduledNotice.getString("requestId"), is(request.getId().toString()));
     assertThat(scheduledNotice.getString("triggeringEvent"), is("Request expiration"));
-    assertThat(scheduledNotice.getString("nextRunTime"), isEquivalentTo(ZonedDateTime.of(
-      requestExpiration.atTime(23, 59, 59), UTC).minusDays(3)));
+    assertThat(scheduledNotice.getString("nextRunTime"), isEquivalentTo(
+      DateTimeUtil.atEndOfTheDay(requestExpiration).minusDays(3)));
     assertThat(noticeConfig.getString("timing"), is("Before"));
     assertThat(noticeConfig.getString("templateId"), is(templateId.toString()));
     assertThat(noticeConfig.getString("format"), is("Email"));
@@ -221,12 +219,12 @@ class RequestScheduledNoticesTests extends APITests {
 
     useDefaultRollingPoliciesAndOnlyAllowPageRequests(noticePolicyBuilder);
 
-    final var requestExpiration = java.time.LocalDate.now(ClockUtil.getClock()).plusMonths(3);
+    final var requestExpiration = ClockUtil.getZonedDateTime().toLocalDate().plusMonths(3);
 
     RequestBuilder requestBuilder = new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration);
@@ -245,7 +243,7 @@ class RequestScheduledNoticesTests extends APITests {
     assertThat(scheduledNotice.getString("requestId"), is(request.getId().toString()));
     assertThat(scheduledNotice.getString("triggeringEvent"), is("Request expiration"));
     assertThat(scheduledNotice.getString("nextRunTime"),
-      isEquivalentTo(ZonedDateTime.of(requestExpiration.atTime(23, 59, 59), UTC)));
+      isEquivalentTo(DateTimeUtil.atEndOfTheDay(requestExpiration)));
     assertThat(noticeConfig.getString("timing"), is("Upon At"));
     assertThat(noticeConfig.getString("templateId"), is(templateId.toString()));
     assertThat(noticeConfig.getString("format"), is("Email"));
@@ -267,7 +265,7 @@ class RequestScheduledNoticesTests extends APITests {
     assertThat(scheduledNotice.getString("requestId"), is(request.getId().toString()));
     assertThat(scheduledNotice.getString("triggeringEvent"), is("Request expiration"));
     assertThat(scheduledNotice.getString("nextRunTime"),
-      isEquivalentTo(ZonedDateTime.of(requestExpiration.atTime(23, 59, 59), UTC).plusDays(1)));
+      isEquivalentTo(DateTimeUtil.atEndOfTheDay(requestExpiration).plusDays(1)));
     assertThat(noticeConfig.getString("timing"), is("Upon At"));
     assertThat(noticeConfig.getString("templateId"), is(templateId.toString()));
     assertThat(noticeConfig.getString("format"), is("Email"));
@@ -290,12 +288,12 @@ class RequestScheduledNoticesTests extends APITests {
 
     useDefaultRollingPoliciesAndOnlyAllowPageRequests(noticePolicyBuilder);
 
-    final var requestExpiration = java.time.LocalDate.now(ClockUtil.getClock()).plusMonths(3);
+    final var requestExpiration = ClockUtil.getZonedDateTime().toLocalDate().plusMonths(3);
 
     RequestBuilder requestBuilder = new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration);
@@ -313,8 +311,8 @@ class RequestScheduledNoticesTests extends APITests {
 
     assertThat(scheduledNotice.getString("requestId"), is(request.getId().toString()));
     assertThat(scheduledNotice.getString("triggeringEvent"), is("Request expiration"));
-    assertThat(scheduledNotice.getString("nextRunTime"), isEquivalentTo(ZonedDateTime.of(
-      requestExpiration.atTime(23, 59, 59), UTC).minusDays(3)));
+    assertThat(scheduledNotice.getString("nextRunTime"), isEquivalentTo(
+      DateTimeUtil.atEndOfTheDay(requestExpiration).minusDays(3)));
     assertThat(noticeConfig.getString("timing"), is("Before"));
     assertThat(noticeConfig.getString("templateId"), is(templateId.toString()));
     assertThat(noticeConfig.getString("format"), is("Email"));
@@ -342,12 +340,12 @@ class RequestScheduledNoticesTests extends APITests {
 
     useDefaultRollingPoliciesAndOnlyAllowPageRequests(noticePolicyBuilder);
 
-    final var requestExpiration = java.time.LocalDate.now(ClockUtil.getClock()).plusMonths(3);
+    final var requestExpiration = ClockUtil.getZonedDateTime().toLocalDate().plusMonths(3);
 
     RequestBuilder requestBuilder = new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration);
@@ -412,12 +410,12 @@ class RequestScheduledNoticesTests extends APITests {
 
     useDefaultRollingPoliciesAndOnlyAllowPageRequests(noticePolicyBuilder);
 
-    final var requestExpiration = java.time.LocalDate.now(ClockUtil.getClock()).plusMonths(3);
+    final var requestExpiration = ClockUtil.getZonedDateTime().toLocalDate().plusMonths(3);
 
     RequestBuilder requestBuilder = new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration);

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -1820,7 +1820,7 @@ public class RequestsAPICreationTests extends APITests {
       .page()
       .forItem(smallAngryPlanet)
       .by(steve)
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .fulfilToHoldShelf()
       .withPickupServicePointId(servicePointsFixture.cd1().getId()));
 
@@ -2405,7 +2405,7 @@ public class RequestsAPICreationTests extends APITests {
       .withPickupServicePointId(requestPickupServicePoint.getId())
       .by(usersFixture.james()));
 
-    checkInFixture.checkInByBarcode(smallAngryPlanet, DateTime.now(DateTimeZone.UTC), requestPickupServicePoint.getId());
+    checkInFixture.checkInByBarcode(smallAngryPlanet, ClockUtil.getDateTime(), requestPickupServicePoint.getId());
 
     Response pagedRequestRecord = itemsClient.getById(smallAngryPlanet.getId());
     assertThat(pagedRequestRecord.getJson().getJsonObject("status").getString("name"), is(ItemStatus.AWAITING_PICKUP.getValue()));
@@ -2432,7 +2432,7 @@ public class RequestsAPICreationTests extends APITests {
     assertThat(firstRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
 
     //check it it at the "wrong" or unintended pickup location
-    checkInFixture.checkInByBarcode(smallAngryPlanet, DateTime.now(DateTimeZone.UTC), pickupServicePoint.getId());
+    checkInFixture.checkInByBarcode(smallAngryPlanet, ClockUtil.getDateTime(), pickupServicePoint.getId());
 
     MultipleRecords<JsonObject> requests = requestsFixture.getQueueFor(smallAngryPlanet);
     JsonObject pagedRequestRecord = requests.getRecords().iterator().next();

--- a/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
+++ b/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
@@ -9,18 +9,17 @@ import static api.support.utl.BlockOverridesUtils.buildOkapiHeadersWithPermissio
 import static org.folio.circulation.resources.RenewalValidator.CAN_NOT_RENEW_ITEM_ERROR;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.joda.time.DateTimeConstants.APRIL;
 
 import java.time.LocalDate;
 import java.util.UUID;
 
 import org.folio.circulation.domain.policy.Period;
-import api.support.http.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.Seconds;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +28,7 @@ import api.support.builders.FixedDueDateSchedule;
 import api.support.builders.FixedDueDateSchedulesBuilder;
 import api.support.builders.LoanPolicyBuilder;
 import api.support.builders.RequestBuilder;
+import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
 import api.support.http.OkapiHeaders;
 import io.vertx.core.json.JsonObject;
@@ -62,7 +62,7 @@ class RequestsAPILoanRenewalTests extends APITests {
 
   @Test
   void allowRenewalLoanByBarcodeWhenProfileIsRollingFirstRequestInQueueIsHoldAndRenewingIsAllowedInLoanPolicy() {
-    final DateTime expectedDueDate = DateTime.now(DateTimeZone.UTC)
+    final DateTime expectedDueDate = ClockUtil.getDateTime()
       .plusWeeks(DEFAULT_HOLD_RENEWAL_PERIOD);
     final ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource rebecca = usersFixture.rebecca();
@@ -110,7 +110,7 @@ class RequestsAPILoanRenewalTests extends APITests {
   @Test
   void allowRenewalWithHoldsWhenProfileIsRollingUseLoanPeriod() {
     final int renewalPeriod = 90;
-    final DateTime expectedDueDate = DateTime.now(DateTimeZone.UTC).plusWeeks(renewalPeriod);
+    final DateTime expectedDueDate = ClockUtil.getDateTime().plusWeeks(renewalPeriod);
     final ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource rebecca = usersFixture.rebecca();
 
@@ -145,7 +145,7 @@ class RequestsAPILoanRenewalTests extends APITests {
   @Test
   void allowRenewalWithHoldsWhenProfileIsRollingUseRenewalPeriod() {
     final int renewalPeriod = 60;
-    final DateTime expectedDueDate = DateTime.now(DateTimeZone.UTC).plusWeeks(renewalPeriod);
+    final DateTime expectedDueDate = ClockUtil.getDateTime().plusWeeks(renewalPeriod);
     final ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource rebecca = usersFixture.rebecca();
 
@@ -223,7 +223,7 @@ class RequestsAPILoanRenewalTests extends APITests {
 
   @Test
   void allowRenewalLoanByIdWhenProfileIsRollingFirstRequestInQueueIsHoldAndRenewingIsAllowedInLoanPolicy() {
-    final DateTime expectedDueDate = DateTime.now(DateTimeZone.UTC)
+    final DateTime expectedDueDate = ClockUtil.getDateTime()
       .plusWeeks(DEFAULT_HOLD_RENEWAL_PERIOD);
     final ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource rebecca = usersFixture.rebecca();
@@ -295,8 +295,8 @@ class RequestsAPILoanRenewalTests extends APITests {
 
   @Test
   void allowRenewalWithHoldsWhenProfileIsFixedUseRenewalSchedule() {
-    final DateTime from = DateTime.now(DateTimeZone.UTC).minusMonths(3);
-    final DateTime to = DateTime.now(DateTimeZone.UTC).plusMonths(3);
+    final DateTime from = ClockUtil.getDateTime().minusMonths(3);
+    final DateTime to = ClockUtil.getDateTime().plusMonths(3);
     final DateTime dueDate = to.plusDays(15);
 
     final ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
@@ -338,8 +338,8 @@ class RequestsAPILoanRenewalTests extends APITests {
 
   @Test
   void allowRenewalWithHoldsWhenProfileIsFixedUseLoanSchedule() {
-    final DateTime from = DateTime.now(DateTimeZone.UTC).minusMonths(3);
-    final DateTime to = DateTime.now(DateTimeZone.UTC).plusMonths(3);
+    final DateTime from = ClockUtil.getDateTime().minusMonths(3);
+    final DateTime to = ClockUtil.getDateTime().plusMonths(3);
     final DateTime dueDate = to.plusDays(15);
 
     final ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
@@ -507,8 +507,8 @@ class RequestsAPILoanRenewalTests extends APITests {
 
   @Test
   void validationErrorWhenRenewalPeriodForHoldsSpecifiedForFixedPolicy() {
-    final DateTime from = DateTime.now(DateTimeZone.UTC).minusMonths(3);
-    final DateTime to = DateTime.now(DateTimeZone.UTC).plusMonths(3);
+    final DateTime from = ClockUtil.getDateTime().minusMonths(3);
+    final DateTime to = ClockUtil.getDateTime().plusMonths(3);
     final DateTime dueDate = to.plusDays(15);
 
     final ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
@@ -551,8 +551,8 @@ class RequestsAPILoanRenewalTests extends APITests {
 
   @Test
   void validationErrorWhenRenewalPeriodSpecifiedForFixedPolicy() {
-    final DateTime from = DateTime.now(DateTimeZone.UTC).minusMonths(3);
-    final DateTime to = DateTime.now(DateTimeZone.UTC).plusMonths(3);
+    final DateTime from = ClockUtil.getDateTime().minusMonths(3);
+    final DateTime to = ClockUtil.getDateTime().plusMonths(3);
     final DateTime dueDate = to.plusDays(15);
 
     final ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
@@ -604,7 +604,9 @@ class RequestsAPILoanRenewalTests extends APITests {
   }
 
   private void loanPolicyWithFixedProfileAndRenewingIsForbiddenWhenHoldIsPending() {
-    LocalDate now = LocalDate.now();
+    final org.joda.time.LocalDate jodaDate = ClockUtil.getLocalDate();
+    LocalDate now = LocalDate.of(jodaDate.getYear(), jodaDate.getMonthOfYear(),
+      jodaDate.getDayOfMonth());
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
       .withName("1 month - Fixed Due Date Schedule")
       .addSchedule(wholeMonth(now.getYear(), now.getMonthValue()));

--- a/src/test/java/api/requests/RequestsAPIUpdatingTests.java
+++ b/src/test/java/api/requests/RequestsAPIUpdatingTests.java
@@ -47,6 +47,7 @@ import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
@@ -790,7 +791,7 @@ class RequestsAPIUpdatingTests extends APITests {
 
     final IndividualResource createdRequest = requestsClient.create(new RequestBuilder()
       .page()
-      .withRequestDate(DateTime.now(UTC))
+      .withRequestDate(ClockUtil.getDateTime())
       .forItem(temeraire)
       .by(steve)
       .fulfilToHoldShelf()

--- a/src/test/java/api/requests/scenarios/CancelRequestTests.java
+++ b/src/test/java/api/requests/scenarios/CancelRequestTests.java
@@ -10,7 +10,6 @@ import static org.folio.circulation.domain.representations.logs.LogEventType.NOT
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.joda.time.DateTimeZone.UTC;
 
 import java.time.LocalDate;
 import java.util.Collection;
@@ -18,6 +17,7 @@ import java.util.Collections;
 import java.util.UUID;
 
 import org.folio.circulation.domain.MultipleRecords;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
@@ -43,7 +43,7 @@ class CancelRequestTests extends APITests {
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, james);
 
     final IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(UTC).minusHours(5));
+      smallAngryPlanet, jessica, ClockUtil.getDateTime().minusHours(5));
 
     requestsFixture.cancelRequest(requestByJessica);
 
@@ -75,16 +75,16 @@ class CancelRequestTests extends APITests {
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, james);
 
     final IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(UTC).minusHours(5));
+      smallAngryPlanet, jessica, ClockUtil.getDateTime().minusHours(5));
 
     final IndividualResource requestBySteve = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, steve, DateTime.now(UTC).minusHours(4));
+      smallAngryPlanet, steve, ClockUtil.getDateTime().minusHours(4));
 
     final IndividualResource requestByCharlotte = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, charlotte, DateTime.now(UTC).minusHours(3));
+      smallAngryPlanet, charlotte, ClockUtil.getDateTime().minusHours(3));
 
     final IndividualResource requestByRebecca = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, rebecca, DateTime.now(UTC).minusHours(2));
+      smallAngryPlanet, rebecca, ClockUtil.getDateTime().minusHours(2));
 
     requestsFixture.cancelRequest(requestBySteve);
 
@@ -119,16 +119,16 @@ class CancelRequestTests extends APITests {
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, james);
 
     final IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(UTC).minusHours(5));
+      smallAngryPlanet, jessica, ClockUtil.getDateTime().minusHours(5));
 
     final IndividualResource requestBySteve = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, steve, DateTime.now(UTC).minusHours(4));
+      smallAngryPlanet, steve, ClockUtil.getDateTime().minusHours(4));
 
     final IndividualResource requestByCharlotte = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, charlotte, DateTime.now(UTC).minusHours(3));
+      smallAngryPlanet, charlotte, ClockUtil.getDateTime().minusHours(3));
 
     final IndividualResource requestByRebecca = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, rebecca, DateTime.now(UTC).minusHours(2));
+      smallAngryPlanet, rebecca, ClockUtil.getDateTime().minusHours(2));
 
     requestsFixture.cancelRequest(requestByJessica);
 
@@ -163,16 +163,16 @@ class CancelRequestTests extends APITests {
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, james);
 
     final IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(UTC).minusHours(5));
+      smallAngryPlanet, jessica, ClockUtil.getDateTime().minusHours(5));
 
     final IndividualResource requestBySteve = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, steve, DateTime.now(UTC).minusHours(4));
+      smallAngryPlanet, steve, ClockUtil.getDateTime().minusHours(4));
 
     final IndividualResource requestByCharlotte = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, charlotte, DateTime.now(UTC).minusHours(3));
+      smallAngryPlanet, charlotte, ClockUtil.getDateTime().minusHours(3));
 
     final IndividualResource requestByRebecca = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, rebecca, DateTime.now(UTC).minusHours(2));
+      smallAngryPlanet, rebecca, ClockUtil.getDateTime().minusHours(2));
 
     requestsFixture.cancelRequest(requestByRebecca);
 

--- a/src/test/java/api/requests/scenarios/ClosedRequestTests.java
+++ b/src/test/java/api/requests/scenarios/ClosedRequestTests.java
@@ -15,6 +15,7 @@ import static org.hamcrest.core.Is.is;
 import java.time.LocalDate;
 
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
@@ -132,7 +133,7 @@ class ClosedRequestTests extends APITests {
       .page()
       .fulfilToHoldShelf()
       .withItemId(smallAngryPlanet.getId())
-      .withRequestDate(DateTime.now(DateTimeZone.UTC).minusHours(4))
+      .withRequestDate(ClockUtil.getDateTime().minusHours(4))
       .withRequesterId(jessica.getId())
       .withPickupServicePointId(servicePointsFixture.cd1().getId()));
 
@@ -147,7 +148,7 @@ class ClosedRequestTests extends APITests {
           .cancelled()
           .withCancellationReasonId(courseReservesCancellationReason.getId())
           .withCancelledByUserId(jessica.getId())
-          .withCancelledDate(DateTime.now(DateTimeZone.UTC).minusHours(3)));
+          .withCancelledDate(ClockUtil.getDateTime().minusHours(3)));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
     assertThat(smallAngryPlanet, hasItemStatus(AVAILABLE));

--- a/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
+++ b/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
@@ -26,8 +26,7 @@ import java.time.temporal.ChronoUnit;
 
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.utils.ClockUtil;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,19 +39,26 @@ import api.support.fixtures.ConfigurationExample;
 import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonObject;
 
-class HoldShelfExpirationDateTests extends APITests{
+class HoldShelfExpirationDateTests extends APITests {
   private static Clock clock;
 
   @BeforeAll
   public static void setUpBeforeClass() {
-    clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
-    ClockUtil.setClock(clock);
+    final Instant now = Instant.ofEpochMilli(ClockUtil.getInstant()
+      .getMillis());
+    clock = Clock.fixed(now, ZoneOffset.UTC);
   }
 
   @BeforeEach
   public void setUp() {
     // reset the clock before each test (just in case)
     ClockUtil.setClock(clock);
+  }
+
+  @AfterEach
+  public void afterEach() {
+    // The clock must be reset after each test.
+    ClockUtil.setDefaultClock();
   }
 
   @ParameterizedTest
@@ -79,7 +85,7 @@ class HoldShelfExpirationDateTests extends APITests{
     checkOutFixture.checkOutByBarcode(nod, james);
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
-        DateTime.now(DateTimeZone.UTC), checkInServicePoint.getId());
+        ClockUtil.getDateTime(), checkInServicePoint.getId());
 
     checkInFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
@@ -93,7 +99,7 @@ class HoldShelfExpirationDateTests extends APITests{
 
     assertThat("request hold shelf expiration date is " + amount + " " + interval.toString() + " in the future",
       storedRequest.getString("holdShelfExpirationDate"),
-      isEquivalentTo(interval.addTo(ZonedDateTime.now(clock), amount)));
+      isEquivalentTo(interval.addTo(ClockUtil.getZonedDateTime(), amount)));
   }
 
   @ParameterizedTest
@@ -121,7 +127,7 @@ class HoldShelfExpirationDateTests extends APITests{
     checkOutFixture.checkOutByBarcode(nod, james);
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
-      DateTime.now(DateTimeZone.UTC), checkInServicePoint.getId());
+      ClockUtil.getDateTime(), checkInServicePoint.getId());
 
     checkInFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
@@ -133,7 +139,7 @@ class HoldShelfExpirationDateTests extends APITests{
     assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
       storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
 
-    ZonedDateTime expectedExpirationDate = atEndOfTheDay(interval.addTo(ZonedDateTime.now(clock), amount));
+    ZonedDateTime expectedExpirationDate = atEndOfTheDay(interval.addTo(ClockUtil.getZonedDateTime(), amount));
 
     assertThat("request hold shelf expiration date is " + amount + " " + interval.toString() + " in the future",
       storedRequest.getString("holdShelfExpirationDate"),
@@ -159,7 +165,7 @@ class HoldShelfExpirationDateTests extends APITests{
     checkOutFixture.checkOutByBarcode(nod, james);
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
-      DateTime.now(DateTimeZone.UTC), checkInServicePoint.getId());
+      ClockUtil.getDateTime(), checkInServicePoint.getId());
 
     checkInFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
@@ -168,8 +174,10 @@ class HoldShelfExpirationDateTests extends APITests{
 
     final JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
 
+    final Instant now = Instant.ofEpochMilli(ClockUtil.getInstant().getMillis());
+
     ZonedDateTime expectedExpirationDate = atEndOfTheDay(
-      interval.addTo(Instant.now(clock).atZone(tenantTimeZone), amount))
+      interval.addTo(now.atZone(tenantTimeZone), amount))
       .toInstant()
       .atZone(ZoneOffset.UTC);
 
@@ -197,7 +205,7 @@ class HoldShelfExpirationDateTests extends APITests{
     checkOutFixture.checkOutByBarcode(nod, james);
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
-      DateTime.now(DateTimeZone.UTC), checkInServicePoint.getId());
+      ClockUtil.getDateTime(), checkInServicePoint.getId());
 
     checkInFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
@@ -205,9 +213,10 @@ class HoldShelfExpirationDateTests extends APITests{
         .at(checkInServicePoint.getId()));
 
     final JsonObject storedRequest = requestsClient.getById(request.getId()).getJson();
+    final Instant now = Instant.ofEpochMilli(ClockUtil.getInstant().getMillis());
 
     ZonedDateTime expectedExpirationDate = interval
-      .addTo(Instant.now(clock).atZone(tenantTimeZone), amount)
+      .addTo(now.atZone(tenantTimeZone), amount)
       .toInstant()
       .atZone(ZoneOffset.UTC);
 
@@ -228,7 +237,7 @@ class HoldShelfExpirationDateTests extends APITests{
     checkOutFixture.checkOutByBarcode(nod, james);
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
-        DateTime.now(DateTimeZone.UTC), checkInServicePoint.getId());
+      ClockUtil.getDateTime(), checkInServicePoint.getId());
 
     checkInFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
@@ -245,7 +254,7 @@ class HoldShelfExpirationDateTests extends APITests{
         storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
 
     final ZonedDateTime expectedExpirationDate = atEndOfTheDay(
-      ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30));
+      ChronoUnit.DAYS.addTo(ClockUtil.getZonedDateTime(), 30));
 
     assertThat("request hold shelf expiration date is 30 days in the future",
       storedRequest.getString("holdShelfExpirationDate"),
@@ -269,12 +278,9 @@ class HoldShelfExpirationDateTests extends APITests{
     assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
         storedSecondCheckInRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
 
-    final ZonedDateTime expectedExpirationDateAfterUpdate = atEndOfTheDay(
-      ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30));
-
     assertThat("request hold shelf expiration date is 30 days in the future and has not been updated",
       storedRequest.getString("holdShelfExpirationDate"),
-      isEquivalentTo(expectedExpirationDateAfterUpdate));
+      isEquivalentTo(expectedExpirationDate));
   }
 
   @Test
@@ -290,7 +296,7 @@ class HoldShelfExpirationDateTests extends APITests{
     checkOutFixture.checkOutByBarcode(nod, james);
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
-        DateTime.now(DateTimeZone.UTC), checkInServicePoint.getId());
+      ClockUtil.getDateTime(), checkInServicePoint.getId());
 
     checkInFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
@@ -308,7 +314,7 @@ class HoldShelfExpirationDateTests extends APITests{
       storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
 
     final ZonedDateTime expectedExpirationDate = atEndOfTheDay(
-      ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30));
+      ChronoUnit.DAYS.addTo(ClockUtil.getZonedDateTime(), 30));
 
     assertThat("request hold shelf expiration date is 30 days in the future",
       storedRequest.getString("holdShelfExpirationDate"),
@@ -339,7 +345,7 @@ class HoldShelfExpirationDateTests extends APITests{
     final IndividualResource requestServicePoint = checkInServicePoint;
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
-        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId(), "Page");
+      ClockUtil.getDateTime(), requestServicePoint.getId(), "Page");
 
     checkInFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()
@@ -356,7 +362,7 @@ class HoldShelfExpirationDateTests extends APITests{
       storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
 
     final ZonedDateTime expectedExpirationDate = atEndOfTheDay(
-      ChronoUnit.DAYS.addTo(ZonedDateTime.now(clock), 30));
+      ChronoUnit.DAYS.addTo(ClockUtil.getZonedDateTime(), 30));
 
     assertThat("request hold shelf expiration date is 30 days in the future",
       storedRequest.getString("holdShelfExpirationDate"),
@@ -376,7 +382,7 @@ class HoldShelfExpirationDateTests extends APITests{
     checkOutFixture.checkOutByBarcode(nod, james);
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
-        DateTime.now(DateTimeZone.UTC), alternateCheckInServicePoint.getId());
+      ClockUtil.getDateTime(), alternateCheckInServicePoint.getId());
 
     nod = itemsClient.get(nod);
 
@@ -414,7 +420,7 @@ class HoldShelfExpirationDateTests extends APITests{
     final IndividualResource requestServicePoint = alternateServicePoint;
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
-        DateTime.now(DateTimeZone.UTC), requestServicePoint.getId(), "Page");
+      ClockUtil.getDateTime(), requestServicePoint.getId(), "Page");
 
     nod = itemsClient.get(nod);
 
@@ -454,7 +460,7 @@ class HoldShelfExpirationDateTests extends APITests{
     checkOutFixture.checkOutByBarcode(nod, james);
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(nod, jessica,
-        DateTime.now(DateTimeZone.UTC), alternateCheckInServicePoint.getId());
+      ClockUtil.getDateTime(), alternateCheckInServicePoint.getId());
 
     checkInFixture.checkInByBarcode(
       new CheckInByBarcodeRequestBuilder()

--- a/src/test/java/api/requests/scenarios/HoldShelfFulfillmentTests.java
+++ b/src/test/java/api/requests/scenarios/HoldShelfFulfillmentTests.java
@@ -15,14 +15,15 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import api.support.http.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
 
 import api.support.APITests;
 import api.support.builders.CheckInByBarcodeRequestBuilder;
+import api.support.http.IndividualResource;
 
 class HoldShelfFulfillmentTests extends APITests {
   @Test
@@ -37,11 +38,11 @@ class HoldShelfFulfillmentTests extends APITests {
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, james);
 
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC),
+      smallAngryPlanet, jessica, ClockUtil.getDateTime(),
       pickupServicePoint.getId());
 
     checkInFixture.checkInByBarcode(smallAngryPlanet,
-      DateTime.now(DateTimeZone.UTC), pickupServicePoint.getId());
+      ClockUtil.getDateTime(), pickupServicePoint.getId());
 
     Response request = requestsClient.getById(requestByJessica.getId());
 
@@ -73,7 +74,7 @@ class HoldShelfFulfillmentTests extends APITests {
       pickupServicePoint.getId());
 
     checkInFixture.checkInByBarcode(smallAngryPlanet,
-      DateTime.now(DateTimeZone.UTC), pickupServicePoint.getId());
+      ClockUtil.getDateTime(), pickupServicePoint.getId());
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica);
 
@@ -99,11 +100,11 @@ class HoldShelfFulfillmentTests extends APITests {
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, james);
 
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC),
+      smallAngryPlanet, jessica, ClockUtil.getDateTime(),
       pickupServicePoint.getId());
 
     checkInFixture.checkInByBarcode(smallAngryPlanet,
-      DateTime.now(DateTimeZone.UTC), checkInServicePoint.getId());
+      ClockUtil.getDateTime(), checkInServicePoint.getId());
 
     Response request = requestsClient.getById(requestByJessica.getId());
 
@@ -138,7 +139,7 @@ class HoldShelfFulfillmentTests extends APITests {
       pickupServicePoint.getId());
 
     checkInFixture.checkInByBarcode(smallAngryPlanet,
-      DateTime.now(DateTimeZone.UTC), checkInServicePoint.getId());
+      ClockUtil.getDateTime(), checkInServicePoint.getId());
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica);
 
@@ -164,14 +165,14 @@ class HoldShelfFulfillmentTests extends APITests {
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, james);
 
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC),
+      smallAngryPlanet, jessica, ClockUtil.getDateTime(),
       pickupServicePoint.getId());
 
     checkInFixture.checkInByBarcode(smallAngryPlanet,
-      DateTime.now(DateTimeZone.UTC), checkInServicePoint.getId());
+      ClockUtil.getDateTime(), checkInServicePoint.getId());
 
     checkInFixture.checkInByBarcode(smallAngryPlanet,
-      DateTime.now(DateTimeZone.UTC), pickupServicePoint.getId());
+      ClockUtil.getDateTime(), pickupServicePoint.getId());
 
     Response request = requestsClient.getById(requestByJessica.getId());
 
@@ -232,7 +233,7 @@ class HoldShelfFulfillmentTests extends APITests {
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, james);
 
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC),
+      smallAngryPlanet, jessica, ClockUtil.getDateTime(),
       requestServicePoint.getId());
 
     checkInFixture.checkInByBarcode(

--- a/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
+++ b/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
@@ -19,7 +19,6 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.joda.time.DateTime.now;
 import static org.joda.time.DateTimeZone.UTC;
 
 import java.time.Clock;
@@ -70,7 +69,9 @@ class LoanDueDatesAfterRecallTests extends APITests {
 
   @BeforeAll
   public static void setUpBeforeClass() {
-    clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final Instant now = Instant.ofEpochMilli(ClockUtil.getInstant()
+      .getMillis());
+    clock = Clock.fixed(now, ZoneOffset.UTC);
   }
 
   @BeforeEach
@@ -80,9 +81,9 @@ class LoanDueDatesAfterRecallTests extends APITests {
   }
 
   @AfterEach
-  public void after() {
-    // reset the clock before each test (just in case)
-    ClockUtil.setClock(Clock.systemUTC());
+  public void afterEach() {
+    // The clock must be reset after each test.
+    ClockUtil.setDefaultClock();
   }
 
   @Test
@@ -93,12 +94,12 @@ class LoanDueDatesAfterRecallTests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
-      smallAngryPlanet, steve, now(UTC));
+      smallAngryPlanet, steve, ClockUtil.getDateTime());
 
     final String originalDueDate = loan.getJson().getString("dueDate");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -129,12 +130,12 @@ class LoanDueDatesAfterRecallTests extends APITests {
     setFallbackPolicies(canCirculateRollingPolicy);
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
-      smallAngryPlanet, steve, now(UTC));
+      smallAngryPlanet, steve, ClockUtil.getDateTime());
 
     final String originalDueDate = loan.getJson().getString("dueDate");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -165,7 +166,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     setFallbackPolicies(canCirculateRollingPolicy);
 
     // We use the loan date to calculate the MGD
-    final DateTime loanDate = now(UTC);
+    final DateTime loanDate = ClockUtil.getDateTime();
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
       smallAngryPlanet, steve, loanDate);
@@ -173,7 +174,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     final String originalDueDate = loan.getJson().getString("dueDate");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -203,7 +204,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     setFallbackPolicies(canCirculateRollingPolicy);
 
     // We use the loan date to calculate the minimum guaranteed due date (MGD)
-    final DateTime loanDate = now(UTC);
+    final DateTime loanDate = ClockUtil.getDateTime();
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
       smallAngryPlanet, steve, loanDate);
@@ -211,7 +212,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     final String originalDueDate = loan.getJson().getString("dueDate");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -241,7 +242,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     setFallbackPolicies(canCirculateRollingPolicy);
 
     // We use the loan date to calculate the minimum guaranteed due date (MGD)
-    final DateTime loanDate = now(UTC);
+    final DateTime loanDate = ClockUtil.getDateTime();
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
       smallAngryPlanet, steve, loanDate);
@@ -249,7 +250,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     final String originalDueDate = loan.getJson().getString("dueDate");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -299,7 +300,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     final String originalDueDate = loan.getJson().getString("dueDate");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), "Recall");
+        ClockUtil.getDateTime(), "Recall");
 
     final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -347,12 +348,12 @@ class LoanDueDatesAfterRecallTests extends APITests {
     setFallbackPolicies(canCirculateRollingPolicy);
 
     // We use the loan date to calculate the minimum guaranteed due date (MGD)
-    final DateTime loanDate = now(UTC);
+    final DateTime loanDate = ClockUtil.getDateTime();
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, steve, loanDate);
 
     final Response response = requestsFixture.attemptPlaceHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     assertThat("Status code should be 422", response.getStatusCode(), is(422));
     assertThat("errors should be present", response.getJson().getJsonArray("errors"), notNullValue());
@@ -384,18 +385,18 @@ class LoanDueDatesAfterRecallTests extends APITests {
     setFallbackPolicies(canCirculateRollingPolicy);
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, charlotte,
-      now(UTC));
+      ClockUtil.getDateTime());
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, steve,
-      now(UTC), requestServicePoint.getId(), "Recall");
+      ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-      now(UTC), requestServicePoint.getId(), "Recall");
+      ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     checkInFixture.checkInByBarcode(smallAngryPlanet);
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
-      smallAngryPlanet, steve, now(UTC));
+      smallAngryPlanet, steve, ClockUtil.getDateTime());
 
     final JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -473,10 +474,10 @@ class LoanDueDatesAfterRecallTests extends APITests {
     setFallbackPolicies(canCirculateRollingPolicy);
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), requestServicePoint.getId(), "Page");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Page");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, james,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
       smallAngryPlanet, jessica, ClockUtil.getDateTime());
@@ -493,7 +494,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     ClockUtil.setClock(Clock.offset(clock, Duration.ofDays(1)));
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, charlotte,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     storedLoan = loansStorageClient.getById(loan.getId()).getJson();
     assertThat("second recall should not change the due date",
@@ -520,10 +521,10 @@ class LoanDueDatesAfterRecallTests extends APITests {
      setFallbackPolicies(canCirculateRollingPolicy);
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), requestServicePoint.getId(), "Page");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Page");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, james,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
       smallAngryPlanet, jessica, ClockUtil.getDateTime());
@@ -541,7 +542,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     ClockUtil.setClock(Clock.offset(clock, Duration.ofDays(15)));
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, charlotte,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     storedLoan = loansStorageClient.getById(loan.getId()).getJson();
     assertThat("second recall should not change the due date",
@@ -573,7 +574,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     final String originalDueDate = loan.getJson().getString("dueDate");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -588,7 +589,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     ClockUtil.setClock(Clock.offset(clock, Duration.ofDays(7)));
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, charlotte,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     storedLoan = loansStorageClient.getById(loan.getId()).getJson();
     assertThat("second recall should not change the due date (2 weeks)",
@@ -620,7 +621,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     final String originalDueDate = loan.getJson().getString("dueDate");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -636,7 +637,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     ClockUtil.setClock(Clock.offset(clock, Duration.ofDays(15)));
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, charlotte,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     storedLoan = loansStorageClient.getById(loan.getId()).getJson();
     assertThat("second recall should not change the due date (2 weeks)",
@@ -662,12 +663,12 @@ class LoanDueDatesAfterRecallTests extends APITests {
     setFallbackPolicies(canCirculateRollingPolicy);
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
-      smallAngryPlanet, steve, now(UTC));
+      smallAngryPlanet, steve, ClockUtil.getDateTime());
 
     final String originalDueDate = loan.getJson().getString("dueDate");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -682,7 +683,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     ClockUtil.setClock(Clock.offset(clock, Duration.ofDays(7)));
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, charlotte,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     storedLoan = loansStorageClient.getById(loan.getId()).getJson();
     assertThat("second recall should not change the due date (2 months)",
@@ -709,12 +710,12 @@ class LoanDueDatesAfterRecallTests extends APITests {
     setFallbackPolicies(canCirculateRollingPolicy);
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
-      smallAngryPlanet, steve, now(UTC));
+      smallAngryPlanet, steve, ClockUtil.getDateTime());
 
     final String originalDueDate = loan.getJson().getString("dueDate");
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, jessica,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -730,7 +731,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     ClockUtil.setClock(Clock.offset(clock, Duration.ofDays(70)));
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, charlotte,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     storedLoan = loansStorageClient.getById(loan.getId()).getJson();
     assertThat("second recall should not change the due date (2 months)",
@@ -764,7 +765,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
     final IndividualResource request = requestsFixture.placeHoldShelfRequest(
-        smallAngryPlanet, james, now(UTC),
+        smallAngryPlanet, james, ClockUtil.getDateTime(),
         requestServicePoint.getId(), "Recall");
 
     final String recalledDueDate = request.getJson().getString("dueDate");
@@ -782,7 +783,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     storedLoan = loansStorageClient.getById(renewal.getId()).getJson();
 
     requestsFixture.placeHoldShelfRequest(smallAngryPlanet, charlotte,
-        now(UTC), requestServicePoint.getId(), "Recall");
+        ClockUtil.getDateTime(), requestServicePoint.getId(), "Recall");
 
     storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -805,7 +806,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
       .withRecallsMinimumGuaranteedLoanPeriod(Period.weeks(2))
       .withRecallsRecallReturnInterval(Period.months(2)));
 
-    final DateTime loanCreateDate = now(UTC)
+    final DateTime loanCreateDate = ClockUtil.getDateTime()
       .minus(loanPeriod.timePeriod()).minusMinutes(1);
     final DateTime expectedLoanDueDate = loanCreateDate.plus(loanPeriod.timePeriod());
 
@@ -849,7 +850,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
       .withAllowRecallsToExtendOverdueLoans(true)
       .withAlternateRecallReturnInterval(alternateLoanPeriod));
 
-    final DateTime loanCreateDate = now(UTC)
+    final DateTime loanCreateDate = DateTime.now(UTC)//ClockUtil.getDateTime()
       .minus(loanPeriod.timePeriod())
       .minusMinutes(1);
     DateTime expectedLoanDueDate = loanCreateDate
@@ -888,7 +889,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
       .withAllowRecallsToExtendOverdueLoans(true)
       .withRecallsRecallReturnInterval(recalReturnInterval));
 
-    final DateTime loanCreateDate = now(UTC)
+    final DateTime loanCreateDate = ClockUtil.getDateTime()
       .minus(loanPeriod.timePeriod())
       .minusMinutes(1);
 
@@ -932,14 +933,14 @@ class LoanDueDatesAfterRecallTests extends APITests {
       .withRecallsMinimumGuaranteedLoanPeriod(Period.weeks(2))
       .withRecallsRecallReturnInterval(Period.weeks(2)));
 
-      checkOutFixture.checkOutByBarcode(smallAngryPlanet, steve, now(UTC));
+      checkOutFixture.checkOutByBarcode(smallAngryPlanet, steve, ClockUtil.getDateTime());
 
       requestsFixture.placeHoldShelfRequest(
-        smallAngryPlanet, james, now(UTC),
+        smallAngryPlanet, james, ClockUtil.getDateTime(),
         requestServicePoint.getId(), "Hold");
 
       requestsFixture.placeHoldShelfRequest(
-        smallAngryPlanet, jessica, now(UTC),
+        smallAngryPlanet, jessica, ClockUtil.getDateTime(),
         requestServicePoint.getId(), "Hold");
 
       requestsFixture.place(new RequestBuilder()
@@ -952,7 +953,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
 
       checkInFixture.checkInByBarcode(smallAngryPlanet);
 
-      final DateTime checkOutDate = now(UTC);
+      final DateTime checkOutDate = ClockUtil.getDateTime();
       final DateTime truncatedLoanDate = checkOutDate.plusWeeks(2);
 
       final IndividualResource loan = checkOutFixture.checkOutByBarcode(

--- a/src/test/java/api/requests/scenarios/MoveRequestPolicyTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestPolicyTests.java
@@ -26,9 +26,8 @@ import org.folio.circulation.domain.notice.NoticeEventType;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.utils.ClockUtil;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,7 +54,10 @@ class MoveRequestPolicyTests extends APITests {
 
   @BeforeAll
   public static void setUpBeforeClass() {
-    clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final Instant now = Instant.ofEpochMilli(ClockUtil.getInstant()
+      .getMillis());
+    clock = Clock.fixed(now, ZoneOffset.UTC);
+
     FakePubSub.clearPublishedEvents();
   }
 
@@ -83,6 +85,12 @@ class MoveRequestPolicyTests extends APITests {
       noticePoliciesFixture.create(noticePolicy).getId(),
       overdueFinePoliciesFixture.facultyStandard().getId(),
       lostItemFeePoliciesFixture.facultyStandard().getId());
+  }
+
+  @AfterEach
+  public void afterEach() {
+    // The clock must be reset after each test.
+    ClockUtil.setDefaultClock();
   }
 
   @Test
@@ -122,10 +130,10 @@ class MoveRequestPolicyTests extends APITests {
     checkOutFixture.checkOutByBarcode(interestingTimes, charlotte);
 
     IndividualResource requestByCharlotte = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(2), RequestType.RECALL.getValue());
+      smallAngryPlanet, charlotte, ClockUtil.getDateTime().minusHours(2), RequestType.RECALL.getValue());
 
     IndividualResource requestByJames = requestsFixture.placeHoldShelfRequest(
-      interestingTimes, james, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.RECALL.getValue());
+      interestingTimes, james, ClockUtil.getDateTime().minusHours(1), RequestType.RECALL.getValue());
 
     // move james' recall request as a hold shelf request from smallAngryPlanet to interestingTimes
     Response response = requestsFixture.attemptMove(new MoveRequestBuilder(
@@ -167,7 +175,7 @@ class MoveRequestPolicyTests extends APITests {
 
     // steve checks out smallAngryPlanet
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
-      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC));
+      smallAngryPlanet, steve, ClockUtil.getDateTime());
 
     final String originalDueDate = loan.getJson().getString("dueDate");
 
@@ -176,7 +184,7 @@ class MoveRequestPolicyTests extends APITests {
 
     // jessica places recall request on interestingTimes
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      interestingTimes, jessica, DateTime.now(DateTimeZone.UTC), RequestType.RECALL.getValue());
+      interestingTimes, jessica, ClockUtil.getDateTime(), RequestType.RECALL.getValue());
 
     // notice for the recall is expected
     verifyNumberOfSentNotices(1);
@@ -219,13 +227,13 @@ class MoveRequestPolicyTests extends APITests {
 
     // steve checks out smallAngryPlanet
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
-      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC));
+      smallAngryPlanet, steve, ClockUtil.getDateTime());
 
     final String originalDueDate = loan.getJson().getString("dueDate");
 
     // charlotte places recall request on smallAngryPlanet
     requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.RECALL.getValue());
+      smallAngryPlanet, charlotte, ClockUtil.getDateTime().minusHours(1), RequestType.RECALL.getValue());
 
     JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -241,7 +249,7 @@ class MoveRequestPolicyTests extends APITests {
 
     // jessica places recall request on interestingTimes
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      interestingTimes, jessica, DateTime.now(DateTimeZone.UTC), RequestType.RECALL.getValue());
+      interestingTimes, jessica, ClockUtil.getDateTime(), RequestType.RECALL.getValue());
 
     // There should be 2 notices for each recall
     waitAtMost(1, SECONDS)
@@ -305,7 +313,7 @@ class MoveRequestPolicyTests extends APITests {
       lostItemFeePoliciesFixture.facultyStandard().getId());
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
-      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC));
+      smallAngryPlanet, steve, ClockUtil.getDateTime());
 
     final String originalDueDate = loan.getJson().getString("dueDate");
 
@@ -314,7 +322,7 @@ class MoveRequestPolicyTests extends APITests {
 
     // jessica places recall request on interestingTimes
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      interestingTimes, jessica, DateTime.now(DateTimeZone.UTC), RequestType.RECALL.getValue());
+      interestingTimes, jessica, ClockUtil.getDateTime(), RequestType.RECALL.getValue());
 
     // One notice for the recall is expected
     verifyNumberOfSentNotices(1);
@@ -376,13 +384,13 @@ class MoveRequestPolicyTests extends APITests {
       lostItemFeePoliciesFixture.facultyStandard().getId());
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(
-      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC));
+      smallAngryPlanet, steve, ClockUtil.getDateTime());
 
     final String originalDueDate = loan.getJson().getString("dueDate");
 
     // charlotte places recall request on smallAngryPlanet
     requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.RECALL.getValue());
+      smallAngryPlanet, charlotte, ClockUtil.getDateTime().minusHours(1), RequestType.RECALL.getValue());
 
     JsonObject storedLoan = loansStorageClient.getById(loan.getId()).getJson();
 
@@ -398,7 +406,7 @@ class MoveRequestPolicyTests extends APITests {
 
     // jessica places recall request on interestingTimes
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      interestingTimes, jessica, DateTime.now(DateTimeZone.UTC), RequestType.RECALL.getValue());
+      interestingTimes, jessica, ClockUtil.getDateTime(), RequestType.RECALL.getValue());
 
     // There should be 2 notices for each recall
     waitAtMost(1, SECONDS)

--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -43,7 +42,6 @@ import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -65,8 +63,9 @@ import lombok.val;
 class MoveRequestTests extends APITests {
 
   @AfterEach
-  public void after() {
-    ClockUtil.setClock(Clock.systemUTC());
+  public void afterEach() {
+    // The clock must be reset after each test.
+    ClockUtil.setDefaultClock();
   }
 
   @Test
@@ -101,7 +100,7 @@ class MoveRequestTests extends APITests {
     assertThat(itemCopyA.getJson().getJsonObject("status").getString("name"), is(ItemStatus.AVAILABLE.getValue()));
     assertThat(itemCopyB.getJson().getJsonObject("status").getString("name"), is(ItemStatus.AVAILABLE.getValue()));
 
-    IndividualResource itemCopyALoan = checkOutFixture.checkOutByBarcode(itemCopyA, james, DateTime.now(DateTimeZone.UTC));
+    IndividualResource itemCopyALoan = checkOutFixture.checkOutByBarcode(itemCopyA, james, ClockUtil.getDateTime());
     assertThat(itemCopyALoan.getJson().getString("userId"), is(james.getId().toString()));
 
     assertThat(itemCopyALoan.getJson().getString("itemId"), is(itemCopyA.getId().toString()));
@@ -109,13 +108,13 @@ class MoveRequestTests extends APITests {
     assertThat(itemsClient.get(itemCopyA).getJson().getJsonObject("status").getString("name"), is(ItemStatus.CHECKED_OUT.getValue()));
 
     IndividualResource pageRequestForItemCopyB = requestsFixture.placeHoldShelfRequest(
-      itemCopyB, jessica, DateTime.now(DateTimeZone.UTC).minusHours(3), RequestType.PAGE.getValue());
+      itemCopyB, jessica, ClockUtil.getDateTime().minusHours(3), RequestType.PAGE.getValue());
 
     IndividualResource recallRequestForItemCopyB = requestsFixture.placeHoldShelfRequest(
-      itemCopyB, steve, DateTime.now(DateTimeZone.UTC).minusHours(2), RequestType.RECALL.getValue());
+      itemCopyB, steve, ClockUtil.getDateTime().minusHours(2), RequestType.RECALL.getValue());
 
     IndividualResource holdRequestForItemCopyA = requestsFixture.placeHoldShelfRequest(
-      itemCopyA, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.HOLD.getValue());
+      itemCopyA, charlotte, ClockUtil.getDateTime().minusHours(1), RequestType.HOLD.getValue());
 
     assertThat(requestsFixture.getQueueFor(itemCopyA).getTotalRecords(), is(1));
     assertThat(requestsFixture.getQueueFor(itemCopyB).getTotalRecords(), is(2));
@@ -187,7 +186,7 @@ class MoveRequestTests extends APITests {
       .hold()
       .fulfilToHoldShelf()
       .withItemId(smallAngryPlanet.getId())
-      .withRequestDate(DateTime.now(DateTimeZone.UTC))
+      .withRequestDate(ClockUtil.getDateTime())
       .withRequesterId(jessica.getId())
       .withPatronComments("Patron comments for smallAngryPlanet")
       .withPickupServicePointId(servicePointsFixture.cd1().getId()));
@@ -244,20 +243,20 @@ class MoveRequestTests extends APITests {
 
     // make requests for smallAngryPlanet
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC).minusHours(5));
+      smallAngryPlanet, jessica, ClockUtil.getDateTime().minusHours(5));
 
     IndividualResource requestBySteve = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.RECALL.getValue());
+      smallAngryPlanet, steve, ClockUtil.getDateTime().minusHours(1), RequestType.RECALL.getValue());
 
     IndividualResource requestByCharlotte = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(3));
+      smallAngryPlanet, charlotte, ClockUtil.getDateTime().minusHours(3));
 
     IndividualResource requestByRebecca = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, rebecca, DateTime.now(DateTimeZone.UTC).minusHours(2), RequestType.RECALL.getValue());
+      smallAngryPlanet, rebecca, ClockUtil.getDateTime().minusHours(2), RequestType.RECALL.getValue());
 
     // make requests for interestingTimes
     IndividualResource requestByJames = requestsFixture.placeHoldShelfRequest(
-      interestingTimes, james, DateTime.now(DateTimeZone.UTC).minusHours(4), RequestType.RECALL.getValue());
+      interestingTimes, james, ClockUtil.getDateTime().minusHours(4), RequestType.RECALL.getValue());
 
     // move steve's recall request from smallAngryPlanet to interestingTimes
     IndividualResource moveRequest = requestsFixture.move(new MoveRequestBuilder(
@@ -322,10 +321,10 @@ class MoveRequestTests extends APITests {
 
     // make requests for smallAngryPlanet
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC).minusHours(2), RequestType.RECALL.getValue());
+      smallAngryPlanet, jessica, ClockUtil.getDateTime().minusHours(2), RequestType.RECALL.getValue());
 
     IndividualResource requestBySteve = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.RECALL.getValue());
+      smallAngryPlanet, steve, ClockUtil.getDateTime().minusHours(1), RequestType.RECALL.getValue());
 
     // check positioning on smallAngryPlanet before moves
     requestByJessica = requestsClient.get(requestByJessica);
@@ -403,7 +402,7 @@ class MoveRequestTests extends APITests {
       .page()
       .fulfilToHoldShelf()
       .withItemId(smallAngryPlanet.getId())
-      .withRequestDate(DateTime.now(DateTimeZone.UTC).minusHours(4))
+      .withRequestDate(ClockUtil.getDateTime().minusHours(4))
       .withRequesterId(jessica.getId())
       .withPickupServicePointId(servicePointsFixture.cd1().getId()));
 
@@ -439,7 +438,7 @@ class MoveRequestTests extends APITests {
 
     // make requests for smallAngryPlanet
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC));
+      smallAngryPlanet, jessica, ClockUtil.getDateTime());
 
     // move jessica's hold shelf request from smallAngryPlanet to interestingTimes
     IndividualResource moveRequest = requestsFixture.move(new MoveRequestBuilder(
@@ -483,20 +482,20 @@ class MoveRequestTests extends APITests {
 
     // make requests for smallAngryPlanet
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC).minusHours(4));
+      smallAngryPlanet, jessica, ClockUtil.getDateTime().minusHours(4));
 
     IndividualResource requestBySteve = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC).minusHours(5));
+      smallAngryPlanet, steve, ClockUtil.getDateTime().minusHours(5));
 
     IndividualResource requestByCharlotte = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(3));
+      smallAngryPlanet, charlotte, ClockUtil.getDateTime().minusHours(3));
 
     // make requests for interestingTimes
     IndividualResource requestByRebecca = requestsFixture.placeHoldShelfRequest(
-      interestingTimes, rebecca, DateTime.now(DateTimeZone.UTC).minusHours(5));
+      interestingTimes, rebecca, ClockUtil.getDateTime().minusHours(5));
 
     IndividualResource requestByJames = requestsFixture.placeHoldShelfRequest(
-      interestingTimes, james, DateTime.now(DateTimeZone.UTC).minusHours(1));
+      interestingTimes, james, ClockUtil.getDateTime().minusHours(1));
 
     // move jessica's hold shelf request from smallAngryPlanet to interestingTimes
     IndividualResource moveRequest = requestsFixture.move(new MoveRequestBuilder(
@@ -562,20 +561,20 @@ class MoveRequestTests extends APITests {
 
     // make requests for smallAngryPlanet
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC).minusHours(4));
+      smallAngryPlanet, jessica, ClockUtil.getDateTime().minusHours(4));
 
     IndividualResource requestBySteve = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC).minusHours(5));
+      smallAngryPlanet, steve, ClockUtil.getDateTime().minusHours(5));
 
     IndividualResource requestByCharlotte = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(3));
+      smallAngryPlanet, charlotte, ClockUtil.getDateTime().minusHours(3));
 
     IndividualResource requestByRebecca = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, rebecca, DateTime.now(DateTimeZone.UTC).minusHours(2));
+      smallAngryPlanet, rebecca, ClockUtil.getDateTime().minusHours(2));
 
     // make requests for interestingTimes
     IndividualResource requestByJames = requestsFixture.placeHoldShelfRequest(
-      interestingTimes, james, DateTime.now(DateTimeZone.UTC).minusHours(1));
+      interestingTimes, james, ClockUtil.getDateTime().minusHours(1));
 
     checkInFixture.checkInByBarcode(interestingTimes);
 
@@ -644,20 +643,20 @@ class MoveRequestTests extends APITests {
 
     // make requests for smallAngryPlanet
     IndividualResource requestByJessica = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, jessica, DateTime.now(DateTimeZone.UTC).minusHours(5));
+      smallAngryPlanet, jessica, ClockUtil.getDateTime().minusHours(5));
 
     IndividualResource requestBySteve = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, steve, DateTime.now(DateTimeZone.UTC).minusHours(4), RequestType.RECALL.getValue());
+      smallAngryPlanet, steve, ClockUtil.getDateTime().minusHours(4), RequestType.RECALL.getValue());
 
     IndividualResource requestByCharlotte = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(3));
+      smallAngryPlanet, charlotte, ClockUtil.getDateTime().minusHours(3));
 
     IndividualResource requestByRebecca = requestsFixture.placeHoldShelfRequest(
-      smallAngryPlanet, rebecca, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.RECALL.getValue());
+      smallAngryPlanet, rebecca, ClockUtil.getDateTime().minusHours(1), RequestType.RECALL.getValue());
 
     // make requests for interestingTimes
     IndividualResource requestByJames = requestsFixture.placeHoldShelfRequest(
-      interestingTimes, james, DateTime.now(DateTimeZone.UTC).minusHours(2), RequestType.RECALL.getValue());
+      interestingTimes, james, ClockUtil.getDateTime().minusHours(2), RequestType.RECALL.getValue());
 
     // move rebecca's recall request from smallAngryPlanet to interestingTimes
     IndividualResource moveRequest = requestsFixture.move(new MoveRequestBuilder(
@@ -737,11 +736,11 @@ class MoveRequestTests extends APITests {
     val jessica = usersFixture.jessica();
 
     // James Checks out Item Copy A
-    checkOutFixture.checkOutByBarcode(itemCopyA, james, DateTime.now(DateTimeZone.UTC));
+    checkOutFixture.checkOutByBarcode(itemCopyA, james, ClockUtil.getDateTime());
 
     // Steve requests Item Copy A
     IndividualResource stevesRequest = requestsFixture.placeHoldShelfRequest(
-      itemCopyA, steve, DateTime.now(DateTimeZone.UTC).minusHours(2), RequestType.RECALL.getValue());
+      itemCopyA, steve, ClockUtil.getDateTime().minusHours(2), RequestType.RECALL.getValue());
 
     assertThat(stevesRequest.getJson().getInteger("position"), is(1));
     assertThat(stevesRequest.getJson().getJsonObject("item").getString("barcode"), is(itemCopyA.getBarcode()));
@@ -750,7 +749,7 @@ class MoveRequestTests extends APITests {
 
     // Jessica requests Item Copy B
     IndividualResource jessicasRequest = requestsFixture.placeHoldShelfRequest(
-      itemCopyB, jessica, DateTime.now(DateTimeZone.UTC).minusHours(1), RequestType.PAGE.getValue());
+      itemCopyB, jessica, ClockUtil.getDateTime().minusHours(1), RequestType.PAGE.getValue());
 
     // Confirm Jessica's request is first on Item Copy B and is a paged request
     assertThat(jessicasRequest.getJson().getInteger("position"), is(1));
@@ -813,19 +812,19 @@ class MoveRequestTests extends APITests {
     IndividualResource steve = usersFixture.steve(); //walker
     IndividualResource jessica = usersFixture.jessica(); //McKenzie
 
-    checkOutFixture.checkOutByBarcode(itemCopyA, james, DateTime.now(DateTimeZone.UTC));
+    checkOutFixture.checkOutByBarcode(itemCopyA, james, ClockUtil.getDateTime());
 
     assertThat(itemsClient.get(itemCopyA).getJson().getJsonObject("status").getString("name"), is(ItemStatus.CHECKED_OUT.getValue()));
 
     // Steve requests Item Copy B
     IndividualResource stevesRequest = requestsFixture.placeHoldShelfRequest(
-      itemCopyB, steve, DateTime.now(DateTimeZone.UTC).minusHours(2), RequestType.PAGE.getValue());
+      itemCopyB, steve, ClockUtil.getDateTime().minusHours(2), RequestType.PAGE.getValue());
 
     assertThat(itemsClient.get(itemCopyB).getJson().getJsonObject("status").getString("name"), is(ItemStatus.PAGED.getValue()));
 
     // Jessica requests Item Copy A
     IndividualResource jessicasRequest = requestsFixture.placeHoldShelfRequest(
-      itemCopyA, jessica, DateTime.now(DateTimeZone.UTC).minusHours(2), RequestType.RECALL.getValue());
+      itemCopyA, jessica, ClockUtil.getDateTime().minusHours(2), RequestType.RECALL.getValue());
 
     requestsFixture.move(new MoveRequestBuilder(stevesRequest.getId(),
       itemCopyA.getId(), RequestType.RECALL.getValue()));
@@ -860,11 +859,12 @@ class MoveRequestTests extends APITests {
   @Test
   void canUpdateSourceAndDestinationLoanDueDateOnMoveRecallRequest() {
     // Recall placed 2 hours from now
-    final Instant expectedJamesLoanDueDate = LocalDateTime
-      .now().plusHours(2).toInstant(ZoneOffset.UTC);
+    final Instant expectedJamesLoanDueDate = Instant.ofEpochMilli(ClockUtil
+      .getDateTime().plusHours(2).toInstant().getMillis());
+
     // Move placed 4 hours from now
-    final Instant expectedJessicaLoanDueDate = LocalDateTime
-      .now().plusHours(4).toInstant(ZoneOffset.UTC);
+    final Instant expectedJessicaLoanDueDate = Instant.ofEpochMilli(ClockUtil
+      .getDateTime().plusHours(4).toInstant().getMillis());
 
     val smallAngryPlanetItem = itemsFixture.basedUponSmallAngryPlanet();
     val interestingTimesItem = itemsFixture.basedUponInterestingTimes();
@@ -1000,18 +1000,18 @@ class MoveRequestTests extends APITests {
     val charlotte = usersFixture.charlotte();
 
     IndividualResource itemCopyALoan = checkOutFixture.checkOutByBarcode(itemCopyA, james,
-      DateTime.now(DateTimeZone.UTC));
+      ClockUtil.getDateTime());
 
     requestsFixture.placeHoldShelfRequest(
-      itemCopyB, jessica, DateTime.now(DateTimeZone.UTC).minusHours(3),
+      itemCopyB, jessica, ClockUtil.getDateTime().minusHours(3),
       RequestType.PAGE.getValue());
 
     IndividualResource recallRequestForItemCopyB = requestsFixture.placeHoldShelfRequest(
-      itemCopyB, steve, DateTime.now(DateTimeZone.UTC).minusHours(2),
+      itemCopyB, steve, ClockUtil.getDateTime().minusHours(2),
       RequestType.RECALL.getValue());
 
     requestsFixture.placeHoldShelfRequest(
-      itemCopyA, charlotte, DateTime.now(DateTimeZone.UTC).minusHours(1),
+      itemCopyA, charlotte, ClockUtil.getDateTime().minusHours(1),
       RequestType.HOLD.getValue());
 
     requestsFixture.move(new MoveRequestBuilder(

--- a/src/test/java/api/requests/scenarios/RecallItemsTests.java
+++ b/src/test/java/api/requests/scenarios/RecallItemsTests.java
@@ -9,8 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 
 import org.folio.circulation.domain.policy.Period;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.Test;
 
 import api.support.APITests;
@@ -31,7 +30,7 @@ class RecallItemsTests extends APITests {
       .rolling(Period.weeks(3)).notRenewable().renewFromSystemDate());
 
     val overrideRenewComment = "Override renew";
-    val newDueDate = DateTime.now(DateTimeZone.UTC).plusMonths(3).toString();
+    val newDueDate = ClockUtil.getDateTime().plusMonths(3).toString();
 
     val item = itemsFixture.basedUponNod();
     val user = usersFixture.james();

--- a/src/test/java/api/requests/scenarios/RequestsServicePointsTests.java
+++ b/src/test/java/api/requests/scenarios/RequestsServicePointsTests.java
@@ -5,19 +5,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.invoke.MethodHandles;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.RequestStatus;
-import api.support.http.IndividualResource;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.Test;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import api.requests.RequestsAPICreationTests;
 import api.support.APITests;
 import api.support.builders.RequestBuilder;
+import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonObject;
 
 class RequestsServicePointsTests extends APITests {
@@ -40,7 +39,7 @@ class RequestsServicePointsTests extends APITests {
     assertThat(requestItem.getString("status"), is(ItemStatus.PAGED.getValue()));
     assertThat(firstRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
 
-    checkInFixture.checkInByBarcode(smallAngryPlanet, DateTime.now(DateTimeZone.UTC), servicePoint.getId());
+    checkInFixture.checkInByBarcode(smallAngryPlanet, ClockUtil.getDateTime(), servicePoint.getId());
 
     MultipleRecords<JsonObject> requests = requestsFixture.getQueueFor(smallAngryPlanet);
     JsonObject pagedRequestRecord = requests.getRecords().iterator().next();
@@ -60,7 +59,7 @@ class RequestsServicePointsTests extends APITests {
       usersFixture, requestsFixture, checkInFixture);
 
     //now, check in at intended service point.
-    checkInFixture.checkInByBarcode(inTransitItem, DateTime.now(DateTimeZone.UTC), requestPickupServicePoint.getId());
+    checkInFixture.checkInByBarcode(inTransitItem, ClockUtil.getDateTime(), requestPickupServicePoint.getId());
     MultipleRecords<JsonObject> requests = requestsFixture.getQueueFor(inTransitItem);
     JsonObject pagedRequestRecord = requests.getRecords().iterator().next();
 
@@ -88,7 +87,7 @@ class RequestsServicePointsTests extends APITests {
     log.info("requestServicePoint" + requestPickupServicePoint.getId());
     log.info("pickupServicePoint" + pickupServicePoint.getId());
 
-    checkInFixture.checkInByBarcode(smallAngryPlanet, DateTime.now(DateTimeZone.UTC), pickupServicePoint.getId());
+    checkInFixture.checkInByBarcode(smallAngryPlanet, ClockUtil.getDateTime(), pickupServicePoint.getId());
 
     MultipleRecords<JsonObject> requests = requestsFixture.getQueueFor(smallAngryPlanet);
     JsonObject pagedRequestRecord = requests.getRecords().iterator().next();

--- a/src/test/java/api/support/APITestContext.java
+++ b/src/test/java/api/support/APITestContext.java
@@ -12,14 +12,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.circulation.Launcher;
 import org.folio.circulation.support.VertxAssistant;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.http.client.VertxWebClientOkapiHttpClient;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import api.support.fakes.FakeOkapi;
 import api.support.fakes.FakeStorageModule;
@@ -34,7 +34,7 @@ public class APITestContext {
   private static String USER_ID = "79ff2a8b-d9c3-5b39-ad4a-0a84025ab085";
 
   private static final String TOKEN = "eyJhbGciOiJIUzUxMiJ9eyJzdWIiOiJhZG1pbiIsInVzZXJfaWQiOiI3OWZmMmE4Yi1kOWMzLTViMzktYWQ0YS0wYTg0MDI1YWIwODUiLCJ0ZW5hbnQiOiJ0ZXN0X3RlbmFudCJ9BShwfHcNClt5ZXJ8ImQTMQtAM1sQEnhsfWNmXGsYVDpuaDN3RVQ9";
-  public static final DateTime END_OF_CURRENT_YEAR_DUE_DATE = DateTime.now(DateTimeZone.UTC)
+  public static final DateTime END_OF_CURRENT_YEAR_DUE_DATE = ClockUtil.getDateTime()
     .withMonthOfYear(12)
     .withDayOfMonth(31)
     .withHourOfDay(23)

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -381,10 +381,8 @@ public abstract class APITests {
   }
 
   protected void mockClockManagerToReturnFixedDateTime(DateTime dateTime) {
-    ClockUtil.setClock(
-      Clock.fixed(
-        Instant.ofEpochMilli(dateTime.getMillis()),
-        ZoneOffset.UTC));
+    ClockUtil.setClock(Clock.fixed(Instant.ofEpochMilli(dateTime.getMillis()),
+      ZoneOffset.UTC));
   }
 
   protected void mockClockManagerToReturnDefaultDateTime() {

--- a/src/test/java/api/support/builders/CalendarBuilder.java
+++ b/src/test/java/api/support/builders/CalendarBuilder.java
@@ -1,19 +1,21 @@
 package api.support.builders;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import api.support.OpeningDayPeriod;
-
-import org.joda.time.DateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collector;
 
+import org.folio.circulation.support.utils.ClockUtil;
+import org.joda.time.DateTime;
+
+import api.support.OpeningDayPeriod;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
 public class CalendarBuilder extends JsonBuilder implements Builder {
 
   private static final String CALENDAR_NAME = "Calendar Name";
-  private static final String START_DATE = DateTime.now().minusMonths(1).toString();
-  private static final String END_DATE = DateTime.now().plusMonths(6).toString();
+  private static final String START_DATE = ClockUtil.getDateTime().minusMonths(1).toString();
+  private static final String END_DATE = ClockUtil.getDateTime().plusMonths(6).toString();
 
   private static final String ID_KEY = "id";
   private static final String SERVICE_POINT_ID_KEY = "servicePointId";

--- a/src/test/java/api/support/builders/ChangeDueDateRequestBuilder.java
+++ b/src/test/java/api/support/builders/ChangeDueDateRequestBuilder.java
@@ -4,8 +4,8 @@ import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
 import java.util.UUID;
 
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import io.vertx.core.json.JsonObject;
 
@@ -14,7 +14,7 @@ public class ChangeDueDateRequestBuilder implements Builder {
   private final String loanId;
 
   public ChangeDueDateRequestBuilder() {
-    this(null, DateTime.now(DateTimeZone.UTC));
+    this(null, ClockUtil.getDateTime());
   }
 
   private ChangeDueDateRequestBuilder(String loanId, DateTime dueDate) {

--- a/src/test/java/api/support/builders/CheckInByBarcodeRequestBuilder.java
+++ b/src/test/java/api/support/builders/CheckInByBarcodeRequestBuilder.java
@@ -2,10 +2,10 @@ package api.support.builders;
 
 import java.util.UUID;
 
-import api.support.http.IndividualResource;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
+import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonObject;
 
 public class CheckInByBarcodeRequestBuilder extends JsonBuilder implements Builder {
@@ -15,7 +15,7 @@ public class CheckInByBarcodeRequestBuilder extends JsonBuilder implements Build
   private final String claimedReturnedResolution;
 
   public CheckInByBarcodeRequestBuilder() {
-    this(null, DateTime.now(DateTimeZone.UTC), null, null);
+    this(null, ClockUtil.getDateTime(), null, null);
   }
 
   private CheckInByBarcodeRequestBuilder(

--- a/src/test/java/api/support/builders/ClaimItemReturnedRequestBuilder.java
+++ b/src/test/java/api/support/builders/ClaimItemReturnedRequestBuilder.java
@@ -4,8 +4,8 @@ import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
 import java.util.UUID;
 
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import io.vertx.core.json.JsonObject;
 
@@ -15,7 +15,7 @@ public class ClaimItemReturnedRequestBuilder implements Builder {
   private final String loanId;
 
   public ClaimItemReturnedRequestBuilder() {
-    this(null, DateTime.now(DateTimeZone.UTC), null);
+    this(null, ClockUtil.getDateTime(), null);
   }
 
   private ClaimItemReturnedRequestBuilder(

--- a/src/test/java/api/support/builders/DeclareItemLostRequestBuilder.java
+++ b/src/test/java/api/support/builders/DeclareItemLostRequestBuilder.java
@@ -4,9 +4,10 @@ import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
 import java.util.UUID;
 
-import io.vertx.core.json.JsonObject;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+
+import io.vertx.core.json.JsonObject;
 
 public class DeclareItemLostRequestBuilder extends JsonBuilder implements Builder {
   private final String loanId;
@@ -15,7 +16,7 @@ public class DeclareItemLostRequestBuilder extends JsonBuilder implements Builde
   private final String servicePointId;
 
   public DeclareItemLostRequestBuilder() {
-    this(null, DateTime.now(DateTimeZone.UTC), null, null);
+    this(null, ClockUtil.getDateTime(), null, null);
   }
 
   public String getLoanId() {
@@ -75,6 +76,6 @@ public class DeclareItemLostRequestBuilder extends JsonBuilder implements Builde
       .forLoanId(loanId)
       .withServicePointId(UUID.randomUUID())
       .withComment("Declaring item lost")
-      .on(DateTime.now(DateTimeZone.UTC));
+      .on(ClockUtil.getDateTime());
   }
 }

--- a/src/test/java/api/support/builders/FixedDueDateSchedule.java
+++ b/src/test/java/api/support/builders/FixedDueDateSchedule.java
@@ -1,5 +1,6 @@
 package api.support.builders;
 
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -49,11 +50,11 @@ public class FixedDueDateSchedule {
   }
 
   public static FixedDueDateSchedule todayOnly() {
-    return forDay(DateTime.now(DateTimeZone.UTC));
+    return forDay(ClockUtil.getDateTime());
   }
 
   public static FixedDueDateSchedule yesterdayOnly() {
-    return forDay(DateTime.now(DateTimeZone.UTC).minusDays(1));
+    return forDay(ClockUtil.getDateTime().minusDays(1));
   }
 
   public static FixedDueDateSchedule forDay(DateTime day) {

--- a/src/test/java/api/support/builders/LoanBuilder.java
+++ b/src/test/java/api/support/builders/LoanBuilder.java
@@ -7,10 +7,11 @@ import java.util.UUID;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.Policies;
 import org.folio.circulation.domain.policy.LoanPolicy;
-import api.support.http.IndividualResource;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
 
+import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonObject;
 
 public class LoanBuilder extends JsonBuilder implements Builder {
@@ -93,7 +94,7 @@ public class LoanBuilder extends JsonBuilder implements Builder {
   public LoanBuilder withRandomPastLoanDate() {
     Random random = new Random();
 
-    return withLoanDate(DateTime.now().minusDays(random.nextInt(10)));
+    return withLoanDate(ClockUtil.getDateTime().minusDays(random.nextInt(10)));
   }
 
   public LoanBuilder withLoanDate(DateTime loanDate) {

--- a/src/test/java/api/support/builders/RequestByInstanceIdRequestBuilder.java
+++ b/src/test/java/api/support/builders/RequestByInstanceIdRequestBuilder.java
@@ -1,11 +1,10 @@
 package api.support.builders;
 
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
-import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTimeZone.UTC;
 
 import java.util.UUID;
 
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 
 import io.vertx.core.json.JsonObject;
@@ -23,7 +22,7 @@ public class RequestByInstanceIdRequestBuilder implements Builder {
   private final String patronComments;
 
   public RequestByInstanceIdRequestBuilder() {
-    this(now(UTC), null, null, now(UTC).plusWeeks(1), null, null);
+    this(ClockUtil.getDateTime(), null, null, ClockUtil.getDateTime().plusWeeks(1), null, null);
   }
 
   @Override

--- a/src/test/java/api/support/fakes/StorageRecordPreProcessors.java
+++ b/src/test/java/api/support/fakes/StorageRecordPreProcessors.java
@@ -19,8 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.folio.circulation.domain.representations.ItemProperties;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.folio.circulation.support.utils.ClockUtil;
 
 import io.vertx.core.json.JsonObject;
 
@@ -61,7 +60,7 @@ public final class StorageRecordPreProcessors {
         if (!Objects.equals(oldItemStatus.getString("name"),
           newItemStatus.getString("name"))) {
           write(newItemStatus, "date",
-            DateTime.now(DateTimeZone.UTC).toString(RMB_DATETIME_PATTERN)
+            ClockUtil.getDateTime().toString(RMB_DATETIME_PATTERN)
           );
         }
       }

--- a/src/test/java/api/support/fixtures/AgeToLostFixture.java
+++ b/src/test/java/api/support/fixtures/AgeToLostFixture.java
@@ -188,7 +188,7 @@ public final class AgeToLostFixture {
   }
 
   private void moveTimeForward(int weeks) {
-    final DateTime newDateTime = now().plusWeeks(weeks);
+    final DateTime newDateTime = ClockUtil.getDateTime().plusWeeks(weeks);
     final Clock fixedClocks = fixed(ofEpochMilli(newDateTime.getMillis()), ZoneOffset.UTC);
 
     ClockUtil.setClock(fixedClocks);

--- a/src/test/java/api/support/fixtures/CheckInFixture.java
+++ b/src/test/java/api/support/fixtures/CheckInFixture.java
@@ -5,14 +5,14 @@ import static api.support.http.InterfaceUrls.checkInByBarcodeUrl;
 
 import java.util.UUID;
 
-import api.support.http.IndividualResource;
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import api.support.CheckInByBarcodeResponse;
 import api.support.RestAssuredClient;
 import api.support.builders.CheckInByBarcodeRequestBuilder;
+import api.support.http.IndividualResource;
 import api.support.http.OkapiHeaders;
 import io.vertx.core.json.JsonObject;
 
@@ -45,7 +45,7 @@ public class CheckInFixture {
   public CheckInByBarcodeResponse checkInByBarcode(IndividualResource item) {
     return checkInByBarcode(new CheckInByBarcodeRequestBuilder()
       .forItem(item)
-      .on(DateTime.now(DateTimeZone.UTC))
+      .on(ClockUtil.getDateTime())
       .at(defaultServicePoint()));
   }
 
@@ -68,7 +68,7 @@ public class CheckInFixture {
   public CheckInByBarcodeResponse checkInByBarcode(IndividualResource item,
     UUID servicePointId) {
 
-    return checkInByBarcode(item, DateTime.now(DateTimeZone.UTC), servicePointId);
+    return checkInByBarcode(item, ClockUtil.getDateTime(), servicePointId);
   }
 
   public void checkInByBarcode(IndividualResource item, DateTime checkInDate,

--- a/src/test/java/api/support/fixtures/DeclareLostFixtures.java
+++ b/src/test/java/api/support/fixtures/DeclareLostFixtures.java
@@ -6,8 +6,7 @@ import static api.support.http.InterfaceUrls.declareLoanItemLostURL;
 import java.util.UUID;
 
 import org.folio.circulation.support.http.client.Response;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.folio.circulation.support.utils.ClockUtil;
 
 import api.support.RestAssuredClient;
 import api.support.builders.DeclareItemLostRequestBuilder;
@@ -44,7 +43,7 @@ public class DeclareLostFixtures {
   public Response declareItemLost(UUID loanId) {
     final DeclareItemLostRequestBuilder builder = new DeclareItemLostRequestBuilder()
       .forLoanId(loanId)
-      .on(DateTime.now(DateTimeZone.UTC))
+      .on(ClockUtil.getDateTime())
       //creating "real" servicepoint data here would require a lot of setup code to
       //initialize a ResourceClient, the intialize a service point creator, and
       //so on.  As this is a convenience function that's only used when the loan

--- a/src/test/java/api/support/fixtures/LoanPoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/LoanPoliciesFixture.java
@@ -3,15 +3,14 @@ package api.support.fixtures;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 
 import org.folio.circulation.domain.policy.Period;
-
-import api.support.http.IndividualResource;
-
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import api.support.builders.FixedDueDateSchedule;
 import api.support.builders.FixedDueDateSchedulesBuilder;
 import api.support.builders.LoanPolicyBuilder;
+import api.support.http.IndividualResource;
 import api.support.http.ResourceClient;
 import io.vertx.core.json.JsonObject;
 
@@ -40,7 +39,7 @@ public class LoanPoliciesFixture {
   }
 
   public IndividualResource createExampleFixedDueDateSchedule() {
-    int currentYear = DateTime.now(DateTimeZone.UTC).getYear();
+    int currentYear = ClockUtil.getDateTime().getYear();
     return createExampleFixedDueDateSchedule(currentYear,
       new DateTime(currentYear, 12, 31, 23, 59, 59, DateTimeZone.UTC));
   }

--- a/src/test/java/api/support/fixtures/LoansFixture.java
+++ b/src/test/java/api/support/fixtures/LoansFixture.java
@@ -17,15 +17,16 @@ import java.net.URL;
 import java.util.UUID;
 
 import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 
 import api.support.MultipleJsonRecords;
 import api.support.RestAssuredClient;
 import api.support.builders.LoanBuilder;
-import api.support.builders.RenewalDueDateRequiredBlockOverrideBuilder;
 import api.support.builders.RenewBlockOverrides;
 import api.support.builders.RenewByBarcodeRequestBuilder;
 import api.support.builders.RenewByIdRequestBuilder;
+import api.support.builders.RenewalDueDateRequiredBlockOverrideBuilder;
 import api.support.http.CqlQuery;
 import api.support.http.IndividualResource;
 import api.support.http.Limit;
@@ -41,7 +42,7 @@ public class LoansFixture {
   }
 
   public IndividualResource createLoan(IndividualResource item, IndividualResource to) {
-    DateTime loanDate = DateTime.now();
+    DateTime loanDate = ClockUtil.getDateTime();
 
     return createLoan(new LoanBuilder()
       .open()

--- a/src/test/java/api/support/fixtures/ProxyRelationshipsFixture.java
+++ b/src/test/java/api/support/fixtures/ProxyRelationshipsFixture.java
@@ -2,10 +2,11 @@ package api.support.fixtures;
 
 import java.util.UUID;
 
-import api.support.http.IndividualResource;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 
 import api.support.builders.ProxyRelationshipBuilder;
+import api.support.http.IndividualResource;
 import api.support.http.ResourceClient;
 
 public class ProxyRelationshipsFixture {
@@ -34,21 +35,21 @@ public class ProxyRelationshipsFixture {
       .sponsor(sponsor.getId())
       .proxy(proxy.getId())
       .inactive()
-      .expires(DateTime.now().plusYears(1)));
+      .expires(ClockUtil.getDateTime().plusYears(1)));
   }
 
   public void currentProxyFor(
     IndividualResource sponsor,
     IndividualResource proxy) {
 
-    proxyFor(sponsor.getId(), proxy.getId(), DateTime.now().plusYears(1));
+    proxyFor(sponsor.getId(), proxy.getId(), ClockUtil.getDateTime().plusYears(1));
   }
 
   public void expiredProxyFor(
     IndividualResource sponsor,
     IndividualResource proxy) {
 
-    proxyFor(sponsor.getId(), proxy.getId(), DateTime.now().minusYears(1));
+    proxyFor(sponsor.getId(), proxy.getId(), ClockUtil.getDateTime().minusYears(1));
   }
 
   private void proxyFor(

--- a/src/test/java/api/support/matchers/TextDateTimeMatcher.java
+++ b/src/test/java/api/support/matchers/TextDateTimeMatcher.java
@@ -47,8 +47,10 @@ public class TextDateTimeMatcher {
 
       @Override
       protected boolean matchesSafely(String textRepresentation) {
+
         //response representation might vary from request representation
-        final var actual = OffsetDateTime.parse(textRepresentation);
+        final var actual = OffsetDateTime.parse(textRepresentation)
+          .truncatedTo(MILLIS);
 
         //The zoned date time could have a higher precision than milliseconds
         //This makes comparison to an ISO formatted date time using milliseconds

--- a/src/test/java/api/support/utl/DateTimeUtils.java
+++ b/src/test/java/api/support/utl/DateTimeUtils.java
@@ -1,13 +1,7 @@
 package api.support.utl;
 
-import static org.joda.time.DateTimeUtils.setCurrentMillisFixed;
-import static org.joda.time.DateTimeUtils.setCurrentMillisSystem;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.function.Supplier;
-
-import org.joda.time.DateTime;
 
 import io.vertx.core.json.JsonObject;
 
@@ -21,12 +15,5 @@ public class DateTimeUtils {
     } else {
       return null;
     }
-  }
-
-  public static <T> T executeWithFixedDateTime(Supplier<T> supplier, DateTime dateTime) {
-    setCurrentMillisFixed(dateTime.getMillis());
-    T result = supplier.get();
-    setCurrentMillisSystem();
-    return result;
   }
 }

--- a/src/test/java/org/folio/circulation/domain/InstanceRequestItemsComparerTests.java
+++ b/src/test/java/org/folio/circulation/domain/InstanceRequestItemsComparerTests.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test
 ;
@@ -95,8 +96,8 @@ class InstanceRequestItemsComparerTests {
     itemQueueSizeMap.put(item2, 2);
 
     Map<Item, DateTime> itemDueDateMap = new LinkedHashMap<>();
-    DateTime item1DueDate = DateTime.now();
-    DateTime item2DueDate = DateTime.now().plusDays(3);
+    DateTime item1DueDate = ClockUtil.getDateTime();
+    DateTime item2DueDate = ClockUtil.getDateTime().plusDays(3);
     itemDueDateMap.put(item1, item1DueDate);
     itemDueDateMap.put(item2, item2DueDate);
 
@@ -116,8 +117,8 @@ class InstanceRequestItemsComparerTests {
     itemQueueSizeMap.put(item2, 2);
 
     Map<Item, DateTime> itemDueDateMap = new LinkedHashMap<>();
-    DateTime item1DueDate = DateTime.now();
-    DateTime item2DueDate = DateTime.now().minusDays(3);
+    DateTime item1DueDate = ClockUtil.getDateTime();
+    DateTime item2DueDate = ClockUtil.getDateTime().minusDays(3);
     itemDueDateMap.put(item1, item1DueDate);
     itemDueDateMap.put(item2, item2DueDate);
 
@@ -137,7 +138,7 @@ class InstanceRequestItemsComparerTests {
     itemQueueSizeMap.put(item2, 2);
 
     Map<Item, DateTime> itemDueDateMap = new LinkedHashMap<>();
-    itemDueDateMap.put(item1, DateTime.now());
+    itemDueDateMap.put(item1, ClockUtil.getDateTime());
     itemDueDateMap.put(item2, null);
 
     Map<Item, Integer> itemIntegerMap = sortRequestQueues(itemQueueSizeMap, itemDueDateMap, null);
@@ -147,7 +148,7 @@ class InstanceRequestItemsComparerTests {
 
     itemDueDateMap.clear();
     itemDueDateMap.put(item1, null);
-    itemDueDateMap.put(item2, DateTime.now());
+    itemDueDateMap.put(item2, ClockUtil.getDateTime());
 
     itemIntegerMap = sortRequestQueues(itemQueueSizeMap, itemDueDateMap, null);
 
@@ -187,7 +188,7 @@ class InstanceRequestItemsComparerTests {
     itemQueueSizeMap.put(item2, 2);
 
     Map<Item, DateTime> itemDueDateMap = new LinkedHashMap<>();
-    DateTime commonDueDate = DateTime.now();
+    DateTime commonDueDate = ClockUtil.getDateTime();
     itemDueDateMap.put(item2, commonDueDate);  //specifically add item2 first and expect that item2 will be first item in the result map.
     itemDueDateMap.put(item1, commonDueDate);
 
@@ -210,7 +211,7 @@ class InstanceRequestItemsComparerTests {
     itemQueueSizeMap.put(item2, 2);
 
     Map<Item, DateTime> itemDueDateMap = new LinkedHashMap<>();
-    DateTime commonDueDate = DateTime.now();
+    DateTime commonDueDate = ClockUtil.getDateTime();
     itemDueDateMap.put(item2, commonDueDate);  //specifically add item2 first and expect that item2 will be first item in the result map.
     itemDueDateMap.put(item1, commonDueDate);
 
@@ -231,7 +232,7 @@ class InstanceRequestItemsComparerTests {
     itemQueueSizeMap.put(item2, 2);
 
     Map<Item, DateTime> itemDueDateMap = new LinkedHashMap<>();
-    DateTime commonDueDate = DateTime.now();
+    DateTime commonDueDate = ClockUtil.getDateTime();
     itemDueDateMap.put(item2, commonDueDate);  //specifically add item2 first and expect that item2 will be first item in the result map.
     itemDueDateMap.put(item1, commonDueDate);
 

--- a/src/test/java/org/folio/circulation/domain/LoanCheckInServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/LoanCheckInServiceTest.java
@@ -1,6 +1,5 @@
 package org.folio.circulation.domain;
 
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -8,7 +7,7 @@ import java.util.Collections;
 import java.util.UUID;
 
 import org.folio.circulation.domain.representations.CheckInByBarcodeRequest;
-import org.joda.time.DateTime;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.Test;
 
 import api.support.builders.CheckInByBarcodeRequestBuilder;
@@ -124,7 +123,7 @@ class LoanCheckInServiceTest {
   private CheckInByBarcodeRequest getCheckInRequest(UUID checkInServicePoint) {
     JsonObject representation = new CheckInByBarcodeRequestBuilder()
       .withItemBarcode("barcode")
-      .on(DateTime.now())
+      .on(ClockUtil.getDateTime())
       .at(checkInServicePoint)
       .create();
 

--- a/src/test/java/org/folio/circulation/domain/LoanLostDateTest.java
+++ b/src/test/java/org/folio/circulation/domain/LoanLostDateTest.java
@@ -3,11 +3,10 @@ package org.folio.circulation.domain;
 import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
-import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.Test;
 
 import api.support.builders.LoanBuilder;
@@ -15,7 +14,7 @@ import api.support.builders.LoanBuilder;
 class LoanLostDateTest {
   @Test
   void declaredLostDateReturnedWhenSet() {
-    final var declaredLostDate = now(UTC);
+    final var declaredLostDate = ClockUtil.getDateTime();
     final var loan = new LoanBuilder().asDomainObject()
       .declareItemLost("Lost", declaredLostDate);
 
@@ -24,7 +23,7 @@ class LoanLostDateTest {
 
   @Test
   void agedToLostDateReturnedWhenSet() {
-    final var agedToLostDate = now(UTC);
+    final var agedToLostDate = ClockUtil.getDateTime();
     final var loan = new LoanBuilder().asDomainObject()
       .ageOverdueItemToLost(agedToLostDate);
 
@@ -33,8 +32,8 @@ class LoanLostDateTest {
 
   @Test
   void declaredLostDateReturnedWhenIsAfterAgedToLostDate() {
-    final var agedToLostDate = now(UTC).minusDays(2);
-    final var declaredLostDate = now(UTC);
+    final var agedToLostDate = ClockUtil.getDateTime().minusDays(2);
+    final var declaredLostDate = ClockUtil.getDateTime();
 
     final var loan = new LoanBuilder().asDomainObject()
       .ageOverdueItemToLost(agedToLostDate)
@@ -50,8 +49,8 @@ class LoanLostDateTest {
 
   @Test
   void agedToLostDateReturnedWhenIsAfterDeclaredLostDate() {
-    final var declaredLostDate = now(UTC).minusDays(3);
-    final var agedToLostDate = now(UTC);
+    final var declaredLostDate = ClockUtil.getDateTime().minusDays(3);
+    final var agedToLostDate = ClockUtil.getDateTime();
 
     final var loan = new LoanBuilder().asDomainObject()
       .ageOverdueItemToLost(agedToLostDate)
@@ -67,7 +66,7 @@ class LoanLostDateTest {
 
   @Test
   void lostDateIsNotNullWhenBothLostDatesAreEqual() {
-    final var lostDate = now(UTC);
+    final var lostDate = ClockUtil.getDateTime();
 
     final var loan = new LoanBuilder().asDomainObject()
       .ageOverdueItemToLost(lostDate)

--- a/src/test/java/org/folio/circulation/domain/OverdueFineCalculatorServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverdueFineCalculatorServiceTest.java
@@ -454,7 +454,7 @@ class OverdueFineCalculatorServiceTest {
       Double maxOverdueRecallFine, Integer periodCalculatorResult, Double correctOverdueFine)
       throws ExecutionException, InterruptedException {
 
-    DateTime dueDateInFuture = DateTime.now(DateTimeZone.UTC).plusDays(1);
+    DateTime dueDateInFuture = ClockUtil.getDateTime().plusDays(1);
     Loan loan = createLoan(overdueFine, overdueFineInterval, overdueRecallFine,
       overdueRecallFineInterval, maxOverdueFine, maxOverdueRecallFine,
       dueDateChangedByRecall).changeDueDate(dueDateInFuture);

--- a/src/test/java/org/folio/circulation/domain/OverduePeriodCalculatorServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverduePeriodCalculatorServiceTest.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.folio.circulation.domain.policy.LoanPolicy;
 import org.folio.circulation.domain.policy.OverdueFinePolicy;
 import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
@@ -44,7 +45,7 @@ class OverduePeriodCalculatorServiceTest {
 
   @Test
   void preconditionsCheckLoanHasNoDueDate() {
-    DateTime systemTime = DateTime.now(UTC);
+    DateTime systemTime = ClockUtil.getDateTime();
     Loan loan = new LoanBuilder().asDomainObject();
 
     assertFalse(calculator.preconditionsAreMet(loan, systemTime, true));
@@ -52,7 +53,7 @@ class OverduePeriodCalculatorServiceTest {
 
   @Test
   void preconditionsCheckLoanDueDateIsInFuture() {
-    DateTime systemTime = DateTime.now(UTC);
+    DateTime systemTime = ClockUtil.getDateTime();
     Loan loan = new LoanBuilder()
       .withDueDate(systemTime.plusDays(1))
       .asDomainObject();
@@ -62,7 +63,7 @@ class OverduePeriodCalculatorServiceTest {
 
   @Test
   void preconditionsCheckCountClosedIsNull() {
-    DateTime systemTime = DateTime.now(UTC);
+    DateTime systemTime = ClockUtil.getDateTime();
     Loan loan = new LoanBuilder()
       .withDueDate(systemTime.minusDays(1))
       .asDomainObject();
@@ -72,7 +73,7 @@ class OverduePeriodCalculatorServiceTest {
 
   @Test
   void allPreconditionsAreMet() {
-    DateTime systemTime = DateTime.now(UTC);
+    DateTime systemTime = ClockUtil.getDateTime();
     Loan loan = new LoanBuilder()
       .withDueDate(systemTime.minusDays(1))
       .asDomainObject();
@@ -83,7 +84,7 @@ class OverduePeriodCalculatorServiceTest {
   @Test
   void countOverdueMinutesWithClosedDays() throws ExecutionException, InterruptedException {
     int expectedResult = MINUTES_PER_WEEK + MINUTES_PER_DAY + MINUTES_PER_HOUR + 1;
-    DateTime systemTime = DateTime.now(UTC);
+    DateTime systemTime = ClockUtil.getDateTime();
 
     Loan loan = new LoanBuilder()
       .withDueDate(systemTime.minusMinutes(expectedResult))
@@ -124,7 +125,7 @@ class OverduePeriodCalculatorServiceTest {
       createOpeningDay(true, new LocalDate("2020-04-09"), LONDON),
       createOpeningDay(false, new LocalDate("2020-04-10"), LONDON));
 
-    LocalTime now = LocalTime.now(UTC);
+    LocalTime now = ClockUtil.getLocalTime();
 
     List<OpeningDay> invalid = Arrays.asList(
       OpeningDay.createOpeningDay(

--- a/src/test/java/org/folio/circulation/domain/ProxyRelationshipTests.java
+++ b/src/test/java/org/folio/circulation/domain/ProxyRelationshipTests.java
@@ -5,7 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 
-import org.joda.time.DateTime;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -41,7 +41,7 @@ class ProxyRelationshipTests {
         .proxy(UUID.randomUUID())
         .sponsor(UUID.randomUUID())
         .active()
-        .expires(DateTime.now().plusWeeks(3))
+        .expires(ClockUtil.getDateTime().plusWeeks(3))
         .useMetaObject(useMetaObject)
         .create());
 
@@ -59,7 +59,7 @@ class ProxyRelationshipTests {
         .proxy(UUID.randomUUID())
         .sponsor(UUID.randomUUID())
         .active()
-        .expires(DateTime.now().minusMonths(2))
+        .expires(ClockUtil.getDateTime().minusMonths(2))
         .useMetaObject(useMetaObject)
         .create());
 
@@ -96,7 +96,7 @@ class ProxyRelationshipTests {
         .proxy(UUID.randomUUID())
         .sponsor(UUID.randomUUID())
         .inactive()
-        .expires(DateTime.now().plusWeeks(3))
+        .expires(ClockUtil.getDateTime().plusWeeks(3))
         .useMetaObject(useMetaObject)
         .create());
 
@@ -115,7 +115,7 @@ class ProxyRelationshipTests {
         .proxy(UUID.randomUUID())
         .sponsor(UUID.randomUUID())
         .inactive()
-        .expires(DateTime.now().minusMonths(2))
+        .expires(ClockUtil.getDateTime().minusMonths(2))
         .useMetaObject(useMetaObject)
         .create());
 

--- a/src/test/java/org/folio/circulation/domain/policy/InvalidLoanPolicyTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/InvalidLoanPolicyTests.java
@@ -13,6 +13,7 @@ import org.folio.circulation.resources.handlers.error.OverridingErrorHandler;
 import org.folio.circulation.resources.renewal.RenewByBarcodeResource;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
@@ -70,7 +71,7 @@ class InvalidLoanPolicyTests {
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
     RenewalContext renewalContext = RenewalContext.create(loan, new JsonObject(), "no-user")
       .withRequestQueue(new RequestQueue(emptyList()));
-    renewByBarcodeResource.regularRenew(renewalContext, errorHandler, DateTime.now());
+    renewByBarcodeResource.regularRenew(renewalContext, errorHandler, ClockUtil.getDateTime());
 
     //TODO: This is fairly ugly, replace with a better message
     assertTrue(errorHandler.getErrors().keySet().stream()

--- a/src/test/java/org/folio/circulation/domain/policy/PeriodTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/PeriodTest.java
@@ -2,12 +2,11 @@ package org.folio.circulation.domain.policy;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -57,7 +56,7 @@ class PeriodTest {
   })
   void hasPassedSinceDateTillNowWhenNowAfterTheDate(String interval, int duration) {
     val period = Period.from(duration, interval);
-    val startDate = now(UTC).minus(period.timePeriod()).minusSeconds(1);
+    val startDate = ClockUtil.getDateTime().minus(period.timePeriod()).minusSeconds(1);
 
     assertTrue(period.hasPassedSinceDateTillNow(startDate));
     assertFalse(period.hasNotPassedSinceDateTillNow(startDate));
@@ -73,7 +72,7 @@ class PeriodTest {
   })
   void hasPassedSinceDateTillNowWhenNowIsTheDate(String interval, int duration) {
     val period = Period.from(duration, interval);
-    val startDate = now(UTC).minus(period.timePeriod());
+    val startDate = ClockUtil.getDateTime().minus(period.timePeriod());
 
     assertTrue(period.hasPassedSinceDateTillNow(startDate));
     assertFalse(period.hasNotPassedSinceDateTillNow(startDate));
@@ -89,7 +88,7 @@ class PeriodTest {
   })
   void hasPassedSinceDateTillNowIsFalse(String interval, int duration) {
     val period = Period.from(duration, interval);
-    val startDate = now(UTC);
+    val startDate = ClockUtil.getDateTime();
 
     assertFalse(period.hasPassedSinceDateTillNow(startDate));
     assertTrue(period.hasNotPassedSinceDateTillNow(startDate));
@@ -105,7 +104,7 @@ class PeriodTest {
   })
   void hasNotPassedSinceDateTillNow(String interval, int duration) {
     val period = Period.from(duration, interval);
-    val startDate = now(UTC).plus(period.timePeriod());
+    val startDate = ClockUtil.getDateTime().plus(period.timePeriod());
 
     assertTrue(period.hasNotPassedSinceDateTillNow(startDate));
     assertFalse(period.hasPassedSinceDateTillNow(startDate));
@@ -121,7 +120,7 @@ class PeriodTest {
   })
   void hasNotPassedSinceDateTillNowIsFalseWhenPassed(String interval, int duration) {
     val period = Period.from(duration, interval);
-    val startDate = now(UTC).minus(period.timePeriod()).minusSeconds(1);
+    val startDate = ClockUtil.getDateTime().minus(period.timePeriod()).minusSeconds(1);
 
     assertFalse(period.hasNotPassedSinceDateTillNow(startDate));
     assertTrue(period.hasPassedSinceDateTillNow(startDate));
@@ -137,7 +136,7 @@ class PeriodTest {
   })
   void isEqualToDateTillNow(String interval, int duration) {
     val period = Period.from(duration, interval);
-    val startDate = now(UTC).minus(period.timePeriod());
+    val startDate = ClockUtil.getDateTime().minus(period.timePeriod());
 
     assertTrue(period.isEqualToDateTillNow(startDate)
       // Sometimes there is difference in mss

--- a/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyRenewalDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/RollingLoanPolicyRenewalDueDateCalculationTests.java
@@ -19,6 +19,7 @@ import org.folio.circulation.resources.handlers.error.OverridingErrorHandler;
 import org.folio.circulation.resources.renewal.RenewByBarcodeResource;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
@@ -191,7 +192,7 @@ class RollingLoanPolicyRenewalDueDateCalculationTests {
     Loan loan = loanFor(loanDate, loanDate, loanPolicy);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
-    renew(loan, DateTime.now(), new RequestQueue(Collections.emptyList()), errorHandler);
+    renew(loan, ClockUtil.getDateTime(), new RequestQueue(Collections.emptyList()), errorHandler);
 
     assertTrue(matchErrorReason(errorHandler,
       "the interval \"Unknown\" in the loan policy is not recognised"));
@@ -213,7 +214,7 @@ class RollingLoanPolicyRenewalDueDateCalculationTests {
     Loan loan = loanFor(loanDate, loanDate, loanPolicy);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
-    renew(loan, DateTime.now(), new RequestQueue(Collections.emptyList()), errorHandler);
+    renew(loan, ClockUtil.getDateTime(), new RequestQueue(Collections.emptyList()), errorHandler);
 
     assertTrue(matchErrorReason(errorHandler, LOAN_PERIOD_IN_THE_LOAN_POLICY_IS_NOT_RECOGNISED));
   }
@@ -234,7 +235,7 @@ class RollingLoanPolicyRenewalDueDateCalculationTests {
     Loan loan = loanFor(loanDate, loanDate, loanPolicy);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
-    renew(loan, DateTime.now(), new RequestQueue(Collections.emptyList()), errorHandler);
+    renew(loan, ClockUtil.getDateTime(), new RequestQueue(Collections.emptyList()), errorHandler);
 
     assertTrue(matchErrorReason(errorHandler, LOAN_PERIOD_IN_THE_LOAN_POLICY_IS_NOT_RECOGNISED));
   }
@@ -255,7 +256,7 @@ class RollingLoanPolicyRenewalDueDateCalculationTests {
     Loan loan = loanFor(loanDate, loanDate, loanPolicy);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
-    renew(loan, DateTime.now(), new RequestQueue(Collections.emptyList()), errorHandler);
+    renew(loan, ClockUtil.getDateTime(), new RequestQueue(Collections.emptyList()), errorHandler);
 
     assertTrue(matchErrorReason(errorHandler, LOAN_PERIOD_IN_THE_LOAN_POLICY_IS_NOT_RECOGNISED));
   }
@@ -278,7 +279,7 @@ class RollingLoanPolicyRenewalDueDateCalculationTests {
     Loan loan = loanFor(loanDate, loanDate, loanPolicy);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
-    renew(loan, DateTime.now(), new RequestQueue(Collections.emptyList()), errorHandler);
+    renew(loan, ClockUtil.getDateTime(), new RequestQueue(Collections.emptyList()), errorHandler);
 
     assertTrue(matchErrorReason(errorHandler,
       String.format("the duration \"%s\" in the loan policy is invalid", duration)));
@@ -303,7 +304,7 @@ class RollingLoanPolicyRenewalDueDateCalculationTests {
     Loan loan = loanFor(loanDate, loanDate.plusDays(15), loanPolicy);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
-    Result<Loan> result = renew(loan, DateTime.now(), new RequestQueue(Collections.emptyList()),
+    Result<Loan> result = renew(loan, ClockUtil.getDateTime(), new RequestQueue(Collections.emptyList()),
       errorHandler);
 
     assertThat(result.value().getDueDate(),
@@ -327,7 +328,7 @@ class RollingLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = loanFor(loanDate, loanDate.plusDays(6), loanPolicy);
 
-    Result<Loan> result = renew(loan, DateTime.now(),
+    Result<Loan> result = renew(loan, ClockUtil.getDateTime(),
       new RequestQueue(Collections.emptyList()), new OverridingErrorHandler(null));
 
     assertThat(result.value().getDueDate(),
@@ -354,7 +355,7 @@ class RollingLoanPolicyRenewalDueDateCalculationTests {
     Loan loan = loanFor(loanDate, loanDate, loanPolicy);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
-    renew(loan, DateTime.now(), new RequestQueue(Collections.emptyList()), errorHandler);
+    renew(loan, ClockUtil.getDateTime(), new RequestQueue(Collections.emptyList()), errorHandler);
 
     assertEquals(1, errorHandler.getErrors().size());
     assertTrue(matchErrorReason(errorHandler, EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
@@ -378,7 +379,7 @@ class RollingLoanPolicyRenewalDueDateCalculationTests {
 
     RequestQueue requestQueue = new RequestQueue(Collections.emptyList());
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
-    renew(loan, DateTime.now(), requestQueue, errorHandler);
+    renew(loan, ClockUtil.getDateTime(), requestQueue, errorHandler);
 
     assertTrue(matchErrorReason(errorHandler, EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));
   }
@@ -400,7 +401,7 @@ class RollingLoanPolicyRenewalDueDateCalculationTests {
     String requestId = UUID.randomUUID().toString();
     RequestQueue requestQueue = creteRequestQueue(requestId, RequestType.RECALL);
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
-    renew(loan, DateTime.now(), requestQueue, errorHandler);
+    renew(loan, ClockUtil.getDateTime(), requestQueue, errorHandler);
 
     assertEquals(2, errorHandler.getErrors().size());
     assertTrue(matchErrorReason(errorHandler, EXPECTED_REASON_DATE_FALLS_OTSIDE_DATE_RANGES));

--- a/src/test/java/org/folio/circulation/domain/policy/UnknownLoanPolicyProfileTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/UnknownLoanPolicyProfileTests.java
@@ -14,6 +14,7 @@ import org.folio.circulation.resources.handlers.error.OverridingErrorHandler;
 import org.folio.circulation.resources.renewal.RenewByBarcodeResource;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
@@ -59,7 +60,7 @@ class UnknownLoanPolicyProfileTests {
       .withLoanPolicy(loanPolicy);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
-    renew(loan, DateTime.now(), new RequestQueue(Collections.emptyList()), errorHandler);
+    renew(loan, ClockUtil.getDateTime(), new RequestQueue(Collections.emptyList()), errorHandler);
 
     assertTrue(errorHandler.getErrors().keySet().stream()
       .map(ValidationErrorFailure.class::cast)

--- a/src/test/java/org/folio/circulation/domain/validation/ChangeDueDateValidatorTest.java
+++ b/src/test/java/org/folio/circulation/domain/validation/ChangeDueDateValidatorTest.java
@@ -14,6 +14,7 @@ import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,7 +53,7 @@ class ChangeDueDateValidatorTest {
     "Aged to lost"
   })
   void canChangeLoanWhenDueDateIsNotChanged(String itemStatus) {
-    val existingLoan = createLoan(itemStatus, DateTime.now());
+    val existingLoan = createLoan(itemStatus, ClockUtil.getDateTime());
 
     changeDueDateValidator = new ChangeDueDateValidator();
 
@@ -67,8 +68,8 @@ class ChangeDueDateValidatorTest {
   }
 
   private Result<LoanAndRelatedRecords> loanAndRelatedRecords(String itemStatus) {
-    val loan = createLoan(itemStatus, DateTime.now());
-    val existingLoan = createLoan(itemStatus, DateTime.now().minusDays(1));
+    val loan = createLoan(itemStatus, ClockUtil.getDateTime());
+    val existingLoan = createLoan(itemStatus, ClockUtil.getDateTime().minusDays(1));
     return succeeded(new LoanAndRelatedRecords(loan, existingLoan));
   }
 

--- a/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/serialization/JsonSchemaValidationTest.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 
 import org.folio.circulation.support.BadRequestFailure;
 import org.folio.circulation.support.results.Result;
-import org.joda.time.DateTime;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.Test;
 
 import api.support.builders.CheckInByBarcodeRequestBuilder;
@@ -31,7 +31,7 @@ class JsonSchemaValidationTest {
 
     final JsonObject checkInRequest = new CheckInByBarcodeRequestBuilder()
       .withItemBarcode("246650492")
-      .on(DateTime.now())
+      .on(ClockUtil.getDateTime())
       .at(UUID.randomUUID())
       .create();
 
@@ -48,7 +48,7 @@ class JsonSchemaValidationTest {
       .withItemId(UUID.randomUUID())
       .withRequesterId(UUID.randomUUID())
       .fulfilToHoldShelf(UUID.randomUUID())
-      .withRequestDate(DateTime.now())
+      .withRequestDate(ClockUtil.getDateTime())
       .create();
 
     assertThat(validator.validate(request.encode()), succeeded());
@@ -62,7 +62,7 @@ class JsonSchemaValidationTest {
 
     write(storageLoanRequest, "itemId", UUID.randomUUID());
     write(storageLoanRequest, "userId", UUID.randomUUID());
-    write(storageLoanRequest, "loanDate", DateTime.now());
+    write(storageLoanRequest, "loanDate", ClockUtil.getDateTime());
     write(storageLoanRequest, "action", "checkedout");
 
     assertThat(validator.validate(storageLoanRequest.encode()), succeeded());
@@ -91,7 +91,7 @@ class JsonSchemaValidationTest {
 
     final JsonObject checkInRequest = new CheckInByBarcodeRequestBuilder()
       .withItemBarcode("246650492")
-      .on(DateTime.now())
+      .on(ClockUtil.getDateTime())
       .atNoServicePoint()
       .create();
 
@@ -111,7 +111,7 @@ class JsonSchemaValidationTest {
 
     final JsonObject checkInRequest = new CheckInByBarcodeRequestBuilder()
       .withItemBarcode("246650492")
-      .on(DateTime.now())
+      .on(ClockUtil.getDateTime())
       .at(UUID.randomUUID())
       .create();
 
@@ -133,7 +133,7 @@ class JsonSchemaValidationTest {
 
     final JsonObject checkInRequest = new CheckInByBarcodeRequestBuilder()
       .withItemBarcode("246650492")
-      .on(DateTime.now())
+      .on(ClockUtil.getDateTime())
       .atNoServicePoint()
       .create();
 

--- a/src/test/java/org/folio/circulation/resources/RenewalValidatorTest.java
+++ b/src/test/java/org/folio/circulation/resources/RenewalValidatorTest.java
@@ -5,10 +5,9 @@ import static api.support.matchers.ResultMatchers.succeeded;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static org.folio.circulation.resources.RenewalValidator.errorWhenEarlierOrSameDueDate;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTimeZone.UTC;
 
 import org.folio.circulation.domain.Loan;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +17,7 @@ import lombok.val;
 class RenewalValidatorTest {
   @Test
   void shouldDisallowRenewalWhenDueDateIsEarlierOrSame() {
-    val dueDate = now(UTC);
+    val dueDate = ClockUtil.getDateTime();
     val proposedDueDate = dueDate.minusWeeks(2);
     val loan = createLoan(dueDate);
 
@@ -30,7 +29,7 @@ class RenewalValidatorTest {
 
   @Test
   void shouldAllowRenewalWhenDueDateAfterCurrentDueDate() {
-    val dueDate = now(UTC);
+    val dueDate = ClockUtil.getDateTime();
     val proposedDueDate = dueDate.plusWeeks(1);
     val loan = createLoan(dueDate);
 

--- a/src/test/java/org/folio/circulation/resources/renewal/RegularRenewalTest.java
+++ b/src/test/java/org/folio/circulation/resources/renewal/RegularRenewalTest.java
@@ -6,8 +6,6 @@ import static org.folio.circulation.domain.ItemStatus.AGED_TO_LOST;
 import static org.folio.circulation.domain.policy.Period.days;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
@@ -24,6 +22,7 @@ import org.folio.circulation.resources.handlers.error.CirculationErrorHandler;
 import org.folio.circulation.resources.handlers.error.OverridingErrorHandler;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -58,7 +57,7 @@ class RegularRenewalTest {
   @Test
   void canRenewLoan() {
     final var rollingPeriod = days(10);
-    final var currentDueDate = now(UTC);
+    final var currentDueDate = ClockUtil.getDateTime();
     final var expectedDueDate = currentDueDate.plus(rollingPeriod.timePeriod());
 
     final var loanPolicy = new LoanPolicyBuilder().rolling(rollingPeriod)
@@ -223,7 +222,7 @@ class RegularRenewalTest {
       .asDomainObject();
 
     final var loan = new LoanBuilder().asDomainObject()
-      .changeDueDate(now(UTC).plusMinutes(rollingPeriod.toMinutes() * 2))
+      .changeDueDate(ClockUtil.getDateTime().plusMinutes(rollingPeriod.toMinutes() * 2))
       .withLoanPolicy(loanPolicy);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
@@ -261,7 +260,7 @@ class RegularRenewalTest {
       .withRequestQueue(new RequestQueue(singletonList(topRequest)));
 
     return new RenewByBarcodeResource(null)
-      .regularRenew(renewalContext, errorHandler, now())
+      .regularRenew(renewalContext, errorHandler, ClockUtil.getDateTime())
       .map(RenewalContext::getLoan);
   }
 
@@ -270,7 +269,7 @@ class RegularRenewalTest {
       .withRequestQueue(new RequestQueue(emptyList()));
 
     return new RenewByBarcodeResource(null)
-      .regularRenew(renewalContext, errorHandler, now())
+      .regularRenew(renewalContext, errorHandler, ClockUtil.getDateTime())
       .map(RenewalContext::getLoan);
   }
 

--- a/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
+++ b/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Location;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 
@@ -519,7 +520,7 @@ class Text2DroolsTest {
   @Test
   void run100() {
     Drools drools = new Drools(Text2Drools.convert(test1));
-    long start = System.currentTimeMillis();
+    long start = ClockUtil.getInstant().getMillis();
     int n = 0;
     while (n < 100) {
       for (String [] s : loanTestCases) {
@@ -528,7 +529,7 @@ class Text2DroolsTest {
         n++;
       }
     }
-    long millis = System.currentTimeMillis() - start;
+    long millis = ClockUtil.getInstant().getMillis() - start;
     float perSecond = 1000f * n / millis;
     log.debug("{} loan policy calculations per second", perSecond);
     assertThat("loan policy calculations per second", perSecond, is(greaterThan(100f)));

--- a/src/test/java/org/folio/circulation/services/LogCheckInServiceTest.java
+++ b/src/test/java/org/folio/circulation/services/LogCheckInServiceTest.java
@@ -17,7 +17,7 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.results.Result;
-import org.joda.time.DateTime;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -63,7 +63,7 @@ class LogCheckInServiceTest {
     JsonObject requestRepresentation = new JsonObject()
       .put("servicePointId", UUID.randomUUID().toString())
       .put("itemBarcode", "barcode")
-      .put("checkInDate", DateTime.now().toString());
+      .put("checkInDate", ClockUtil.getDateTime().toString());
 
     JsonObject itemRepresentation = new JsonObject()
       .put("id", UUID.randomUUID().toString())

--- a/src/test/java/org/folio/circulation/support/http/client/CqlQueryTests.java
+++ b/src/test/java/org/folio/circulation/support/http/client/CqlQueryTests.java
@@ -10,16 +10,15 @@ import static org.folio.circulation.support.http.client.CqlQuery.lessThan;
 import static org.folio.circulation.support.http.client.CqlQuery.notEqual;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.joda.time.DateTime.now;
-import static org.joda.time.DateTimeZone.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 
 import org.folio.circulation.support.CqlSortBy;
 import org.folio.circulation.support.CqlSortClause;
-import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
@@ -92,7 +91,7 @@ class CqlQueryTests {
 
   @Test
   void canApplyLessThenOperator() {
-    DateTime dateTime = now(UTC);
+    DateTime dateTime = ClockUtil.getDateTime();
     Result<CqlQuery> query = lessThan("nextRunTime", dateTime);
 
     assertThat(query.value().asText(), is(format("nextRunTime<\"%s\"", dateTime)));
@@ -100,7 +99,7 @@ class CqlQueryTests {
 
   @Test
   void canApplyGreaterThenOperator() {
-    DateTime dateTime = now(UTC);
+    DateTime dateTime = ClockUtil.getDateTime();
 
     Result<CqlQuery> query = greaterThan("lastTime", dateTime);
 
@@ -109,7 +108,7 @@ class CqlQueryTests {
 
   @Test
   void canApplyNotEqualOperator() {
-    DateTime dateTime = now(UTC);
+    DateTime dateTime = ClockUtil.getDateTime();
     Result<CqlQuery> query = notEqual("lastTime", dateTime);
 
     assertThat(query.value().asText(), is(format("lastTime<>\"%s\"", dateTime)));


### PR DESCRIPTION
A staged approach is being used to implement all of the necessary changes for resolving [CIRC-966](https://issues.folio.org/browse/CIRC-966).

This is Stage 3: For CU & DTU, implement and refactor now() and similar.

## Purpose
Update the project, changing every case where `now()` and any similar operation as a staged approach to migrating from JodaTime to JavaTime. This changeset is isolated to mostly just changes to `now()` for better regression isolation and a more focused review of the change set.

## Approach
Refactor `now()` and similar calls to use the appropriate `ClockUtil` or `DateTimeUtil` methods.

Fix several tests where the clock is not being correctly adjusted.

Fix one test where test is incorrect (originally fixed here: 69ad724614b84a8d9bdeb5ff72727047fc47f1a2).

Always reset the Clock at the end of changing it (such as with `@AfterEach`).
This solves a problem where the changing statically defined Clock in one test could result in the altered Clock being used in a completely different test.

The `runWithFrozenTime()` method is redundant and now wrong.
It is now wrong because it sets the JodaTime internal clock, which is no longer being used as of this commit and going forward.
Remove runWithFrozenTime()` entirely.
Remove `executeWithFixedDateTime()` entirely, for the same reasons.

The matcher should truncate both dates to milliseconds rather than just one of the dates.

## Learning
There were problems observed in performing these changes.

Some tests were observed to be fundamentally incorrect in that they did not actually change the clock when testing based on the clock. The [LoanDueDatesAfterRecallTests.pagedItemRecalledThenLoanedBecomesOverdueAndNextRecallDoesNotChangeDueDate](https://github.com/folio-org/mod-circulation/blob/997863d06c183b5abb539bc54502f17a6cac9bc8/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java#L629) is an example of this.
This tells me that certain test that alter the Clock in Circulation are wrong. The Clock is never actually being changed!
(Tests that set the Clock using `DateTimeUtils.setCurrentMillisFixed()` did work but those methods apply only to JodaTime's internal Clock and is only applicable to JodaTime.)

Fix one test where test is incorrect (originally fixed here: 69ad724614b84a8d9bdeb5ff72727047fc47f1a2).
The original code is testing against the fixed clock, which is set to epoch.
If the date should not update because it is in the future, then the original expected date still remains the expected date.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
