### PR TITLE
CIRC-966: Stage 4, For CU & DTU, start of day and end of day methods.

### DIFF
--- a/src/main/java/org/folio/circulation/domain/OpeningDay.java
+++ b/src/main/java/org/folio/circulation/domain/OpeningDay.java
@@ -5,6 +5,7 @@ import static org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher.
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getBooleanProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getJodaLocalDateProperty;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
+import static org.folio.circulation.support.utils.DateTimeUtil.atStartOfDay;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.joda.time.LocalTime.MIDNIGHT;
 
@@ -107,7 +108,7 @@ public class OpeningDay {
   public JsonObject toJson() {
     final var json = new JsonObject();
 
-    write(json, DATE_KEY, date.toDateTime(MIDNIGHT, UTC));
+    write(json, DATE_KEY, atStartOfDay(date, UTC));
     write(json, ALL_DAY_KEY, allDay);
     write(json, OPEN_KEY, open);
     write(json, OPENING_HOUR_KEY, openingHourToJsonArray());

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -25,13 +25,13 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTime
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getIntegerProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.LocalTime;
 
 import io.vertx.core.json.JsonObject;
 import lombok.AllArgsConstructor;
@@ -348,10 +348,8 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   public Request truncateRequestExpirationDateToTheEndOfTheDay(DateTimeZone zone) {
     DateTime requestExpirationDate = getRequestExpirationDate();
     if (requestExpirationDate != null) {
-      DateTime requestDateTime = requestExpirationDate
-        .withZoneRetainFields(zone)
-        .withTime(LocalTime.MIDNIGHT.minusSeconds(1));
-      write(requestRepresentation, REQUEST_EXPIRATION_DATE, requestDateTime);
+      final DateTime dateTime = atEndOfDay(requestExpirationDate, zone);
+      write(requestRepresentation, REQUEST_EXPIRATION_DATE, dateTime);
     }
     return this;
   }

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -21,7 +21,7 @@ import org.folio.circulation.resources.context.ReorderRequestContext;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.utils.ClockUtil;
-import org.folio.circulation.support.utils.DateTimeUtil;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -299,7 +299,7 @@ public class UpdateRequestQueue {
       .addTo(now, holdShelfExpiryPeriod.getDuration());
 
     if (holdShelfExpiryPeriod.isLongTermPeriod()) {
-      holdShelfExpirationDate = DateTimeUtil.atEndOfTheDay(holdShelfExpirationDate);
+      holdShelfExpirationDate = atEndOfDay(holdShelfExpirationDate);
     }
 
     return holdShelfExpirationDate;

--- a/src/main/java/org/folio/circulation/domain/policy/FixedDueDateSchedules.java
+++ b/src/main/java/org/folio/circulation/domain/policy/FixedDueDateSchedules.java
@@ -4,6 +4,7 @@ import static org.folio.circulation.support.StreamToListMapper.toList;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher.toStream;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,7 +13,6 @@ import java.util.function.Supplier;
 
 import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.results.Result;
-import org.folio.circulation.support.utils.DateTimeUtil;
 import org.joda.time.DateTime;
 
 import io.vertx.core.json.JsonObject;
@@ -49,7 +49,7 @@ public class FixedDueDateSchedules {
   private Predicate<? super JsonObject> isWithin(DateTime date) {
     return schedule -> {
       DateTime from = DateTime.parse(schedule.getString("from"));
-      DateTime to = DateTimeUtil.atEndOfTheDay(DateTime.parse(schedule.getString("to")));
+      DateTime to = atEndOfDay(DateTime.parse(schedule.getString("to")));
 
       return date.isAfter(from) && date.isBefore(to);
     };

--- a/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyUtils.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyUtils.java
@@ -11,11 +11,8 @@ import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.LocalTime;
 
 public final class ClosedLibraryStrategyUtils {
-
-  public static final LocalTime END_OF_A_DAY = LocalTime.MIDNIGHT.minusSeconds(1);
 
   private ClosedLibraryStrategyUtils() {
   }

--- a/src/main/java/org/folio/circulation/domain/policy/library/EndOfCurrentHoursStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/EndOfCurrentHoursStrategy.java
@@ -34,8 +34,6 @@ public class EndOfCurrentHoursStrategy extends ShortTermLoansBaseStrategy {
     return succeeded(currentTimeInterval.getNext().getEndTime());
   }
 
-  public static final LocalTime END_OF_A_DAY = LocalTime.MIDNIGHT.minusSeconds(1);
-
   private boolean hasLibraryRolloverWorkingDay(LibraryTimetable libraryTimetable,
                                                LibraryInterval requestedInterval) {
 

--- a/src/main/java/org/folio/circulation/domain/policy/library/EndOfNextOpenDayStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/EndOfNextOpenDayStrategy.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.domain.policy.library;
 
-import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
 import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.failureForAbsentTimetable;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.succeeded;
 
@@ -25,13 +25,13 @@ public class EndOfNextOpenDayStrategy implements ClosedLibraryStrategy {
   public Result<DateTime> calculateDueDate(DateTime requestedDate, AdjacentOpeningDays openingDays) {
     Objects.requireNonNull(openingDays);
     if (openingDays.getRequestedDay().getOpen()) {
-      return succeeded(
-        requestedDate.withZone(zone).withTime(END_OF_A_DAY));
+      return succeeded(atEndOfDay(requestedDate, zone));
     }
     OpeningDay nextDay = openingDays.getNextDay();
     if (!nextDay.getOpen()) {
       return failed(failureForAbsentTimetable());
     }
-    return succeeded(nextDay.getDate().toDateTime(END_OF_A_DAY, zone));
+
+    return succeeded(atEndOfDay(nextDay.getDate(), zone));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/library/EndOfPreviousDayStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/EndOfPreviousDayStrategy.java
@@ -1,6 +1,6 @@
 package org.folio.circulation.domain.policy.library;
 
-import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.failureForAbsentTimetable;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.succeeded;
@@ -25,12 +25,13 @@ public class EndOfPreviousDayStrategy implements ClosedLibraryStrategy {
   public Result<DateTime> calculateDueDate(DateTime requestedDate, AdjacentOpeningDays openingDays) {
     Objects.requireNonNull(openingDays);
     if (openingDays.getRequestedDay().getOpen()) {
-      return succeeded(requestedDate.withZone(zone).withTime(END_OF_A_DAY));
+      return succeeded(atEndOfDay(requestedDate, zone));
     }
     OpeningDay previousDay = openingDays.getPreviousDay();
     if (!previousDay.getOpen()) {
       return failed(failureForAbsentTimetable());
     }
-    return succeeded(previousDay.getDate().toDateTime(END_OF_A_DAY, zone));
+
+    return succeeded(atEndOfDay(previousDay.getDate(), zone));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/library/EndOfPreviousDayTruncateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/EndOfPreviousDayTruncateStrategy.java
@@ -27,7 +27,6 @@ public class EndOfPreviousDayTruncateStrategy extends EndOfPreviousDayStrategy {
       return failed(failureForAbsentTimetable());
     }
 
-    return succeeded(atEndOfDay(openingDays.getPreviousDay().getDate(),
-      zone));
+    return succeeded(atEndOfDay(openingDays.getPreviousDay().getDate(), zone));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/library/EndOfPreviousDayTruncateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/EndOfPreviousDayTruncateStrategy.java
@@ -1,9 +1,9 @@
 package org.folio.circulation.domain.policy.library;
 
-import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
 import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.failureForAbsentTimetable;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.succeeded;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 
 import java.util.Objects;
 
@@ -27,6 +27,7 @@ public class EndOfPreviousDayTruncateStrategy extends EndOfPreviousDayStrategy {
       return failed(failureForAbsentTimetable());
     }
 
-    return succeeded(openingDays.getPreviousDay().getDate().toDateTime(END_OF_A_DAY, zone));
+    return succeeded(atEndOfDay(openingDays.getPreviousDay().getDate(),
+      zone));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/library/KeepCurrentDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/KeepCurrentDateStrategy.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.domain.policy.library;
 
-import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
 import static org.folio.circulation.support.results.Result.succeeded;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 
 import org.folio.circulation.AdjacentOpeningDays;
 import org.folio.circulation.support.results.Result;
@@ -17,6 +17,6 @@ public class KeepCurrentDateStrategy implements ClosedLibraryStrategy {
 
   @Override
   public Result<DateTime> calculateDueDate(DateTime requestedDate, AdjacentOpeningDays openingDays) {
-    return succeeded(requestedDate.withZoneRetainFields(zone).withTime(END_OF_A_DAY));
+    return succeeded(atEndOfDay(requestedDate, zone));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/library/KeepCurrentDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/KeepCurrentDateStrategy.java
@@ -2,6 +2,7 @@ package org.folio.circulation.domain.policy.library;
 
 import static org.folio.circulation.support.results.Result.succeeded;
 import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
+import static org.joda.time.DateTimeZone.UTC;
 
 import org.folio.circulation.AdjacentOpeningDays;
 import org.folio.circulation.support.results.Result;
@@ -17,6 +18,6 @@ public class KeepCurrentDateStrategy implements ClosedLibraryStrategy {
 
   @Override
   public Result<DateTime> calculateDueDate(DateTime requestedDate, AdjacentOpeningDays openingDays) {
-    return succeeded(atEndOfDay(requestedDate, zone));
+    return succeeded(atEndOfDay(requestedDate, zone).withZone(UTC));
   }
 }

--- a/src/main/java/org/folio/circulation/resources/DueDateNotRealTimeScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/DueDateNotRealTimeScheduledNoticeProcessingResource.java
@@ -2,6 +2,8 @@ package org.folio.circulation.resources;
 
 import static java.lang.Math.max;
 import static org.folio.circulation.support.results.ResultBinding.mapResult;
+import static org.folio.circulation.support.utils.ClockUtil.getDateTime;
+import static org.folio.circulation.support.utils.DateTimeUtil.atStartOfDay;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -23,7 +25,6 @@ import org.folio.circulation.support.CqlSortBy;
 import org.folio.circulation.support.CqlSortClause;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.results.Result;
-import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -57,9 +58,7 @@ public class DueDateNotRealTimeScheduledNoticeProcessingResource extends Schedul
   }
 
   private DateTime startOfTodayInTimeZone(DateTimeZone zone) {
-    return ClockUtil.getDateTime()
-      .withZone(zone)
-      .withTimeAtStartOfDay();
+    return atStartOfDay(getDateTime().withZone(zone));
   }
 
   private CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNotices(
@@ -94,7 +93,7 @@ public class DueDateNotRealTimeScheduledNoticeProcessingResource extends Schedul
       .map(Map.Entry::getValue)
       .collect(Collectors.toList());
 
-    return new GroupedLoanScheduledNoticeHandler(clients, ClockUtil.getDateTime())
+    return new GroupedLoanScheduledNoticeHandler(clients, getDateTime())
       .handleNotices(noticeGroups)
       .thenApply(mapResult(v -> notices));
   }

--- a/src/main/java/org/folio/circulation/support/utils/DateTimeUtil.java
+++ b/src/main/java/org/folio/circulation/support/utils/DateTimeUtil.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.support.utils;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -24,19 +25,6 @@ import org.joda.time.DateTimeZone;
 public class DateTimeUtil {
   private DateTimeUtil() {
     throw new UnsupportedOperationException("Do not instantiate");
-  }
-
-  /**
-   * Convert from DateTime to ZonedDateTime.
-   *
-   * TODO: This should be removed once migrated from JodaTime to JavaTime.
-   *
-   * @param dateTime
-   * @return
-   */
-  public static ZonedDateTime toZonedDateTime(DateTime dateTime) {
-    return java.time.Instant.ofEpochMilli(dateTime.getMillis())
-      .atZone(ZoneId.of(dateTime.getZone().getID()));
   }
 
   /**
@@ -100,7 +88,7 @@ public class DateTimeUtil {
   }
 
   /**
-   * Get the first second of the day.
+   * Get the first second of the year.
    * <p>
    * This operates in the time zone specified by dateTime.
    * <p>
@@ -109,13 +97,27 @@ public class DateTimeUtil {
    * @param dateTime The dateTime to convert.
    * @return The converted dateTime.
    */
-  public static ZonedDateTime atStartOfTheDay(ZonedDateTime dateTime) {
-    return dateTime.withHour(0).withMinute(0).withSecond(0)
-      .truncatedTo(ChronoUnit.SECONDS);
+  public static ZonedDateTime atStartOfYear(ZonedDateTime dateTime) {
+    return atStartOfYear(dateTime, dateTime.getZone());
   }
 
   /**
-   * Get the last second of the day.
+   * Get the first second of the year for the given time zone.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param dateTime The dateTime to convert.
+   * @param zone The time zone to use.
+   * @return The converted dateTime.
+   */
+  public static ZonedDateTime atStartOfYear(ZonedDateTime dateTime, ZoneId zone) {
+    return atStartOfDay(dateTime
+      .withZoneSameInstant(zone)
+      .withDayOfYear(1));
+  }
+
+  /**
+   * Get the last second of the year.
    * <p>
    * This operates in the time zone specified by dateTime.
    * <p>
@@ -124,89 +126,513 @@ public class DateTimeUtil {
    * @param dateTime The dateTime to convert.
    * @return The converted dateTime.
    */
-  public static ZonedDateTime atEndOfTheDay(ZonedDateTime dateTime) {
-    return dateTime.withHour(23).withMinute(59).withSecond(59)
-      .truncatedTo(ChronoUnit.SECONDS);
+  public static ZonedDateTime atEndOfYear(ZonedDateTime dateTime) {
+    return atEndOfYear(dateTime, dateTime.getZone());
   }
 
   /**
-   * Get the first second of the day.
+   * Get the last second of the year for the given time zone.
    * <p>
-   * This operates in the time zone specified by dateTime.
+   * This will truncate to seconds.
+   *
+   * @param dateTime The dateTime to convert.
+   * @param zone The time zone to use.
+   * @return The converted dateTime.
+   */
+  public static ZonedDateTime atEndOfYear(ZonedDateTime dateTime, ZoneId zone) {
+    return atEndOfDay(dateTime
+      .withZoneSameInstant(zone)
+      .withDayOfYear(1)
+      .plusYears(1)
+      .minusDays(1));
+  }
+
+  /**
+   * Get the first second of the year for the given time zone.
    * <p>
    * This will truncate to seconds.
    *
    * @param LocalDate The localDate to convert.
+   * @param zone The time zone to use.
    * @return The converted localDate.
    */
-  public static ZonedDateTime atStartOfTheDay(java.time.LocalDate localDate) {
-    return localDate.atStartOfDay(ClockUtil.getZoneId())
-      .truncatedTo(ChronoUnit.SECONDS);
+  public static ZonedDateTime atStartOfYear(LocalDate localDate, ZoneId zone) {
+    return atStartOfDay(localDate.withDayOfYear(1), zone);
   }
 
   /**
-   * Get the last second of the day.
+   * Get the last second of the year for the given time zone.
    * <p>
    * This operates in the time zone specified by dateTime.
    * <p>
    * This will truncate to seconds.
    *
    * @param dateTime The localDate to convert.
+   * @param zone The time zone to use.
    * @return The converted localDate.
    */
-  public static ZonedDateTime atEndOfTheDay(java.time.LocalDate localDate) {
-    return ZonedDateTime.of(localDate.atTime(23, 59, 59, 0)
-      .truncatedTo(ChronoUnit.SECONDS), ClockUtil.getZoneId());
+  public static ZonedDateTime atEndOfYear(LocalDate localDate, ZoneId zone) {
+    return atEndOfDay(localDate
+      .withDayOfYear(localDate
+        .lengthOfYear()),
+      zone);
   }
 
   /**
-   * Get the first second of the day.
+   * Get the first second of the year.
    *
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
    * @return The converted dateTime.
    */
-  public static DateTime atStartOfTheDay(DateTime dateTime) {
-    return dateTime.withTimeAtStartOfDay();
+  public static DateTime atStartOfYear(DateTime dateTime) {
+    return atStartOfYear(dateTime, dateTime.getZone());
   }
 
   /**
-   * Get the last second of the day.
+   * Get the first second of the year.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The dateTime to convert.
+   * @param zone The time zone to use.
+   * @return The converted dateTime.
+   */
+  public static DateTime atStartOfYear(DateTime dateTime, DateTimeZone zone) {
+    final DateTime zonedDateTime = dateTime.withZone(zone);
+
+    return atStartOfDay(zonedDateTime
+      .withDayOfYear(dateTime
+        .dayOfYear()
+        .getMinimumValue()));
+  }
+
+  /**
+   * Get the last second of the year.
    *
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
    * @return The converted dateTime.
    */
-  public static DateTime atEndOfTheDay(DateTime dateTime) {
-    return dateTime.withTime(23, 59, 59, 0);
+  public static DateTime atEndOfYear(DateTime dateTime) {
+    return atEndOfYear(dateTime, dateTime.getZone());
   }
 
   /**
-   * Get the first second of the day.
+   * Get the last second of the year.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The dateTime to convert.
+   * @param zone The time zone to use.
+   * @return The converted dateTime.
+   */
+  public static DateTime atEndOfYear(DateTime dateTime, DateTimeZone zone) {
+    final DateTime zonedDateTime = dateTime.withZone(zone);
+
+    return atEndOfDay(zonedDateTime
+      .withDayOfYear(zonedDateTime
+        .dayOfYear()
+        .getMaximumValue()));
+  }
+
+  /**
+   * Get the first second of the year.
    *
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param LocalDate The localDate to convert.
+   * @param zone The time zone to use.
    * @return The converted localDate.
    */
-  public static DateTime atStartOfTheDay(org.joda.time.LocalDate localDate) {
-    return localDate.toDateTimeAtStartOfDay();
+  public static DateTime atStartOfYear(org.joda.time.LocalDate localDate, DateTimeZone zone) {
+    return atStartOfDay(localDate, zone)
+      .withDayOfYear(localDate
+        .dayOfYear()
+        .getMinimumValue());
   }
 
   /**
-   * Get the last second of the day.
+   * Get the last second of the year.
    *
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The localDate to convert.
+   * @param zone The time zone to use.
    * @return The converted localDate.
    */
-  public static DateTime atEndOfTheDay(org.joda.time.LocalDate localDate) {
-    return localDate.toDateTime(org.joda.time.LocalTime.now()
-      .withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59)
-      .withMillisOfSecond(0), DateTimeZone.UTC);
+  public static DateTime atEndOfYear(org.joda.time.LocalDate localDate, DateTimeZone zone) {
+    return atEndOfDay(localDate, zone)
+      .withDayOfYear(localDate
+        .dayOfYear()
+        .getMaximumValue());
+  }
+
+  /**
+   * Get the first second of the month.
+   * <p>
+   * This operates in the time zone specified by dateTime.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param dateTime The dateTime to convert.
+   * @return The converted dateTime.
+   */
+  public static ZonedDateTime atStartOfMonth(ZonedDateTime dateTime) {
+    return atStartOfMonth(dateTime, dateTime.getZone());
+  }
+
+  /**
+   * Get the first second of the month for the given time zone.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param dateTime The dateTime to convert.
+   * @param zone The time zone to use.
+   * @return The converted dateTime.
+   */
+  public static ZonedDateTime atStartOfMonth(ZonedDateTime dateTime, ZoneId zone) {
+    return atStartOfDay(dateTime
+      .withZoneSameInstant(zone)
+      .withDayOfMonth(1));
+  }
+
+  /**
+   * Get the last second of the month.
+   * <p>
+   * This operates in the time zone specified by dateTime.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param dateTime The dateTime to convert.
+   * @return The converted dateTime.
+   */
+  public static ZonedDateTime atEndOfMonth(ZonedDateTime dateTime) {
+    return atEndOfMonth(dateTime, dateTime.getZone());
+  }
+
+  /**
+   * Get the last second of the month for the given time zone.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param dateTime The dateTime to convert.
+   * @param zone The time zone to use.
+   * @return The converted dateTime.
+   */
+  public static ZonedDateTime atEndOfMonth(ZonedDateTime dateTime, ZoneId zone) {
+    return atEndOfDay(dateTime
+      .withZoneSameInstant(zone)
+      .withDayOfMonth(1)
+      .plusMonths(1)
+      .minusDays(1));
+  }
+
+  /**
+   * Get the first second of the month for the given time zone.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param LocalDate The localDate to convert.
+   * @param zone The time zone to use.
+   * @return The converted localDate.
+   */
+  public static ZonedDateTime atStartOfMonth(LocalDate localDate, ZoneId zone) {
+    return atStartOfDay(localDate.withDayOfMonth(1), zone);
+  }
+
+  /**
+   * Get the last second of the month for the given time zone.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param dateTime The localDate to convert.
+   * @param zone The time zone to use.
+   * @return The converted localDate.
+   */
+  public static ZonedDateTime atEndOfMonth(LocalDate localDate, ZoneId zone) {
+    return atEndOfDay(localDate
+      .withDayOfMonth(localDate
+        .lengthOfMonth()),
+      zone);
+  }
+
+  /**
+   * Get the first second of the month.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The dateTime to convert.
+   * @return The converted dateTime.
+   */
+  public static DateTime atStartOfMonth(DateTime dateTime) {
+    return atStartOfMonth(dateTime, dateTime.getZone());
+  }
+
+  /**
+   * Get the first second of the month.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The dateTime to convert.
+   * @param zone The time zone to use.
+   * @return The converted dateTime.
+   */
+  public static DateTime atStartOfMonth(DateTime dateTime, DateTimeZone zone) {
+    final DateTime zonedDateTme = dateTime.withZone(zone);
+
+    return atStartOfDay(zonedDateTme
+      .withDayOfMonth(zonedDateTme
+        .dayOfMonth()
+        .getMinimumValue()));
+  }
+
+  /**
+   * Get the last second of the month.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The dateTime to convert.
+   * @return The converted dateTime.
+   */
+  public static DateTime atEndOfMonth(DateTime dateTime) {
+    return atEndOfMonth(dateTime, dateTime.getZone());
+  }
+
+  /**
+   * Get the last second of the month.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The dateTime to convert.
+   * @param zone The time zone to use.
+   * @return The converted dateTime.
+   */
+  public static DateTime atEndOfMonth(DateTime dateTime, DateTimeZone zone) {
+    final DateTime zonedDateTme = dateTime.withZone(zone);
+
+    return atEndOfDay(zonedDateTme
+      .withDayOfMonth(zonedDateTme
+        .dayOfMonth()
+        .getMaximumValue()));
+  }
+
+  /**
+   * Get the first second of the month.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param LocalDate The localDate to convert.
+   * @param zone The time zone to use.
+   * @return The converted localDate.
+   */
+  public static DateTime atStartOfMonth(org.joda.time.LocalDate localDate, DateTimeZone zone) {
+    return atStartOfDay(localDate, zone)
+      .withDayOfMonth(localDate
+        .dayOfMonth()
+        .getMinimumValue());
+  }
+
+  /**
+   * Get the last second of the month.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The localDate to convert.
+   * @param zone The time zone to use.
+   * @return The converted localDate.
+   */
+  public static DateTime atEndOfMonth(org.joda.time.LocalDate localDate, DateTimeZone zone) {
+    return atEndOfDay(localDate, zone)
+      .withDayOfMonth(localDate
+        .dayOfMonth()
+        .getMaximumValue());
+  }
+
+  /**
+   * Get the first second of the day.
+   * <p>
+   * This operates in the time zone specified by dateTime.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param dateTime The dateTime to convert.
+   * @return The converted dateTime.
+   */
+  public static ZonedDateTime atStartOfDay(ZonedDateTime dateTime) {
+    return atStartOfDay(dateTime, dateTime.getZone());
+  }
+
+  /**
+   * Get the first second of the day for the given time zone.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param dateTime The dateTime to convert.
+   * @param zone The time zone to use.
+   * @return The converted dateTime.
+   */
+  public static ZonedDateTime atStartOfDay(ZonedDateTime dateTime, ZoneId zone) {
+    return dateTime
+      .withZoneSameInstant(zone)
+      .withHour(0)
+      .withMinute(0)
+      .withSecond(0)
+      .truncatedTo(ChronoUnit.SECONDS);
+  }
+
+  /**
+   * Get the last second of the day.
+   * <p>
+   * This operates in the time zone specified by dateTime.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param dateTime The dateTime to convert.
+   * @return The converted dateTime.
+   */
+  public static ZonedDateTime atEndOfDay(ZonedDateTime dateTime) {
+    return atEndOfDay(dateTime, dateTime.getZone());
+  }
+
+  /**
+   * Get the last second of the day for the given time zone.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param dateTime The dateTime to convert.
+   * @param zone The time zone to use.
+   * @return The converted dateTime.
+   */
+  public static ZonedDateTime atEndOfDay(ZonedDateTime dateTime, ZoneId zone) {
+    return atStartOfDay(dateTime, zone)
+      .plusDays(1)
+      .minusSeconds(1)
+      .truncatedTo(ChronoUnit.SECONDS);
+  }
+
+  /**
+   * Get the first second of the day for the given time zone.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param LocalDate The localDate to convert.
+   * @param zone The time zone to use.
+   * @return The converted localDate.
+   */
+  public static ZonedDateTime atStartOfDay(LocalDate localDate, ZoneId zone) {
+    return localDate
+      .atStartOfDay(zone)
+      .truncatedTo(ChronoUnit.SECONDS);
+  }
+
+  /**
+   * Get the last second of the day for the given time zone.
+   * <p>
+   * This will truncate to seconds.
+   *
+   * @param dateTime The localDate to convert.
+   * @param zone The time zone to use.
+   * @return The converted localDate.
+   */
+  public static ZonedDateTime atEndOfDay(LocalDate localDate, ZoneId zone) {
+    return atStartOfDay(localDate, zone)
+      .plusDays(1)
+      .minusSeconds(1)
+      .truncatedTo(ChronoUnit.SECONDS);
+  }
+
+  /**
+   * Get the first second of the day.
+   * <p>
+   * This operates in the time zone specified by dateTime.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The dateTime to convert.
+   * @return The converted dateTime.
+   */
+  public static DateTime atStartOfDay(DateTime dateTime) {
+    return atStartOfDay(dateTime, dateTime.getZone());
+  }
+
+  /**
+   * Get the first second of the day for the given time zone.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The dateTime to convert.
+   * @param zone The time zone to use.
+   * @return The converted dateTime.
+   */
+  public static DateTime atStartOfDay(DateTime dateTime, DateTimeZone zone) {
+    return dateTime
+      .withZone(zone)
+      .withTimeAtStartOfDay()
+      .withMillisOfSecond(0);
+  }
+
+  /**
+   * Get the last second of the day.
+   * <p>
+   * This operates in the time zone specified by dateTime.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The dateTime to convert.
+   * @return The converted dateTime.
+   */
+  public static DateTime atEndOfDay(DateTime dateTime) {
+    return atEndOfDay(dateTime, dateTime.getZone());
+  }
+
+  /**
+   * Get the last second of the day for the given time zone.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The dateTime to convert.
+   * @param zone The time zone to use.
+   * @return The converted dateTime.
+   */
+  public static DateTime atEndOfDay(DateTime dateTime, DateTimeZone zone) {
+    return atStartOfDay(dateTime, zone)
+      .plusDays(1)
+      .minusSeconds(1)
+      .withMillisOfSecond(0);
+  }
+
+  /**
+   * Get the first second of the day for the given time zone.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param LocalDate The localDate to convert.
+   * @param zone The time zone to use.
+   * @return The converted localDate.
+   */
+  public static DateTime atStartOfDay(org.joda.time.LocalDate localDate, DateTimeZone zone) {
+    return localDate
+      .toDateTimeAtStartOfDay(zone)
+      .withMillisOfSecond(0);
+  }
+
+  /**
+   * Get the last second of the day for the given time zone.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The localDate to convert.
+   * @param zone The time zone to use.
+   * @return The converted localDate.
+   */
+  public static DateTime atEndOfDay(org.joda.time.LocalDate localDate, DateTimeZone zone) {
+    return atStartOfDay(localDate, zone)
+      .plusDays(1)
+      .minusSeconds(1)
+      .withMillisOfSecond(0);
   }
 
   /**
@@ -238,6 +664,19 @@ public class DateTimeUtil {
   }
 
   /**
+   * Convert from DateTime to ZonedDateTime.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param dateTime The JodaTime DateTime to convert from.
+   * @return The converted dateTime.
+   */
+  public static ZonedDateTime toZonedDateTime(DateTime dateTime) {
+    return java.time.Instant.ofEpochMilli(dateTime.getMillis())
+      .atZone(ZoneId.of(dateTime.getZone().getID()));
+  }
+
+  /**
    * Convert the JodaTime DateTime to JavaTime OffsetDateTime.
    *
    * TODO: Remove this after migrating from JodaTime to JavaTime.
@@ -248,61 +687,8 @@ public class DateTimeUtil {
   public static OffsetDateTime toOffsetDateTime(DateTime dateTime) {
     final var instant = java.time.Instant.ofEpochMilli(dateTime.getMillis());
 
-    return OffsetDateTime.ofInstant(instant, ZoneId.of(dateTime.getZone().getID()));
-  }
-
-  /**
-   * Convert the Local Date Time to a dateTime.
-   *
-   * TODO: This is temporarily designed to work with JodaTime. Replace this as
-   * appropriate when migrating from JodaTime to JavaTime.
-   *
-   * @param date The date to convert.
-   * @param time The time to convert.
-   * @return The converted dateTime.
-   */
-  public static DateTime toDateTime(org.joda.time.LocalDate date, org.joda.time.LocalTime time) {
-    return date.toDateTime(time, ClockUtil.getDateTimeZone());
-  }
-
-  /**
-   * Convert the Local Date Time to a dateTime set to UTC.
-   *
-   * TODO: This is temporarily designed to work with JodaTime. Replace this as
-   * appropriate when migrating from JodaTime to JavaTime.
-   *
-   * @param date The date to convert.
-   * @param time The time to convert.
-   * @return The converted dateTime.
-   */
-  public static DateTime toUtcDateTime(org.joda.time.LocalDate date, org.joda.time.LocalTime time) {
-    return date.toDateTime(time, DateTimeZone.UTC);
-  }
-
-  /**
-   * Get the start of the day in the time zone of the current Clock.
-   *
-   * TODO: This is temporarily designed to work with JodaTime. Replace this as
-   * appropriate when migrating from JodaTime to JavaTime.
-   *
-   * @param localDate The local date to convert from.
-   * @return The converted dateTime.
-   */
-  public static DateTime toStartOfDayDateTime(org.joda.time.LocalDate date) {
-    return date.toDateTimeAtStartOfDay();
-  }
-
-  /**
-   * Get the start of the day in the UTC.
-   *
-   * TODO: This is temporarily designed to work with JodaTime. Replace this as
-   * appropriate when migrating from JodaTime to JavaTime.
-   *
-   * @param localDate The local date to convert from.
-   * @return The converted dateTime.
-   */
-  public static DateTime toUtcStartOfDayDateTime(org.joda.time.LocalDate date) {
-    return date.toDateTimeAtStartOfDay(DateTimeZone.UTC);
+    return OffsetDateTime.ofInstant(instant,
+      ZoneId.of(dateTime.getZone().getID()));
   }
 
 }

--- a/src/test/java/api/loans/CheckOutByBarcodeFixedDueDateScenariosTest.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeFixedDueDateScenariosTest.java
@@ -1,27 +1,29 @@
 package api.loans;
 
-import api.support.APITests;
-import api.support.builders.CheckOutByBarcodeRequestBuilder;
-import api.support.builders.FixedDueDateSchedulesBuilder;
-import api.support.builders.LoanPolicyBuilder;
-import org.folio.circulation.domain.policy.DueDateManagement;
-import org.folio.circulation.domain.policy.Period;
-import api.support.http.IndividualResource;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeConstants;
-import org.joda.time.DateTimeZone;
-import org.junit.jupiter.api.Test;
-
-import java.util.UUID;
-
 import static api.support.builders.FixedDueDateSchedule.wholeMonth;
 import static api.support.fixtures.CalendarExamples.CASE_FRI_SAT_MON_SERVICE_POINT_CURR_DAY;
 import static api.support.fixtures.CalendarExamples.CASE_FRI_SAT_MON_SERVICE_POINT_ID;
 import static api.support.fixtures.CalendarExamples.CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY;
 import static api.support.fixtures.CalendarExamples.CASE_FRI_SAT_MON_SERVICE_POINT_PREV_DAY;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
-import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
+import static org.folio.circulation.support.utils.DateTimeUtil.atStartOfDay;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.joda.time.DateTimeZone.UTC;
+
+import java.util.UUID;
+
+import org.folio.circulation.domain.policy.DueDateManagement;
+import org.folio.circulation.domain.policy.Period;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeConstants;
+import org.junit.jupiter.api.Test;
+
+import api.support.APITests;
+import api.support.builders.CheckOutByBarcodeRequestBuilder;
+import api.support.builders.FixedDueDateSchedulesBuilder;
+import api.support.builders.LoanPolicyBuilder;
+import api.support.http.IndividualResource;
 
 /**
  * Test cases for scenarios when due date calculated by CLDDM
@@ -37,10 +39,10 @@ class CheckOutByBarcodeFixedDueDateScenariosTest extends APITests {
     UUID checkoutServicePointId = UUID.fromString(CASE_FRI_SAT_MON_SERVICE_POINT_ID);
 
     DateTime loanDate =
-      new DateTime(2019, DateTimeConstants.JANUARY, 25, 10, 0, DateTimeZone.UTC);
+      new DateTime(2019, DateTimeConstants.JANUARY, 25, 10, 0, UTC);
 
     DateTime limitDueDate =
-      CASE_FRI_SAT_MON_SERVICE_POINT_CURR_DAY.toDateTimeAtStartOfDay(DateTimeZone.UTC);
+      atStartOfDay(CASE_FRI_SAT_MON_SERVICE_POINT_CURR_DAY, UTC);
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
       .withName("Fixed Due Date Schedule")
       .addSchedule(wholeMonth(2019, DateTimeConstants.JANUARY, limitDueDate));
@@ -63,8 +65,8 @@ class CheckOutByBarcodeFixedDueDateScenariosTest extends APITests {
         .on(loanDate));
 
     DateTime expectedDate =
-      CASE_FRI_SAT_MON_SERVICE_POINT_PREV_DAY
-        .toDateTime(END_OF_A_DAY, DateTimeZone.UTC);
+      atEndOfDay(CASE_FRI_SAT_MON_SERVICE_POINT_PREV_DAY, UTC);
+
     assertThat("due date should be " + expectedDate,
       loan.getJson().getString("dueDate"), isEquivalentTo(expectedDate));
   }
@@ -77,10 +79,10 @@ class CheckOutByBarcodeFixedDueDateScenariosTest extends APITests {
     UUID checkoutServicePointId = UUID.fromString(CASE_FRI_SAT_MON_SERVICE_POINT_ID);
 
     DateTime loanDate =
-      new DateTime(2019, DateTimeConstants.JANUARY, 25, 10, 0, DateTimeZone.UTC);
+      new DateTime(2019, DateTimeConstants.JANUARY, 25, 10, 0, UTC);
 
     DateTime limitDueDate =
-      CASE_FRI_SAT_MON_SERVICE_POINT_CURR_DAY.toDateTimeAtStartOfDay(DateTimeZone.UTC);
+      atStartOfDay(CASE_FRI_SAT_MON_SERVICE_POINT_CURR_DAY, UTC);
 
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
       .withName("Fixed Due Date Schedule")
@@ -103,12 +105,11 @@ class CheckOutByBarcodeFixedDueDateScenariosTest extends APITests {
         .on(loanDate));
 
     DateTime expectedDate =
-      CASE_FRI_SAT_MON_SERVICE_POINT_PREV_DAY
-        .toDateTime(END_OF_A_DAY, DateTimeZone.UTC);
+      atEndOfDay(CASE_FRI_SAT_MON_SERVICE_POINT_PREV_DAY, UTC);
+
     assertThat("due date should be " + expectedDate,
       loan.getJson().getString("dueDate"), isEquivalentTo(expectedDate));
   }
-
 
   @Test
   void shouldUseSelectedClosedLibraryStrategyWhenDueDateDoesNotExtendBeyondFixedDueDate() {
@@ -118,11 +119,10 @@ class CheckOutByBarcodeFixedDueDateScenariosTest extends APITests {
     UUID checkoutServicePointId = UUID.fromString(CASE_FRI_SAT_MON_SERVICE_POINT_ID);
 
     DateTime loanDate =
-      new DateTime(2019, DateTimeConstants.JANUARY, 25, 10, 0, DateTimeZone.UTC);
+      new DateTime(2019, DateTimeConstants.JANUARY, 25, 10, 0, UTC);
 
     DateTime limitDueDate =
-      CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY
-        .toDateTimeAtStartOfDay(DateTimeZone.UTC);
+      atStartOfDay(CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY, UTC);
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
       .withName("Fixed Due Date Schedule")
       .addSchedule(wholeMonth(2019, DateTimeConstants.JANUARY, limitDueDate));
@@ -145,8 +145,8 @@ class CheckOutByBarcodeFixedDueDateScenariosTest extends APITests {
         .on(loanDate));
 
     DateTime expectedDate =
-      CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY
-        .toDateTime(END_OF_A_DAY, DateTimeZone.UTC);
+      atEndOfDay(CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY, UTC);
+
     assertThat("due date should be " + expectedDate,
       loan.getJson().getString("dueDate"), isEquivalentTo(expectedDate));
   }

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -52,6 +52,8 @@ import static org.folio.circulation.domain.policy.Period.months;
 import static org.folio.circulation.domain.representations.ItemProperties.CALL_NUMBER_COMPONENTS;
 import static org.folio.circulation.domain.representations.logs.LogEventType.CHECK_OUT;
 import static org.folio.circulation.domain.representations.logs.LogEventType.CHECK_OUT_THROUGH_OVERRIDE;
+import static org.folio.circulation.support.utils.ClockUtil.getDateTime;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -74,7 +76,6 @@ import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.domain.representations.logs.LogEventType;
 import org.folio.circulation.support.http.client.Response;
-import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalTime;
@@ -269,7 +270,9 @@ class CheckOutByBarcodeTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    final DateTime loanDate = ClockUtil.getDateTime()
+    final DateTime loanDate = atEndOfDay(getDateTime());
+
+    getDateTime()
       .withMonthOfYear(3)
       .withDayOfMonth(18)
       .withHourOfDay(11)
@@ -373,7 +376,7 @@ class CheckOutByBarcodeTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    final DateTime requestDate = ClockUtil.getDateTime();
+    final DateTime requestDate = getDateTime();
 
     final IndividualResource response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -1331,7 +1334,7 @@ class CheckOutByBarcodeTests extends APITests {
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
         .to(steve)
-        .on(ClockUtil.getDateTime())
+        .on(getDateTime())
         .at(UUID.randomUUID()));
 
     final JsonObject loan = response.getJson();
@@ -1377,7 +1380,7 @@ class CheckOutByBarcodeTests extends APITests {
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
         .to(steve)
-        .on(ClockUtil.getDateTime())
+        .on(getDateTime())
         .at(UUID.randomUUID()));
 
     final JsonObject loan = response.getJson();
@@ -1422,7 +1425,7 @@ class CheckOutByBarcodeTests extends APITests {
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
         .to(steve)
-        .on(ClockUtil.getDateTime())
+        .on(getDateTime())
         .at(UUID.randomUUID()));
 
     assertThat(response.getBody(), containsString(
@@ -1444,7 +1447,7 @@ class CheckOutByBarcodeTests extends APITests {
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
         .to(steve)
-        .on(ClockUtil.getDateTime())
+        .on(getDateTime())
         .at(UUID.randomUUID()));
 
     usersFixture.remove(steve);

--- a/src/test/java/api/loans/CheckOutCalculateDueDateTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateDueDateTests.java
@@ -29,9 +29,9 @@ import static org.folio.circulation.domain.policy.DueDateManagement.MOVE_TO_BEGI
 import static org.folio.circulation.domain.policy.DueDateManagement.MOVE_TO_THE_END_OF_THE_NEXT_OPEN_DAY;
 import static org.folio.circulation.domain.policy.DueDateManagement.MOVE_TO_THE_END_OF_THE_PREVIOUS_OPEN_DAY;
 import static org.folio.circulation.domain.policy.LoanPolicyPeriod.HOURS;
-import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
-import static org.folio.circulation.support.utils.DateTimeUtil.toStartOfDayDateTime;
-import static org.folio.circulation.support.utils.DateTimeUtil.toUtcDateTime;
+import static org.folio.circulation.support.utils.ClockUtil.getDateTime;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
+import static org.folio.circulation.support.utils.DateTimeUtil.atStartOfDay;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
@@ -46,7 +46,6 @@ import org.folio.circulation.domain.OpeningHour;
 import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.http.client.Response;
-import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
@@ -172,7 +171,7 @@ class CheckOutCalculateDueDateTests extends APITests {
         .at(checkoutServicePointId));
 
     assertThat(response.getDueDate(),
-      isEquivalentTo(WEDNESDAY_DATE.toDateTime(END_OF_A_DAY, UTC)));
+      isEquivalentTo(atEndOfDay(WEDNESDAY_DATE, UTC)));
   }
 
   /**
@@ -201,7 +200,7 @@ class CheckOutCalculateDueDateTests extends APITests {
         .at(checkoutServicePointId));
 
     assertThat(response.getDueDate(),
-      isEquivalentTo(WEDNESDAY_DATE.toDateTime(END_OF_A_DAY, UTC)));
+      isEquivalentTo(atEndOfDay(WEDNESDAY_DATE, UTC)));
   }
 
   /**
@@ -230,7 +229,8 @@ class CheckOutCalculateDueDateTests extends APITests {
         .to(steve)
         .at(checkoutServicePointId));
 
-    assertThat(response.getDueDate(), isEquivalentTo(FRIDAY_DATE.toDateTime(END_OF_A_DAY, UTC)));
+    assertThat(response.getDueDate(),isEquivalentTo(
+      atEndOfDay(FRIDAY_DATE, UTC)));
   }
 
   /**
@@ -258,7 +258,8 @@ class CheckOutCalculateDueDateTests extends APITests {
         .to(steve)
         .at(checkoutServicePointId));
 
-    assertThat(response.getDueDate(), isEquivalentTo(FRIDAY_DATE.toDateTime(END_OF_A_DAY, UTC)));
+    assertThat(response.getDueDate(), isEquivalentTo(
+      atEndOfDay(FRIDAY_DATE, UTC)));
   }
 
   /**
@@ -689,7 +690,9 @@ class CheckOutCalculateDueDateTests extends APITests {
     }
 
     LocalTime localTime = Objects.isNull(newOffsetTime) ? offsetTime.withMinuteOfHour(0) : newOffsetTime;
-    return toUtcDateTime(currentDate, isInPeriod ? localTime : offsetTime);
+
+    return atStartOfDay(currentDate, UTC)
+      .withTime(isInPeriod ? localTime : offsetTime);
   }
 
   private DateTime getStartDateTimeOpeningDayRollover(List<OpeningDayPeriod> openingDays, String interval, int duration) {
@@ -711,11 +714,13 @@ class CheckOutCalculateDueDateTests extends APITests {
           LocalDate localDate = nextOpeningDay.getDate();
 
           if (nextOpeningDay.getAllDay()) {
-            return toUtcDateTime(localDate, MIDNIGHT);
+            return atStartOfDay(localDate, UTC)
+              .withTime(MIDNIGHT);
           } else {
             OpeningHour openingHour = nextOpeningDay.getOpeningHour().get(0);
-            LocalTime startTime = openingHour.getStartTime();
-            return toUtcDateTime(localDate, startTime);
+
+            return atStartOfDay(localDate, UTC)
+              .withTime(openingHour.getStartTime());
           }
         }
       }
@@ -725,7 +730,7 @@ class CheckOutCalculateDueDateTests extends APITests {
 
       if (currentOpeningDay.getOpen()) {
         if (currentOpeningDay.getAllDay()) {
-          DateTime currentEndDateTime = currentDate.toDateTime(END_OF_A_DAY);
+          DateTime currentEndDateTime = atEndOfDay(currentDate, UTC);
           DateTime offsetDateTime = currentDate.toDateTime(TEST_TIME_MORNING)
               .plusMinutes(duration);
 
@@ -736,27 +741,32 @@ class CheckOutCalculateDueDateTests extends APITests {
             LocalDate nextDate = nextOpeningDay.getDate();
 
             if (nextOpeningDay.getAllDay()) {
-              return toUtcDateTime(nextDate, MIDNIGHT);
+              return atStartOfDay(nextDate, UTC)
+                .withTime(MIDNIGHT);
             } else {
               OpeningHour openingHour = nextOpeningDay.getOpeningHour().get(0);
-              LocalTime startTime = openingHour.getStartTime();
-              return toUtcDateTime(nextDate, startTime);
+
+              return atStartOfDay(nextDate, UTC)
+                .withTime(openingHour.getStartTime());
             }
           }
         } else {
           LocalTime offsetTime = TEST_TIME_MORNING.plusMinutes(duration);
           if (isInPeriodOpeningDay(currentOpeningDay.getOpeningHour(), offsetTime)) {
-            return toUtcDateTime(currentDate, offsetTime);
+            return atStartOfDay(currentDate, UTC)
+              .withTime(offsetTime);
           } else {
             OpeningDay nextOpeningDay = nextDayPeriod.getOpeningDay();
             LocalDate nextDate = nextOpeningDay.getDate();
 
             if (nextOpeningDay.getAllDay()) {
-              return toUtcDateTime(nextDate, MIDNIGHT);
+              return atStartOfDay(nextDate, UTC)
+                .withTime(MIDNIGHT);
             } else {
               OpeningHour openingHour = nextOpeningDay.getOpeningHour().get(0);
-              LocalTime startTime = openingHour.getStartTime();
-              return toUtcDateTime(nextDate, startTime);
+
+              return atStartOfDay(nextDate, UTC)
+                .withTime(openingHour.getStartTime());
             }
           }
         }
@@ -765,11 +775,13 @@ class CheckOutCalculateDueDateTests extends APITests {
         LocalDate nextDate = nextOpeningDay.getDate();
 
         if (nextOpeningDay.getAllDay()) {
-          return toUtcDateTime(nextDate, MIDNIGHT);
+          return atStartOfDay(nextDate, UTC)
+            .withTime(MIDNIGHT);
         }
         OpeningHour openingHour = nextOpeningDay.getOpeningHour().get(0);
-        LocalTime startTime = openingHour.getStartTime();
-        return toUtcDateTime(nextDate, startTime);
+
+        return atStartOfDay(nextDate, UTC)
+          .withTime(openingHour.getStartTime());
       }
     }
   }
@@ -800,8 +812,7 @@ class CheckOutCalculateDueDateTests extends APITests {
   }
 
   private DateTime getEndDateTimeOpeningDay(OpeningDay openingDay) {
-    LocalDate date = openingDay.getDate();
-    return date.toDateTime(END_OF_A_DAY, UTC);
+    return atEndOfDay(openingDay.getDate(), UTC);
   }
 
   private DateTime getStartDateTimeOpeningDay(OpeningDay openingDay) {
@@ -809,16 +820,17 @@ class CheckOutCalculateDueDateTests extends APITests {
     LocalDate date = openingDay.getDate();
 
     if (allDay) {
-      return toStartOfDayDateTime(date);
+      return atStartOfDay(date, UTC);
     } else {
       List<OpeningHour> openingHours = openingDay.getOpeningHour();
-
       if (openingHours.isEmpty()) {
-        return toStartOfDayDateTime(date);
+        return atStartOfDay(date, UTC);
       }
+
       OpeningHour openingHour = openingHours.get(0);
-      LocalTime localTime = openingHour.getStartTime();
-      return toUtcDateTime(date, localTime);
+
+      return atStartOfDay(date, UTC)
+        .withTime(openingHour.getStartTime());
     }
   }
 
@@ -873,7 +885,8 @@ class CheckOutCalculateDueDateTests extends APITests {
   private DateTime currentYearDateTime(int month, int day, int hour, int minute,
     int second, DateTimeZone zone) {
 
-    return ClockUtil.getDateTime().withZone(zone)
+    return getDateTime()
+      .withZone(zone)
       .withMonthOfYear(month)
       .withDayOfMonth(day)
       .withHourOfDay(hour)

--- a/src/test/java/api/loans/CheckOutCalculateDueDateTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateDueDateTests.java
@@ -714,8 +714,7 @@ class CheckOutCalculateDueDateTests extends APITests {
           LocalDate localDate = nextOpeningDay.getDate();
 
           if (nextOpeningDay.getAllDay()) {
-            return atStartOfDay(localDate, UTC)
-              .withTime(MIDNIGHT);
+            return atStartOfDay(localDate, UTC);
           } else {
             OpeningHour openingHour = nextOpeningDay.getOpeningHour().get(0);
 

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -48,9 +48,10 @@ import static org.folio.circulation.domain.policy.DueDateManagement.MOVE_TO_BEGI
 import static org.folio.circulation.domain.policy.DueDateManagement.MOVE_TO_END_OF_CURRENT_SERVICE_POINT_HOURS;
 import static org.folio.circulation.domain.policy.DueDateManagement.MOVE_TO_THE_END_OF_THE_NEXT_OPEN_DAY;
 import static org.folio.circulation.domain.policy.DueDateManagement.MOVE_TO_THE_END_OF_THE_PREVIOUS_OPEN_DAY;
-import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE_ERROR;
+import static org.folio.circulation.support.utils.ClockUtil.getDateTime;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -74,7 +75,6 @@ import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.server.ValidationError;
-import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.Is;
 import org.joda.time.DateTime;
@@ -137,13 +137,13 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-            new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+            new DateTime(2018, 4, 21, 11, 21, 43, UTC));
     final UUID loanId = loan
       .getId();
 
     //TODO: Renewal based upon system date,
     // needs to be approximated, at least until we introduce a calendar and clock
-    DateTime approximateRenewalDate = ClockUtil.getDateTime();
+    DateTime approximateRenewalDate = getDateTime();
 
     final JsonObject renewedLoan = renew(smallAngryPlanet, jessica).getJson();
 
@@ -183,7 +183,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     final UUID loanId = loan.getId();
 
@@ -220,7 +220,7 @@ public abstract class RenewalAPITests extends APITests {
 
     assertThat("due date should be 2 months after initial due date date",
       renewedLoan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, 7, 12, 11, 21, 43, DateTimeZone.UTC)));
+      isEquivalentTo(new DateTime(2018, 7, 12, 11, 21, 43, UTC)));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 
@@ -249,7 +249,7 @@ public abstract class RenewalAPITests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    final DateTime loanDate = new DateTime(2018, 3, 7, 11, 43, 54, DateTimeZone.UTC);
+    final DateTime loanDate = new DateTime(2018, 3, 7, 11, 43, 54, UTC);
 
     checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -266,7 +266,7 @@ public abstract class RenewalAPITests extends APITests {
 
     assertThat("due date should be limited by schedule",
       loan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, 3, 31, 23, 59, 59, DateTimeZone.UTC)));
+      isEquivalentTo(new DateTime(2018, 3, 31, 23, 59, 59, UTC)));
   }
 
   @Test
@@ -275,7 +275,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     final UUID loanId = loan.getId();
 
@@ -313,7 +313,7 @@ public abstract class RenewalAPITests extends APITests {
 
     assertThat("due date should be 2 months after initial due date date",
       renewedLoan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, 6, 12, 11, 21, 43, DateTimeZone.UTC)));
+      isEquivalentTo(new DateTime(2018, 6, 12, 11, 21, 43, UTC)));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 
@@ -343,7 +343,7 @@ public abstract class RenewalAPITests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    final DateTime loanDate = new DateTime(2018, 3, 4, 11, 43, 54, DateTimeZone.UTC);
+    final DateTime loanDate = new DateTime(2018, 3, 4, 11, 43, 54, UTC);
 
     checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -360,7 +360,7 @@ public abstract class RenewalAPITests extends APITests {
 
     assertThat("due date should be limited by schedule",
       loan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, 3, 31, 23, 59, 59, DateTimeZone.UTC)));
+      isEquivalentTo(new DateTime(2018, 3, 31, 23, 59, 59, UTC)));
   }
 
   @Test
@@ -386,7 +386,7 @@ public abstract class RenewalAPITests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    final DateTime loanDate = new DateTime(2018, 3, 4, 11, 43, 54, DateTimeZone.UTC);
+    final DateTime loanDate = new DateTime(2018, 3, 4, 11, 43, 54, UTC);
 
     checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -403,13 +403,13 @@ public abstract class RenewalAPITests extends APITests {
 
     assertThat("due date should be limited by schedule",
       loan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, 3, 31, 23, 59, 59, DateTimeZone.UTC)));
+      isEquivalentTo(new DateTime(2018, 3, 31, 23, 59, 59, UTC)));
   }
 
   @Test
   void canCheckOutUsingFixedDueDateLoanPolicy() {
     //TODO: Need to be able to inject system date here
-    final DateTime renewalDate = ClockUtil.getDateTime();
+    final DateTime renewalDate = getDateTime();
     //e.g. Clock.freeze(renewalDate)
 
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
@@ -432,7 +432,7 @@ public abstract class RenewalAPITests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    final DateTime loanDate = new DateTime(2018, 2, 10, 11, 23, 12, DateTimeZone.UTC);
+    final DateTime loanDate = new DateTime(2018, 2, 10, 11, 23, 12, UTC);
 
     checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -450,11 +450,7 @@ public abstract class RenewalAPITests extends APITests {
     assertThat("renewal count should be incremented",
       loan.getInteger("renewalCount"), is(1));
 
-    final DateTime endOfRenewalDate = renewalDate
-      .withTimeAtStartOfDay()
-      .withHourOfDay(23)
-      .withMinuteOfHour(59)
-      .withSecondOfMinute(59);
+    final DateTime endOfRenewalDate = atEndOfDay(renewalDate);
 
     assertThat("due date should be defined by schedule",
       loan.getString("dueDate"), isEquivalentTo(endOfRenewalDate));
@@ -476,7 +472,7 @@ public abstract class RenewalAPITests extends APITests {
     use(limitedRenewalsPolicy);
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     final UUID loanId = loan.getId();
 
@@ -501,7 +497,7 @@ public abstract class RenewalAPITests extends APITests {
 
     assertThat("due date should be 8 days after initial loan date date",
       renewedLoan.getString("dueDate"),
-      isEquivalentTo(new DateTime(2018, 4, 29, 11, 21, 43, DateTimeZone.UTC)));
+      isEquivalentTo(new DateTime(2018, 4, 29, 11, 21, 43, UTC)));
 
     smallAngryPlanet = itemsClient.get(smallAngryPlanet);
 
@@ -514,12 +510,12 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     final UUID loanId = checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC))
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC))
       .getId();
 
     //TODO: Renewal based upon system date,
     // needs to be approximated, at least until we introduce a calendar and clock
-    DateTime approximateRenewalDate = ClockUtil.getDateTime();
+    DateTime approximateRenewalDate = getDateTime();
 
     final IndividualResource response = renew(smallAngryPlanet, jessica);
 
@@ -559,7 +555,7 @@ public abstract class RenewalAPITests extends APITests {
     final UUID unknownLoanPolicyId = UUID.randomUUID();
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     IndividualResource record = loanPoliciesFixture.create(new LoanPolicyBuilder()
       .withId(unknownLoanPolicyId)
@@ -593,7 +589,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource loanPolicyResponse = loanPoliciesFixture.create(limitedRenewalsPolicy);
 
     IndividualResource loan = checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-        new DateTime(2019, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+        new DateTime(2019, 4, 21, 11, 21, 43, UTC));
 
     loanHasLoanPolicyProperties(loan.getJson(), loanPoliciesFixture.canCirculateRolling());
 
@@ -621,7 +617,7 @@ public abstract class RenewalAPITests extends APITests {
     use(limitedRenewalsPolicy);
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     renew(smallAngryPlanet, jessica);
     renew(smallAngryPlanet, jessica);
@@ -640,7 +636,7 @@ public abstract class RenewalAPITests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     IndividualResource jessica = usersFixture.jessica();
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     final UUID userId = jessica.getId();
     JsonObject userRecord = jessica.copyJson();
@@ -675,7 +671,7 @@ public abstract class RenewalAPITests extends APITests {
     use(limitedRenewalsPolicy);
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     renew(smallAngryPlanet, jessica);
     renew(smallAngryPlanet, jessica);
@@ -723,7 +719,7 @@ public abstract class RenewalAPITests extends APITests {
     use(limitedRenewalsPolicy);
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      ClockUtil.getDateTime().minusDays(1)).getJson();
+      getDateTime().minusDays(1)).getJson();
 
     renew(smallAngryPlanet, jessica);
 
@@ -756,7 +752,7 @@ public abstract class RenewalAPITests extends APITests {
     use(limitedRenewalsPolicy);
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     final Response response = attemptRenewal(smallAngryPlanet, jessica);
 
@@ -791,7 +787,7 @@ public abstract class RenewalAPITests extends APITests {
     use(limitedRenewalsPolicy);
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      ClockUtil.getDateTime());
+      getDateTime());
 
     final Response response = attemptRenewal(smallAngryPlanet, jessica);
 
@@ -815,7 +811,7 @@ public abstract class RenewalAPITests extends APITests {
     use(policyForCheckout);
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     LoanPolicyBuilder nonLoanablePolicy = new LoanPolicyBuilder()
       .withName("Non loanable policy")
@@ -867,7 +863,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource jessica = usersFixture.jessica();
     final String comment = "testing";
-    final DateTime dateTime = ClockUtil.getDateTime();
+    final DateTime dateTime = getDateTime();
 
     final JsonObject loanJson = checkOutFixture.checkOutByBarcode(smallAngryPlanet,
       usersFixture.jessica())
@@ -944,7 +940,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     final Response response = attemptRenewal(smallAngryPlanet, james);
 
@@ -962,7 +958,7 @@ public abstract class RenewalAPITests extends APITests {
     int renewPeriodDays = 3;
 
     DateTime loanDate =
-      new DateTime(2019, DateTimeConstants.JANUARY, 25, 10, 0, DateTimeZone.UTC);
+      new DateTime(2019, DateTimeConstants.JANUARY, 25, 10, 0, UTC);
 
     LoanPolicyBuilder loanPolicy = new LoanPolicyBuilder()
       .withName("Loan policy")
@@ -990,8 +986,7 @@ public abstract class RenewalAPITests extends APITests {
     JsonObject renewedLoan = renew(smallAngryPlanet, jessica).getJson();
 
     DateTime expectedDate =
-      CASE_FRI_SAT_MON_SERVICE_POINT_PREV_DAY
-        .toDateTime(END_OF_A_DAY, DateTimeZone.UTC);
+      atEndOfDay(CASE_FRI_SAT_MON_SERVICE_POINT_PREV_DAY, UTC);
     assertThat("due date should be " + expectedDate,
       renewedLoan.getString("dueDate"), isEquivalentTo(expectedDate));
   }
@@ -1005,7 +1000,7 @@ public abstract class RenewalAPITests extends APITests {
     int renewPeriodDays = 3;
 
     DateTime loanDate =
-      new DateTime(2019, DateTimeConstants.JANUARY, 25, 10, 0, DateTimeZone.UTC);
+      new DateTime(2019, DateTimeConstants.JANUARY, 25, 10, 0, UTC);
 
     LoanPolicyBuilder loanPolicy = new LoanPolicyBuilder()
       .withName("Loan policy")
@@ -1033,8 +1028,7 @@ public abstract class RenewalAPITests extends APITests {
     JsonObject renewedLoan = renew(smallAngryPlanet, jessica).getJson();
 
     DateTime expectedDate =
-      CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY
-        .toDateTime(END_OF_A_DAY, DateTimeZone.UTC);
+      atEndOfDay(CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY, UTC);
     assertThat("due date should be " + expectedDate,
       renewedLoan.getString("dueDate"), isEquivalentTo(expectedDate));
   }
@@ -1047,7 +1041,7 @@ public abstract class RenewalAPITests extends APITests {
     int loanPeriodHours = 8;
 
     DateTime loanDate =
-      new DateTime(2019, DateTimeConstants.FEBRUARY, 1, 10, 0, DateTimeZone.UTC);
+      new DateTime(2019, DateTimeConstants.FEBRUARY, 1, 10, 0, UTC);
 
     LoanPolicyBuilder loanPolicy = new LoanPolicyBuilder()
       .withName("Loan policy")
@@ -1075,7 +1069,7 @@ public abstract class RenewalAPITests extends APITests {
 
     DateTime expectedDate =
       CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY
-        .toDateTime(START_TIME_FIRST_PERIOD, DateTimeZone.UTC);
+        .toDateTime(START_TIME_FIRST_PERIOD, UTC);
     assertThat("due date should be " + expectedDate,
       renewedLoan.getString("dueDate"), isEquivalentTo(expectedDate));
   }
@@ -1089,7 +1083,7 @@ public abstract class RenewalAPITests extends APITests {
     int renewPeriodHours = 5;
 
     DateTime loanDate =
-      WEDNESDAY_DATE.toDateTime(START_TIME_SECOND_PERIOD, DateTimeZone.UTC);
+      WEDNESDAY_DATE.toDateTime(START_TIME_SECOND_PERIOD, UTC);
 
     LoanPolicyBuilder loanPolicy = new LoanPolicyBuilder()
       .withName("Loan policy")
@@ -1120,7 +1114,7 @@ public abstract class RenewalAPITests extends APITests {
 
     DateTime expectedDate =
       WEDNESDAY_DATE
-        .toDateTime(END_TIME_SECOND_PERIOD, DateTimeZone.UTC);
+        .toDateTime(END_TIME_SECOND_PERIOD, UTC);
     assertThat("due date should be " + expectedDate,
       renewedLoan.getString("dueDate"), isEquivalentTo(expectedDate));
   }
@@ -1184,7 +1178,7 @@ public abstract class RenewalAPITests extends APITests {
 
     DateTime expectedDueDate =
       new DateTime(2019, DateTimeConstants.MAY, 31, 23, 59, 59)
-        .withZoneRetainFields(DateTimeZone.UTC);
+        .withZoneRetainFields(UTC);
 
     final UUID fixedDueDateSchedulesId = loanPoliciesFixture.createSchedule(
       fixedDueDateSchedules).getId();
@@ -1208,11 +1202,7 @@ public abstract class RenewalAPITests extends APITests {
       .addSchedule(wholeMonth(2019, DateTimeConstants.MARCH))
       .addSchedule(todayOnly());
 
-    DateTime expectedDueDate = ClockUtil.getDateTime()
-      .withTimeAtStartOfDay()
-      .withHourOfDay(23)
-      .withMinuteOfHour(59)
-      .withSecondOfMinute(59);
+    DateTime expectedDueDate = atEndOfDay(getDateTime());
 
     final UUID fixedDueDateSchedulesId = loanPoliciesFixture.createSchedule(
       fixedDueDateSchedules).getId();
@@ -1231,7 +1221,7 @@ public abstract class RenewalAPITests extends APITests {
 
   @Test
   void cannotRenewWhenCurrentDueDateDoesNotFallWithinLimitingDueDateSchedule() {
-    DateTime futureDateTime = ClockUtil.getDateTime().plusMonths(1);
+    DateTime futureDateTime = getDateTime().plusMonths(1);
 
     FixedDueDateSchedulesBuilder fixedDueDateSchedules = new FixedDueDateSchedulesBuilder()
       .withName("Fixed Due Date Schedule in the Future")
@@ -1269,7 +1259,7 @@ public abstract class RenewalAPITests extends APITests {
 
     DateTime expectedDueDate =
       new DateTime(2019, DateTimeConstants.MAY, 31, 23, 59, 59)
-        .withZoneRetainFields(DateTimeZone.UTC);
+        .withZoneRetainFields(UTC);
 
     final UUID dueDateLimitScheduleId = loanPoliciesFixture.createSchedule(
       dueDateLimitSchedule).getId();
@@ -1294,11 +1284,7 @@ public abstract class RenewalAPITests extends APITests {
       .addSchedule(wholeMonth(2019, DateTimeConstants.MARCH))
       .addSchedule(todayOnly());
 
-    DateTime expectedDueDate = ClockUtil.getDateTime()
-      .withTimeAtStartOfDay()
-      .withHourOfDay(23)
-      .withMinuteOfHour(59)
-      .withSecondOfMinute(59);
+    DateTime expectedDueDate = atEndOfDay(getDateTime());
 
     final UUID dueDateLimitScheduleId = loanPoliciesFixture.createSchedule(
       dueDateLimitSchedule).getId();
@@ -1353,7 +1339,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource steve = usersFixture.steve();
 
     final DateTime loanDate =
-      new DateTime(2018, 3, 18, 11, 43, 54, DateTimeZone.UTC);
+      new DateTime(2018, 3, 18, 11, 43, 54, UTC);
 
     checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -1408,7 +1394,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource steve = usersFixture.steve();
 
     final DateTime loanDate =
-      new DateTime(2018, 3, 18, 11, 43, 54, DateTimeZone.UTC);
+      new DateTime(2018, 3, 18, 11, 43, 54, UTC);
 
     checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -1455,7 +1441,7 @@ public abstract class RenewalAPITests extends APITests {
       item.withPermanentLocation(homeLocation.getId()));
 
     final IndividualResource loan = checkOutFixture.checkOutByBarcode(nod, james,
-      new DateTime(2020, 1, 1, 12, 0, 0, DateTimeZone.UTC));
+      new DateTime(2020, 1, 1, 12, 0, 0, UTC));
 
     JsonObject servicePointOwner = new JsonObject();
     servicePointOwner.put("value", homeLocation.getJson().getString("primaryServicePoint"));
@@ -1526,7 +1512,7 @@ public abstract class RenewalAPITests extends APITests {
       item.withPermanentLocation(homeLocation.getId()));
 
     checkOutFixture.checkOutByBarcode(nod, james,
-      new DateTime(2020, 1, 1, 12, 0, 0, DateTimeZone.UTC));
+      new DateTime(2020, 1, 1, 12, 0, 0, UTC));
 
     JsonObject servicePointOwner = new JsonObject();
     servicePointOwner.put("value", homeLocation.getJson().getString("primaryServicePoint"));
@@ -1559,7 +1545,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     final JsonObject renewedLoan = renew(smallAngryPlanet, jessica).getJson();
 
@@ -1586,7 +1572,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
     automatedPatronBlocksFixture.blockAction(jessica.getId().toString(), false, true, true);
 
     final Response response = attemptRenewal(smallAngryPlanet, jessica);
@@ -1609,7 +1595,7 @@ public abstract class RenewalAPITests extends APITests {
     use(policyForCheckout);
 
     checkOutFixture.checkOutByBarcode(smallAngryPlanet, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     LoanPolicyBuilder nonLoanablePolicy = new LoanPolicyBuilder()
       .withName("Non loanable policy")
@@ -1642,7 +1628,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     checkOutFixture.checkOutByBarcode(item, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
     automatedPatronBlocksFixture.blockAction(jessica.getId().toString(), false, true, false);
 
     final Response response = attemptRenewal(item, jessica);
@@ -1668,7 +1654,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     checkOutFixture.checkOutByBarcode(item, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
     automatedPatronBlocksFixture.blockAction(jessica.getId().toString(), false, true, false);
 
     Response response = loansFixture.attemptRenewal(
@@ -1685,7 +1671,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     checkOutFixture.checkOutByBarcode(item, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
     automatedPatronBlocksFixture.blockAction(jessica.getId().toString(), false, true, false);
 
     final OkapiHeaders okapiHeaders = buildOkapiHeadersWithPermissions(
@@ -1723,7 +1709,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource user = usersFixture.jessica();
 
     checkOutFixture.checkOutByBarcode(item, user,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
 
     final OkapiHeaders okapiHeaders = buildOkapiHeadersWithPermissions(
       OVERRIDE_PATRON_BLOCK_PERMISSION);
@@ -1742,7 +1728,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     checkOutFixture.checkOutByBarcode(item, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
     userManualBlocksFixture.createRenewalsManualPatronBlockForUser(jessica.getId());
 
     final Response response = attemptRenewal(item, jessica);
@@ -1767,7 +1753,7 @@ public abstract class RenewalAPITests extends APITests {
     final IndividualResource jessica = usersFixture.jessica();
 
     checkOutFixture.checkOutByBarcode(item, jessica,
-      new DateTime(2018, 4, 21, 11, 21, 43, DateTimeZone.UTC));
+      new DateTime(2018, 4, 21, 11, 21, 43, UTC));
     userManualBlocksFixture.createRenewalsManualPatronBlockForUser(jessica.getId());
     automatedPatronBlocksFixture.blockAction(jessica.getId().toString(), false, true, false);
 
@@ -1797,14 +1783,14 @@ public abstract class RenewalAPITests extends APITests {
     IndividualResource item = itemsFixture.basedUponNod();
     DateTime patronExpirationDate = loanDate.plusDays(1);
     IndividualResource steve = usersFixture.steve(user -> user.expires(patronExpirationDate));
+    DateTime expectedDate = atEndOfDay(MONDAY_DATE, UTC);
 
-    checkOutItem(loanDate, item, MONDAY_DATE.toDateTime(END_OF_A_DAY, UTC), steve,
+    checkOutItem(loanDate, item, expectedDate, steve,
       CASE_MON_WED_FRI_OPEN_TUE_THU_CLOSED);
 
     mockClockManagerToReturnFixedDateTime(loanDate.plusDays(1));
     JsonObject renewedLoan = loansFixture.renewLoan(item, steve).getJson();
     mockClockManagerToReturnDefaultDateTime();
-    DateTime expectedDate = MONDAY_DATE.toDateTime(END_OF_A_DAY, DateTimeZone.UTC);
 
     assertThat("due date should be " + expectedDate, renewedLoan.getString("dueDate"),
       isEquivalentTo(expectedDate));
@@ -1818,14 +1804,14 @@ public abstract class RenewalAPITests extends APITests {
     IndividualResource item = itemsFixture.basedUponNod();
     DateTime patronExpirationDate = loanDate.plusDays(1);
     IndividualResource steve = usersFixture.steve(user -> user.expires(patronExpirationDate));
+    DateTime expectedDate = atEndOfDay(MONDAY_DATE, UTC);
 
-    checkOutItem(loanDate, item, MONDAY_DATE.toDateTime(END_OF_A_DAY, UTC), steve,
+    checkOutItem(loanDate, item, expectedDate, steve,
       CASE_MON_WED_FRI_OPEN_TUE_THU_CLOSED);
 
     mockClockManagerToReturnFixedDateTime(loanDate.plusDays(1));
     JsonObject renewedLoan = loansFixture.renewLoan(item, steve).getJson();
     mockClockManagerToReturnDefaultDateTime();
-    DateTime expectedDate = MONDAY_DATE.toDateTime(END_OF_A_DAY, DateTimeZone.UTC);
 
     assertThat("due date should be " + expectedDate, renewedLoan.getString("dueDate"),
       isEquivalentTo(expectedDate));

--- a/src/test/java/api/requests/RequestScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/requests/RequestScheduledNoticesProcessingTests.java
@@ -13,11 +13,15 @@ import static org.awaitility.Awaitility.waitAtMost;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE_ERROR;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTimeProperty;
+import static org.folio.circulation.support.utils.ClockUtil.getDateTime;
+import static org.folio.circulation.support.utils.ClockUtil.getLocalDate;
+import static org.folio.circulation.support.utils.DateTimeUtil.atStartOfDay;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.joda.time.DateTimeZone.UTC;
 
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -25,7 +29,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.folio.circulation.domain.policy.Period;
-import org.folio.circulation.support.utils.ClockUtil;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 import org.junit.FixMethodOrder;
@@ -87,7 +90,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .create();
     setupNoticePolicyWithRequestNotice(noticeConfiguration);
 
-    final org.joda.time.LocalDate localDate = ClockUtil.getLocalDate()
+    final org.joda.time.LocalDate localDate = getLocalDate()
       .minusDays(1);
     final var requestExpiration = LocalDate.of(localDate.getYear(),
       localDate.getMonthOfYear(), localDate.getDayOfMonth());
@@ -95,7 +98,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(ClockUtil.getDateTime())
+      .withRequestDate(getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration));
@@ -129,7 +132,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .create();
     setupNoticePolicyWithRequestNotice(noticeConfiguration);
 
-    final org.joda.time.LocalDate localDate = ClockUtil.getLocalDate()
+    final org.joda.time.LocalDate localDate = getLocalDate()
       .minusDays(1);
     final var requestExpiration = LocalDate.of(localDate.getYear(),
       localDate.getMonthOfYear(), localDate.getDayOfMonth());
@@ -137,14 +140,14 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(ClockUtil.getDateTime())
+      .withRequestDate(getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration));
 
     verifyNumberOfScheduledNotices(1);
 
-    scheduledNoticeProcessingClient.runRequestNoticesProcessing(ClockUtil.getDateTime().plusMonths(2));
+    scheduledNoticeProcessingClient.runRequestNoticesProcessing(getDateTime().plusMonths(2));
 
     verifyNumberOfScheduledNotices(1);
     verifyNumberOfSentNotices(0);
@@ -168,7 +171,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(ClockUtil.getDateTime())
+      .withRequestDate(getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint));
 
@@ -185,7 +188,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       request.getJson().put("status", "Closed - Pickup expired"));
 
     scheduledNoticeProcessingClient.runRequestNoticesProcessing(
-      ClockUtil.getLocalDate().plusDays(31).toDateTimeAtStartOfDay());
+      atStartOfDay(getLocalDate().plusDays(31), UTC));
 
     verifyNumberOfScheduledNotices(0);
     verifyNumberOfSentNotices(1);
@@ -206,7 +209,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(ClockUtil.getDateTime())
+      .withRequestDate(getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint));
 
@@ -219,7 +222,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     verifyNumberOfScheduledNotices(1);
 
     scheduledNoticeProcessingClient.runRequestNoticesProcessing(
-      ClockUtil.getLocalDate().plusDays(31).toDateTimeAtStartOfDay());
+      atStartOfDay(getLocalDate().plusDays(31), UTC));
 
     verifyNumberOfScheduledNotices(1);
     verifyNumberOfSentNotices(0);
@@ -240,7 +243,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(ClockUtil.getDateTime())
+      .withRequestDate(getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint));
 
@@ -261,7 +264,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
         equalTo("Closed - Filled"));
 
     scheduledNoticeProcessingClient.runRequestNoticesProcessing(
-      ClockUtil.getLocalDate().plusDays(100).toDateTimeAtStartOfDay());
+      atStartOfDay(getLocalDate().plusDays(100), UTC));
 
     verifyNumberOfScheduledNotices(0);
     verifyNumberOfSentNotices(0);
@@ -279,7 +282,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .create();
     setupNoticePolicyWithRequestNotice(noticeConfiguration);
 
-    final org.joda.time.LocalDate localDate = ClockUtil.getLocalDate()
+    final org.joda.time.LocalDate localDate = getLocalDate()
       .plusDays(4);
     final var requestExpiration = LocalDate.of(localDate.getYear(),
       localDate.getMonthOfYear(), localDate.getDayOfMonth());
@@ -287,7 +290,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(ClockUtil.getDateTime())
+      .withRequestDate(getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration));
@@ -315,7 +318,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .create();
     setupNoticePolicyWithRequestNotice(noticeConfiguration);
 
-    final org.joda.time.LocalDate localDate = ClockUtil.getLocalDate()
+    final org.joda.time.LocalDate localDate = getLocalDate()
       .plusDays(2);
     final var requestExpiration = LocalDate.of(localDate.getYear(),
       localDate.getMonthOfYear(), localDate.getDayOfMonth());
@@ -323,7 +326,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(ClockUtil.getDateTime())
+      .withRequestDate(getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration));
@@ -358,7 +361,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .create();
     setupNoticePolicyWithRequestNotice(noticeConfiguration);
 
-    final org.joda.time.LocalDate localDate = ClockUtil.getLocalDate()
+    final org.joda.time.LocalDate localDate = getLocalDate()
       .plusMonths(3);
     final var requestExpiration = LocalDate.of(localDate.getYear(),
       localDate.getMonthOfYear(), localDate.getDayOfMonth());
@@ -366,7 +369,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
     IndividualResource request = requestsFixture.place(new RequestBuilder().page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(ClockUtil.getDateTime())
+      .withRequestDate(getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withRequestExpiration(requestExpiration));
@@ -380,7 +383,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
    verifyNumberOfScheduledNotices(1);
 
     scheduledNoticeProcessingClient.runRequestNoticesProcessing(
-      ClockUtil.getLocalDate().plusDays(28).toDateTimeAtStartOfDay());
+    atStartOfDay(getLocalDate().plusDays(28), UTC));
 
     verifyNumberOfSentNotices(1);
     assertThat(FakeModNotify.getFirstSentPatronNotice(),
@@ -406,7 +409,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(ClockUtil.getDateTime())
+      .withRequestDate(getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint)
       .withNoRequestExpiration());
@@ -441,7 +444,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .page()
       .forItem(item)
       .withRequesterId(requester.getId())
-      .withRequestDate(ClockUtil.getDateTime())
+      .withRequestDate(getDateTime())
       .withStatus(OPEN_NOT_YET_FILLED)
       .withPickupServicePoint(pickupServicePoint);
     IndividualResource request = requestsFixture.place(requestBuilder);
@@ -457,7 +460,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
       .withStatus(CLOSED_PICKUP_EXPIRED));
 
     scheduledNoticeProcessingClient.runRequestNoticesProcessing(
-      ClockUtil.getLocalDate().plusDays(35).toDateTimeAtStartOfDay());
+      atStartOfDay(getLocalDate().plusDays(35), UTC));
 
     verifyNumberOfScheduledNotices(0);
     verifyNumberOfSentNotices(1);
@@ -471,7 +474,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
 
     templateFixture.delete(templateId);
 
-    scheduledNoticeProcessingClient.runRequestNoticesProcessing(ClockUtil.getDateTime().plusMonths(2));
+    scheduledNoticeProcessingClient.runRequestNoticesProcessing(getDateTime().plusMonths(2));
 
     verifyNumberOfSentNotices(0);
     verifyNumberOfScheduledNotices(0);
@@ -485,7 +488,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
 
     requestsStorageClient.delete(request);
 
-    scheduledNoticeProcessingClient.runRequestNoticesProcessing(ClockUtil.getDateTime().plusMonths(2));
+    scheduledNoticeProcessingClient.runRequestNoticesProcessing(getDateTime().plusMonths(2));
 
     verifyNumberOfSentNotices(0);
     verifyNumberOfScheduledNotices(0);
@@ -499,7 +502,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
 
     usersFixture.remove(requester);
 
-    scheduledNoticeProcessingClient.runRequestNoticesProcessing(ClockUtil.getDateTime().plusMonths(2));
+    scheduledNoticeProcessingClient.runRequestNoticesProcessing(getDateTime().plusMonths(2));
 
     verifyNumberOfSentNotices(0);
     verifyNumberOfScheduledNotices(0);
@@ -513,7 +516,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
 
     itemsClient.delete(item);
 
-    scheduledNoticeProcessingClient.runRequestNoticesProcessing(ClockUtil.getDateTime().plusMonths(2));
+    scheduledNoticeProcessingClient.runRequestNoticesProcessing(getDateTime().plusMonths(2));
 
     verifyNumberOfSentNotices(0);
     verifyNumberOfScheduledNotices(0);
@@ -527,7 +530,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
 
     FakeModNotify.setFailPatronNoticesWithBadRequest(true);
 
-    scheduledNoticeProcessingClient.runRequestNoticesProcessing(ClockUtil.getDateTime().plusMonths(2));
+    scheduledNoticeProcessingClient.runRequestNoticesProcessing(getDateTime().plusMonths(2));
 
     verifyNumberOfSentNotices(0);
     verifyNumberOfScheduledNotices(1);
@@ -545,7 +548,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
         .create()
     );
 
-    final org.joda.time.LocalDate localDate = ClockUtil.getLocalDate();
+    final org.joda.time.LocalDate localDate = getLocalDate();
     final var requestExpiration = LocalDate.of(localDate.getYear(),
       localDate.getMonthOfYear(), localDate.getDayOfMonth());
 
@@ -554,7 +557,7 @@ class RequestScheduledNoticesProcessingTests extends APITests {
         .page()
         .forItem(item)
         .withRequesterId(requester.getId())
-        .withRequestDate(ClockUtil.getDateTime())
+        .withRequestDate(getDateTime())
         .withRequestExpiration(requestExpiration)
         .withStatus(OPEN_NOT_YET_FILLED)
         .withPickupServicePoint(pickupServicePoint)

--- a/src/test/java/api/requests/RequestScheduledNoticesTests.java
+++ b/src/test/java/api/requests/RequestScheduledNoticesTests.java
@@ -2,7 +2,9 @@ package api.requests;
 
 import static api.support.builders.RequestBuilder.OPEN_NOT_YET_FILLED;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
+import static java.time.ZoneOffset.UTC;
 import static org.folio.circulation.domain.representations.RequestProperties.HOLD_SHELF_EXPIRATION_DATE;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
@@ -18,7 +20,6 @@ import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.utils.ClockUtil;
-import org.folio.circulation.support.utils.DateTimeUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -94,7 +95,7 @@ class RequestScheduledNoticesTests extends APITests {
     assertThat(scheduledNotice.getString("requestId"), is(request.getId().toString()));
     assertThat(scheduledNotice.getString("triggeringEvent"), is("Request expiration"));
     assertThat(scheduledNotice.getString("nextRunTime"),
-      isEquivalentTo(DateTimeUtil.atEndOfTheDay(requestExpiration)));
+      isEquivalentTo(atEndOfDay(requestExpiration, UTC)));
     assertThat(noticeConfig.getString("timing"), is("Upon At"));
     assertThat(noticeConfig.getString("templateId"), is(templateId.toString()));
     assertThat(noticeConfig.getString("format"), is("Email"));
@@ -197,7 +198,7 @@ class RequestScheduledNoticesTests extends APITests {
     assertThat(scheduledNotice.getString("requestId"), is(request.getId().toString()));
     assertThat(scheduledNotice.getString("triggeringEvent"), is("Request expiration"));
     assertThat(scheduledNotice.getString("nextRunTime"), isEquivalentTo(
-      DateTimeUtil.atEndOfTheDay(requestExpiration).minusDays(3)));
+      atEndOfDay(requestExpiration, UTC).minusDays(3)));
     assertThat(noticeConfig.getString("timing"), is("Before"));
     assertThat(noticeConfig.getString("templateId"), is(templateId.toString()));
     assertThat(noticeConfig.getString("format"), is("Email"));
@@ -243,7 +244,7 @@ class RequestScheduledNoticesTests extends APITests {
     assertThat(scheduledNotice.getString("requestId"), is(request.getId().toString()));
     assertThat(scheduledNotice.getString("triggeringEvent"), is("Request expiration"));
     assertThat(scheduledNotice.getString("nextRunTime"),
-      isEquivalentTo(DateTimeUtil.atEndOfTheDay(requestExpiration)));
+      isEquivalentTo(atEndOfDay(requestExpiration, UTC)));
     assertThat(noticeConfig.getString("timing"), is("Upon At"));
     assertThat(noticeConfig.getString("templateId"), is(templateId.toString()));
     assertThat(noticeConfig.getString("format"), is("Email"));
@@ -265,7 +266,7 @@ class RequestScheduledNoticesTests extends APITests {
     assertThat(scheduledNotice.getString("requestId"), is(request.getId().toString()));
     assertThat(scheduledNotice.getString("triggeringEvent"), is("Request expiration"));
     assertThat(scheduledNotice.getString("nextRunTime"),
-      isEquivalentTo(DateTimeUtil.atEndOfTheDay(requestExpiration).plusDays(1)));
+      isEquivalentTo(atEndOfDay(requestExpiration, UTC).plusDays(1)));
     assertThat(noticeConfig.getString("timing"), is("Upon At"));
     assertThat(noticeConfig.getString("templateId"), is(templateId.toString()));
     assertThat(noticeConfig.getString("format"), is("Email"));
@@ -312,7 +313,7 @@ class RequestScheduledNoticesTests extends APITests {
     assertThat(scheduledNotice.getString("requestId"), is(request.getId().toString()));
     assertThat(scheduledNotice.getString("triggeringEvent"), is("Request expiration"));
     assertThat(scheduledNotice.getString("nextRunTime"), isEquivalentTo(
-      DateTimeUtil.atEndOfTheDay(requestExpiration).minusDays(3)));
+      atEndOfDay(requestExpiration, UTC).minusDays(3)));
     assertThat(noticeConfig.getString("timing"), is("Before"));
     assertThat(noticeConfig.getString("templateId"), is(templateId.toString()));
     assertThat(noticeConfig.getString("format"), is("Email"));

--- a/src/test/java/api/requests/RequestsAPIRetrievalTests.java
+++ b/src/test/java/api/requests/RequestsAPIRetrievalTests.java
@@ -687,7 +687,7 @@ class RequestsAPIRetrievalTests extends APITests {
         .by(sponsor)
         .proxiedBy(proxy)
         .fulfilToHoldShelf()
-        .withRequestExpiration(LocalDate.of(2017, 7, 30))
+        .withRequestExpiration(LocalDate.of(2017, 7, 31))
         .withHoldShelfExpiration(LocalDate.of(2017, 8, 31))
         .withPickupServicePointId(pickupServicePointId)
         .withTags(new RequestBuilder.Tags(asList(NEW_TAG, IMPORTANT_TAG)))

--- a/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
+++ b/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
@@ -11,7 +11,7 @@ import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
 import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static org.folio.HttpStatus.HTTP_OK;
-import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfTheDay;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
@@ -139,7 +139,7 @@ class HoldShelfExpirationDateTests extends APITests {
     assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
       storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
 
-    ZonedDateTime expectedExpirationDate = atEndOfTheDay(interval.addTo(ClockUtil.getZonedDateTime(), amount));
+    ZonedDateTime expectedExpirationDate = atEndOfDay(interval.addTo(ClockUtil.getZonedDateTime(), amount));
 
     assertThat("request hold shelf expiration date is " + amount + " " + interval.toString() + " in the future",
       storedRequest.getString("holdShelfExpirationDate"),
@@ -176,7 +176,7 @@ class HoldShelfExpirationDateTests extends APITests {
 
     final Instant now = Instant.ofEpochMilli(ClockUtil.getInstant().getMillis());
 
-    ZonedDateTime expectedExpirationDate = atEndOfTheDay(
+    ZonedDateTime expectedExpirationDate = atEndOfDay(
       interval.addTo(now.atZone(tenantTimeZone), amount))
       .toInstant()
       .atZone(ZoneOffset.UTC);
@@ -253,7 +253,7 @@ class HoldShelfExpirationDateTests extends APITests {
     assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
         storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
 
-    final ZonedDateTime expectedExpirationDate = atEndOfTheDay(
+    final ZonedDateTime expectedExpirationDate = atEndOfDay(
       ChronoUnit.DAYS.addTo(ClockUtil.getZonedDateTime(), 30));
 
     assertThat("request hold shelf expiration date is 30 days in the future",
@@ -313,7 +313,7 @@ class HoldShelfExpirationDateTests extends APITests {
     assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
       storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
 
-    final ZonedDateTime expectedExpirationDate = atEndOfTheDay(
+    final ZonedDateTime expectedExpirationDate = atEndOfDay(
       ChronoUnit.DAYS.addTo(ClockUtil.getZonedDateTime(), 30));
 
     assertThat("request hold shelf expiration date is 30 days in the future",
@@ -361,7 +361,7 @@ class HoldShelfExpirationDateTests extends APITests {
     assertThat("request status snapshot in storage is " + OPEN_AWAITING_PICKUP,
       storedRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
 
-    final ZonedDateTime expectedExpirationDate = atEndOfTheDay(
+    final ZonedDateTime expectedExpirationDate = atEndOfDay(
       ChronoUnit.DAYS.addTo(ClockUtil.getZonedDateTime(), 30));
 
     assertThat("request hold shelf expiration date is 30 days in the future",

--- a/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
+++ b/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
@@ -12,7 +12,7 @@ import static java.time.Clock.fixed;
 import static java.time.Clock.offset;
 import static java.time.Duration.ofDays;
 import static org.folio.circulation.domain.policy.DueDateManagement.KEEP_THE_CURRENT_DUE_DATE;
-import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -308,8 +308,8 @@ class LoanDueDatesAfterRecallTests extends APITests {
         storedLoan.getString("dueDate"), not(originalDueDate));
 
     final String expectedDueDate =
-        CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY
-          .toDateTime(END_OF_A_DAY, UTC).toString(ISODateTimeFormat.dateTime());
+      atEndOfDay(CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY, UTC)
+        .toString(ISODateTimeFormat.dateTime());
 
     assertThat("due date should be moved to Monday",
         storedLoan.getString("dueDate"), is(expectedDueDate));

--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -24,7 +24,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;

--- a/src/test/java/api/support/OpeningPeriod.java
+++ b/src/test/java/api/support/OpeningPeriod.java
@@ -1,11 +1,13 @@
 package api.support;
 
-import io.vertx.core.json.JsonObject;
+import static org.folio.circulation.support.utils.DateTimeUtil.atStartOfDay;
+
 import org.folio.circulation.domain.OpeningDay;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
-import org.joda.time.LocalTime;
+
+import io.vertx.core.json.JsonObject;
 
 public class OpeningPeriod {
   private static final String OPENING_DAY_KEY = "openingDay";
@@ -27,7 +29,7 @@ public class OpeningPeriod {
   public JsonObject toJson() {
     return new JsonObject()
       .put(OPENING_DAY_KEY, openingDay.toJson())
-      .put(DATE_KEY, date.toDateTime(LocalTime.MIDNIGHT, DateTimeZone.UTC).toString());
+      .put(DATE_KEY, atStartOfDay(date, DateTimeZone.UTC).toString());
   }
 
   public OpeningDay getOpeningDay() {

--- a/src/test/java/api/support/builders/FixedDueDateSchedule.java
+++ b/src/test/java/api/support/builders/FixedDueDateSchedule.java
@@ -1,8 +1,16 @@
 package api.support.builders;
 
-import org.folio.circulation.support.utils.ClockUtil;
+import static org.folio.circulation.support.utils.ClockUtil.getDateTime;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfMonth;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfYear;
+import static org.folio.circulation.support.utils.DateTimeUtil.atStartOfDay;
+import static org.folio.circulation.support.utils.DateTimeUtil.atStartOfMonth;
+import static org.folio.circulation.support.utils.DateTimeUtil.atStartOfYear;
+import static org.joda.time.DateTimeZone.UTC;
+
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
 
 public class FixedDueDateSchedule {
   final DateTime from;
@@ -20,51 +28,34 @@ public class FixedDueDateSchedule {
   }
 
   public static FixedDueDateSchedule wholeYear(int year) {
-    return dueAtEnd(
-      new DateTime(year, 1, 1, 0, 0, 0, DateTimeZone.UTC),
-      new DateTime(year, 12, 31, 23, 59, 59, DateTimeZone.UTC));
+    final LocalDate date = new LocalDate(year, 1, 1);
+
+    return dueAtEnd(atStartOfYear(date, UTC), atEndOfYear(date, UTC));
   }
 
   public static FixedDueDateSchedule wholeMonth(int year, int month) {
-    final DateTime firstOfMonth = new DateTime(year, month, 1, 0, 0, 0, DateTimeZone.UTC);
+    final LocalDate date = new LocalDate(year, month, 1);
 
-    final DateTime lastOfMonth = firstOfMonth
-      .withDayOfMonth(firstOfMonth.dayOfMonth().getMaximumValue())
-      .withHourOfDay(23)
-      .withMinuteOfHour(59)
-      .withSecondOfMinute(59);
-
-    return dueAtEnd(firstOfMonth, lastOfMonth);
+    return dueAtEnd(atStartOfMonth(date, UTC), atEndOfMonth(date, UTC));
   }
 
   public static FixedDueDateSchedule wholeMonth(int year, int month, DateTime dueDate) {
-    final DateTime firstOfMonth = new DateTime(year, month, 1, 0, 0, 0, DateTimeZone.UTC);
+    final LocalDate date = new LocalDate(year, month, 1);
 
-    final DateTime lastOfMonth = firstOfMonth
-      .withDayOfMonth(firstOfMonth.dayOfMonth().getMaximumValue())
-      .withHourOfDay(23)
-      .withMinuteOfHour(59)
-      .withSecondOfMinute(59);
-
-    return new FixedDueDateSchedule(firstOfMonth, lastOfMonth, dueDate);
+    return new FixedDueDateSchedule(atStartOfMonth(date, UTC),
+      atEndOfMonth(date, UTC), dueDate);
   }
 
   public static FixedDueDateSchedule todayOnly() {
-    return forDay(ClockUtil.getDateTime());
+    return forDay(getDateTime());
   }
 
   public static FixedDueDateSchedule yesterdayOnly() {
-    return forDay(ClockUtil.getDateTime().minusDays(1));
+    return forDay(getDateTime().minusDays(1));
   }
 
   public static FixedDueDateSchedule forDay(DateTime day) {
-    final DateTime beginningOfDay = day.withTimeAtStartOfDay();
-
-    final DateTime endOfDay = beginningOfDay
-      .withHourOfDay(23)
-      .withMinuteOfHour(59)
-      .withSecondOfMinute(59);
-
-    return new FixedDueDateSchedule(beginningOfDay, endOfDay, endOfDay);
+    return new FixedDueDateSchedule(atStartOfDay(day, UTC),
+      atEndOfDay(day, UTC), atEndOfDay(day, UTC));
   }
 }

--- a/src/test/java/org/folio/circulation/domain/policy/FixedLoanPolicyRenewalDueDateCalculationTests.java
+++ b/src/test/java/org/folio/circulation/domain/policy/FixedLoanPolicyRenewalDueDateCalculationTests.java
@@ -28,7 +28,8 @@ import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import static org.joda.time.DateTimeZone.UTC;
+import org.joda.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 import api.support.builders.FixedDueDateSchedule;
@@ -62,7 +63,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = existingLoan(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2017, 12, 30, 14, 32, 21, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2017, 12, 30, 14, 32, 21, UTC);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
     renew(loan, renewalDate, new RequestQueue(Collections.emptyList()), errorHandler);
@@ -83,7 +84,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = existingLoan(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2018, 12, 15, 14, 32, 21, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 12, 15, 14, 32, 21, UTC);
 
     String requestId = UUID.randomUUID().toString();
     RequestQueue requestQueue = creteRequestQueue(requestId, RequestType.RECALL);
@@ -108,7 +109,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = existingLoan(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2019, 1, 1, 8, 10, 45, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2019, 1, 1, 8, 10, 45, UTC);
 
     RequestQueue requestQueue =  new RequestQueue(Collections.emptyList());
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
@@ -129,7 +130,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = existingLoan(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2018, 3, 14, 11, 14, 54, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 3, 14, 11, 14, 54, UTC);
 
     String requestId = UUID.randomUUID().toString();
     RequestQueue requestQueue = creteRequestQueue(requestId, RequestType.PAGE);
@@ -137,9 +138,12 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
     Result<Loan> result = renew(loan, renewalDate, requestQueue, errorHandler);
 
-    assertThat(result.value().getDueDate(), is(
-      new DateTime(2018, 12, 31, 23, 59, 59,
-      DateTimeZone.UTC)));
+    final DateTime expectedDate = new LocalDate(2018, 12, 31)
+      .toDateTimeAtStartOfDay(UTC)
+      .plusDays(1)
+      .minusSeconds(1);
+
+    assertThat(result.value().getDueDate(), is(expectedDate));
   }
 
   @Test
@@ -157,12 +161,12 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = new LoanBuilder()
       .open()
-      .withLoanDate(new DateTime(2018, 1, 20, 13, 45, 21, DateTimeZone.UTC))
-      .withDueDate(new DateTime(2018, 1, 31, 23, 59, 59, DateTimeZone.UTC))
+      .withLoanDate(new DateTime(2018, 1, 20, 13, 45, 21, UTC))
+      .withDueDate(new DateTime(2018, 1, 31, 23, 59, 59, UTC))
       .asDomainObject()
       .withLoanPolicy(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2018, 2, 8, 11, 14, 54, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 2, 8, 11, 14, 54, UTC);
 
     Result<Loan> result = renew(loan, renewalDate,
       new RequestQueue(Collections.emptyList()), new OverridingErrorHandler(null));
@@ -185,7 +189,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = existingLoan(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2018, 2, 27, 16, 23, 43, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 2, 27, 16, 23, 43, UTC);
 
     Result<Loan> result = renew(loan, renewalDate, new RequestQueue(Collections.emptyList()),
       new OverridingErrorHandler(null));
@@ -208,9 +212,9 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = existingLoan(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2018, 3, 12, 7, 15, 23, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 3, 12, 7, 15, 23, UTC);
 
-   Result<Loan> result = renew(loan, renewalDate,
+    Result<Loan> result = renew(loan, renewalDate,
       new RequestQueue(Collections.emptyList()), new OverridingErrorHandler(null));
 
     assertThat(result.value().getDueDate(), is(expectedSchedule.due));
@@ -234,7 +238,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = existingLoan(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2018, 2, 5, 14, 22, 32, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 2, 5, 14, 22, 32, UTC);
 
     Result<Loan> result = renew(loan, renewalDate, new RequestQueue(Collections.emptyList()),
       new OverridingErrorHandler(null));
@@ -246,7 +250,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
   void shouldApplyAlternateScheduleWhenQueuedRequestIsHoldAndFixed() {
     final Period alternateCheckoutLoanPeriod = Period.from(2, "Weeks");
 
-    final DateTime systemTime = new DateTime(2019, 6, 14, 11, 23, 43, DateTimeZone.UTC);
+    final DateTime systemTime = new DateTime(2019, 6, 14, 11, 23, 43, UTC);
 
     LoanPolicy loanPolicy = LoanPolicy.from(new LoanPolicyBuilder()
       .fixed(UUID.randomUUID())
@@ -315,7 +319,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = existingLoan(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2017, 12, 30, 14, 32, 21, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2017, 12, 30, 14, 32, 21, UTC);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
 
@@ -337,12 +341,12 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = new LoanBuilder()
       .open()
-      .withLoanDate(new DateTime(2018, 1, 20, 13, 45, 21, DateTimeZone.UTC))
-      .withDueDate(new DateTime(2018, 1, 31, 23, 59, 59, DateTimeZone.UTC))
+      .withLoanDate(new DateTime(2018, 1, 20, 13, 45, 21, UTC))
+      .withDueDate(new DateTime(2018, 1, 31, 23, 59, 59, UTC))
       .asDomainObject()
       .withLoanPolicy(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2018, 1, 3, 8, 12, 32, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 1, 3, 8, 12, 32, UTC);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
     renew(loan, renewalDate, new RequestQueue(Collections.emptyList()), errorHandler);
@@ -362,12 +366,12 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = new LoanBuilder()
       .open()
-      .withLoanDate(new DateTime(2018, 1, 20, 13, 45, 21, DateTimeZone.UTC))
-      .withDueDate(new DateTime(2018, 2, 28, 23, 59, 59, DateTimeZone.UTC))
+      .withLoanDate(new DateTime(2018, 1, 20, 13, 45, 21, UTC))
+      .withDueDate(new DateTime(2018, 2, 28, 23, 59, 59, UTC))
       .asDomainObject()
       .withLoanPolicy(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2018, 1, 3, 8, 12, 32, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 1, 3, 8, 12, 32, UTC);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
     renew(loan, renewalDate, new RequestQueue(Collections.emptyList()), errorHandler);
@@ -389,18 +393,18 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = new LoanBuilder()
       .open()
-      .withLoanDate(new DateTime(2018, 1, 20, 13, 45, 21, DateTimeZone.UTC))
-      .withDueDate(new DateTime(2018, 1, 31, 23, 59, 59, DateTimeZone.UTC))
+      .withLoanDate(new DateTime(2018, 1, 20, 13, 45, 21, UTC))
+      .withDueDate(new DateTime(2018, 1, 31, 23, 59, 59, UTC))
       .asDomainObject()
       .withLoanPolicy(loanPolicy);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
 
     loan = renew(loan,
-      new DateTime(2018, 2, 1, 11, 23, 43, DateTimeZone.UTC),
+      new DateTime(2018, 2, 1, 11, 23, 43, UTC),
       new RequestQueue(Collections.emptyList()), errorHandler).value();
 
-    DateTime renewalDate = new DateTime(2018, 3, 5, 8, 12, 32, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 3, 5, 8, 12, 32, UTC);
 
     renew(loan, renewalDate, new RequestQueue(Collections.emptyList()), errorHandler);
 
@@ -423,16 +427,16 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = new LoanBuilder()
       .open()
-      .withLoanDate(new DateTime(2018, 1, 20, 13, 45, 21, DateTimeZone.UTC))
-      .withDueDate(new DateTime(2018, 1, 31, 23, 59, 59, DateTimeZone.UTC))
+      .withLoanDate(new DateTime(2018, 1, 20, 13, 45, 21, UTC))
+      .withDueDate(new DateTime(2018, 1, 31, 23, 59, 59, UTC))
       .asDomainObject()
       .withLoanPolicy(loanPolicy);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
-    loan = renew(loan, new DateTime(2018, 2, 1, 11, 23, 43, DateTimeZone.UTC),
+    loan = renew(loan, new DateTime(2018, 2, 1, 11, 23, 43, UTC),
       new RequestQueue(Collections.emptyList()), errorHandler).value();
 
-    DateTime renewalDate = new DateTime(2018, 3, 5, 8, 12, 32, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 3, 5, 8, 12, 32, UTC);
 
     String requestId = UUID.randomUUID().toString();
     RequestQueue requestQueue = creteRequestQueue(requestId, RequestType.RECALL);
@@ -458,7 +462,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = existingLoan(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2018, 4, 1, 6, 34, 21, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 4, 1, 6, 34, 21, UTC);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
     renew(loan, renewalDate, new RequestQueue(Collections.emptyList()), errorHandler);
@@ -479,7 +483,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = existingLoan(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2018, 2, 18, 6, 34, 21, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 2, 18, 6, 34, 21, UTC);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
     renew(loan, renewalDate, new RequestQueue(Collections.emptyList()), errorHandler);
@@ -498,7 +502,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
     Loan loan = existingLoan(loanPolicy);
 
-    DateTime renewalDate = new DateTime(2018, 3, 14, 11, 14, 54, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 3, 14, 11, 14, 54, UTC);
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
     renew(loan, renewalDate, new RequestQueue(Collections.emptyList()), errorHandler);
@@ -508,7 +512,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
   @Test
   void shouldFailWhenSchedulesCollectionIsNull() {
-    DateTime renewalDate = new DateTime(2018, 3, 14, 11, 14, 54, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 3, 14, 11, 14, 54, UTC);
 
     final FixedScheduleRenewalDueDateStrategy calculator =
       new FixedScheduleRenewalDueDateStrategy(UUID.randomUUID().toString(),
@@ -525,7 +529,7 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
 
   @Test
   void shouldFailWhenNoSchedules() {
-    DateTime renewalDate = new DateTime(2018, 3, 14, 11, 14, 54, DateTimeZone.UTC);
+    DateTime renewalDate = new DateTime(2018, 3, 14, 11, 14, 54, UTC);
 
     final FixedScheduleRenewalDueDateStrategy calculator =
       new FixedScheduleRenewalDueDateStrategy(UUID.randomUUID().toString(),
@@ -550,8 +554,8 @@ class FixedLoanPolicyRenewalDueDateCalculationTests {
   private Loan existingLoan() {
     return new LoanBuilder()
       .open()
-      .withLoanDate(new DateTime(2018, 1, 20, 13, 45, 21, DateTimeZone.UTC))
-      .withDueDate(new DateTime(2018, 1, 31, 23, 59, 59, DateTimeZone.UTC))
+      .withLoanDate(new DateTime(2018, 1, 20, 13, 45, 21, UTC))
+      .withDueDate(new DateTime(2018, 1, 31, 23, 59, 59, UTC))
       .withCheckoutServicePointId(checkoutServicePointId)
       .asDomainObject();
   }

--- a/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
@@ -109,6 +109,6 @@ class KeepCurrentStrategyTest {
     final DateTime requested = new DateTime(year, month, utcDay, utcHour, 0, 0, UTC);
     final DateTime dateEnd = strategy.calculateDueDate(requested, null).value();
 
-    assertEquals(newYorkDateEnd, dateEnd);
+    assertEquals(newYorkDateEnd.withZone(UTC), dateEnd);
   }
 }

--- a/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
@@ -97,7 +97,7 @@ class KeepCurrentStrategyTest {
     "16, 17, 3",
     "16, 17, 4"
   })
-  void shouldNeverChangeLocalDayWhenConvertingToTimeZone(int newYorkDay, int utcDay, int utcHour) {
+  void shouldAlwaysStayTheSameZonedDay(int newYorkDay, int utcDay, int utcHour) {
     final int year = 2020;
     final int month = 11;
     final DateTimeZone newYorkZone = DateTimeZone.forID("America/New_York");

--- a/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
@@ -1,6 +1,6 @@
 package org.folio.circulation.domain.policy.library;
 
-import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.END_OF_A_DAY;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 import static org.joda.time.DateTimeConstants.JANUARY;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.joda.time.DateTimeZone.forOffsetHours;
@@ -11,7 +11,10 @@ import java.util.stream.IntStream;
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class KeepCurrentStrategyTest {
 
@@ -23,7 +26,7 @@ class KeepCurrentStrategyTest {
 
     Result<DateTime> calculatedDateTime = keepCurrentStrategy.calculateDueDate(requestDate, null);
 
-    DateTime expectedDate = requestDate.withTime(END_OF_A_DAY);
+    DateTime expectedDate = atEndOfDay(requestDate, UTC);
     assertEquals(expectedDate, calculatedDateTime.value());
   }
 
@@ -38,6 +41,7 @@ class KeepCurrentStrategyTest {
     assertEquals(requestDate, calculatedDateTime.value());
   }
 
+  @Disabled
   @Test
   void shouldAlwaysKeepCurrentDateWhenConvertingToTimeZone() {
     final int year = 2020;
@@ -64,5 +68,47 @@ class KeepCurrentStrategyTest {
         final int zoneOffsetInMs = zoneOffset * 60 * 60 * 1000;
         assertEquals(zoneOffsetInMs, newDueDate.getZone().getOffset(now));
       });
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "16, 16, 5",
+    "16, 16, 6",
+    "16, 16, 7",
+    "16, 16, 8",
+    "16, 16, 9",
+    "16, 16, 10",
+    "16, 16, 11",
+    "16, 16, 12",
+    "16, 16, 13",
+    "16, 16, 14",
+    "16, 16, 15",
+    "16, 16, 16",
+    "16, 16, 17",
+    "16, 16, 18",
+    "16, 16, 19",
+    "16, 16, 20",
+    "16, 16, 21",
+    "16, 16, 22",
+    "16, 16, 23",
+    "16, 17, 0",
+    "16, 17, 1",
+    "16, 17, 2",
+    "16, 17, 3",
+    "16, 17, 4"
+  })
+  void shouldNeverChangeLocalDayWhenConvertingToTimeZone(int newYorkDay, int utcDay, int utcHour) {
+    final int year = 2020;
+    final int month = 11;
+    final DateTimeZone newYorkZone = DateTimeZone.forID("America/New_York");
+    final KeepCurrentDateStrategy strategy = new KeepCurrentDateStrategy(newYorkZone);
+
+    // https://www.timeanddate.com/worldclock/converter.html?iso=20201117T030000&p1=1440&p2=179
+    // https://www.timeanddate.com/worldclock/converter.html?iso=20201116T140000&p1=1440&p2=179
+    final DateTime newYorkDateEnd = new DateTime(year, month, newYorkDay, 23, 59, 59, newYorkZone);
+    final DateTime requested = new DateTime(year, month, utcDay, utcHour, 0, 0, UTC);
+    final DateTime dateEnd = strategy.calculateDueDate(requested, null).value();
+
+    assertEquals(newYorkDateEnd, dateEnd);
   }
 }

--- a/src/test/java/org/folio/circulation/support/utils/DateTimeUtilTests.java
+++ b/src/test/java/org/folio/circulation/support/utils/DateTimeUtilTests.java
@@ -1,0 +1,461 @@
+package org.folio.circulation.support.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DateTimeUtilsTests {
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectStartOfYearForZonedDateTimeParameters")
+  void shouldGetCorrectStartOfYearForZonedDateTime(int id, ZonedDateTime from, ZonedDateTime expected, ZoneId zone) {
+    final ZonedDateTime result = zone == null
+      ? DateTimeUtil.atStartOfYear(from)
+      : DateTimeUtil.atStartOfYear(from, zone);
+
+    assertEquals(expected.format(DateTimeFormatter.ISO_DATE), result.format(DateTimeFormatter.ISO_DATE), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectStartOfYearForZonedDateTimeParameters() {
+    return new Object[] {
+      new Object[] { 0, ZonedDateTime.parse("2018-03-01T02:28:19-05:00"), ZonedDateTime.parse("2018-01-01T00:00:00-05:00"), null },
+      new Object[] { 1, ZonedDateTime.parse("2018-02-28T21:28:19+00:00"), ZonedDateTime.parse("2018-01-01T00:00:00-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 2, ZonedDateTime.parse("2018-01-01T00:14:03-05:00"), ZonedDateTime.parse("2018-01-01T00:00:00-05:00"), null },
+      new Object[] { 3, ZonedDateTime.parse("2018-01-01T00:14:03+00:00"), ZonedDateTime.parse("2017-01-01T00:00:00-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 4, ZonedDateTime.parse("2018-12-31T23:40:50+01:00"), ZonedDateTime.parse("2018-01-01T00:00:00+01:00"), null },
+      new Object[] { 5, ZonedDateTime.parse("2018-12-31T23:40:50+00:00"), ZonedDateTime.parse("2019-01-01T00:00:00+01:00"), ZoneId.of("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectEndOfYearForZonedDateTimeParameters")
+  void shouldGetCorrectEndOfYearForZonedDateTime(int id, ZonedDateTime from, ZonedDateTime expected, ZoneId zone) {
+    final ZonedDateTime result = zone == null
+      ? DateTimeUtil.atEndOfYear(from)
+      : DateTimeUtil.atEndOfYear(from, zone);
+
+    assertEquals(expected.format(DateTimeFormatter.ISO_DATE), result.format(DateTimeFormatter.ISO_DATE), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectEndOfYearForZonedDateTimeParameters() {
+    return new Object[] {
+      new Object[] { 0, ZonedDateTime.parse("2018-03-01T02:28:19-05:00"), ZonedDateTime.parse("2018-12-31T23:59:59-05:00"), null },
+      new Object[] { 1, ZonedDateTime.parse("2018-02-28T21:28:19+00:00"), ZonedDateTime.parse("2018-12-31T23:59:59-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 2, ZonedDateTime.parse("2018-01-01T00:14:03-05:00"), ZonedDateTime.parse("2018-12-31T23:59:59-05:00"), null },
+      new Object[] { 3, ZonedDateTime.parse("2018-01-01T00:14:03+00:00"), ZonedDateTime.parse("2017-12-31T23:59:59-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 4, ZonedDateTime.parse("2018-12-31T23:40:50+01:00"), ZonedDateTime.parse("2018-12-31T23:59:59+01:00"), null },
+      new Object[] { 5, ZonedDateTime.parse("2018-12-31T23:40:50+00:00"), ZonedDateTime.parse("2019-12-31T23:59:59+01:00"), ZoneId.of("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectStartOfYearForLocalDateParameters")
+  void shouldGetCorrectStartOfYearForLocalDate(int id, LocalDate from, ZonedDateTime expected, ZoneId zone) {
+    final ZonedDateTime result = DateTimeUtil.atStartOfYear(from, zone);
+
+    assertEquals(expected.format(DateTimeFormatter.ISO_DATE), result.format(DateTimeFormatter.ISO_DATE), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectStartOfYearForLocalDateParameters() {
+    return new Object[] {
+      new Object[] { 0, LocalDate.parse("2018-02-28"), ZonedDateTime.parse("2018-01-01T00:00:00-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 1, LocalDate.parse("2018-01-01"), ZonedDateTime.parse("2018-01-01T00:00:00-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 2, LocalDate.parse("2018-12-31"), ZonedDateTime.parse("2018-01-01T00:00:00+01:00"), ZoneId.of("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectEndOfYearForLocalDateParameters")
+  void shouldGetCorrectEndOfYearForLocalDate(int id, LocalDate from, ZonedDateTime expected, ZoneId zone) {
+    final ZonedDateTime result = DateTimeUtil.atEndOfYear(from, zone);
+
+    assertEquals(expected.format(DateTimeFormatter.ISO_DATE), result.format(DateTimeFormatter.ISO_DATE), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectEndOfYearForLocalDateParameters() {
+    return new Object[] {
+      new Object[] { 0, LocalDate.parse("2018-02-28"), ZonedDateTime.parse("2018-12-31T23:59:59-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 1, LocalDate.parse("2018-01-01"), ZonedDateTime.parse("2018-12-31T23:59:59-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 2, LocalDate.parse("2018-12-31"), ZonedDateTime.parse("2018-12-31T23:59:59+01:00"), ZoneId.of("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectStartOfYearForDateTimeParameters")
+  void shouldGetCorrectStartOfYearForDateTime(int id, DateTime from, DateTime expected, DateTimeZone zone) {
+    final DateTime result = zone == null
+      ? DateTimeUtil.atStartOfYear(from)
+      : DateTimeUtil.atStartOfYear(from, zone);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectStartOfYearForDateTimeParameters() {
+    return new Object[] {
+      new Object[] { 0, DateTime.parse("2018-03-01T02:28:19-05:00"), DateTime.parse("2018-01-01T00:00:00-05:00"), null },
+      new Object[] { 1, DateTime.parse("2018-02-28T21:28:19+00:00"), DateTime.parse("2018-01-01T00:00:00-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 2, DateTime.parse("2018-01-01T00:14:03-05:00"), DateTime.parse("2018-01-01T00:00:00-05:00"), null },
+      new Object[] { 3, DateTime.parse("2018-01-01T00:14:03+00:00"), DateTime.parse("2017-01-01T00:00:00-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 4, DateTime.parse("2018-12-31T23:40:50+01:00"), DateTime.parse("2018-01-01T00:00:00+01:00"), null },
+      new Object[] { 5, DateTime.parse("2018-12-31T23:40:50+00:00"), DateTime.parse("2019-01-01T00:00:00+01:00"), DateTimeZone.forID("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectEndOfYearForDateTimeParameters")
+  void shouldGetCorrectEndOfYearForDateTime(int id, DateTime from, DateTime expected, DateTimeZone zone) {
+    final DateTime result = zone == null
+      ? DateTimeUtil.atEndOfYear(from)
+      : DateTimeUtil.atEndOfYear(from, zone);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectEndOfYearForDateTimeParameters() {
+    return new Object[] {
+      new Object[] { 0, DateTime.parse("2018-03-01T02:28:19-05:00"), DateTime.parse("2018-12-31T23:59:59-05:00"), null },
+      new Object[] { 1, DateTime.parse("2018-02-28T21:28:19+00:00"), DateTime.parse("2018-12-31T23:59:59-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 2, DateTime.parse("2018-01-01T00:14:03-05:00"), DateTime.parse("2018-12-31T23:59:59-05:00"), null },
+      new Object[] { 3, DateTime.parse("2018-01-01T00:14:03+00:00"), DateTime.parse("2017-12-31T23:59:59-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 4, DateTime.parse("2018-12-31T23:40:50+01:00"), DateTime.parse("2018-12-31T23:59:59+01:00"), null },
+      new Object[] { 5, DateTime.parse("2018-12-31T23:40:50+00:00"), DateTime.parse("2019-12-31T23:59:59+01:00"), DateTimeZone.forID("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectStartOfYearForJodaLocalDateParameters")
+  void shouldGetCorrectStartOfYearForJodaLocalDate(int id, org.joda.time.LocalDate from, DateTime expected, DateTimeZone zone) {
+    final DateTime result = DateTimeUtil.atStartOfYear(from, zone);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectStartOfYearForJodaLocalDateParameters() {
+    return new Object[] {
+      new Object[] { 0, org.joda.time.LocalDate.parse("2018-02-28"), DateTime.parse("2018-01-01T00:00:00-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 1, org.joda.time.LocalDate.parse("2018-01-01"), DateTime.parse("2018-01-01T00:00:00-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 2, org.joda.time.LocalDate.parse("2018-12-31"), DateTime.parse("2018-01-01T00:00:00+01:00"), DateTimeZone.forID("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectEndOfYearForJodaLocalDateParameters")
+  void shouldGetCorrectEndOfYearForJodaLocalDate(int id, org.joda.time.LocalDate from, DateTime expected, DateTimeZone zone) {
+    final DateTime result = DateTimeUtil.atEndOfYear(from, zone);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectEndOfYearForJodaLocalDateParameters() {
+    return new Object[] {
+      new Object[] { 0, org.joda.time.LocalDate.parse("2018-02-28"), DateTime.parse("2018-12-31T23:59:59-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 1, org.joda.time.LocalDate.parse("2018-01-01"), DateTime.parse("2018-12-31T23:59:59-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 2, org.joda.time.LocalDate.parse("2018-12-31"), DateTime.parse("2018-12-31T23:59:59+01:00"), DateTimeZone.forID("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectStartOfMonthForZonedDateTimeParameters")
+  void shouldGetCorrectStartOfMonthForZonedDateTime(int id, ZonedDateTime from, ZonedDateTime expected, ZoneId zone) {
+    final ZonedDateTime result = zone == null
+      ? DateTimeUtil.atStartOfMonth(from)
+      : DateTimeUtil.atStartOfMonth(from, zone);
+
+    assertEquals(expected.format(DateTimeFormatter.ISO_DATE), result.format(DateTimeFormatter.ISO_DATE), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectStartOfMonthForZonedDateTimeParameters() {
+    return new Object[] {
+      new Object[] { 0, ZonedDateTime.parse("2018-03-01T02:28:19-05:00"), ZonedDateTime.parse("2018-03-01T00:00:00-05:00"), null },
+      new Object[] { 1, ZonedDateTime.parse("2018-02-28T21:28:19+00:00"), ZonedDateTime.parse("2018-02-01T00:00:00-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 2, ZonedDateTime.parse("2018-01-01T00:14:03-05:00"), ZonedDateTime.parse("2018-01-01T00:00:00-05:00"), null },
+      new Object[] { 3, ZonedDateTime.parse("2018-01-01T00:14:03+00:00"), ZonedDateTime.parse("2017-12-01T00:00:00-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 4, ZonedDateTime.parse("2018-12-31T23:40:50+01:00"), ZonedDateTime.parse("2018-12-01T00:00:00+01:00"), null },
+      new Object[] { 5, ZonedDateTime.parse("2018-12-31T23:40:50+00:00"), ZonedDateTime.parse("2019-01-01T00:00:00+01:00"), ZoneId.of("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectEndOfMonthForZonedDateTimeParameters")
+  void shouldGetCorrectEndOfMonthForZonedDateTime(int id, ZonedDateTime from, ZonedDateTime expected, ZoneId zone) {
+    final ZonedDateTime result = zone == null
+      ? DateTimeUtil.atEndOfMonth(from)
+      : DateTimeUtil.atEndOfMonth(from, zone);
+
+    assertEquals(expected.format(DateTimeFormatter.ISO_DATE), result.format(DateTimeFormatter.ISO_DATE), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectEndOfMonthForZonedDateTimeParameters() {
+    return new Object[] {
+      new Object[] { 0, ZonedDateTime.parse("2018-03-01T02:28:19-05:00"), ZonedDateTime.parse("2018-03-31T23:59:59-05:00"), null },
+      new Object[] { 1, ZonedDateTime.parse("2018-02-28T21:28:19+00:00"), ZonedDateTime.parse("2018-02-28T23:59:59-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 2, ZonedDateTime.parse("2018-01-01T00:14:03-05:00"), ZonedDateTime.parse("2018-01-31T23:59:59-05:00"), null },
+      new Object[] { 3, ZonedDateTime.parse("2018-01-01T00:14:03+00:00"), ZonedDateTime.parse("2017-12-31T23:59:59-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 4, ZonedDateTime.parse("2018-12-31T23:40:50+01:00"), ZonedDateTime.parse("2018-12-31T23:59:59+01:00"), null },
+      new Object[] { 5, ZonedDateTime.parse("2018-12-31T23:40:50+00:00"), ZonedDateTime.parse("2019-01-31T23:59:59+01:00"), ZoneId.of("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectStartOfMonthForLocalDateParameters")
+  void shouldGetCorrectStartOfMonthForLocalDate(int id, LocalDate from, ZonedDateTime expected, ZoneId zone) {
+    final ZonedDateTime result = DateTimeUtil.atStartOfMonth(from, zone);
+
+    assertEquals(expected.format(DateTimeFormatter.ISO_DATE), result.format(DateTimeFormatter.ISO_DATE), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectStartOfMonthForLocalDateParameters() {
+    return new Object[] {
+      new Object[] { 0, LocalDate.parse("2018-02-28"), ZonedDateTime.parse("2018-02-01T00:00:00-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 1, LocalDate.parse("2018-01-01"), ZonedDateTime.parse("2018-01-01T00:00:00-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 2, LocalDate.parse("2018-12-31"), ZonedDateTime.parse("2018-12-01T00:00:00+01:00"), ZoneId.of("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectEndOfMonthForLocalDateParameters")
+  void shouldGetCorrectEndOfMonthForLocalDate(int id, LocalDate from, ZonedDateTime expected, ZoneId zone) {
+    final ZonedDateTime result = DateTimeUtil.atEndOfMonth(from, zone);
+
+    assertEquals(expected.format(DateTimeFormatter.ISO_DATE), result.format(DateTimeFormatter.ISO_DATE), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectEndOfMonthForLocalDateParameters() {
+    return new Object[] {
+      new Object[] { 0, LocalDate.parse("2018-02-28"), ZonedDateTime.parse("2018-02-28T23:59:59-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 1, LocalDate.parse("2018-01-01"), ZonedDateTime.parse("2018-01-31T23:59:59-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 2, LocalDate.parse("2018-12-31"), ZonedDateTime.parse("2018-12-31T23:59:59+01:00"), ZoneId.of("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectStartOfMonthForDateTimeParameters")
+  void shouldGetCorrectStartOfMonthForDateTime(int id, DateTime from, DateTime expected, DateTimeZone zone) {
+    final DateTime result = zone == null
+      ? DateTimeUtil.atStartOfMonth(from)
+      : DateTimeUtil.atStartOfMonth(from, zone);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectStartOfMonthForDateTimeParameters() {
+    return new Object[] {
+      new Object[] { 0, DateTime.parse("2018-03-01T02:28:19-05:00"), DateTime.parse("2018-03-01T00:00:00-05:00"), null },
+      new Object[] { 1, DateTime.parse("2018-02-28T21:28:19+00:00"), DateTime.parse("2018-02-01T00:00:00-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 2, DateTime.parse("2018-01-01T00:14:03-05:00"), DateTime.parse("2018-01-01T00:00:00-05:00"), null },
+      new Object[] { 3, DateTime.parse("2018-01-01T00:14:03+00:00"), DateTime.parse("2017-12-01T00:00:00-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 4, DateTime.parse("2018-12-31T23:40:50+01:00"), DateTime.parse("2018-12-01T00:00:00+01:00"), null },
+      new Object[] { 5, DateTime.parse("2018-12-31T23:40:50+00:00"), DateTime.parse("2019-01-01T00:00:00+01:00"), DateTimeZone.forID("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectEndOfMonthForDateTimeParameters")
+  void shouldGetCorrectEndOfMonthForDateTime(int id, DateTime from, DateTime expected, DateTimeZone zone) {
+    final DateTime result = zone == null
+      ? DateTimeUtil.atEndOfMonth(from)
+      : DateTimeUtil.atEndOfMonth(from, zone);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectEndOfMonthForDateTimeParameters() {
+    return new Object[] {
+      new Object[] { 0, DateTime.parse("2018-03-01T02:28:19-05:00"), DateTime.parse("2018-03-31T23:59:59-05:00"), null },
+      new Object[] { 1, DateTime.parse("2018-02-28T21:28:19+00:00"), DateTime.parse("2018-02-28T23:59:59-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 2, DateTime.parse("2018-01-01T00:14:03-05:00"), DateTime.parse("2018-01-31T23:59:59-05:00"), null },
+      new Object[] { 3, DateTime.parse("2018-01-01T00:14:03+00:00"), DateTime.parse("2017-12-31T23:59:59-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 4, DateTime.parse("2018-12-31T23:40:50+01:00"), DateTime.parse("2018-12-31T23:59:59+01:00"), null },
+      new Object[] { 5, DateTime.parse("2018-12-31T23:40:50+00:00"), DateTime.parse("2019-01-31T23:59:59+01:00"), DateTimeZone.forID("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectStartOfMonthForJodaLocalDateParameters")
+  void shouldGetCorrectStartOfMonthForJodaLocalDate(int id, org.joda.time.LocalDate from, DateTime expected, DateTimeZone zone) {
+    final DateTime result = DateTimeUtil.atStartOfMonth(from, zone);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectStartOfMonthForJodaLocalDateParameters() {
+    return new Object[] {
+      new Object[] { 0, org.joda.time.LocalDate.parse("2018-02-28"), DateTime.parse("2018-02-01T00:00:00-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 1, org.joda.time.LocalDate.parse("2018-01-01"), DateTime.parse("2018-01-01T00:00:00-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 2, org.joda.time.LocalDate.parse("2018-12-31"), DateTime.parse("2018-12-01T00:00:00+01:00"), DateTimeZone.forID("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectEndOfMonthForJodaLocalDateParameters")
+  void shouldGetCorrectEndOfMonthForJodaLocalDate(int id, org.joda.time.LocalDate from, DateTime expected, DateTimeZone zone) {
+    final DateTime result = DateTimeUtil.atEndOfMonth(from, zone);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectEndOfMonthForJodaLocalDateParameters() {
+    return new Object[] {
+      new Object[] { 0, org.joda.time.LocalDate.parse("2018-02-28"), DateTime.parse("2018-02-28T23:59:59-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 1, org.joda.time.LocalDate.parse("2018-01-01"), DateTime.parse("2018-01-31T23:59:59-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 2, org.joda.time.LocalDate.parse("2018-12-31"), DateTime.parse("2018-12-31T23:59:59+01:00"), DateTimeZone.forID("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectStartOfDayForZonedDateTimeParameters")
+  void shouldGetCorrectStartOfDayForZonedDateTime(int id, ZonedDateTime from, ZonedDateTime expected, ZoneId zone) {
+    final ZonedDateTime result = zone == null
+      ? DateTimeUtil.atStartOfDay(from)
+      : DateTimeUtil.atStartOfDay(from, zone);
+
+    assertEquals(expected.format(DateTimeFormatter.ISO_DATE), result.format(DateTimeFormatter.ISO_DATE), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectStartOfDayForZonedDateTimeParameters() {
+    return new Object[] {
+      new Object[] { 0, ZonedDateTime.parse("2018-03-01T02:28:19-05:00"), ZonedDateTime.parse("2018-03-01T00:00:00-05:00"), null },
+      new Object[] { 1, ZonedDateTime.parse("2018-02-28T21:28:19+00:00"), ZonedDateTime.parse("2018-02-28T00:00:00-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 2, ZonedDateTime.parse("2018-01-01T00:14:03-05:00"), ZonedDateTime.parse("2018-01-01T00:00:00-05:00"), null },
+      new Object[] { 3, ZonedDateTime.parse("2018-01-01T00:14:03+00:00"), ZonedDateTime.parse("2017-12-31T00:00:00-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 4, ZonedDateTime.parse("2018-12-31T23:40:50+01:00"), ZonedDateTime.parse("2018-12-31T00:00:00+01:00"), null },
+      new Object[] { 5, ZonedDateTime.parse("2018-12-31T23:40:50+00:00"), ZonedDateTime.parse("2019-01-01T00:00:00+01:00"), ZoneId.of("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectEndOfDayForZonedDateTimeParameters")
+  void shouldGetCorrectEndOfDayForZonedDateTime(int id, ZonedDateTime from, ZonedDateTime expected, ZoneId zone) {
+    final ZonedDateTime result = zone == null
+      ? DateTimeUtil.atEndOfDay(from)
+      : DateTimeUtil.atEndOfDay(from, zone);
+
+    assertEquals(expected.format(DateTimeFormatter.ISO_DATE), result.format(DateTimeFormatter.ISO_DATE), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectEndOfDayForZonedDateTimeParameters() {
+    return new Object[] {
+      new Object[] { 0, ZonedDateTime.parse("2018-03-01T02:28:19-05:00"), ZonedDateTime.parse("2018-03-01T23:59:59-05:00"), null },
+      new Object[] { 1, ZonedDateTime.parse("2018-02-28T21:28:19+00:00"), ZonedDateTime.parse("2018-02-28T23:59:59-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 2, ZonedDateTime.parse("2018-01-01T00:14:03-05:00"), ZonedDateTime.parse("2018-01-01T23:59:59-05:00"), null },
+      new Object[] { 3, ZonedDateTime.parse("2018-01-01T00:14:03+00:00"), ZonedDateTime.parse("2017-12-31T23:59:59-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 4, ZonedDateTime.parse("2018-12-31T23:40:50+01:00"), ZonedDateTime.parse("2018-12-31T23:59:59+01:00"), null },
+      new Object[] { 5, ZonedDateTime.parse("2018-12-31T23:40:50+00:00"), ZonedDateTime.parse("2019-01-01T23:59:59+01:00"), ZoneId.of("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectStartOfDayForLocalDateParameters")
+  void shouldGetCorrectStartOfDayForLocalDate(int id, LocalDate from, ZonedDateTime expected, ZoneId zone) {
+    final ZonedDateTime result = DateTimeUtil.atStartOfDay(from, zone);
+
+    assertEquals(expected.format(DateTimeFormatter.ISO_DATE), result.format(DateTimeFormatter.ISO_DATE), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectStartOfDayForLocalDateParameters() {
+    return new Object[] {
+      new Object[] { 0, LocalDate.parse("2018-02-28"), ZonedDateTime.parse("2018-02-28T00:00:00-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 1, LocalDate.parse("2018-01-01"), ZonedDateTime.parse("2018-01-01T00:00:00-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 2, LocalDate.parse("2018-12-31"), ZonedDateTime.parse("2018-12-31T00:00:00+01:00"), ZoneId.of("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectEndOfDayForLocalDateParameters")
+  void shouldGetCorrectEndOfDayForLocalDate(int id, LocalDate from, ZonedDateTime expected, ZoneId zone) {
+    final ZonedDateTime result = DateTimeUtil.atEndOfDay(from, zone);
+
+    assertEquals(expected.format(DateTimeFormatter.ISO_DATE), result.format(DateTimeFormatter.ISO_DATE), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectEndOfDayForLocalDateParameters() {
+    return new Object[] {
+      new Object[] { 0, LocalDate.parse("2018-02-28"), ZonedDateTime.parse("2018-02-28T23:59:59-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 1, LocalDate.parse("2018-01-01"), ZonedDateTime.parse("2018-01-01T23:59:59-05:00"), ZoneId.of("America/New_York") },
+      new Object[] { 2, LocalDate.parse("2018-12-31"), ZonedDateTime.parse("2018-12-31T23:59:59+01:00"), ZoneId.of("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectStartOfDayForDateTimeParameters")
+  void shouldGetCorrectStartOfDayForDateTime(int id, DateTime from, DateTime expected, DateTimeZone zone) {
+    final DateTime result = zone == null
+      ? DateTimeUtil.atStartOfDay(from)
+      : DateTimeUtil.atStartOfDay(from, zone);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectStartOfDayForDateTimeParameters() {
+    return new Object[] {
+      new Object[] { 0, DateTime.parse("2018-03-01T02:28:19-05:00"), DateTime.parse("2018-03-01T00:00:00-05:00"), null },
+      new Object[] { 1, DateTime.parse("2018-02-28T21:28:19+00:00"), DateTime.parse("2018-02-28T00:00:00-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 2, DateTime.parse("2018-01-01T00:14:03-05:00"), DateTime.parse("2018-01-01T00:00:00-05:00"), null },
+      new Object[] { 3, DateTime.parse("2018-01-01T00:14:03+00:00"), DateTime.parse("2017-12-31T00:00:00-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 4, DateTime.parse("2018-12-31T23:40:50+01:00"), DateTime.parse("2018-12-31T00:00:00+01:00"), null },
+      new Object[] { 5, DateTime.parse("2018-12-31T23:40:50+00:00"), DateTime.parse("2019-01-01T00:00:00+01:00"), DateTimeZone.forID("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectEndOfDayForDateTimeParameters")
+  void shouldGetCorrectEndOfDayForDateTime(int id, DateTime from, DateTime expected, DateTimeZone zone) {
+    final DateTime result = zone == null
+      ? DateTimeUtil.atEndOfDay(from)
+      : DateTimeUtil.atEndOfDay(from, zone);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectEndOfDayForDateTimeParameters() {
+    return new Object[] {
+      new Object[] { 0, DateTime.parse("2018-03-01T02:28:19-05:00"), DateTime.parse("2018-03-01T23:59:59-05:00"), null },
+      new Object[] { 1, DateTime.parse("2018-02-28T21:28:19+00:00"), DateTime.parse("2018-02-28T23:59:59-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 2, DateTime.parse("2018-01-01T00:14:03-05:00"), DateTime.parse("2018-01-01T23:59:59-05:00"), null },
+      new Object[] { 3, DateTime.parse("2018-01-01T00:14:03+00:00"), DateTime.parse("2017-12-31T23:59:59-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 4, DateTime.parse("2018-12-31T23:40:50+01:00"), DateTime.parse("2018-12-31T23:59:59+01:00"), null },
+      new Object[] { 5, DateTime.parse("2018-12-31T23:40:50+00:00"), DateTime.parse("2019-01-01T23:59:59+01:00"), DateTimeZone.forID("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectStartOfDayForJodaLocalDateParameters")
+  void shouldGetCorrectStartOfDayForJodaLocalDate(int id, org.joda.time.LocalDate from, DateTime expected, DateTimeZone zone) {
+    final DateTime result = DateTimeUtil.atStartOfDay(from, zone);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectStartOfDayForJodaLocalDateParameters() {
+    return new Object[] {
+      new Object[] { 0, org.joda.time.LocalDate.parse("2018-02-28"), DateTime.parse("2018-02-28T00:00:00-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 1, org.joda.time.LocalDate.parse("2018-01-01"), DateTime.parse("2018-01-01T00:00:00-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 2, org.joda.time.LocalDate.parse("2018-12-31"), DateTime.parse("2018-12-31T00:00:00+01:00"), DateTimeZone.forID("Europe/Warsaw") }
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldGetCorrectEndOfDayForJodaLocalDateParameters")
+  void shouldGetCorrectEndOfDayForJodaLocalDate(int id, org.joda.time.LocalDate from, DateTime expected, DateTimeZone zone) {
+    final DateTime result = DateTimeUtil.atEndOfDay(from, zone);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  private static Object[] shouldGetCorrectEndOfDayForJodaLocalDateParameters() {
+    return new Object[] {
+      new Object[] { 0, org.joda.time.LocalDate.parse("2018-02-28"), DateTime.parse("2018-02-28T23:59:59-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 1, org.joda.time.LocalDate.parse("2018-01-01"), DateTime.parse("2018-01-01T23:59:59-05:00"), DateTimeZone.forID("America/New_York") },
+      new Object[] { 2, org.joda.time.LocalDate.parse("2018-12-31"), DateTime.parse("2018-12-31T23:59:59+01:00"), DateTimeZone.forID("Europe/Warsaw") }
+    };
+  }
+
+}


### PR DESCRIPTION
A staged approach is being used to implement all of the necessary changes for resolving [CIRC-966](https://issues.folio.org/browse/CIRC-966).

This is Stage 4: For CU & DTU, start of day and end of day methods.

## Purpose
Update all operations where start of day and end of day are calculated to use the utility.
Operations such as start of year or end of month are also updated to use the utility.

There are some serious concerns with how start and end datetimes are calculated relative to the time zones.
For this reason, review this in full as there are likely controversial changes.

## Approach
The start and end of day utility methods are implemented along with their respective tests and are in use.
I discovered that there are also start/end of year and start/end of month.
These utility methods have also been implemented.

The start/end year/month/day methods are implemented to accept a zone (or default to a zone on an Object if available) in order to ensure that the order in which the zone is applied is consistent and correct.
If the time zone is applied at the wrong step, then the start and end times will be incorrect.

The `Request.truncateRequestExpirationDateToTheEndOfTheDay()` method is calling `.withZoneRetainFields()` when it should instead be calling `.withZone()`.
The related test also seems wrong.
Both of these have been corrected.

There is a problem with `KeepCurrentDateStrategy.calculateDueDate()` where the requested date is probably incorrectly altered.
Based on UICIRC-565 and PR 759, this was done to solve a problem with incorrect date being displayed.
I believe that the problem is instead related to how the UI passes down a date with time in the tenants timezone for some date only value.
That date only value (date without time) is represented in the tenants timezone and is not directly related to the datetime representation.
This can be a bit confusing, so a test `shouldNeverChangeLocalDayWhenConvertingToTimeZone()` has been added to show this and the other test `shouldAlwaysKeepCurrentDateWhenConvertingToTimeZone()` has been disabled.
The fix in CIRC-565 is effectively reverted and that problem may re-appear with this commit.

see: https://issues.folio.org/browse/UICIRC-565
see: https://github.com/folio-org/mod-circulation/pull/759

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
The start and end of any given day is relative to the time zone being represented.
For example
- take `2020-11-17T030000+0000`, the start of the day is `00:00:00` on `2020-11-17`.
- take `2020-11-17T030000-5000`, the start of the day is `00:00:00` on `2020-11-16`.

This is because the representation of the datetime string is in `UTC` with the a given offset.
For `UTC`, the day is the 17th but for `America/New_York`, that day is the 16th.

see: https://www.timeanddate.com/worldclock/converter.html?iso=20201117T030000&p1=1440&p2=179

For selecting the `KeepCurrentDateStrategy`, the UI presents a Date (without a time).
That date is presumed to be represented in the **Tenants** time zone.
Therefore, a user would see `2020-11-16` as the selected date in the UI.
The UI, however, represents this as a date as the string `2020-11-17T030000-5000`, which is sent to the backend.
The backend does not know that this is a "Date" only value and adjusts the time zone.
This resulted in the observed bug in [CIRC-565](https://issues.folio.org/browse/CIRC-565).
That solution, however, adjusted the actual date to some timezone, which could result in setting a date string a string such as `2020-11-17T030000-0000`.
The end of the day then gets calculated by that string, resulting in the end of the day for `2020-11-17`.
A user with a Tenant whose timezone is set to `America/New_York` would then see an end of day date for `2020-11-17` when the actual `America/New_York` end of day is on `2020-11-16`.

The test `KeepCurrentStrategyTest.shouldNeverChangeLocalDayWhenConvertingToTimeZone` is written to expose this situation.
To see the failure case mentioned above, in `KeepCurrentDateStrategy.calculateDueDate()`, change
```
return succeeded(atEndOfDay(requestedDate, zone));
```
into
```
return succeeded(atEndOfDay(requestedDate.withZoneRetainFields(zone), zone));
```
and run the mentioned test.

Therefore, this explicitly needs to be tested to see if [CIRC-565](https://issues.folio.org/browse/CIRC-565) is regressed.
I would assume so because the test written for that fails.
This problem likely needs further discussion.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
