### PR TITLE
CIRC-1214 check-out should allow notice policy access

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1399,6 +1399,7 @@
         "circulation-storage.loan-policies.item.get",
         "circulation-storage.loan-policies.collection.get",
         "circulation-storage.circulation-rules.get",
+        "circulation-storage.patron-notice-policies.item.get",
         "circulation-storage.request-batch.item.post",
         "circulation-storage.request-policies.item.get",
         "circulation-storage.requests.collection.get",


### PR DESCRIPTION
## Purpose

`circulation-storage.patron-notice-policies.item.get` was missing from
`modperms.circulation.check-out-by-barcode.post`, preventing notices
from being sent to patrons because the staff-member did not have the
necessary permission, causing a silent failure.

## Approach

Adding the missing permission.

## Nihilism

If nobody notices they didn't receive a notice, does anybody notice? 

Refs [CIRC-1214](https://issues.folio.org/browse/CIRC-1214)