### PR TITLE
Remove code owners and checklist CIRC-1215

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @folio-org/circulation-backend-code-owners

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
   to provide to the reviewer and to future readers than the cause
   that gave rise to this pull request. Be careful to avoid circular
   statements like "the purpose is to update the schema." and
-  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
+  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
   which is currently missing in the schema"
 
   The purpose may seem self-evident to you now, but the standard to
@@ -49,34 +49,3 @@
   you did. Add links to blog posts, patterns, libraries or addons used
   to solve this problem.
 -->
-
-## Pre-Merge Checklist:
-Before merging this PR, please go through the following list and take appropriate actions.
-
-- Does this PR meet or exceed the expected quality standards?
-  - [ ] Code coverage on new code is 80% or greater
-  - [ ] Duplications on new code is 3% or less
-  - [ ] There are no major code smells or security issues
-- Does this introduce breaking changes?
-  - [ ] Were any API paths or methods changed, added or removed?
-  - [ ] Were there any schema changes?
-  - [ ] Did any of the interface versions change?
-  - [ ] Were permissions changed, added, or removed?
-  - [ ] Are there new interface dependencies?
-  - [ ] There are no breaking changes in this PR.
-  
-If there are breaking changes, please **STOP** and consider the following:
-
-- What other modules will these changes impact?
-- Do JIRAs exist to update the impacted modules?
-  - [ ] If not, please create them
-  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
-  - [ ] Do they have all they appropriate links to blocked/related issues?
-- Are the JIRAs under active development?  
-  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
-- Do PRs exist for these changes?
-  - [ ] If so, have they been approved?
-
-Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  
-
-While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.


### PR DESCRIPTION
## Purpose

Removes the code owners definition as it led to unnecessary notifications that folks started ignoring

Removes the check list from the pull request template as folks aren't using it

## Learning
* Folks start to ignore notifications after a certain threshold of irrelevant notifications have been received
* Folks seem to ignore the check lists on pull requests