### PR TITLE
CIRC-966: Stage 6, For CU, CF & DTU, refactor to use milliseconds. 

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Account.java
+++ b/src/main/java/org/folio/circulation/domain/Account.java
@@ -150,7 +150,7 @@ public class Account {
   public Optional<DateTime> getClosedDate() {
     return feeFineActions.stream()
       .filter(ffa -> ffa.getBalance().equals(NumberUtils.DOUBLE_ZERO))
-      .max((i, j) -> compareToMillis(i.getDateAction(), j.getDateAction()))
+      .max(this::compareByDateAction)
       .map(FeeFineAction::getDateAction);
   }
 
@@ -182,4 +182,9 @@ public class Account {
   public boolean hasPaidOrTransferredAmount() {
     return getPaidAndTransferredAmount().hasAmount();
   }
+
+  private int compareByDateAction(FeeFineAction left, FeeFineAction right) {
+    return compareToMillis(left.getDateAction(), right.getDateAction());
+  }
+
 }

--- a/src/main/java/org/folio/circulation/domain/Account.java
+++ b/src/main/java/org/folio/circulation/domain/Account.java
@@ -4,10 +4,10 @@ import static org.folio.circulation.domain.FeeAmount.noFeeAmount;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedDateTimeProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.utils.DateTimeUtil.compareToMillis;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Optional;
 
 import org.apache.commons.lang3.math.NumberUtils;
@@ -150,7 +150,7 @@ public class Account {
   public Optional<DateTime> getClosedDate() {
     return feeFineActions.stream()
       .filter(ffa -> ffa.getBalance().equals(NumberUtils.DOUBLE_ZERO))
-      .max(Comparator.comparing(FeeFineAction::getDateAction))
+      .max((i, j) -> compareToMillis(i.getDateAction(), j.getDateAction()))
       .map(FeeFineAction::getDateAction);
   }
 

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -50,11 +50,12 @@ import static org.folio.circulation.support.json.JsonPropertyWriter.writeByPath;
 import static org.folio.circulation.support.results.CommonFailures.failedDueToServerError;
 import static org.folio.circulation.support.results.Result.succeeded;
 import static org.folio.circulation.support.utils.CommonUtils.executeIfNotNull;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isSameMillis;
 import static org.folio.circulation.support.utils.DateTimeUtil.mostRecentDate;
 import static org.joda.time.DateTimeZone.UTC;
 
 import java.util.Collection;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -518,7 +519,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   public boolean hasDueDateChanged() {
-    return !Objects.equals(originalDueDate, getDueDate());
+    return !isSameMillis(originalDueDate, getDueDate());
   }
 
   public DateTime getSystemReturnDate() {
@@ -554,7 +555,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     DateTime dueDate = getDueDate();
 
     return ObjectUtils.allNotNull(dueDate, systemTime)
-      && dueDate.isBefore(systemTime);
+      && isBeforeMillis(dueDate, systemTime);
   }
 
   public Loan claimItemReturned(String comment, DateTime claimedReturnedDate) {

--- a/src/main/java/org/folio/circulation/domain/OverduePeriodCalculatorService.java
+++ b/src/main/java/org/folio/circulation/domain/OverduePeriodCalculatorService.java
@@ -4,6 +4,9 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.commons.lang3.ObjectUtils.allNotNull;
 import static org.folio.circulation.support.results.Result.succeeded;
 import static org.folio.circulation.support.results.ResultBinding.flatMapResult;
+import static org.folio.circulation.support.utils.DateTimeUtil.isAfterMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isWithinMillis;
 import static org.joda.time.DateTimeConstants.MINUTES_PER_HOUR;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.joda.time.Minutes.minutesBetween;
@@ -12,8 +15,8 @@ import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
-import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
 import org.folio.circulation.infrastructure.storage.CalendarRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDateTime;
@@ -102,17 +105,16 @@ public class OverduePeriodCalculatorService {
       LocalDateTime endTime = datePart.withTime(openingHour.getEndTime())
         .withZone(UTC).toLocalDateTime();
 
-      if (dueDate.isAfter(startTime) && dueDate.isBefore(endTime)) {
+      if (isWithinMillis(dueDate, startTime, endTime)) {
         startTime = dueDate;
       }
 
-      if (returnDate.isAfter(startTime) && returnDate.isBefore(endTime)) {
+      if (isWithinMillis(returnDate, startTime, endTime)) {
         endTime = returnDate;
       }
 
-      if (endTime.isAfter(startTime) && endTime.isAfter(dueDate)
-        && startTime.isBefore(returnDate)) {
-
+      if (isAfterMillis(endTime, startTime) && isAfterMillis(endTime, dueDate)
+        && isBeforeMillis(startTime, returnDate)) {
         return calculateDiffInMinutes(startTime, endTime);
       }
     }

--- a/src/main/java/org/folio/circulation/domain/ProxyRelationship.java
+++ b/src/main/java/org/folio/circulation/domain/ProxyRelationship.java
@@ -1,13 +1,15 @@
 package org.folio.circulation.domain;
 
-import io.vertx.core.json.JsonObject;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTimeProperty;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedDateTimeProperty;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
+
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 
-import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTimeProperty;
-import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedDateTimeProperty;
-import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
+import io.vertx.core.json.JsonObject;
 
 public class ProxyRelationship {
 
@@ -52,7 +54,7 @@ public class ProxyRelationship {
 
   public boolean isActive() {
       boolean expired = expirationDate != null
-        && expirationDate.isBefore(ClockUtil.getDateTime());
+        && isBeforeMillis(expirationDate, ClockUtil.getDateTime());
 
       return active && !expired;
   }

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -25,13 +25,13 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTime
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getIntegerProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
-import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.LocalTime;
 
 import io.vertx.core.json.JsonObject;
 import lombok.AllArgsConstructor;
@@ -347,8 +347,13 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   public Request truncateRequestExpirationDateToTheEndOfTheDay(DateTimeZone zone) {
     DateTime requestExpirationDate = getRequestExpirationDate();
     if (requestExpirationDate != null) {
-      final DateTime dateTime = atEndOfDay(requestExpirationDate, zone);
-      write(requestRepresentation, REQUEST_EXPIRATION_DATE, dateTime);
+      // TODO: this introduces behavioral change not yet intended, use this after converting JodaTime to JavaTime.
+      //final DateTime dateTime = atEndOfDay(requestExpirationDate, zone);
+      //write(requestRepresentation, REQUEST_EXPIRATION_DATE, dateTime);
+      DateTime requestDateTime = requestExpirationDate
+        .withZoneRetainFields(zone)
+        .withTime(LocalTime.MIDNIGHT.minusSeconds(1));
+      write(requestRepresentation, REQUEST_EXPIRATION_DATE, requestDateTime);
     }
     return this;
   }

--- a/src/main/java/org/folio/circulation/domain/User.java
+++ b/src/main/java/org/folio/circulation/domain/User.java
@@ -7,6 +7,7 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTime
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getObjectProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
 
 import java.util.Objects;
 
@@ -56,7 +57,7 @@ public class User {
       return false;
     }
     else {
-      return expirationDate.isBefore(ClockUtil.getDateTime());
+      return isBeforeMillis(expirationDate, ClockUtil.getDateTime());
     }
   }
 

--- a/src/main/java/org/folio/circulation/domain/anonymization/checkers/FeesAndFinesClosePeriodChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checkers/FeesAndFinesClosePeriodChecker.java
@@ -1,12 +1,11 @@
 package org.folio.circulation.domain.anonymization.checkers;
 
-import static org.folio.circulation.support.utils.DateTimeUtil.compareToMillis;
-
 import java.util.Optional;
 
 import org.folio.circulation.domain.Account;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.support.utils.DateTimeUtil;
 import org.joda.time.DateTime;
 
 public class FeesAndFinesClosePeriodChecker extends TimePeriodChecker {
@@ -29,7 +28,7 @@ public class FeesAndFinesClosePeriodChecker extends TimePeriodChecker {
       .map(Account::getClosedDate)
       .filter(Optional::isPresent)
       .map(Optional::get)
-      .max(DateTimeUtil::compareToMillis); 
+      .max(DateTimeUtil::compareToMillis);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/anonymization/checkers/FeesAndFinesClosePeriodChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checkers/FeesAndFinesClosePeriodChecker.java
@@ -1,5 +1,7 @@
 package org.folio.circulation.domain.anonymization.checkers;
 
+import static org.folio.circulation.support.utils.DateTimeUtil.compareToMillis;
+
 import java.util.Optional;
 
 import org.folio.circulation.domain.Account;
@@ -27,7 +29,7 @@ public class FeesAndFinesClosePeriodChecker extends TimePeriodChecker {
       .map(Account::getClosedDate)
       .filter(Optional::isPresent)
       .map(Optional::get)
-      .max(DateTime::compareTo);
+      .max((i, j) -> compareToMillis(i, j));
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/anonymization/checkers/FeesAndFinesClosePeriodChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checkers/FeesAndFinesClosePeriodChecker.java
@@ -29,7 +29,7 @@ public class FeesAndFinesClosePeriodChecker extends TimePeriodChecker {
       .map(Account::getClosedDate)
       .filter(Optional::isPresent)
       .map(Optional::get)
-      .max((i, j) -> compareToMillis(i, j));
+      .max(DateTimeUtil::compareToMillis); 
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/anonymization/checkers/TimePeriodChecker.java
+++ b/src/main/java/org/folio/circulation/domain/anonymization/checkers/TimePeriodChecker.java
@@ -1,7 +1,9 @@
 package org.folio.circulation.domain.anonymization.checkers;
 
+import static org.folio.circulation.support.utils.ClockUtil.getDateTime;
+import static org.folio.circulation.support.utils.DateTimeUtil.isAfterMillis;
+
 import org.folio.circulation.domain.policy.Period;
-import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 
 abstract class TimePeriodChecker implements AnonymizationChecker {
@@ -13,8 +15,7 @@ abstract class TimePeriodChecker implements AnonymizationChecker {
   }
 
   boolean checkTimePeriodPassed(DateTime startDate) {
-    return startDate != null && ClockUtil.getDateTime()
-      .isAfter(startDate.plus(period.timePeriod()));
+    return startDate != null && isAfterMillis(getDateTime(), startDate.plus(period.timePeriod()));
   }
 
 }

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
@@ -4,6 +4,7 @@ import static java.util.Collections.singletonList;
 import static org.folio.circulation.domain.notice.TemplateContextUtil.createFeeFineNoticeContext;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.ResultBinding.mapResult;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -108,7 +109,7 @@ public class FeeFineScheduledNoticeHandler extends ScheduledNoticeHandler {
     DateTime nextRunTime = notice.getNextRunTime().plus(recurringPeriod);
     DateTime now = ClockUtil.getDateTime();
 
-    if (nextRunTime.isBefore(now)) {
+    if (isBeforeMillis(nextRunTime, now)) {
       nextRunTime = now.plus(recurringPeriod);
     }
 

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
@@ -13,6 +13,8 @@ import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
 import static org.folio.circulation.support.results.ResultBinding.mapResult;
+import static org.folio.circulation.support.utils.DateTimeUtil.isAfterMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -94,7 +96,7 @@ public class LoanScheduledNoticeHandler extends ScheduledNoticeHandler {
     DateTime recurringNoticeNextRunTime = notice.getNextRunTime()
       .plus(noticeConfig.getRecurringPeriod().timePeriod());
 
-    if (recurringNoticeNextRunTime.isBefore(systemTime)) {
+    if (isBeforeMillis(recurringNoticeNextRunTime, systemTime)) {
       recurringNoticeNextRunTime =
         systemTime.plus(noticeConfig.getRecurringPeriod().timePeriod());
     }
@@ -147,7 +149,7 @@ public class LoanScheduledNoticeHandler extends ScheduledNoticeHandler {
     if (loan.isClosed()) {
       logMessages.add("Loan is closed");
     }
-    if (noticeConfig.hasBeforeTiming() && dueDate.isBefore(systemTime)) {
+    if (noticeConfig.hasBeforeTiming() && isBeforeMillis(dueDate, systemTime)) {
       logMessages.add("Loan is overdue");
     }
     if (isRecurringAfterNotice(notice) &&
@@ -207,7 +209,7 @@ public class LoanScheduledNoticeHandler extends ScheduledNoticeHandler {
 
     return noticeConfig.isRecurring() &&
       noticeConfig.getTiming() == BEFORE &&
-      notice.getNextRunTime().isAfter(loan.getDueDate());
+      isAfterMillis(notice.getNextRunTime(), loan.getDueDate());
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
@@ -6,6 +6,8 @@ import static org.folio.circulation.domain.notice.TemplateContextUtil.createRequ
 import static org.folio.circulation.domain.notice.schedule.TriggeringEvent.HOLD_EXPIRATION;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.ResultBinding.mapResult;
+import static org.folio.circulation.support.utils.DateTimeUtil.isAfterMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -131,7 +133,7 @@ public class RequestScheduledNoticeHandler extends ScheduledNoticeHandler {
     DateTime recurringNoticeNextRunTime = notice.getNextRunTime()
       .plus(noticeConfig.getRecurringPeriod().timePeriod());
 
-    if (recurringNoticeNextRunTime.isBefore(systemTime)) {
+    if (isBeforeMillis(recurringNoticeNextRunTime, systemTime)) {
       recurringNoticeNextRunTime =
         systemTime.plus(noticeConfig.getRecurringPeriod().timePeriod());
     }
@@ -152,8 +154,8 @@ public class RequestScheduledNoticeHandler extends ScheduledNoticeHandler {
     DateTime requestExpirationDate = request.getRequestExpirationDate();
     DateTime holdShelfExpirationDate = request.getHoldShelfExpirationDate();
 
-    return requestExpirationDate != null && nextRunTime.isAfter(requestExpirationDate) ||
-      holdShelfExpirationDate != null && nextRunTime.isAfter(holdShelfExpirationDate);
+    return requestExpirationDate != null && isAfterMillis(nextRunTime, requestExpirationDate) ||
+      holdShelfExpirationDate != null && isAfterMillis(nextRunTime, holdShelfExpirationDate);
   }
 
 }

--- a/src/main/java/org/folio/circulation/domain/policy/FixedDueDateSchedules.java
+++ b/src/main/java/org/folio/circulation/domain/policy/FixedDueDateSchedules.java
@@ -6,6 +6,7 @@ import static org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher.
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.utils.DateFormatUtil.parseJodaDateTime;
 import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +15,7 @@ import java.util.function.Supplier;
 
 import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.DateTimeUtil;
 import org.joda.time.DateTime;
 
 import io.vertx.core.json.JsonObject;
@@ -52,7 +54,7 @@ public class FixedDueDateSchedules {
       DateTime from = parseJodaDateTime(schedule.getString("from"));
       DateTime to = atEndOfDay(parseJodaDateTime(schedule.getString("to")));
 
-      return date.isAfter(from) && date.isBefore(to);
+      return DateTimeUtil.isWithinMillis(date, from, to);
     };
   }
 
@@ -76,7 +78,7 @@ public class FixedDueDateSchedules {
   }
 
   private DateTime earliest(DateTime rollingDueDate, DateTime limit) {
-    return limit.isBefore(rollingDueDate)
+    return isBeforeMillis(limit, rollingDueDate)
       ? limit
       : rollingDueDate;
   }

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -10,6 +10,7 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedSt
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getObjectProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.results.Result.succeeded;
+import static org.folio.circulation.support.utils.DateTimeUtil.isAfterMillis;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -470,7 +471,7 @@ public class LoanPolicy extends Policy {
         }
 
         if (minimumGuaranteedDueDate == null ||
-          recallDueDate.isAfter(minimumGuaranteedDueDate)) {
+          isAfterMillis(recallDueDate, minimumGuaranteedDueDate)) {
           return recallDueDate;
         } else {
           return minimumGuaranteedDueDate;

--- a/src/main/java/org/folio/circulation/domain/policy/Period.java
+++ b/src/main/java/org/folio/circulation/domain/policy/Period.java
@@ -5,6 +5,9 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getIntegerP
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.succeeded;
+import static org.folio.circulation.support.utils.ClockUtil.getDateTime;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isSameMillis;
 import static org.joda.time.DateTimeConstants.MINUTES_PER_DAY;
 import static org.joda.time.DateTimeConstants.MINUTES_PER_HOUR;
 import static org.joda.time.DateTimeConstants.MINUTES_PER_WEEK;
@@ -20,7 +23,6 @@ import java.util.function.Supplier;
 import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.results.Result;
-import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 
 import io.vertx.core.json.JsonObject;
@@ -186,10 +188,10 @@ public class Period {
   }
 
   public boolean hasPassedSinceDateTillNow(DateTime startDate) {
-    final DateTime now = ClockUtil.getDateTime();
+    final DateTime now = getDateTime();
     final DateTime startPlusPeriod = startDate.plus(timePeriod());
 
-    return startPlusPeriod.isBefore(now) || startPlusPeriod.isEqual(now);
+    return isBeforeMillis(startPlusPeriod, now) || isSameMillis(startPlusPeriod, now);
   }
 
   public boolean hasNotPassedSinceDateTillNow(DateTime startDate) {
@@ -197,10 +199,9 @@ public class Period {
   }
 
   public boolean isEqualToDateTillNow(DateTime startDate) {
-    final DateTime now = ClockUtil.getDateTime();
     final DateTime startPlusPeriod = startDate.plus(timePeriod());
 
-    return now.isEqual(startPlusPeriod);
+    return isSameMillis(getDateTime(), startPlusPeriod);
   }
 
   public boolean hasZeroDuration() {

--- a/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyService.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyService.java
@@ -5,17 +5,19 @@ import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyU
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
 import static org.folio.circulation.support.results.ResultBinding.mapResult;
+import static org.folio.circulation.support.utils.DateTimeUtil.compareToMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
 
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.circulation.AdjacentOpeningDays;
-import org.folio.circulation.domain.User;
-import org.folio.circulation.infrastructure.storage.CalendarRepository;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
+import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.policy.LoanPolicy;
+import org.folio.circulation.infrastructure.storage.CalendarRepository;
 import org.folio.circulation.resources.context.RenewalContext;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
@@ -86,7 +88,7 @@ public class ClosedLibraryStrategyService {
 
     User user = loan.getUser();
     if (user != null && user.getExpirationDate() != null &&
-      user.getExpirationDate().isBefore(dueDate)) {
+      isBeforeMillis(user.getExpirationDate(), dueDate)) {
 
       return calendarRepository.lookupOpeningDays(user.getExpirationDate().toLocalDate(),
         loan.getCheckoutServicePointId())

--- a/src/main/java/org/folio/circulation/domain/policy/library/EndOfCurrentHoursStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/EndOfCurrentHoursStrategy.java
@@ -3,6 +3,7 @@ package org.folio.circulation.domain.policy.library;
 import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.failureForAbsentTimetable;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.succeeded;
+import static org.folio.circulation.support.utils.DateTimeUtil.compareToMillis;
 
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
@@ -54,6 +55,6 @@ public class EndOfCurrentHoursStrategy extends ShortTermLoansBaseStrategy {
   }
 
   private boolean isDateEqualToBoundaryValueOfDay(LocalTime requestedInterval, LocalTime boundaryValueOfDay) {
-    return requestedInterval.compareTo(boundaryValueOfDay) == 0;
+    return compareToMillis(requestedInterval, boundaryValueOfDay) == 0;
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/library/KeepCurrentDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/KeepCurrentDateStrategy.java
@@ -1,13 +1,12 @@
 package org.folio.circulation.domain.policy.library;
 
 import static org.folio.circulation.support.results.Result.succeeded;
-import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
-import static org.joda.time.DateTimeZone.UTC;
 
 import org.folio.circulation.AdjacentOpeningDays;
 import org.folio.circulation.support.results.Result;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.LocalTime;
 
 public class KeepCurrentDateStrategy implements ClosedLibraryStrategy {
   private final DateTimeZone zone;
@@ -18,6 +17,10 @@ public class KeepCurrentDateStrategy implements ClosedLibraryStrategy {
 
   @Override
   public Result<DateTime> calculateDueDate(DateTime requestedDate, AdjacentOpeningDays openingDays) {
-    return succeeded(atEndOfDay(requestedDate, zone).withZone(UTC));
+    // TODO: this introduces behavioral change not yet intended, use this after converting JodaTime to JavaTime.
+    //return succeeded(atEndOfDay(requestedDate, zone).withZone(UTC));
+    return succeeded(requestedDate
+      .withZoneRetainFields(zone)
+      .withTime(LocalTime.MIDNIGHT.minusSeconds(1)));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/validation/ChangeDueDateValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ChangeDueDateValidator.java
@@ -1,17 +1,18 @@
 package org.folio.circulation.domain.validation;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
-import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
+import static org.folio.circulation.support.utils.DateTimeUtil.isSameMillis;
 
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
-import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.ValidationErrorFailure;
+import org.folio.circulation.support.results.Result;
 
 public class ChangeDueDateValidator {
 
@@ -48,7 +49,7 @@ public class ChangeDueDateValidator {
 
   private Result<Boolean> dueDateHasChanged(Loan existingLoan, Loan changedLoan) {
     return succeeded(existingLoan != null
-        && !existingLoan.getDueDate().equals(changedLoan.getDueDate()));
+        && !isSameMillis(existingLoan.getDueDate(), changedLoan.getDueDate()));
   }
 
   private ValidationErrorFailure dueDateChangeFailedForItem(Item item) {

--- a/src/main/java/org/folio/circulation/domain/validation/UserManualBlocksValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/UserManualBlocksValidator.java
@@ -5,6 +5,8 @@ import static org.folio.circulation.support.fetching.RecordFetching.findWithCqlQ
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
 import static org.folio.circulation.support.results.Result.of;
 import static org.folio.circulation.support.results.Result.ofAsync;
+import static org.folio.circulation.support.utils.ClockUtil.getDateTime;
+import static org.folio.circulation.support.utils.DateTimeUtil.isAfterMillis;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -22,7 +24,6 @@ import org.folio.circulation.support.FindWithCqlQuery;
 import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.results.Result;
-import org.folio.circulation.support.utils.ClockUtil;
 import org.joda.time.DateTime;
 
 public class UserManualBlocksValidator {
@@ -94,7 +95,6 @@ public class UserManualBlocksValidator {
   }
 
   private boolean isBlockedAction(DateTime expirationDate, boolean isBlocked) {
-    final DateTime now = ClockUtil.getDateTime();
-    return isBlocked && (expirationDate == null || expirationDate.isAfter(now));
+    return isBlocked && (expirationDate == null || isAfterMillis(expirationDate, getDateTime()));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/validation/overriding/OverridingLoanValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/overriding/OverridingLoanValidator.java
@@ -4,6 +4,7 @@ import static org.folio.circulation.domain.LoanAction.CHECKED_OUT_THROUGH_OVERRI
 import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.succeeded;
+import static org.folio.circulation.support.utils.DateTimeUtil.isAfterMillis;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -81,7 +82,7 @@ public class OverridingLoanValidator extends OverridingBlockValidator<LoanAndRel
     DateTime loanDate = loanAndRelatedRecords.getLoan().getLoanDate();
     DateTime requestedDueDate = itemNotLoanableBlockOverride.getDueDate();
 
-    if (itemNotLoanableBlockOverride.isRequested() && !requestedDueDate.isAfter(loanDate)) {
+    if (itemNotLoanableBlockOverride.isRequested() && !isAfterMillis(requestedDueDate, loanDate)) {
       return failed(singleValidationError(new ValidationError(DUE_DATE_NOT_AFTER_LOAN_DATE,
         DUE_DATE_PARAM_NAME, itemNotLoanableBlockOverride.getDueDateRaw())));
     }

--- a/src/main/java/org/folio/circulation/resources/RenewalValidator.java
+++ b/src/main/java/org/folio/circulation/resources/RenewalValidator.java
@@ -2,6 +2,8 @@ package org.folio.circulation.resources;
 
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.results.Result.succeeded;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isSameMillis;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,8 +50,8 @@ public final class RenewalValidator {
   }
 
   private static boolean isSameOrBefore(Loan loan, DateTime proposedDueDate) {
-    return proposedDueDate.isEqual(loan.getDueDate())
-      || proposedDueDate.isBefore(loan.getDueDate());
+    return isSameMillis(proposedDueDate, loan.getDueDate())
+      || isBeforeMillis(proposedDueDate, loan.getDueDate());
   }
 
   public static ValidationError loanPolicyValidationError(LoanPolicy loanPolicy,

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -38,6 +38,7 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty
 import static org.folio.circulation.support.results.CommonFailures.failedDueToServerError;
 import static org.folio.circulation.support.results.Result.succeeded;
 import static org.folio.circulation.support.results.ResultBinding.mapResult;
+import static org.folio.circulation.support.utils.DateTimeUtil.isAfterMillis;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -449,7 +450,7 @@ public abstract class RenewalResource extends Resource {
   }
 
   private boolean newDueDateAfterCurrentDueDate(Loan loan, Result<DateTime> proposedDueDateResult) {
-    return proposedDueDateResult.map(proposedDueDate -> proposedDueDate.isAfter(loan.getDueDate()))
+    return proposedDueDateResult.map(proposedDueDate -> isAfterMillis(proposedDueDate, loan.getDueDate()))
       .orElse(false);
   }
 

--- a/src/main/java/org/folio/circulation/support/utils/ClockUtil.java
+++ b/src/main/java/org/folio/circulation/support/utils/ClockUtil.java
@@ -18,6 +18,13 @@ import org.joda.time.DateTimeZone;
 
 /**
  * A clock manager for safely getting and setting the time.
+ * <p>
+ * Provides management of the clock that is then exposed and used as the
+ * default clock for all methods within this utility.
+ * <p>
+ * Use these methods rather than using the now() methods for any given date and
+ * time related class.
+ * Failure to do so may result in the inability to properly perform tests.
  */
 public class ClockUtil {
   private static Clock clock = Clock.systemUTC();
@@ -78,7 +85,7 @@ public class ClockUtil {
 
   /**
    * Get the current system time according to the clock manager.
-   *
+   * <p>
    * TODO: This is temporarily designed to work with JodaTime. Replace this as
    * appropriate when migrating from JodaTime to JavaTime.
    *
@@ -124,7 +131,7 @@ public class ClockUtil {
 
   /**
    * Get the current system time according to the clock manager.
-   *
+   * <p>
    * TODO: Remove this once JodaTime is fully converted to JavaTime.
    *
    * @return
@@ -138,7 +145,7 @@ public class ClockUtil {
 
   /**
    * Get the current system time according to the clock manager.
-   *
+   * <p>
    * TODO: Remove this once JodaTime is fully converted to JavaTime.
    *
    * @return
@@ -151,7 +158,7 @@ public class ClockUtil {
 
   /**
    * Get the current system time according to the clock manager.
-   *
+   * <p>
    * TODO: Remove this once JodaTime is fully converted to JavaTime.
    *
    * @return
@@ -176,7 +183,7 @@ public class ClockUtil {
 
   /**
    * Get the current system time according to the clock manager.
-   *
+   * <p>
    * TODO: Remove this once JodaTime is fully converted to JavaTime.
    *
    * @return
@@ -190,7 +197,7 @@ public class ClockUtil {
 
   /**
    * Get the time zone of the system clock according to the clock manager.
-   *
+   * <p>
    * TODO: Remove this once JodaTime is fully converted to JavaTime.
    *
    * @return
@@ -223,9 +230,9 @@ public class ClockUtil {
 
   /**
    * Get the time zone from the clock.
-   *
+   * <p>
    * This will be converted from JavaTimes time zone to JodaTimes time zone.
-   *
+   * <p>
    * TODO: Remove this once JodaTime is fully converted to JavaTime.
    */
   public static DateTimeZone jodaTimezone() {

--- a/src/main/java/org/folio/circulation/support/utils/DateFormatUtil.java
+++ b/src/main/java/org/folio/circulation/support/utils/DateFormatUtil.java
@@ -6,9 +6,8 @@ import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
-import static org.folio.circulation.support.utils.DateTimeUtil.normalizeDate;
-import static org.folio.circulation.support.utils.DateTimeUtil.normalizeDateTime;
-import static org.folio.circulation.support.utils.DateTimeUtil.normalizeZone;
+import static org.folio.circulation.support.utils.DateTimeUtil.defaultToClockZone;
+import static org.folio.circulation.support.utils.DateTimeUtil.defaultToNow;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -190,7 +189,7 @@ public class DateFormatUtil {
    * @return The converted dateTime string.
    */
   public static String formatDate(ZonedDateTime dateTime) {
-    return normalizeDateTime(dateTime).format(ISO_LOCAL_DATE);
+    return defaultToNow(dateTime).format(ISO_LOCAL_DATE);
   }
 
   /**
@@ -204,7 +203,7 @@ public class DateFormatUtil {
    * @return The converted dateTime string.
    */
   public static String formatDate(OffsetDateTime dateTime) {
-    return normalizeDateTime(dateTime).format(ISO_LOCAL_DATE);
+    return defaultToNow(dateTime).format(ISO_LOCAL_DATE);
   }
 
   /**
@@ -218,7 +217,7 @@ public class DateFormatUtil {
    * @return The converted date string.
    */
   public static String formatDate(LocalDate date) {
-    return normalizeDate(date).format(ISO_LOCAL_DATE);
+    return defaultToNow(date).format(ISO_LOCAL_DATE);
   }
 
   /**
@@ -234,7 +233,7 @@ public class DateFormatUtil {
    * @return The converted dateTime string.
    */
   public static String formatDate(org.joda.time.LocalDate date) {
-    return normalizeDate(date).toString(ISODateTimeFormat.date());
+    return defaultToNow(date).toString(ISODateTimeFormat.date());
   }
 
   /**
@@ -307,7 +306,7 @@ public class DateFormatUtil {
    * @return The converted dateTime string.
    */
   public static String formatDateTime(ZonedDateTime dateTime) {
-    return normalizeDateTime(dateTime).format(DATE_TIME);
+    return defaultToNow(dateTime).format(DATE_TIME);
   }
 
   /**
@@ -321,7 +320,7 @@ public class DateFormatUtil {
    * @return The converted dateTime string.
    */
   public static String formatDateTime(OffsetDateTime dateTime) {
-    return normalizeDateTime(dateTime).format(DATE_TIME);
+    return defaultToNow(dateTime).format(DATE_TIME);
   }
 
   /**
@@ -337,7 +336,7 @@ public class DateFormatUtil {
    * @return The converted date string.
    */
   public static String formatDateTime(LocalDate date) {
-    return ZonedDateTime.of(normalizeDate(date), LocalTime.MIDNIGHT, ClockUtil.getZoneId())
+    return ZonedDateTime.of(defaultToNow(date), LocalTime.MIDNIGHT, ClockUtil.getZoneId())
       .format(DATE_TIME);
   }
 
@@ -354,7 +353,7 @@ public class DateFormatUtil {
    * @return The converted dateTime string.
    */
   public static String formatDateTime(DateTime dateTime) {
-    return normalizeDateTime(dateTime).toString(ISODateTimeFormat.dateTime());
+    return defaultToNow(dateTime).toString(ISODateTimeFormat.dateTime());
   }
 
   /**
@@ -384,7 +383,7 @@ public class DateFormatUtil {
    */
   public static ZonedDateTime parseDateTime(String value, ZoneId zone) {
     if (value == null) {
-      final ZonedDateTime dateTime = normalizeDateTime((ZonedDateTime) null);
+      final ZonedDateTime dateTime = defaultToNow((ZonedDateTime) null);
 
       if (zone == null) {
         return dateTime;
@@ -452,7 +451,7 @@ public class DateFormatUtil {
    */
   public static DateTime parseJodaDateTime(String value, DateTimeZone zone) {
     if (value == null) {
-      final DateTime dateTime = normalizeDateTime((DateTime) null);
+      final DateTime dateTime = defaultToNow((DateTime) null);
 
       if (zone == null) {
         return dateTime;
@@ -497,7 +496,7 @@ public class DateFormatUtil {
    */
   public static LocalDate parseDate(String value, ZoneId zone) {
     if (value == null) {
-      return normalizeDate((LocalDate) null);
+      return defaultToNow((LocalDate) null);
     }
 
     List<DateTimeFormatter> formatters = getDateTimeFormatters();
@@ -505,7 +504,7 @@ public class DateFormatUtil {
     for (int i = 0; i < formatters.size(); i++) {
       try {
         DateTimeFormatter formatter = formatters.get(i)
-          .withZone(normalizeZone(zone));
+          .withZone(defaultToClockZone(zone));
         return LocalDate.parse(value, formatter);
       } catch (DateTimeParseException e1) {
         if (i == formatters.size() - 1) {
@@ -539,7 +538,7 @@ public class DateFormatUtil {
    * @return A date parsed from the value.
    */
   public static org.joda.time.LocalDate parseJodaDate(String value, DateTimeZone zone) {
-    final ZoneId jodaZone = ZoneId.of(normalizeZone(zone).getID());
+    final ZoneId jodaZone = ZoneId.of(defaultToClockZone(zone).getID());
     final LocalDate date = parseDateTimeString(value, jodaZone).toLocalDate();
 
     return new org.joda.time.LocalDate(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
@@ -558,7 +557,7 @@ public class DateFormatUtil {
     for (int i = 0; i < formatters.size(); i++) {
       try {
         DateTimeFormatter formatter = formatters.get(i)
-          .withZone(normalizeZone(zone));
+          .withZone(defaultToClockZone(zone));
         return ZonedDateTime.parse(value, formatter)
           .truncatedTo(ChronoUnit.MILLIS);
       } catch (DateTimeParseException e1) {

--- a/src/main/java/org/folio/circulation/support/utils/DateTimeUtil.java
+++ b/src/main/java/org/folio/circulation/support/utils/DateTimeUtil.java
@@ -55,7 +55,7 @@ public class DateTimeUtil {
    * @param dateTime The dateTime to normalize.
    * @return The provided dateTime or if dateTime is null then ClockUtil.getZonedDateTime().
    */
-  public static ZonedDateTime normalizeDateTime(ZonedDateTime dateTime) {
+  public static ZonedDateTime defaultToNow(ZonedDateTime dateTime) {
     if (dateTime == null) {
       return ClockUtil.getZonedDateTime();
     }
@@ -72,7 +72,7 @@ public class DateTimeUtil {
    * @param dateTime The dateTime to normalize.
    * @return The provided dateTime or if dateTime is null then ClockUtil.getZonedDateTime().
    */
-  public static OffsetDateTime normalizeDateTime(OffsetDateTime dateTime) {
+  public static OffsetDateTime defaultToNow(OffsetDateTime dateTime) {
     if (dateTime == null) {
       return ClockUtil.getOffsetDateTime();
     }
@@ -89,7 +89,7 @@ public class DateTimeUtil {
    * @param dateTime The dateTime to normalize.
    * @return The provided dateTime or if dateTime is null then ClockUtil.getZonedDateTime().
    */
-  public static LocalDateTime normalizeDateTime(LocalDateTime dateTime) {
+  public static LocalDateTime defaultToNow(LocalDateTime dateTime) {
     if (dateTime == null) {
       return ClockUtil.getLocalDateTime();
     }
@@ -106,7 +106,7 @@ public class DateTimeUtil {
    * @param date The date to normalize.
    * @return The provided date or if date is null then ClockUtil.getZonedDate().
    */
-  public static LocalDate normalizeDate(LocalDate date) {
+  public static LocalDate defaultToNow(LocalDate date) {
     if (date == null) {
       return ClockUtil.getLocalDate();
     }
@@ -125,7 +125,7 @@ public class DateTimeUtil {
    * @param dateTime The dateTime to normalize.
    * @return The provided dateTime or if dateTime is null then ClockUtil.getZonedDateTime().
    */
-  public static DateTime normalizeDateTime(DateTime dateTime) {
+  public static DateTime defaultToNow(DateTime dateTime) {
     if (dateTime == null) {
       return ClockUtil.getDateTime();
     }
@@ -142,7 +142,7 @@ public class DateTimeUtil {
    * @param dateTime The dateTime to normalize.
    * @return The provided dateTime or if dateTime is null then ClockUtil.getZonedDateTime().
    */
-  public static Instant normalizeDateTime(Instant dateTime) {
+  public static Instant defaultToNow(Instant dateTime) {
     if (dateTime == null) {
       return ClockUtil.getZonedDateTime().toInstant();
     }
@@ -161,7 +161,7 @@ public class DateTimeUtil {
    * @param dateTime The dateTime to normalize.
    * @return The provided dateTime or if dateTime is null then ClockUtil.getZonedDateTime().
    */
-  public static org.joda.time.LocalDateTime normalizeDateTime(org.joda.time.LocalDateTime dateTime) {
+  public static org.joda.time.LocalDateTime defaultToNow(org.joda.time.LocalDateTime dateTime) {
     if (dateTime == null) {
       return ClockUtil.getDateTime().toLocalDateTime();
     }
@@ -177,7 +177,7 @@ public class DateTimeUtil {
    *
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    */
-  public static org.joda.time.LocalDate normalizeDate(org.joda.time.LocalDate date) {
+  public static org.joda.time.LocalDate defaultToNow(org.joda.time.LocalDate date) {
     if (date == null) {
       return ClockUtil.getJodaLocalDate();
     }
@@ -194,7 +194,7 @@ public class DateTimeUtil {
    * @param time The time to normalize.
    * @return The provided date or if time is null then ClockUtil.getLocalTime().
    */
-  public static LocalTime normalizeTime(LocalTime time) {
+  public static LocalTime defaultToNow(LocalTime time) {
     if (time == null) {
       return ClockUtil.getLocalTime();
     }
@@ -211,7 +211,7 @@ public class DateTimeUtil {
    * @param time The time to normalize.
    * @return The provided date or if time is null then ClockUtil.getLocalTime().
    */
-  public static org.joda.time.LocalTime normalizeTime(org.joda.time.LocalTime time) {
+  public static org.joda.time.LocalTime defaultToNow(org.joda.time.LocalTime time) {
     if (time == null) {
       return ClockUtil.getJodaLocalTime();
     }
@@ -228,7 +228,7 @@ public class DateTimeUtil {
    * @param dateTime The dateTime to normalize.
    * @return The provided dateTime or if dateTime is null then ClockUtil.getZonedDateTime().
    */
-  public static org.joda.time.Instant normalizeDateTime(org.joda.time.Instant dateTime) {
+  public static org.joda.time.Instant defaultToNow(org.joda.time.Instant dateTime) {
     if (dateTime == null) {
       return org.joda.time.Instant
         .ofEpochMilli(ClockUtil.getZonedDateTime().toInstant().toEpochMilli());
@@ -246,7 +246,7 @@ public class DateTimeUtil {
    * @param zone The time zone to normalize.
    * @return The provided time zone or if zone is null a default time zone.
    */
-  public static ZoneId normalizeZone(ZoneId zone) {
+  public static ZoneId defaultToClockZone(ZoneId zone) {
     if (zone == null) {
       return ClockUtil.getZoneId();
     }
@@ -263,7 +263,7 @@ public class DateTimeUtil {
    * @param zone The time zone to normalize.
    * @return The provided time zone or if zone is null a default time zone.
    */
-  public static ZoneOffset normalizeZone(ZoneOffset zone) {
+  public static ZoneOffset defaultToClockZone(ZoneOffset zone) {
     if (zone == null) {
       return ClockUtil.getZoneOffset();
     }
@@ -279,7 +279,7 @@ public class DateTimeUtil {
    *
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    */
-  public static DateTimeZone normalizeZone(DateTimeZone zone) {
+  public static DateTimeZone defaultToClockZone(DateTimeZone zone) {
     if (zone == null) {
       return ClockUtil.jodaTimezone();
     }
@@ -902,8 +902,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isBeforeMillis(ZonedDateTime left, ZonedDateTime right) {
-    return normalizeDateTime(left).toInstant().toEpochMilli() <
-      normalizeDateTime(right).toInstant().toEpochMilli();
+    return defaultToNow(left).toInstant().toEpochMilli() <
+      defaultToNow(right).toInstant().toEpochMilli();
   }
 
   /**
@@ -917,8 +917,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isBeforeMillis(LocalDateTime left, LocalDateTime right) {
-    return normalizeDateTime(left).toInstant(UTC).toEpochMilli() <
-      normalizeDateTime(right).toInstant(UTC).toEpochMilli();
+    return defaultToNow(left).toInstant(UTC).toEpochMilli() <
+      defaultToNow(right).toInstant(UTC).toEpochMilli();
   }
 
   /**
@@ -934,8 +934,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isBeforeMillis(DateTime left, DateTime right) {
-    return normalizeDateTime(left).toInstant().getMillis() <
-      normalizeDateTime(right).toInstant().getMillis();
+    return defaultToNow(left).toInstant().getMillis() <
+      defaultToNow(right).toInstant().getMillis();
   }
 
   /**
@@ -951,8 +951,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isBeforeMillis(org.joda.time.LocalDateTime left, org.joda.time.LocalDateTime right) {
-    return normalizeDateTime(left).toDateTime(DateTimeZone.UTC).getMillis() <
-      normalizeDateTime(right).toDateTime(DateTimeZone.UTC).getMillis();
+    return defaultToNow(left).toDateTime(DateTimeZone.UTC).getMillis() <
+      defaultToNow(right).toDateTime(DateTimeZone.UTC).getMillis();
   }
 
   /**
@@ -966,8 +966,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isBeforeMillis(LocalTime left, LocalTime right) {
-    return normalizeTime(left).truncatedTo(MILLIS)
-      .isBefore(normalizeTime(right).truncatedTo(MILLIS));
+    return defaultToNow(left).truncatedTo(MILLIS)
+      .isBefore(defaultToNow(right).truncatedTo(MILLIS));
   }
 
   /**
@@ -983,7 +983,7 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isBeforeMillis(org.joda.time.LocalTime left, org.joda.time.LocalTime right) {
-    return normalizeTime(left).isBefore(normalizeTime(right));
+    return defaultToNow(left).isBefore(defaultToNow(right));
   }
 
   /**
@@ -997,8 +997,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isAfterMillis(ZonedDateTime left, ZonedDateTime right) {
-    return normalizeDateTime(left).toInstant().toEpochMilli() >
-      normalizeDateTime(right).toInstant().toEpochMilli();
+    return defaultToNow(left).toInstant().toEpochMilli() >
+      defaultToNow(right).toInstant().toEpochMilli();
   }
 
   /**
@@ -1012,8 +1012,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isAfterMillis(LocalDateTime left, LocalDateTime right) {
-    return normalizeDateTime(left).toInstant(UTC).toEpochMilli() >
-      normalizeDateTime(right).toInstant(UTC).toEpochMilli();
+    return defaultToNow(left).toInstant(UTC).toEpochMilli() >
+      defaultToNow(right).toInstant(UTC).toEpochMilli();
   }
 
   /**
@@ -1029,8 +1029,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isAfterMillis(DateTime left, DateTime right) {
-    return normalizeDateTime(left).toInstant().getMillis() >
-      normalizeDateTime(right).toInstant().getMillis();
+    return defaultToNow(left).toInstant().getMillis() >
+      defaultToNow(right).toInstant().getMillis();
   }
 
   /**
@@ -1046,8 +1046,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isAfterMillis(org.joda.time.LocalDateTime left, org.joda.time.LocalDateTime right) {
-    return normalizeDateTime(left).toDateTime(DateTimeZone.UTC).getMillis() >
-      normalizeDateTime(right).toDateTime(DateTimeZone.UTC).getMillis();
+    return defaultToNow(left).toDateTime(DateTimeZone.UTC).getMillis() >
+      defaultToNow(right).toDateTime(DateTimeZone.UTC).getMillis();
   }
 
   /**
@@ -1061,8 +1061,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isAfterMillis(LocalTime left, LocalTime right) {
-    return normalizeTime(left).truncatedTo(MILLIS)
-      .isAfter(normalizeTime(right).truncatedTo(MILLIS));
+    return defaultToNow(left).truncatedTo(MILLIS)
+      .isAfter(defaultToNow(right).truncatedTo(MILLIS));
   }
   /**
    * Check if the the left time is after the right time in milliseconds.
@@ -1077,7 +1077,7 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isAfterMillis(org.joda.time.LocalTime left, org.joda.time.LocalTime right) {
-    return normalizeTime(left).isAfter(normalizeTime(right));
+    return defaultToNow(left).isAfter(defaultToNow(right));
   }
 
   /**
@@ -1091,8 +1091,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isSameMillis(ZonedDateTime left, ZonedDateTime right) {
-    return normalizeDateTime(left).toInstant().toEpochMilli() ==
-      normalizeDateTime(right).toInstant().toEpochMilli();
+    return defaultToNow(left).toInstant().toEpochMilli() ==
+      defaultToNow(right).toInstant().toEpochMilli();
   }
 
   /**
@@ -1106,8 +1106,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isSameMillis(LocalDateTime left, LocalDateTime right) {
-    return normalizeDateTime(left).toInstant(UTC).toEpochMilli() ==
-      normalizeDateTime(right).toInstant(UTC).toEpochMilli();
+    return defaultToNow(left).toInstant(UTC).toEpochMilli() ==
+      defaultToNow(right).toInstant(UTC).toEpochMilli();
   }
 
   /**
@@ -1121,8 +1121,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isSameMillis(LocalTime left, LocalTime right) {
-    return normalizeTime(left).truncatedTo(MILLIS).toNanoOfDay() ==
-      normalizeTime(right).truncatedTo(MILLIS).toNanoOfDay();
+    return defaultToNow(left).truncatedTo(MILLIS).toNanoOfDay() ==
+      defaultToNow(right).truncatedTo(MILLIS).toNanoOfDay();
   }
 
   /**
@@ -1138,8 +1138,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isSameMillis(DateTime left, DateTime right) {
-    return normalizeDateTime(left).toInstant().getMillis() ==
-      normalizeDateTime(right).toInstant().getMillis();
+    return defaultToNow(left).toInstant().getMillis() ==
+      defaultToNow(right).toInstant().getMillis();
   }
 
   /**
@@ -1153,7 +1153,7 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isSameMillis(Instant left, Instant right) {
-    return normalizeDateTime(left).toEpochMilli() == normalizeDateTime(right).toEpochMilli();
+    return defaultToNow(left).toEpochMilli() == defaultToNow(right).toEpochMilli();
   }
 
   /**
@@ -1169,7 +1169,7 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static boolean isSameMillis(org.joda.time.Instant left, org.joda.time.Instant right) {
-    return normalizeDateTime(left).getMillis() == normalizeDateTime(right).getMillis();
+    return defaultToNow(left).getMillis() == defaultToNow(right).getMillis();
   }
 
   /**
@@ -1283,13 +1283,13 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static int compareToMillis(ZonedDateTime left, ZonedDateTime right) {
-    if (normalizeDateTime(left).toInstant().toEpochMilli()
-      == normalizeDateTime(right).toInstant().toEpochMilli()) {
+    if (defaultToNow(left).toInstant().toEpochMilli()
+      == defaultToNow(right).toInstant().toEpochMilli()) {
       return 0;
     }
 
-    if (normalizeDateTime(left).toInstant().toEpochMilli()
-      < normalizeDateTime(right).toInstant().toEpochMilli()) {
+    if (defaultToNow(left).toInstant().toEpochMilli()
+      < defaultToNow(right).toInstant().toEpochMilli()) {
       return -1;
     }
 
@@ -1304,8 +1304,8 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static int compareToMillis(LocalTime left, LocalTime right) {
-    return normalizeTime(left).truncatedTo(MILLIS)
-      .compareTo(normalizeTime(right).truncatedTo(MILLIS));
+    return defaultToNow(left).truncatedTo(MILLIS)
+      .compareTo(defaultToNow(right).truncatedTo(MILLIS));
   }
 
   /**
@@ -1323,13 +1323,13 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static int compareToMillis(DateTime left, DateTime right) {
-    if (normalizeDateTime(left).toInstant().getMillis()
-      == normalizeDateTime(right).toInstant().getMillis()) {
+    if (defaultToNow(left).toInstant().getMillis()
+      == defaultToNow(right).toInstant().getMillis()) {
       return 0;
     }
 
-    if (normalizeDateTime(left).toInstant().getMillis()
-      < normalizeDateTime(right).toInstant().getMillis()) {
+    if (defaultToNow(left).toInstant().getMillis()
+      < defaultToNow(right).toInstant().getMillis()) {
       return -1;
     }
 
@@ -1346,7 +1346,7 @@ public class DateTimeUtil {
    * @return true if left is before right and false otherwise.
    */
   public static int compareToMillis(org.joda.time.LocalTime left, org.joda.time.LocalTime right) {
-    return normalizeTime(left).compareTo(normalizeTime(right));
+    return defaultToNow(left).compareTo(defaultToNow(right));
   }
 
   /**
@@ -1361,9 +1361,9 @@ public class DateTimeUtil {
    * exclusive end.
    */
   public static long millisBetween(ZonedDateTime begin, ZonedDateTime end) {
-    if (isBeforeMillis(normalizeDateTime(begin), normalizeDateTime(end))) {
-      return normalizeDateTime(end).toInstant().toEpochMilli()
-        - normalizeDateTime(begin).toInstant().toEpochMilli();
+    if (isBeforeMillis(defaultToNow(begin), defaultToNow(end))) {
+      return defaultToNow(end).toInstant().toEpochMilli()
+        - defaultToNow(begin).toInstant().toEpochMilli();
     }
 
     return 0L;
@@ -1383,8 +1383,8 @@ public class DateTimeUtil {
    * exclusive end.
    */
   public static long millisBetween(LocalDateTime begin, LocalDateTime end) {
-    final ZonedDateTime zonedBegin = ZonedDateTime.of(normalizeDateTime(begin), UTC);
-    final ZonedDateTime zonedEnd = ZonedDateTime.of(normalizeDateTime(end), UTC);
+    final ZonedDateTime zonedBegin = ZonedDateTime.of(defaultToNow(begin), UTC);
+    final ZonedDateTime zonedEnd = ZonedDateTime.of(defaultToNow(end), UTC);
 
     return millisBetween(zonedBegin, zonedEnd);
   }

--- a/src/main/java/org/folio/circulation/support/utils/DateTimeUtil.java
+++ b/src/main/java/org/folio/circulation/support/utils/DateTimeUtil.java
@@ -1,5 +1,9 @@
 package org.folio.circulation.support.utils;
 
+import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.ChronoUnit.MILLIS;
+
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -17,13 +21,25 @@ import org.joda.time.DateTimeZone;
 /**
  * A utility for centralizing common date time operations.
  * <p>
+ * JavaTime tends to have granularity down to the nanoseconds but most of this
+ * project expects granularity down to the milliseconds.
+ * Many of the methods provided ensure precision is against milliseconds, often
+ * truncated to the milliseconds.
+ * Some methods may provide different precision as noted.
+ * <p>
+ * The zoned date time could have a higher precision than milliseconds.
+ * This makes comparison to an ISO formatted date time using milliseconds
+ * excessively precise and brittle
+ * This was discovered when using JDK 13.0.1 instead of JDK 1.8.0_202-b08.
+ * <p>
  * Be careful with the differences of withZoneSameInstant() vs
  * withZoneSameLocal().
  * <p>
  * The "SameInstant" version changes the time zone so that the representation
- * changes but the actual date does not.
+ * changes but the milliseconds since epoch does not change.
  * <p>
- * The "SameLocal" version changes the actual time and preserves the time zone.
+ * The "SameLocal" version changes the milliseconds since epoch and only changes
+ * the time zone without changing any values.
  */
 public class DateTimeUtil {
   private DateTimeUtil() {
@@ -123,6 +139,23 @@ public class DateTimeUtil {
    * For compatibility with JodaTime, when value is null, then a now() call
    * via ClockUtil is used.
    *
+   * @param dateTime The dateTime to normalize.
+   * @return The provided dateTime or if dateTime is null then ClockUtil.getZonedDateTime().
+   */
+  public static Instant normalizeDateTime(Instant dateTime) {
+    if (dateTime == null) {
+      return ClockUtil.getZonedDateTime().toInstant();
+    }
+
+    return dateTime;
+  }
+
+  /**
+   * Given a dateTime, normalize it.
+   * <p>
+   * For compatibility with JodaTime, when value is null, then a now() call
+   * via ClockUtil is used.
+   *
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to normalize.
@@ -187,6 +220,24 @@ public class DateTimeUtil {
   }
 
   /**
+   * Given a dateTime, normalize it.
+   * <p>
+   * For compatibility with JodaTime, when value is null, then a now() call
+   * via ClockUtil is used.
+   *
+   * @param dateTime The dateTime to normalize.
+   * @return The provided dateTime or if dateTime is null then ClockUtil.getZonedDateTime().
+   */
+  public static org.joda.time.Instant normalizeDateTime(org.joda.time.Instant dateTime) {
+    if (dateTime == null) {
+      return org.joda.time.Instant
+        .ofEpochMilli(ClockUtil.getZonedDateTime().toInstant().toEpochMilli());
+    }
+
+    return dateTime;
+  }
+
+  /**
    * Given a time zone id, normalize it.
    * <p>
    * For compatibility with JodaTime, when value is null, then a now() call
@@ -222,7 +273,7 @@ public class DateTimeUtil {
 
   /**
    * A stub-like function for normalizing the DateTimeZone.
-   *
+   * <p>
    * The normalization is for making JavaTime backward compatible with
    * JodaTime behavior. Therefore, this does nothing.
    *
@@ -329,7 +380,7 @@ public class DateTimeUtil {
 
   /**
    * Get the first second of the year.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
@@ -341,7 +392,7 @@ public class DateTimeUtil {
 
   /**
    * Get the first second of the year.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
@@ -359,7 +410,7 @@ public class DateTimeUtil {
 
   /**
    * Get the last second of the year.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
@@ -371,7 +422,7 @@ public class DateTimeUtil {
 
   /**
    * Get the last second of the year.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
@@ -389,7 +440,7 @@ public class DateTimeUtil {
 
   /**
    * Get the first second of the year.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param LocalDate The localDate to convert.
@@ -405,7 +456,7 @@ public class DateTimeUtil {
 
   /**
    * Get the last second of the year.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The localDate to convert.
@@ -510,7 +561,7 @@ public class DateTimeUtil {
 
   /**
    * Get the first second of the month.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
@@ -522,7 +573,7 @@ public class DateTimeUtil {
 
   /**
    * Get the first second of the month.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
@@ -540,7 +591,7 @@ public class DateTimeUtil {
 
   /**
    * Get the last second of the month.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
@@ -552,7 +603,7 @@ public class DateTimeUtil {
 
   /**
    * Get the last second of the month.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
@@ -570,7 +621,7 @@ public class DateTimeUtil {
 
   /**
    * Get the first second of the month.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param LocalDate The localDate to convert.
@@ -709,7 +760,7 @@ public class DateTimeUtil {
 
   /**
    * Get the first second of the day for the given time zone.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
@@ -727,7 +778,7 @@ public class DateTimeUtil {
    * Get the last second of the day.
    * <p>
    * This operates in the time zone specified by dateTime.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
@@ -739,7 +790,7 @@ public class DateTimeUtil {
 
   /**
    * Get the last second of the day for the given time zone.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The dateTime to convert.
@@ -755,7 +806,7 @@ public class DateTimeUtil {
 
   /**
    * Get the first second of the day for the given time zone.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param LocalDate The localDate to convert.
@@ -770,7 +821,7 @@ public class DateTimeUtil {
 
   /**
    * Get the last second of the day for the given time zone.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The localDate to convert.
@@ -814,7 +865,7 @@ public class DateTimeUtil {
 
   /**
    * Convert from DateTime to ZonedDateTime.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The JodaTime DateTime to convert from.
@@ -827,7 +878,7 @@ public class DateTimeUtil {
 
   /**
    * Convert the JodaTime DateTime to JavaTime OffsetDateTime.
-   *
+   * <p>
    * TODO: Remove this after migrating from JodaTime to JavaTime.
    *
    * @param dateTime The JodaTime DateTime to convert from.
@@ -838,6 +889,525 @@ public class DateTimeUtil {
 
     return OffsetDateTime.ofInstant(instant,
       ZoneId.of(dateTime.getZone().getID()));
+  }
+
+  /**
+   * Check if the the left date is before the right date in milliseconds.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isBeforeMillis(ZonedDateTime left, ZonedDateTime right) {
+    return normalizeDateTime(left).toInstant().toEpochMilli() <
+      normalizeDateTime(right).toInstant().toEpochMilli();
+  }
+
+  /**
+   * Check if the the left date is before the right date in milliseconds.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isBeforeMillis(LocalDateTime left, LocalDateTime right) {
+    return normalizeDateTime(left).toInstant(UTC).toEpochMilli() <
+      normalizeDateTime(right).toInstant(UTC).toEpochMilli();
+  }
+
+  /**
+   * Check if the the left date is before the right date in milliseconds.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   * <p>
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isBeforeMillis(DateTime left, DateTime right) {
+    return normalizeDateTime(left).toInstant().getMillis() <
+      normalizeDateTime(right).toInstant().getMillis();
+  }
+
+  /**
+   * Check if the the left date is before the right date in milliseconds.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   * <p>
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isBeforeMillis(org.joda.time.LocalDateTime left, org.joda.time.LocalDateTime right) {
+    return normalizeDateTime(left).toDateTime(DateTimeZone.UTC).getMillis() <
+      normalizeDateTime(right).toDateTime(DateTimeZone.UTC).getMillis();
+  }
+
+  /**
+   * Check if the the left time is before the right time in milliseconds.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   *
+   * @param left the time to compare on the left.
+   * @param right the time to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isBeforeMillis(LocalTime left, LocalTime right) {
+    return normalizeTime(left).truncatedTo(MILLIS)
+      .isBefore(normalizeTime(right).truncatedTo(MILLIS));
+  }
+
+  /**
+   * Check if the the left time is before the right time in milliseconds.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   *
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param left the time to compare on the left.
+   * @param right the time to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isBeforeMillis(org.joda.time.LocalTime left, org.joda.time.LocalTime right) {
+    return normalizeTime(left).isBefore(normalizeTime(right));
+  }
+
+  /**
+   * Check if the the left date is after the right date in milliseconds.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isAfterMillis(ZonedDateTime left, ZonedDateTime right) {
+    return normalizeDateTime(left).toInstant().toEpochMilli() >
+      normalizeDateTime(right).toInstant().toEpochMilli();
+  }
+
+  /**
+   * Check if the the left date is after the right date in milliseconds.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isAfterMillis(LocalDateTime left, LocalDateTime right) {
+    return normalizeDateTime(left).toInstant(UTC).toEpochMilli() >
+      normalizeDateTime(right).toInstant(UTC).toEpochMilli();
+  }
+
+  /**
+   * Check if the the left date is after the right date in milliseconds.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   * <p>
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isAfterMillis(DateTime left, DateTime right) {
+    return normalizeDateTime(left).toInstant().getMillis() >
+      normalizeDateTime(right).toInstant().getMillis();
+  }
+
+  /**
+   * Check if the the left date is after the right date in milliseconds.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   * <p>
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isAfterMillis(org.joda.time.LocalDateTime left, org.joda.time.LocalDateTime right) {
+    return normalizeDateTime(left).toDateTime(DateTimeZone.UTC).getMillis() >
+      normalizeDateTime(right).toDateTime(DateTimeZone.UTC).getMillis();
+  }
+
+  /**
+   * Check if the the left time is after the right time in milliseconds.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   *
+   * @param left the time to compare on the left.
+   * @param right the time to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isAfterMillis(LocalTime left, LocalTime right) {
+    return normalizeTime(left).truncatedTo(MILLIS)
+      .isAfter(normalizeTime(right).truncatedTo(MILLIS));
+  }
+  /**
+   * Check if the the left time is after the right time in milliseconds.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   * <p>
+   * TODO: Remove this after migrating from JodaTime to JavaTime.
+   *
+   * @param left the time to compare on the left.
+   * @param right the time to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isAfterMillis(org.joda.time.LocalTime left, org.joda.time.LocalTime right) {
+    return normalizeTime(left).isAfter(normalizeTime(right));
+  }
+
+  /**
+   * Check if the the left date is the same as the right date in milliseconds.
+   * <p>
+   * The equalTo() methods tend to work with nanoseconds and cannot be used
+   * safely for millisecond comparisons.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isSameMillis(ZonedDateTime left, ZonedDateTime right) {
+    return normalizeDateTime(left).toInstant().toEpochMilli() ==
+      normalizeDateTime(right).toInstant().toEpochMilli();
+  }
+
+  /**
+   * Check if the the left date is the same as the right date in milliseconds.
+   * <p>
+   * The equalTo() methods tend to work with nanoseconds and cannot be used
+   * safely for millisecond comparisons.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isSameMillis(LocalDateTime left, LocalDateTime right) {
+    return normalizeDateTime(left).toInstant(UTC).toEpochMilli() ==
+      normalizeDateTime(right).toInstant(UTC).toEpochMilli();
+  }
+
+  /**
+   * Check if the the left time is the same as the right time in milliseconds.
+   * <p>
+   * The equalTo() methods tend to work with nanoseconds and cannot be used
+   * safely for millisecond comparisons.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isSameMillis(LocalTime left, LocalTime right) {
+    return normalizeTime(left).truncatedTo(MILLIS).toNanoOfDay() ==
+      normalizeTime(right).truncatedTo(MILLIS).toNanoOfDay();
+  }
+
+  /**
+   * Check if the the left date is the same as the right date in milliseconds.
+   * <p>
+   * The equalTo() methods tend to work with nanoseconds and cannot be used
+   * safely for millisecond comparisons.
+   * <p>
+   * TODO: Remove this once JodaTime is fully converted to JavaTime.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isSameMillis(DateTime left, DateTime right) {
+    return normalizeDateTime(left).toInstant().getMillis() ==
+      normalizeDateTime(right).toInstant().getMillis();
+  }
+
+  /**
+   * Check if the the left instant is the same as the right instant in milliseconds.
+   * <p>
+   * The equalTo() methods tend to work with nanoseconds and cannot be used
+   * safely for millisecond comparisons.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isSameMillis(Instant left, Instant right) {
+    return normalizeDateTime(left).toEpochMilli() == normalizeDateTime(right).toEpochMilli();
+  }
+
+  /**
+   * Check if the the left instant is the same as the right instant in milliseconds.
+   * <p>
+   * The equalTo() methods tend to work with nanoseconds and cannot be used
+   * safely for millisecond comparisons.
+   *
+   * TODO: Remove this once JodaTime is fully converted to JavaTime.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static boolean isSameMillis(org.joda.time.Instant left, org.joda.time.Instant right) {
+    return normalizeDateTime(left).getMillis() == normalizeDateTime(right).getMillis();
+  }
+
+  /**
+   * Check if the date is within the first and last dates, exclusively.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   *
+   * @param date the date to check if is within.
+   * @param first the date representing the beginning.
+   * @param last the date representing the end.
+   * @return true if date is within and false otherwise.
+   */
+  public static boolean isWithinMillis(ZonedDateTime date, ZonedDateTime first, ZonedDateTime last) {
+    return isBeforeMillis(date, last) && isAfterMillis(date, first);
+  }
+
+  /**
+   * Check if the date is within the first and last dates, exclusively.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   *
+   * @param date the date to check if is within.
+   * @param first the date representing the beginning.
+   * @param last the date representing the end.
+   * @return true if date is within and false otherwise.
+   */
+  public static boolean isWithinMillis(LocalDateTime date, LocalDateTime first, LocalDateTime last) {
+    return isBeforeMillis(date, last) && isAfterMillis(date, first);
+  }
+
+  /**
+   * Check if the date is within the first and last dates, exclusively.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   * <p>
+   * TODO: Remove this once JodaTime is fully converted to JavaTime.
+   *
+   * @param time the time to check if is within.
+   * @param first the time representing the beginning.
+   * @param last the time representing the end.
+   * @return true if time is within and false otherwise.
+   */
+  public static boolean isWithinMillis(LocalTime time, LocalTime first, LocalTime last) {
+    return isBeforeMillis(time, last) && isAfterMillis(time, first);
+  }
+
+  /**
+   * Check if the date is within the first and last dates, exclusively.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   * <p>
+   * TODO: Remove this once JodaTime is fully converted to JavaTime.
+   *
+   * @param date the date to check if is within.
+   * @param first the date representing the beginning.
+   * @param last the date representing the end.
+   * @return true if date is within and false otherwise.
+   */
+  public static boolean isWithinMillis(DateTime date, DateTime first, DateTime last) {
+    return isBeforeMillis(date, last) && isAfterMillis(date, first);
+  }
+
+  /**
+   * Check if the date is within the first and last dates, exclusively.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   * <p>
+   * TODO: Remove this once JodaTime is fully converted to JavaTime.
+   *
+   * @param date the date to check if is within.
+   * @param first the date representing the beginning.
+   * @param last the date representing the end.
+   * @return true if date is within and false otherwise.
+   */
+  public static boolean isWithinMillis(org.joda.time.LocalDateTime date, org.joda.time.LocalDateTime first, org.joda.time.LocalDateTime last) {
+    return isBeforeMillis(date, last) && isAfterMillis(date, first);
+  }
+
+  /**
+   * Check if the date is within the first and last dates, exclusively.
+   * <p>
+   * The isBefore()/isAfter() methods tend to work with nanoseconds and cannot
+   * be used safely for millisecond comparisons.
+   * <p>
+   * TODO: Remove this once JodaTime is fully converted to JavaTime.
+   *
+   * @param time the time to check if is within.
+   * @param first the time representing the beginning.
+   * @param last the time representing the end.
+   * @return true if time is within and false otherwise.
+   */
+  public static boolean isWithinMillis(org.joda.time.LocalTime time, org.joda.time.LocalTime first, org.joda.time.LocalTime last) {
+    return isBeforeMillis(time, last) && isAfterMillis(time, first);
+  }
+
+  /**
+   * Compare the the left date with the right date in milliseconds.
+   * <p>
+   * The compareTo() method states that it compares to millis but this appears
+   * to not be the case. Instead, this takes the approach of directly
+   * converting to epoch millis to guarantee positioning and granularity before
+   * comparing.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static int compareToMillis(ZonedDateTime left, ZonedDateTime right) {
+    if (normalizeDateTime(left).toInstant().toEpochMilli()
+      == normalizeDateTime(right).toInstant().toEpochMilli()) {
+      return 0;
+    }
+
+    if (normalizeDateTime(left).toInstant().toEpochMilli()
+      < normalizeDateTime(right).toInstant().toEpochMilli()) {
+      return -1;
+    }
+
+    return 1;
+  }
+
+  /**
+   * Compare the the left time with the right time in milliseconds.
+   *
+   * @param left the time to compare on the left.
+   * @param right the time to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static int compareToMillis(LocalTime left, LocalTime right) {
+    return normalizeTime(left).truncatedTo(MILLIS)
+      .compareTo(normalizeTime(right).truncatedTo(MILLIS));
+  }
+
+  /**
+   * Compare the the left date with the right date in milliseconds.
+   * <p>
+   * The compareTo() method states that it compares to millis but this appears
+   * to not be the case. Instead, this takes the approach of directly
+   * converting to epoch millis to guarantee positioning and granularity before
+   * comparing.
+   * <p>
+   * TODO: Remove this once JodaTime is fully converted to JavaTime.
+   *
+   * @param left the date to compare on the left.
+   * @param right the date to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static int compareToMillis(DateTime left, DateTime right) {
+    if (normalizeDateTime(left).toInstant().getMillis()
+      == normalizeDateTime(right).toInstant().getMillis()) {
+      return 0;
+    }
+
+    if (normalizeDateTime(left).toInstant().getMillis()
+      < normalizeDateTime(right).toInstant().getMillis()) {
+      return -1;
+    }
+
+    return 1;
+  }
+
+  /**
+   * Compare the the left time with the right time in milliseconds.
+   * <p>
+   * TODO: Remove this once JodaTime is fully converted to JavaTime.
+   *
+   * @param left the time to compare on the left.
+   * @param right the time to compare on the right.
+   * @return true if left is before right and false otherwise.
+   */
+  public static int compareToMillis(org.joda.time.LocalTime left, org.joda.time.LocalTime right) {
+    return normalizeTime(left).compareTo(normalizeTime(right));
+  }
+
+  /**
+   * Get the number of milliseconds between two date times.
+   * <p>
+   * If "begin" is greater than "end", then milliseconds is set to 0.
+   *
+   * @param begin The inclusive begin time.
+   * @param end The exclusive end time.
+   *
+   * @return The number of milliseconds between the inclusive begin and the
+   * exclusive end.
+   */
+  public static long millisBetween(ZonedDateTime begin, ZonedDateTime end) {
+    if (isBeforeMillis(normalizeDateTime(begin), normalizeDateTime(end))) {
+      return normalizeDateTime(end).toInstant().toEpochMilli()
+        - normalizeDateTime(begin).toInstant().toEpochMilli();
+    }
+
+    return 0L;
+  }
+
+  /**
+   * Get the number of milliseconds between two date times.
+   * <p>
+   * If "begin" is greater than "end", then milliseconds is set to 0.
+   * <p>
+   * LocalDateTime does not have the time zone so be sure that these dates are
+   * both representative of the same time zone.
+   *
+   * @param begin The inclusive begin time.
+   * @param end The exclusive end time.
+   * @return The number of milliseconds between the inclusive begin and the
+   * exclusive end.
+   */
+  public static long millisBetween(LocalDateTime begin, LocalDateTime end) {
+    final ZonedDateTime zonedBegin = ZonedDateTime.of(normalizeDateTime(begin), UTC);
+    final ZonedDateTime zonedEnd = ZonedDateTime.of(normalizeDateTime(end), UTC);
+
+    return millisBetween(zonedBegin, zonedEnd);
+  }
+
+  /**
+   * Get the number of milliseconds between two date times.
+   * <p>
+   * If "begin" is greater than "end", then milliseconds is set to 0.
+   * <p>
+   * LocalDateTime does not have the time zone so be sure that these dates are
+   * both representative of the same time zone.
+   *
+   * @param begin The inclusive begin time.
+   * @param end The exclusive end time.
+   * @return The number of milliseconds between the inclusive begin and the
+   * exclusive end.
+   */
+  public static long millisBetween(long begin, long end) {
+    if (begin < end) {
+      return end - begin;
+    }
+
+    return 0L;
   }
 
 }

--- a/src/test/java/api/loans/CheckOutCalculateDueDateShortTermTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateDueDateShortTermTests.java
@@ -11,6 +11,7 @@ import static api.support.fixtures.CalendarExamples.END_TIME_FIRST_PERIOD;
 import static api.support.fixtures.CalendarExamples.ROLLOVER_SCENARIO_NEXT_DAY_CLOSED_SERVICE_POINT_ID;
 import static api.support.fixtures.CalendarExamples.ROLLOVER_SCENARIO_SERVICE_POINT_ID;
 import static org.folio.circulation.support.utils.DateFormatUtil.parseJodaDateTime;
+import static org.folio.circulation.support.utils.DateTimeUtil.isSameMillis;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -205,7 +206,7 @@ class CheckOutCalculateDueDateShortTermTests extends APITests {
     DateTime thresholdDateTime = getThresholdDateTime(expectedDueDate);
 
     assertThat("due date should be " + thresholdDateTime + ", actual due date is " + actualDueDate,
-      actualDueDate.isEqual(thresholdDateTime));
+      isSameMillis(actualDueDate, thresholdDateTime));
   }
 
   /**

--- a/src/test/java/api/loans/CheckOutCalculateDueDateTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateDueDateTests.java
@@ -32,6 +32,10 @@ import static org.folio.circulation.domain.policy.LoanPolicyPeriod.HOURS;
 import static org.folio.circulation.support.utils.ClockUtil.getDateTime;
 import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
 import static org.folio.circulation.support.utils.DateTimeUtil.atStartOfDay;
+import static org.folio.circulation.support.utils.DateTimeUtil.isAfterMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isSameMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isWithinMillis;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
@@ -680,7 +684,7 @@ class CheckOutCalculateDueDateTests extends APITests {
     for (int i = 0; i < openingHoursList.size() - 1; i++) {
       LocalTime startTimeFirst = openingHoursList.get(i).getStartTime();
       LocalTime startTimeSecond = openingHoursList.get(i + 1).getStartTime();
-      if (offsetTime.isAfter(startTimeFirst) && offsetTime.isBefore(startTimeSecond)) {
+      if (isWithinMillis(offsetTime, startTimeFirst, startTimeSecond)) {
         isInPeriod = true;
         newOffsetTime = startTimeSecond;
         break;
@@ -798,7 +802,7 @@ class CheckOutCalculateDueDateTests extends APITests {
    * Determine whether the `time` is within a period `startTime` and `endTime`
    */
   private static boolean isTimeInCertainPeriod(LocalTime time, LocalTime startTime, LocalTime endTime) {
-    return !time.isBefore(startTime) && !time.isAfter(endTime);
+    return !isBeforeMillis(time, startTime) && !isAfterMillis(time, endTime);
   }
 
   /**
@@ -841,7 +845,7 @@ class CheckOutCalculateDueDateTests extends APITests {
    * @return true if offsetDateTime is contains offsetDateTime in the time period
    */
   private boolean isInCurrentDateTime(DateTime currentDateTime, DateTime offsetDateTime) {
-    return offsetDateTime.isBefore(currentDateTime) || offsetDateTime.isEqual(currentDateTime);
+    return isBeforeMillis(offsetDateTime, currentDateTime) || isSameMillis(offsetDateTime, currentDateTime);
   }
 
   private JsonObject createLoanPolicy(String name, boolean loanable,

--- a/src/test/java/api/loans/CheckOutCalculateOffsetTimeTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateOffsetTimeTests.java
@@ -16,6 +16,9 @@ import static api.support.fixtures.CalendarExamples.getFirstFakeOpeningDayByServ
 import static api.support.fixtures.CalendarExamples.getLastFakeOpeningDayByServId;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
+import static org.folio.circulation.support.utils.DateTimeUtil.isAfterMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isSameMillis;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.joda.time.DateTimeConstants.HOURS_PER_DAY;
@@ -25,10 +28,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.circulation.domain.OpeningDay;
-import api.support.OpeningDayPeriod;
 import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.Period;
-import api.support.http.IndividualResource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Hours;
@@ -37,8 +38,10 @@ import org.joda.time.LocalTime;
 import org.junit.jupiter.api.Test;
 
 import api.support.APITests;
+import api.support.OpeningDayPeriod;
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
 import api.support.builders.LoanPolicyBuilder;
+import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -254,7 +257,7 @@ class CheckOutCalculateOffsetTimeTests extends APITests {
     LocalTime timeNow = new LocalTime(13, 0);
 
     // The value of `duration` is calculated taking into account the exit for the period.
-    if (timeNow.isBefore(endTimeOfPeriod)) {
+    if (isBeforeMillis(timeNow, endTimeOfPeriod)) {
       duration = Hours.hoursBetween(timeNow, endTimeOfPeriod).getHours() + 1;
     } else {
       duration = HOURS_PER_DAY - Hours.hoursBetween(endTimeOfPeriod, timeNow).getHours() + 1;
@@ -288,7 +291,7 @@ class CheckOutCalculateOffsetTimeTests extends APITests {
     LocalTime timeNow = new LocalTime(13, 0);
 
     // The value of `duration` is calculated taking into account the exit for the period.
-    if (timeNow.isBefore(endTimeOfPeriod)) {
+    if (isBeforeMillis(timeNow, endTimeOfPeriod)) {
       duration = Hours.hoursBetween(timeNow, endTimeOfPeriod).getHours() + 1;
     } else {
       duration = HOURS_PER_DAY - Hours.hoursBetween(endTimeOfPeriod, timeNow).getHours() + 1;
@@ -321,7 +324,7 @@ class CheckOutCalculateOffsetTimeTests extends APITests {
     LocalTime timeNow = new LocalTime(11, 0);
 
     // The value is calculated taking into account the transition to the next period
-    if (timeNow.isAfter(starTmeOfPeriod)) {
+    if (isAfterMillis(timeNow, starTmeOfPeriod)) {
       duration = HOURS_PER_DAY - Hours.hoursBetween(starTmeOfPeriod, timeNow).getHours() - 1;
     } else {
       duration = Hours.hoursBetween(timeNow, starTmeOfPeriod).getHours() - 1;
@@ -450,7 +453,7 @@ class CheckOutCalculateOffsetTimeTests extends APITests {
     DateTime thresholdDateTime = getThresholdDateTime(expectedDueDate);
 
     assertThat("due date should be " + thresholdDateTime + ", actual due date is "
-      + actualDueDate, actualDueDate.isEqual(thresholdDateTime));
+      + actualDueDate, isSameMillis(actualDueDate, thresholdDateTime));
   }
 
   /**

--- a/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
@@ -151,9 +151,7 @@ class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests {
     assertTrue(scheduledNoticesClient.getAll().stream()
       .map(entries -> entries.getString("nextRunTime"))
       .map(DateTime::parse)
-      .allMatch(d -> {
-        return isSameMillis(newNextRunTime, d);
-      }),
+      .allMatch(d -> isSameMillis(newNextRunTime, d)),
       "all scheduled notices are rescheduled");
 
     verifyNumberOfSentNotices(1);

--- a/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
@@ -9,6 +9,7 @@ import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfScheduledNoti
 import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfSentNotices;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE_ERROR;
+import static org.folio.circulation.support.utils.DateTimeUtil.isSameMillis;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -150,7 +151,9 @@ class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests {
     assertTrue(scheduledNoticesClient.getAll().stream()
       .map(entries -> entries.getString("nextRunTime"))
       .map(DateTime::parse)
-      .allMatch(newNextRunTime::isEqual),
+      .allMatch(d -> {
+        return isSameMillis(newNextRunTime, d);
+      }),
       "all scheduled notices are rescheduled");
 
     verifyNumberOfSentNotices(1);

--- a/src/test/java/api/requests/RequestsAPIRetrievalTests.java
+++ b/src/test/java/api/requests/RequestsAPIRetrievalTests.java
@@ -687,7 +687,7 @@ class RequestsAPIRetrievalTests extends APITests {
         .by(sponsor)
         .proxiedBy(proxy)
         .fulfilToHoldShelf()
-        .withRequestExpiration(LocalDate.of(2017, 7, 31))
+        .withRequestExpiration(LocalDate.of(2017, 7, 30))
         .withHoldShelfExpiration(LocalDate.of(2017, 8, 31))
         .withPickupServicePointId(pickupServicePointId)
         .withTags(new RequestBuilder.Tags(asList(NEW_TAG, IMPORTANT_TAG)))

--- a/src/test/java/api/support/builders/CalendarBuilder.java
+++ b/src/test/java/api/support/builders/CalendarBuilder.java
@@ -23,7 +23,7 @@ public class CalendarBuilder extends JsonBuilder implements Builder {
   private static final String ID_KEY = "id";
   private static final String SERVICE_POINT_ID_KEY = "servicePointId";
   private static final String NAME_KEY = "name";
-  public static final String START_DATE_KEY = "startDate";
+  private static final String START_DATE_KEY = "startDate";
   private static final String END_DATE_KEY = "endDate";
   private static final String OPENING_DAYS_KEY = "openingDays";
 

--- a/src/test/java/api/support/matchers/TextDateTimeMatcher.java
+++ b/src/test/java/api/support/matchers/TextDateTimeMatcher.java
@@ -2,6 +2,8 @@ package api.support.matchers;
 
 import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTimeOptional;
 import static org.folio.circulation.support.utils.DateFormatUtil.parseDateTimeOptional;
+import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
+import static org.folio.circulation.support.utils.DateTimeUtil.isSameMillis;
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -27,7 +29,7 @@ public class TextDateTimeMatcher {
         //response representation might vary from request representation
         DateTime actual = DateTime.parse(textRepresentation);
 
-        return expected.isEqual(actual);
+        return isSameMillis(expected, actual);
       }
     };
   }
@@ -48,13 +50,7 @@ public class TextDateTimeMatcher {
       protected boolean matchesSafely(String textRepresentation) {
 
         //response representation might vary from request representation
-        final Instant actual = parseDateTimeOptional(textRepresentation).toInstant();
-
-        //The zoned date time could have a higher precision than milliseconds
-        //This makes comparison to an ISO formatted date time using milliseconds
-        //excessively precise and brittle
-        //Discovered when using JDK 13.0.1 instead of JDK 1.8.0_202-b08
-        return expected.toEpochMilli() == actual.toEpochMilli();
+        return isSameMillis(expected, parseDateTimeOptional(textRepresentation).toInstant());
       }
     };
   }
@@ -73,7 +69,7 @@ public class TextDateTimeMatcher {
         //response representation might vary from request representation
         DateTime actual = DateTime.parse(textRepresentation);
 
-        return !actual.isBefore(after) &&
+        return !isBeforeMillis(actual, after) &&
           Seconds.secondsBetween(after, actual).isLessThan(seconds);
       }
     };
@@ -92,7 +88,7 @@ public class TextDateTimeMatcher {
       protected boolean matchesSafely(String textRepresentation) {
         DateTime actual = DateTime.parse(textRepresentation);
 
-        return actual.isBefore(before) &&
+        return isBeforeMillis(actual, before) &&
           Seconds.secondsBetween(actual, before).isLessThan(seconds);
       }
     };

--- a/src/test/java/org/folio/circulation/domain/LoanLostDateTest.java
+++ b/src/test/java/org/folio/circulation/domain/LoanLostDateTest.java
@@ -1,6 +1,7 @@
 package org.folio.circulation.domain;
 
 import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
+import static org.folio.circulation.support.utils.DateTimeUtil.isSameMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -18,7 +19,7 @@ class LoanLostDateTest {
     final var loan = new LoanBuilder().asDomainObject()
       .declareItemLost("Lost", declaredLostDate);
 
-    assertTrue(declaredLostDate.isEqual(loan.getLostDate()));
+    assertTrue(isSameMillis(declaredLostDate, loan.getLostDate()));
   }
 
   @Test
@@ -27,7 +28,7 @@ class LoanLostDateTest {
     final var loan = new LoanBuilder().asDomainObject()
       .ageOverdueItemToLost(agedToLostDate);
 
-    assertTrue(agedToLostDate.isEqual(loan.getLostDate()));
+    assertTrue(isSameMillis(agedToLostDate, loan.getLostDate()));
   }
 
   @Test
@@ -39,7 +40,7 @@ class LoanLostDateTest {
       .ageOverdueItemToLost(agedToLostDate)
       .declareItemLost("Lost", declaredLostDate);
 
-    assertTrue(declaredLostDate.isEqual(loan.getLostDate()));
+    assertTrue(isSameMillis(declaredLostDate, loan.getLostDate()));
     // make sure properties are not cleared
     assertThat(loan.asJson(), allOf(
       hasJsonPath("declaredLostDate", declaredLostDate.toString()),
@@ -56,7 +57,7 @@ class LoanLostDateTest {
       .ageOverdueItemToLost(agedToLostDate)
       .declareItemLost("Lost", declaredLostDate);
 
-    assertTrue(agedToLostDate.isEqual(loan.getLostDate()));
+    assertTrue(isSameMillis(agedToLostDate, loan.getLostDate()));
     // make sure properties are not cleared
     assertThat(loan.asJson(), allOf(
       hasJsonPath("declaredLostDate", declaredLostDate.toString()),
@@ -72,7 +73,7 @@ class LoanLostDateTest {
       .ageOverdueItemToLost(lostDate)
       .declareItemLost("Lost", lostDate);
 
-    assertTrue(lostDate.isEqual(loan.getLostDate()));
+    assertTrue(isSameMillis(lostDate, loan.getLostDate()));
   }
 
   @Test

--- a/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/library/KeepCurrentStrategyTest.java
@@ -41,7 +41,6 @@ class KeepCurrentStrategyTest {
     assertEquals(requestDate, calculatedDateTime.value());
   }
 
-  @Disabled
   @Test
   void shouldAlwaysKeepCurrentDateWhenConvertingToTimeZone() {
     final int year = 2020;
@@ -70,6 +69,7 @@ class KeepCurrentStrategyTest {
       });
   }
 
+  @Disabled
   @ParameterizedTest
   @CsvSource(value = {
     "16, 16, 5",

--- a/src/test/java/org/folio/circulation/support/utils/DateFormatUtilTests.java
+++ b/src/test/java/org/folio/circulation/support/utils/DateFormatUtilTests.java
@@ -14,6 +14,7 @@ import java.time.ZonedDateTime;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -24,6 +25,11 @@ class DateFormatUtilTests {
   private static final String FORMATTED_DATE_TIME = "2010-10-10T10:10:10.000Z";
   private static final String FORMATTED_DATE_TIME_FROM_DATE = "2010-10-10T00:00:00.000Z";
   private static final String FORMATTED_DATE_TIME_NOW = "2020-10-20T10:10:10.000Z";
+
+  @BeforeEach
+  public void beforeEach() {
+    ClockUtil.setClock(Clock.fixed(Instant.parse(FORMATTED_DATE_TIME_NOW), ZoneOffset.UTC));
+  }
 
   @AfterEach
   public void afterEach() {
@@ -128,12 +134,10 @@ class DateFormatUtilTests {
   @CsvSource(value = {
     "0, null, null, " + FORMATTED_DATE_TIME_NOW,
     "1, Z, null, " + FORMATTED_DATE_TIME_NOW,
-    "2, null, " + FORMATTED_DATE_TIME + ", " + FORMATTED_DATE_TIME,
-    "3, Z, " + FORMATTED_DATE_TIME + ", " + FORMATTED_DATE_TIME
+    "2, null, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z",
+    "3, Z, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z"
   }, nullValues = {"null"})
   void shouldParseZonedDateTimeWithZone(int id, ZoneId zone, String value, String match) {
-    ClockUtil.setClock(Clock.fixed(Instant.parse(FORMATTED_DATE_TIME_NOW), ZoneOffset.UTC));
-
     final ZonedDateTime date = ZonedDateTime.parse(match);
     final ZonedDateTime result = DateFormatUtil.parseDateTime(value, zone);
 
@@ -144,12 +148,10 @@ class DateFormatUtilTests {
   @CsvSource(value = {
     "0, null, null, null",
     "1, UTC, null, null",
-    "2, null, " + FORMATTED_DATE_TIME + ", " + FORMATTED_DATE_TIME,
-    "3, UTC, " + FORMATTED_DATE_TIME + ", " + FORMATTED_DATE_TIME
+    "2, null, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z",
+    "3, UTC, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z"
   }, nullValues = {"null"})
-  void shouldParseJodaDateTimeOptional(int id, ZoneId zone, String value, String match) {
-    ClockUtil.setClock(Clock.fixed(Instant.parse(FORMATTED_DATE_TIME_NOW), ZoneOffset.UTC));
-
+  void shouldParseZonedDateTimeOptional(int id, ZoneId zone, String value, String match) {
     final ZonedDateTime date = match == null
       ? null
       : ZonedDateTime.parse(match);
@@ -162,12 +164,10 @@ class DateFormatUtilTests {
   @CsvSource(value = {
     "0, null, null, null",
     "1, Z, null, null",
-    "2, null, " + FORMATTED_DATE_TIME + ", " + FORMATTED_DATE_TIME,
-    "3, Z, " + FORMATTED_DATE_TIME + ", " + FORMATTED_DATE_TIME
+    "2, null, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z",
+    "3, Z, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z"
   }, nullValues = {"null"})
   void shouldParseZonedDateTimeOptionalWithZone(int id, ZoneId zone, String value, String match) {
-    ClockUtil.setClock(Clock.fixed(Instant.parse(FORMATTED_DATE_TIME_NOW), ZoneOffset.UTC));
-
     final ZonedDateTime date = match == null
       ? null
       : ZonedDateTime.parse(match);
@@ -188,12 +188,10 @@ class DateFormatUtilTests {
   @CsvSource(value = {
     "0, null, null, " + FORMATTED_DATE_TIME_NOW,
     "1, UTC, null, " + FORMATTED_DATE_TIME_NOW,
-    "2, null, " + FORMATTED_DATE_TIME + ", " + FORMATTED_DATE_TIME,
-    "3, UTC, " + FORMATTED_DATE_TIME + ", " + FORMATTED_DATE_TIME
+    "2, null, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z",
+    "3, UTC, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z"
   }, nullValues = {"null"})
   void shouldParseJodaDateTimeWithZone(int id, DateTimeZone zone, String value, String match) {
-    ClockUtil.setClock(Clock.fixed(Instant.parse(FORMATTED_DATE_TIME_NOW), ZoneOffset.UTC));
-
     final DateTime date = DateTime.parse(match);
     final DateTime result = DateFormatUtil.parseJodaDateTime(value, zone);
 
@@ -211,13 +209,11 @@ class DateFormatUtilTests {
   @ParameterizedTest
   @CsvSource(value = {
     "0, null, null, " + FORMATTED_DATE_NOW,
-    "1, UTC, null, " + FORMATTED_DATE_NOW,
-    "2, null, " + FORMATTED_DATE + ", " + FORMATTED_DATE,
-    "3, UTC, " + FORMATTED_DATE + ", " + FORMATTED_DATE
+    "1, Z, null, " + FORMATTED_DATE_NOW,
+    "2, null, 2010-10-10, 2010-10-10",
+    "3, Z, 2010-10-10, 2010-10-10"
   }, nullValues = {"null"})
   void shouldParseZonedDateWithZone(int id, ZoneId zone, String value, String match) {
-    ClockUtil.setClock(Clock.fixed(Instant.parse(FORMATTED_DATE_TIME_NOW), ZoneOffset.UTC));
-
     final LocalDate date = LocalDate.parse(match);
     final LocalDate result = DateFormatUtil.parseDate(value, zone);
 
@@ -236,12 +232,10 @@ class DateFormatUtilTests {
   @CsvSource(value = {
     "0, null, null, " + FORMATTED_DATE_NOW,
     "1, UTC, null, " + FORMATTED_DATE_NOW,
-    "2, null, " + FORMATTED_DATE + ", " + FORMATTED_DATE,
-    "3, UTC, " + FORMATTED_DATE + ", " + FORMATTED_DATE
+    "2, null, 2010-10-10, 2010-10-10",
+    "3, UTC, 2010-10-10, 2010-10-10"
   }, nullValues = {"null"})
   void shouldParseJodaDateWithZone(int id, DateTimeZone zone) {
-    ClockUtil.setClock(Clock.fixed(Instant.parse(FORMATTED_DATE_TIME_NOW), ZoneOffset.UTC));
-
     final org.joda.time.LocalDate date = org.joda.time.LocalDate.parse(FORMATTED_DATE);
     final org.joda.time.LocalDate result = DateFormatUtil.parseJodaDate(FORMATTED_DATE, zone);
 

--- a/src/test/java/org/folio/circulation/support/utils/DateTimeUtilTests.java
+++ b/src/test/java/org/folio/circulation/support/utils/DateTimeUtilTests.java
@@ -44,7 +44,7 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_DATE_TIME_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedZonedDateTime(int id, ZonedDateTime from, ZonedDateTime expected) {
-    final ZonedDateTime result = DateTimeUtil.normalizeDateTime(from);
+    final ZonedDateTime result = DateTimeUtil.defaultToNow(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
   }
@@ -55,7 +55,7 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_DATE_TIME_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedOffsetDateTime(int id, OffsetDateTime from, OffsetDateTime expected) {
-    final OffsetDateTime result = DateTimeUtil.normalizeDateTime(from);
+    final OffsetDateTime result = DateTimeUtil.defaultToNow(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
   }
@@ -66,7 +66,7 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_LOCAL_DATE_TIME_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedLocalDateTime(int id, LocalDateTime from, LocalDateTime expected) {
-    final LocalDateTime result = DateTimeUtil.normalizeDateTime(from);
+    final LocalDateTime result = DateTimeUtil.defaultToNow(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
   }
@@ -77,7 +77,7 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_DATE_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedLocalDate(int id, LocalDate from, LocalDate expected) {
-    final LocalDate result = DateTimeUtil.normalizeDate(from);
+    final LocalDate result = DateTimeUtil.defaultToNow(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
   }
@@ -88,7 +88,7 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_TIME_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedLocalTime(int id, LocalTime from, LocalTime expected) {
-    final LocalTime result = DateTimeUtil.normalizeTime(from);
+    final LocalTime result = DateTimeUtil.defaultToNow(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
   }
@@ -104,7 +104,7 @@ class DateTimeUtilTests {
       : from.toInstant();
     final Instant expectedInstant = expected.toInstant();
 
-    final Instant result = DateTimeUtil.normalizeDateTime(fromInstant);
+    final Instant result = DateTimeUtil.defaultToNow(fromInstant);
 
     assertEquals(expectedInstant.toString(), result.toString(), "For test " + id);
   }
@@ -115,7 +115,7 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_DATE_TIME_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedJodaDateTime(int id, DateTime from, DateTime expected) {
-    final DateTime result = DateTimeUtil.normalizeDateTime(from);
+    final DateTime result = DateTimeUtil.defaultToNow(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
   }
@@ -126,7 +126,7 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_LOCAL_DATE_TIME_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedJodaLocalDateTime(int id, org.joda.time.LocalDateTime from, org.joda.time.LocalDateTime expected) {
-    final org.joda.time.LocalDateTime result = DateTimeUtil.normalizeDateTime(from);
+    final org.joda.time.LocalDateTime result = DateTimeUtil.defaultToNow(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
   }
@@ -137,7 +137,7 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_DATE_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedJodaLocalDate(int id, org.joda.time.LocalDate from, org.joda.time.LocalDate expected) {
-    final org.joda.time.LocalDate result = DateTimeUtil.normalizeDate(from);
+    final org.joda.time.LocalDate result = DateTimeUtil.defaultToNow(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
   }
@@ -148,7 +148,7 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_DATE_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedJodaDate(int id, org.joda.time.LocalDate from, org.joda.time.LocalDate expected) {
-    final org.joda.time.LocalDate result = DateTimeUtil.normalizeDate(from);
+    final org.joda.time.LocalDate result = DateTimeUtil.defaultToNow(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
   }
@@ -164,7 +164,7 @@ class DateTimeUtilTests {
       : from.toInstant();
     final org.joda.time.Instant expectedInstant = expected.toInstant();
 
-    final org.joda.time.Instant result = DateTimeUtil.normalizeDateTime(fromInstant);
+    final org.joda.time.Instant result = DateTimeUtil.defaultToNow(fromInstant);
 
     assertEquals(expectedInstant.toString(), result.toString(), "For test " + id);
   }
@@ -175,7 +175,7 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_TIME_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedJodaLocalTime(int id, org.joda.time.LocalTime from, org.joda.time.LocalTime expected) {
-    final org.joda.time.LocalTime result = DateTimeUtil.normalizeTime(from);
+    final org.joda.time.LocalTime result = DateTimeUtil.defaultToNow(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
   }
@@ -187,7 +187,7 @@ class DateTimeUtilTests {
     "2, null, Z"
   }, nullValues = {"null"})
   void shouldGetNormalizedZoneId(int id, ZoneId from, ZoneId expected) {
-    final ZoneId result = DateTimeUtil.normalizeZone(from);
+    final ZoneId result = DateTimeUtil.defaultToClockZone(from);
 
     assertEquals(expected, result, "For test " + id);
   }
@@ -204,7 +204,7 @@ class DateTimeUtilTests {
       : from.getRules().getOffset(Instant.EPOCH);
 
     final ZoneOffset expectedOffset = expected.getRules().getOffset(Instant.EPOCH);
-    final ZoneOffset result = DateTimeUtil.normalizeZone(fromOffset);
+    final ZoneOffset result = DateTimeUtil.defaultToClockZone(fromOffset);
 
     assertEquals(expectedOffset, result, "For test " + id);
   }
@@ -216,7 +216,7 @@ class DateTimeUtilTests {
     "2, null, UTC"
   }, nullValues = {"null"})
   void shouldGetNormalizedJodaZone(int id, DateTimeZone from, DateTimeZone expected) {
-    final DateTimeZone result = DateTimeUtil.normalizeZone(from);
+    final DateTimeZone result = DateTimeUtil.defaultToClockZone(from);
 
     assertEquals(expected, result, "For test " + id);
   }

--- a/src/test/java/org/folio/circulation/support/utils/DateTimeUtilTests.java
+++ b/src/test/java/org/folio/circulation/support/utils/DateTimeUtilTests.java
@@ -16,15 +16,21 @@ import java.time.format.DateTimeFormatter;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 class DateTimeUtilTests {
-  private static final String FORMATTED_DATE_TIME_NOW = "2020-10-20T10:20:10.000Z";
-  private static final String FORMATTED_LOCAL_DATE_TIME_NOW = "2020-10-20T10:20:10";
   private static final String FORMATTED_DATE_NOW = "2020-10-20";
   private static final String FORMATTED_TIME_NOW = "10:20:10.000";
+  private static final String FORMATTED_DATE_TIME_NOW = "2020-10-20T10:20:10.000Z";
+  private static final String FORMATTED_LOCAL_DATE_TIME_NOW = "2020-10-20T10:20:10";
+
+  @BeforeEach
+  public void beforeEach() {
+    ClockUtil.setClock(Clock.fixed(Instant.parse(FORMATTED_DATE_TIME_NOW), ZoneOffset.UTC));
+  }
 
   @AfterEach
   public void afterEach() {
@@ -38,8 +44,6 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_DATE_TIME_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedZonedDateTime(int id, ZonedDateTime from, ZonedDateTime expected) {
-    setFixedClock();
-
     final ZonedDateTime result = DateTimeUtil.normalizeDateTime(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
@@ -51,8 +55,6 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_DATE_TIME_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedOffsetDateTime(int id, OffsetDateTime from, OffsetDateTime expected) {
-    setFixedClock();
-
     final OffsetDateTime result = DateTimeUtil.normalizeDateTime(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
@@ -64,8 +66,6 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_LOCAL_DATE_TIME_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedLocalDateTime(int id, LocalDateTime from, LocalDateTime expected) {
-    setFixedClock();
-
     final LocalDateTime result = DateTimeUtil.normalizeDateTime(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
@@ -77,8 +77,6 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_DATE_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedLocalDate(int id, LocalDate from, LocalDate expected) {
-    setFixedClock();
-
     final LocalDate result = DateTimeUtil.normalizeDate(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
@@ -90,8 +88,6 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_TIME_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedLocalTime(int id, LocalTime from, LocalTime expected) {
-    setFixedClock();
-
     final LocalTime result = DateTimeUtil.normalizeTime(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
@@ -102,10 +98,35 @@ class DateTimeUtilTests {
     "0, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z",
     "1, null, " + FORMATTED_DATE_TIME_NOW
   }, nullValues = {"null"})
-  void shouldGetNormalizedJodaDateTime(int id, DateTime from, DateTime expected) {
-    setFixedClock();
+  void shouldGetNormalizedInstant(int id, ZonedDateTime from, ZonedDateTime expected) {
+    final Instant fromInstant = from == null
+      ? null
+      : from.toInstant();
+    final Instant expectedInstant = expected.toInstant();
 
+    final Instant result = DateTimeUtil.normalizeDateTime(fromInstant);
+
+    assertEquals(expectedInstant.toString(), result.toString(), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z",
+    "1, null, " + FORMATTED_DATE_TIME_NOW
+  }, nullValues = {"null"})
+  void shouldGetNormalizedJodaDateTime(int id, DateTime from, DateTime expected) {
     final DateTime result = DateTimeUtil.normalizeDateTime(from);
+
+    assertEquals(expected.toString(), result.toString(), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, 2010-10-10T10:10:10, 2010-10-10T10:10:10",
+    "1, null, " + FORMATTED_LOCAL_DATE_TIME_NOW
+  }, nullValues = {"null"})
+  void shouldGetNormalizedJodaLocalDateTime(int id, org.joda.time.LocalDateTime from, org.joda.time.LocalDateTime expected) {
+    final org.joda.time.LocalDateTime result = DateTimeUtil.normalizeDateTime(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
   }
@@ -116,8 +137,6 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_DATE_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedJodaLocalDate(int id, org.joda.time.LocalDate from, org.joda.time.LocalDate expected) {
-    setFixedClock();
-
     final org.joda.time.LocalDate result = DateTimeUtil.normalizeDate(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
@@ -129,8 +148,6 @@ class DateTimeUtilTests {
     "1, null, " + FORMATTED_DATE_NOW
   }, nullValues = {"null"})
   void shouldGetNormalizedJodaDate(int id, org.joda.time.LocalDate from, org.joda.time.LocalDate expected) {
-    setFixedClock();
-
     final org.joda.time.LocalDate result = DateTimeUtil.normalizeDate(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
@@ -138,12 +155,26 @@ class DateTimeUtilTests {
 
   @ParameterizedTest
   @CsvSource(value = {
+    "0, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z",
+    "1, null, " + FORMATTED_DATE_TIME_NOW
+  }, nullValues = {"null"})
+  void shouldGetNormalizedJodaInstant(int id, DateTime from, DateTime expected) {
+    final org.joda.time.Instant fromInstant = from == null
+      ? null
+      : from.toInstant();
+    final org.joda.time.Instant expectedInstant = expected.toInstant();
+
+    final org.joda.time.Instant result = DateTimeUtil.normalizeDateTime(fromInstant);
+
+    assertEquals(expectedInstant.toString(), result.toString(), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
     "0, 10:10:10, 10:10:10",
     "1, null, " + FORMATTED_TIME_NOW
   }, nullValues = {"null"})
-  void shouldGetNormalizedLocalTime(int id, org.joda.time.LocalTime from, org.joda.time.LocalTime expected) {
-    setFixedClock();
-
+  void shouldGetNormalizedJodaLocalTime(int id, org.joda.time.LocalTime from, org.joda.time.LocalTime expected) {
     final org.joda.time.LocalTime result = DateTimeUtil.normalizeTime(from);
 
     assertEquals(expected.toString(), result.toString(), "For test " + id);
@@ -156,8 +187,6 @@ class DateTimeUtilTests {
     "2, null, Z"
   }, nullValues = {"null"})
   void shouldGetNormalizedZoneId(int id, ZoneId from, ZoneId expected) {
-    setFixedClock();
-
     final ZoneId result = DateTimeUtil.normalizeZone(from);
 
     assertEquals(expected, result, "For test " + id);
@@ -170,8 +199,6 @@ class DateTimeUtilTests {
     "2, null, Z"
   }, nullValues = {"null"})
   void shouldGetNormalizedZoneOffset(int id, ZoneId from, ZoneId expected) {
-    setFixedClock();
-
     final ZoneOffset fromOffset = from == null
       ? null
       : from.getRules().getOffset(Instant.EPOCH);
@@ -189,8 +216,6 @@ class DateTimeUtilTests {
     "2, null, UTC"
   }, nullValues = {"null"})
   void shouldGetNormalizedJodaZone(int id, DateTimeZone from, DateTimeZone expected) {
-    setFixedClock();
-
     final DateTimeZone result = DateTimeUtil.normalizeZone(from);
 
     assertEquals(expected, result, "For test " + id);
@@ -630,8 +655,6 @@ class DateTimeUtilTests {
 
   @Test
   void shouldGetMostRecentZonedDateTime() {
-    setFixedClock();
-
     final ZonedDateTime datePast = ClockUtil.getZonedDateTime().minusDays(2);
     final ZonedDateTime datePresent = ClockUtil.getZonedDateTime();
     final ZonedDateTime dateFuture = ClockUtil.getZonedDateTime().plusDays(2);
@@ -643,8 +666,6 @@ class DateTimeUtilTests {
 
   @Test
   void shouldGetMostRecentJodaDateTime() {
-    setFixedClock();
-
     final DateTime datePast = ClockUtil.getDateTime().minusDays(2);
     final DateTime datePresent = ClockUtil.getDateTime();
     final DateTime dateFuture = ClockUtil.getDateTime().plusDays(2);
@@ -656,8 +677,6 @@ class DateTimeUtilTests {
 
   @Test
   void shouldGetToZonedDateTime() {
-    setFixedClock();
-
     final DateTime jodaDate = ClockUtil.getDateTime();
     final ZonedDateTime result = DateTimeUtil.toZonedDateTime(jodaDate);
 
@@ -666,15 +685,450 @@ class DateTimeUtilTests {
 
   @Test
   void shouldGetToOffsetDateTime() {
-    setFixedClock();
-
     final DateTime jodaDate = ClockUtil.getDateTime();
     final OffsetDateTime result = DateTimeUtil.toOffsetDateTime(jodaDate);
 
     assertEquals(ClockUtil.getDateTime().toInstant().getMillis(), result.toInstant().toEpochMilli());
   }
 
-  private void setFixedClock() {
-    ClockUtil.setClock(Clock.fixed(Instant.parse(FORMATTED_DATE_TIME_NOW), ZoneOffset.UTC));
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, false",
+    "1, 2010-10-10T10:10:10.000Z, null, true",
+    "2, null, 2010-10-10T10:10:10.000Z, false",
+    "3, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z, false",
+    "4, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.001Z, true",
+    "5, 2010-10-10T10:10:10.001Z, 2010-10-10T10:10:10.000Z, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsZonedDateTimeBeforeMillis(int id, ZonedDateTime left, ZonedDateTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isBeforeMillis(left, right), "For test " + id);
   }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, false",
+    "1, 2010-10-10T10:10:10.000, null, true",
+    "2, null, 2010-10-10T10:10:10.000, false",
+    "3, 2010-10-10T10:10:10.000, 2010-10-10T10:10:10.000, false",
+    "4, 2010-10-10T10:10:10.000, 2010-10-10T10:10:10.001, true",
+    "5, 2010-10-10T10:10:10.001, 2010-10-10T10:10:10.000, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsLocalDateTimeBeforeMillis(int id, LocalDateTime left, LocalDateTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isBeforeMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, false",
+    "1, 10:10:10.000, null, true",
+    "2, null, 10:10:10.000, false",
+    "3, 10:10:10.000, 10:10:10.000, false",
+    "4, 10:10:10.000, 10:10:10.001, true",
+    "5, 10:10:10.001, 10:10:10.000, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsLocalTimeBeforeMillis(int id, LocalTime left, LocalTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isBeforeMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, false",
+    "1, 2010-10-10T10:10:10.000Z, null, true",
+    "2, null, 2010-10-10T10:10:10.000Z, false",
+    "3, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z, false",
+    "4, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.001Z, true",
+    "5, 2010-10-10T10:10:10.001Z, 2010-10-10T10:10:10.000Z, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaDateTimeBeforeMillis(int id, DateTime left, DateTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isBeforeMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, false",
+    "1, 2010-10-10T10:10:10.000, null, true",
+    "2, null, 2010-10-10T10:10:10.000, false",
+    "3, 2010-10-10T10:10:10.000, 2010-10-10T10:10:10.000, false",
+    "4, 2010-10-10T10:10:10.000, 2010-10-10T10:10:10.001, true",
+    "5, 2010-10-10T10:10:10.001, 2010-10-10T10:10:10.000, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaLocalDateTimeBeforeMillis(int id, org.joda.time.LocalDateTime left, org.joda.time.LocalDateTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isBeforeMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, false",
+    "1, 10:10:10.000, null, true",
+    "2, null, 10:10:10.000, false",
+    "3, 10:10:10.000, 10:10:10.000, false",
+    "4, 10:10:10.000, 10:10:10.001, true",
+    "5, 10:10:10.001, 10:10:10.000, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaLocalTimeBeforeMillis(int id, org.joda.time.LocalTime left, org.joda.time.LocalTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isBeforeMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, false",
+    "1, 2010-10-10T10:10:10.000Z, null, false",
+    "2, null, 2010-10-10T10:10:10.000Z, true",
+    "3, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z, false",
+    "4, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.001Z, false",
+    "5, 2010-10-10T10:10:10.001Z, 2010-10-10T10:10:10.000Z, true",
+  }, nullValues = {"null"})
+  void shouldCompareIsZonedDateTimeAfterMillis(int id, ZonedDateTime left, ZonedDateTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isAfterMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, false",
+    "1, 2010-10-10T10:10:10.000, null, false",
+    "2, null, 2010-10-10T10:10:10.000, true",
+    "3, 2010-10-10T10:10:10.000, 2010-10-10T10:10:10.000, false",
+    "4, 2010-10-10T10:10:10.000, 2010-10-10T10:10:10.001, false",
+    "5, 2010-10-10T10:10:10.001, 2010-10-10T10:10:10.000, true",
+  }, nullValues = {"null"})
+  void shouldCompareIsLocalDateTimeAfterMillis(int id, LocalDateTime left, LocalDateTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isAfterMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, false",
+    "1, 10:10:10.000, null, false",
+    "2, null, 10:10:10.000, true",
+    "3, 10:10:10.000, 10:10:10.000, false",
+    "4, 10:10:10.000, 10:10:10.001, false",
+    "5, 10:10:10.001, 10:10:10.000, true",
+  }, nullValues = {"null"})
+  void shouldCompareIsLocalTimeAfterMillis(int id, LocalTime left, LocalTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isAfterMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, false",
+    "1, 2010-10-10T10:10:10.000Z, null, false",
+    "2, null, 2010-10-10T10:10:10.000Z, true",
+    "3, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z, false",
+    "4, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.001Z, false",
+    "5, 2010-10-10T10:10:10.001Z, 2010-10-10T10:10:10.000Z, true",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaDateTimeAfterMillis(int id, DateTime left, DateTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isAfterMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, false",
+    "1, 2010-10-10T10:10:10.000, null, false",
+    "2, null, 2010-10-10T10:10:10.000, true",
+    "3, 2010-10-10T10:10:10.000, 2010-10-10T10:10:10.000, false",
+    "4, 2010-10-10T10:10:10.000, 2010-10-10T10:10:10.001, false",
+    "5, 2010-10-10T10:10:10.001, 2010-10-10T10:10:10.000, true",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaLocalDateTimeAfterMillis(int id, org.joda.time.LocalDateTime left, org.joda.time.LocalDateTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isAfterMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, false",
+    "1, 10:10:10.000, null, false",
+    "2, null, 10:10:10.000, true",
+    "3, 10:10:10.000, 10:10:10.000, false",
+    "4, 10:10:10.000, 10:10:10.001, false",
+    "5, 10:10:10.001, 10:10:10.000, true",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaLocalDateTimeAfterMillis(int id, org.joda.time.LocalTime left, org.joda.time.LocalTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isAfterMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, true",
+    "1, 2010-10-10T10:10:10.000Z, null, false",
+    "2, null, 2010-10-10T10:10:10.000Z, false",
+    "3, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z, true",
+    "4, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.001Z, false",
+    "5, 2010-10-10T10:10:10.001Z, 2010-10-10T10:10:10.000Z, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsZonedDateTimeSameMillis(int id, ZonedDateTime left, ZonedDateTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isSameMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, true",
+    "1, 2010-10-10T10:10:10.000, null, false",
+    "2, null, 2010-10-10T10:10:10.000, false",
+    "3, 2010-10-10T10:10:10.000, 2010-10-10T10:10:10.000, true",
+    "4, 2010-10-10T10:10:10.000, 2010-10-10T10:10:10.001, false",
+    "5, 2010-10-10T10:10:10.001, 2010-10-10T10:10:10.000, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsLocalDateTimeSameMillis(int id, LocalDateTime left, LocalDateTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isSameMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, true",
+    "1, 10:10:10.000, null, false",
+    "2, null, 10:10:10.000, false",
+    "3, 10:10:10.000, 10:10:10.000, true",
+    "4, 10:10:10.000, 10:10:10.001, false",
+    "5, 10:10:10.001, 10:10:10.000, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsLocalTimeSameMillis(int id, LocalTime left, LocalTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isSameMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, true",
+    "1, 2010-10-10T10:10:10.000Z, null, false",
+    "2, null, 2010-10-10T10:10:10.000Z, false",
+    "3, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z, true",
+    "4, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.001Z, false",
+    "5, 2010-10-10T10:10:10.001Z, 2010-10-10T10:10:10.000Z, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaDateTimeSameMillis(int id, DateTime left, DateTime right, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isSameMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, true",
+    "1, 2010-10-10T10:10:10.000Z, null, false",
+    "2, null, 2010-10-10T10:10:10.000Z, false",
+    "3, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z, true",
+    "4, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.001Z, false",
+    "5, 2010-10-10T10:10:10.001Z, 2010-10-10T10:10:10.000Z, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsInstantSameMillis(int id, ZonedDateTime left, ZonedDateTime right, boolean expected) {
+    final Instant leftInstant = left == null
+      ? null
+      : left.toInstant();
+
+    final Instant rightInstant = right == null
+      ? null
+      : right.toInstant();
+
+    assertEquals(expected, DateTimeUtil.isSameMillis(leftInstant, rightInstant), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, true",
+    "1, 2010-10-10T10:10:10.000Z, null, false",
+    "2, null, 2010-10-10T10:10:10.000Z, false",
+    "3, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z, true",
+    "4, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.001Z, false",
+    "5, 2010-10-10T10:10:10.001Z, 2010-10-10T10:10:10.000Z, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaInstantSameMillis(int id, DateTime left, DateTime right, boolean expected) {
+    final org.joda.time.Instant leftInstant = left == null
+      ? null
+      : left.toInstant();
+
+    final org.joda.time.Instant rightInstant = right == null
+      ? null
+      : right.toInstant();
+
+    assertEquals(expected, DateTimeUtil.isSameMillis(leftInstant, rightInstant), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, null, false",
+    "1, null, 2010-05-05T10:05:05.000Z, 2010-12-12T10:12:12.000Z, false",
+    "2, 2010-10-10T10:10:10.000Z, null, 2010-12-12T10:12:12.000Z, false",
+    "3, 2010-10-10T10:10:10.000Z, 2010-05-05T10:05:05.000Z, null, true",
+    "4, null, null, 2010-12-12T10:12:12.000Z, false",
+    "5, 2010-10-10T10:10:10.000Z, null, null, false",
+    "6, 2010-10-10T10:10:10.000Z, 2010-05-05T10:05:05.000Z, 2010-12-12T10:12:12.000Z, true",
+    "7, 2010-01-01T00:00:00.000Z, 2010-05-05T10:05:05.000Z, 2010-12-12T10:12:12.000Z, false",
+    "8, 2010-12-12T12:00:00.000Z, 2010-05-05T10:05:05.000Z, 2010-12-12T10:12:12.000Z, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsZonedDateTimeWithinMillis(int id, ZonedDateTime date, ZonedDateTime first, ZonedDateTime last, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isWithinMillis(date, first, last), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, null, false",
+    "1, null, 2010-05-05T10:05:05.000, 2010-12-12T10:12:12.000, false",
+    "2, 2010-10-10T10:10:10.000, null, 2010-12-12T10:12:12.000, false",
+    "3, 2010-10-10T10:10:10.000, 2010-05-05T10:05:05.000, null, true",
+    "4, null, null, 2010-12-12T10:12:12.000, false",
+    "5, 2010-10-10T10:10:10.000, null, null, false",
+    "6, 2010-10-10T10:10:10.000, 2010-05-05T10:05:05.000, 2010-12-12T10:12:12.000, true",
+    "7, 2010-01-01T00:00:00.000, 2010-05-05T10:05:05.000, 2010-12-12T10:12:12.000, false",
+    "8, 2010-12-12T12:00:00.000, 2010-05-05T10:05:05.000, 2010-12-12T10:12:12.000, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsLocalDateTimeWithinMillis(int id, LocalDateTime date, LocalDateTime first, LocalDateTime last, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isWithinMillis(date, first, last), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, null, false",
+    "1, null, 10:05:05.000, 10:12:12.000, false",
+    "2, 10:10:10.000, null, 10:12:12.000, false",
+    "3, 10:10:10.000, 10:05:05.000, null, true",
+    "4, null, null, 10:12:12.000, false",
+    "5, 10:10:10.000, null, null, false",
+    "6, 10:10:10.000, 10:05:05.000, 10:12:12.000, true",
+    "7, 00:00:00.000, 10:05:05.000, 10:12:12.000, false",
+    "8, 12:00:00.000, 10:05:05.000, 10:12:12.000, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsLocalTimeWithinMillis(int id, LocalTime date, LocalTime first, LocalTime last, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isWithinMillis(date, first, last), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, null, false",
+    "1, null, 2010-05-05T10:05:05.000Z, 2010-12-12T10:12:12.000Z, false",
+    "2, 2010-10-10T10:10:10.000Z, null, 2010-12-12T10:12:12.000Z, false",
+    "3, 2010-10-10T10:10:10.000Z, 2010-05-05T10:05:05.000Z, null, true",
+    "4, null, null, 2010-12-12T10:12:12.000Z, false",
+    "5, 2010-10-10T10:10:10.000Z, null, null, false",
+    "6, 2010-10-10T10:10:10.000Z, 2010-05-05T10:05:05.000Z, 2010-12-12T10:12:12.000Z, true",
+    "7, 2010-01-01T00:00:00.000Z, 2010-05-05T10:05:05.000Z, 2010-12-12T10:12:12.000Z, false",
+    "8, 2010-12-12T12:00:00.000Z, 2010-05-05T10:05:05.000Z, 2010-12-12T10:12:12.000Z, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaZonedDateTimeWithinMillis(int id, DateTime date, DateTime first, DateTime last, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isWithinMillis(date, first, last), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, null, false",
+    "1, null, 2010-05-05T10:05:05.000, 2010-12-12T10:12:12.000, false",
+    "2, 2010-10-10T10:10:10.000, null, 2010-12-12T10:12:12.000, false",
+    "3, 2010-10-10T10:10:10.000, 2010-05-05T10:05:05.000, null, true",
+    "4, null, null, 2010-12-12T10:12:12.000, false",
+    "5, 2010-10-10T10:10:10.000, null, null, false",
+    "6, 2010-10-10T10:10:10.000, 2010-05-05T10:05:05.000, 2010-12-12T10:12:12.000, true",
+    "7, 2010-01-01T00:00:00.000, 2010-05-05T10:05:05.000, 2010-12-12T10:12:12.000, false",
+    "8, 2010-12-12T12:00:00.000, 2010-05-05T10:05:05.000, 2010-12-12T10:12:12.000, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaLocalDateTimeWithinMillis(int id, org.joda.time.LocalDateTime date, org.joda.time.LocalDateTime first, org.joda.time.LocalDateTime last, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isWithinMillis(date, first, last), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, null, false",
+    "1, null, 10:05:05.000, 10:12:12.000, false",
+    "2, 10:10:10.000, null, 10:12:12.000, false",
+    "3, 10:10:10.000, 10:05:05.000, null, true",
+    "4, null, null, 10:12:12.000, false",
+    "5, 10:10:10.000, null, null, false",
+    "6, 10:10:10.000, 10:05:05.000, 10:12:12.000, true",
+    "7, 00:00:00.000, 10:05:05.000, 10:12:12.000, false",
+    "8, 12:00:00.000, 10:05:05.000, 10:12:12.000, false",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaLocalTimeWithinMillis(int id, org.joda.time.LocalTime date, org.joda.time.LocalTime first, org.joda.time.LocalTime last, boolean expected) {
+    assertEquals(expected, DateTimeUtil.isWithinMillis(date, first, last), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, 0",
+    "1, 2010-10-10T10:10:10.000Z, null, -1",
+    "2, null, 2010-10-10T10:10:10.000Z, 1",
+    "3, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z, 0",
+    "4, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.001Z, -1",
+    "5, 2010-10-10T10:10:10.001Z, 2010-10-10T10:10:10.000Z, 1",
+  }, nullValues = {"null"})
+  void shouldCompareIsZonedDateTimeCompareToMillis(int id, ZonedDateTime left, ZonedDateTime right, int expected) {
+    assertEquals(expected, DateTimeUtil.compareToMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, 0",
+    "1, 10:10:10.000, null, -1",
+    "2, null, 10:10:10.000, 1",
+    "3, 10:10:10.000, 10:10:10.000, 0",
+    "4, 10:10:10.000, 10:10:10.001, -1",
+    "5, 10:10:10.001, 10:10:10.000, 1",
+  }, nullValues = {"null"})
+  void shouldCompareIsLocalTimeCompareToMillis(int id, LocalTime left, LocalTime right, int expected) {
+    assertEquals(expected, DateTimeUtil.compareToMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, 0",
+    "1, 2010-10-10T10:10:10.000Z, null, -1",
+    "2, null, 2010-10-10T10:10:10.000Z, 1",
+    "3, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z, 0",
+    "4, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.001Z, -1",
+    "5, 2010-10-10T10:10:10.001Z, 2010-10-10T10:10:10.000Z, 1",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaDateTimeCompareToMillis(int id, DateTime left, DateTime right, int expected) {
+    assertEquals(expected, DateTimeUtil.compareToMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, 0",
+    "1, 10:10:10.000, null, -1",
+    "2, null, 10:10:10.000, 1",
+    "3, 10:10:10.000, 10:10:10.000, 0",
+    "4, 10:10:10.000, 10:10:10.001, -1",
+    "5, 10:10:10.001, 10:10:10.000, 1",
+  }, nullValues = {"null"})
+  void shouldCompareIsJodaLocalTimeCompareToMillis(int id, org.joda.time.LocalTime left, org.joda.time.LocalTime right, int expected) {
+    assertEquals(expected, DateTimeUtil.compareToMillis(left, right), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, 0",
+    "1, 1970-01-01T00:03:20.000Z, null, 0",
+    "2, null, 1970-01-01T00:03:20.000Z, 100000",
+    "3, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.000Z, 0",
+    "4, 2010-10-10T10:10:10.000Z, 2010-10-10T10:10:10.001Z, 1",
+    "5, 2010-10-10T10:10:10.001Z, 2010-10-10T10:10:10.000Z, 0",
+  }, nullValues = {"null"})
+  void shouldGetMillisBetweenZonedDateTimes(int id, ZonedDateTime begin, ZonedDateTime end, int expected) {
+    ClockUtil.setClock(Clock.fixed(Instant.ofEpochMilli(100000), ZoneOffset.UTC));
+
+    assertEquals(expected, DateTimeUtil.millisBetween(begin, end), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, null, null, 0",
+    "1, 1970-01-01T00:03:20.000, null, 0",
+    "2, null, 1970-01-01T00:03:20.000, 100000",
+    "3, 2010-10-10T10:10:10.000, 2010-10-10T10:10:10.000, 0",
+    "4, 2010-10-10T10:10:10.000, 2010-10-10T10:10:10.001, 1",
+    "5, 2010-10-10T10:10:10.001, 2010-10-10T10:10:10.000, 0",
+  }, nullValues = {"null"})
+  void shouldGetMillisBetweenLocalDateTimes(int id, LocalDateTime begin, LocalDateTime end, int expected) {
+    ClockUtil.setClock(Clock.fixed(Instant.ofEpochMilli(100000), ZoneOffset.UTC));
+
+    assertEquals(expected, DateTimeUtil.millisBetween(begin, end), "For test " + id);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "0, 0, 0, 0",
+    "1, 0, 1, 1",
+    "2, 1, 0, 0",
+  }, nullValues = {"null"})
+  void shouldGetMillisBetweenMilliseconds(int id, long begin, long end, int expected) {
+    ClockUtil.setClock(Clock.fixed(Instant.ofEpochMilli(100000), ZoneOffset.UTC));
+
+    assertEquals(expected, DateTimeUtil.millisBetween(begin, end), "For test " + id);
+  }
+
 }


### PR DESCRIPTION
A staged approach is being used to implement all of the necessary changes for resolving [CIRC-966](https://issues.folio.org/browse/CIRC-966).

This is Stage 5, For CU, CF & DTU, parse and format methods.


## Purpose
Implement milliseconds related utility methods and switch to them.
This ended up being necessary to address the migration from JodaTime to JavaTime as a result of the millisecond vs nanosecond precision discrepencies.

## Approach
JodaTime is granularity down to the milliseconds but JavaTime is granularity down to the nanoseconds.
This causes comparison failures and similar problems, including some already documented problems.
    
Provide a series of millisecond related methods for processing these milliseconds.
This primarily provides tools for comparing one date and time to another with regards to milliseconds.
    
Additional normalization against an Instant is now added due to necessity.
    
The appropriate tests have been added, documentation has been updated, and some existing tests have been simplified.

## Learning
Several of the methods are made available but are not yet used.
During the previous iteration of attempting to solve CIRC-966, a custom Interval class was created.
This was early on in the process and with any luck it will not be needed again.
Some of these unused methods are to be used by the custom Interval class and if I can get away without using the custom Interval class, then these unused methods may be removed in the next stage.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
