### PR TITLE
CIRC-1174 Add contributors fields to fee/fine records

### DIFF
--- a/src/main/java/org/folio/circulation/domain/representations/StoredAccount.java
+++ b/src/main/java/org/folio/circulation/domain/representations/StoredAccount.java
@@ -2,7 +2,9 @@ package org.folio.circulation.domain.representations;
 
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.folio.circulation.domain.Account;
 import org.folio.circulation.domain.FeeAmount;
@@ -39,6 +41,13 @@ public class StoredAccount extends JsonObject {
 
     this.put("paymentStatus", createNamedObject("Outstanding"));
     this.put("status", createNamedObject("Open"));
+
+    if (item.getContributors() != null) {
+      this.put("contributors", item.getContributors()
+        .map(contributor -> new JsonObject().put("name", contributor.getString("name")))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList()));
+    }
   }
 
   private StoredAccount(JsonObject json) {

--- a/src/test/java/api/loans/DeclareLostAPITests.java
+++ b/src/test/java/api/loans/DeclareLostAPITests.java
@@ -33,6 +33,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.joda.time.Seconds.seconds;
@@ -194,17 +197,22 @@ class DeclareLostAPITests extends APITests {
 
     assertThat(loan.getJson(), isOpen());
 
+    String contributorName = itemsFixture.basedUponSmallAngryPlanet().getInstance().getJson()
+      .getJsonArray("contributors")
+      .getJsonObject(0)
+      .getString("name");
+
     verifyFeeHasBeenCharged(loan.getId(), "Lost item fee", allOf(
       hasJsonPath("ownerId", expectedOwnerId),
       hasJsonPath("feeFineType", "Lost item fee"),
-      hasJsonPath("amount", expectedItemFee)
-    ));
+      hasJsonPath("amount", expectedItemFee),
+      hasJsonPath("contributors[0].name", contributorName)));
 
     verifyFeeHasBeenCharged(loan.getId(), "Lost item processing fee", allOf(
       hasJsonPath("ownerId", expectedOwnerId),
       hasJsonPath("feeFineType", "Lost item processing fee"),
-      hasJsonPath("amount", expectedProcessingFee)
-    ));
+      hasJsonPath("amount", expectedProcessingFee),
+      hasJsonPath("contributors[0].name", contributorName)));
   }
 
   @Test

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
@@ -136,10 +136,19 @@ class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
 
     assertThat(result.getLoan().getJson(), isLostItemHasBeenBilled());
 
-    assertThat(result.getLoan(), hasLostItemFee(isOpen(expectedItemFee)));
+    String contributorName = itemsFixture.basedUponSmallAngryPlanet().getInstance().getJson()
+      .getJsonArray("contributors")
+      .getJsonObject(0)
+      .getString("name");
+
+    assertThat(result.getLoan(), hasLostItemFee(allOf(
+      isOpen(expectedItemFee),
+      hasJsonPath("contributors[0].name", contributorName))));
     assertThat(result.getLoan(), hasLostItemFeeCreatedBySystemAction());
 
-    assertThat(result.getLoan(), hasLostItemProcessingFee(isOpen(expectedProcessingFee)));
+    assertThat(result.getLoan(), hasLostItemProcessingFee(allOf(
+      isOpen(expectedProcessingFee),
+      hasJsonPath("contributors[0].name", contributorName))));
     assertThat(result.getLoan(), hasLostItemProcessingFeeCreatedBySystemAction());
     assertThat(scheduledNoticesClient.getAll(), hasSize(2));
     assertThatPublishedLoanLogRecordEventsAreValid(loansClient.getById(result.getLoan().getId()).getJson());

--- a/src/test/java/org/folio/circulation/domain/OverdueFineCalculatorServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverdueFineCalculatorServiceTest.java
@@ -79,6 +79,9 @@ class OverdueFineCalculatorServiceTest {
     new User(new UserBuilder().withUsername("admin").create());
   private static final String LOGGED_IN_USER_ID = LOGGED_IN_USER.getId();
   private static final String CHECK_IN_SERVICE_POINT_NAME = "test service point";
+  private static final List<JsonObject> CONTRIBUTORS = List.of(
+    new JsonObject().put("name", "Contributor 1"),
+    new JsonObject().put("name", "Contributor 2"));
 
   private static final Map<String, Integer> MINUTES_IN_INTERVAL = new HashMap<>();
   static {
@@ -215,6 +218,12 @@ class OverdueFineCalculatorServiceTest {
     assertEquals(ITEM_ID.toString(), account.getValue().getString("itemId"));
     assertEquals(DUE_DATE, getDateTimeProperty(account.getValue(), "dueDate"));
     assertEquals(RETURNED_DATE, getDateTimeProperty(account.getValue(), "returnedDate"));
+
+    assertEquals(CONTRIBUTORS.size(), account.getValue().getJsonArray("contributors").size());
+    assertEquals(CONTRIBUTORS.get(0).getString("name"),
+      account.getValue().getJsonArray("contributors").getJsonObject(0).getString("name"));
+    assertEquals(CONTRIBUTORS.get(1).getString("name"),
+      account.getValue().getJsonArray("contributors").getJsonObject(1).getString("name"));
 
     ArgumentCaptor<StoredFeeFineAction> feeFineAction =
       ArgumentCaptor.forClass(StoredFeeFineAction.class);
@@ -607,7 +616,8 @@ class OverdueFineCalculatorServiceTest {
           .withName(LOCATION_NAME)
           .withPrimaryServicePoint(SERVICE_POINT_ID)
           .create()))
-      .withInstance(new InstanceBuilder(TITLE, UUID.randomUUID()).create())
+      .withInstance(new InstanceBuilder(TITLE, UUID.randomUUID()).create()
+        .put("contributors", CONTRIBUTORS))
       .withMaterialType(materialType);
   }
 


### PR DESCRIPTION
Resolves [CIRC-1174](https://issues.folio.org/browse/CIRC-1174)

## Purpose
Fee/fine (Account) schema was extended with `contributors` field on `mod-feesfines` side, now we need to add this field on `mod-circulation` side. This field needs to be populated when Overdue fines and Lost item / Lost item processing fees are created.

## Approach
Change StoredAccount class, change tests for Overdue fines and Lost item / Lost item processing fees.
