### PR TITLE
Add optional fulfilment preference to instance requests

### DIFF
--- a/ramls/request-by-instance-id.json
+++ b/ramls/request-by-instance-id.json
@@ -32,6 +32,10 @@
     "patronComments": {
       "description": "Comments made by the patron",
       "type": "string"
+    },
+    "fulfilmentPreference": {
+      "description": "Hold Shelf or Delivery",
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/ramls/request-by-instance-id.json
+++ b/ramls/request-by-instance-id.json
@@ -34,8 +34,9 @@
       "type": "string"
     },
     "fulfilmentPreference": {
-      "description": "Hold Shelf or Delivery",
-      "type": "string"
+      "description": "How should the request be fulfilled (whether the item should be kept on the hold shelf for collection or delivered to the requester)",
+      "type": "string",
+      "enum": ["Hold Shelf", "Delivery"]
     }
   },
   "additionalProperties": false,

--- a/src/main/java/org/folio/circulation/domain/representations/RequestByInstanceIdRequest.java
+++ b/src/main/java/org/folio/circulation/domain/representations/RequestByInstanceIdRequest.java
@@ -55,7 +55,10 @@ public class RequestByInstanceIdRequest {
     final DateTime requestExpirationDate = getDateTimeProperty(json, REQUEST_EXPIRATION_DATE);
     final UUID pickupServicePointId = getUUIDProperty(json, PICKUP_SERVICE_POINT_ID);
 
-    final String fulfilmentPreference = getProperty(json, FULFILMENT_PREFERENCE);
+    String fulfilmentPreference = getProperty(json, FULFILMENT_PREFERENCE);
+    if (fulfilmentPreference == null){
+      fulfilmentPreference = "Hold Shelf";
+    }
 
     return succeeded(new RequestByInstanceIdRequest(requestDate, requesterId, instanceId,
         requestExpirationDate, pickupServicePointId, getProperty(json, "patronComments"), fulfilmentPreference));

--- a/src/main/java/org/folio/circulation/domain/representations/RequestByInstanceIdRequest.java
+++ b/src/main/java/org/folio/circulation/domain/representations/RequestByInstanceIdRequest.java
@@ -23,6 +23,7 @@ public class RequestByInstanceIdRequest {
   private static final String INSTANCE_ID = "instanceId";
   private static final String REQUEST_EXPIRATION_DATE = "requestExpirationDate";
   private static final String PICKUP_SERVICE_POINT_ID = "pickupServicePointId";
+  private static final String FULFILMENT_PREFERENCE = "fulfilmentPreference";
 
   private final DateTime requestDate;
   private final UUID requesterId;
@@ -30,6 +31,7 @@ public class RequestByInstanceIdRequest {
   private final DateTime requestExpirationDate;
   private final UUID pickupServicePointId;
   private final String patronComments;
+  private final String fulfilmentPreference;
 
   public static Result<RequestByInstanceIdRequest> from(JsonObject json) {
     final DateTime requestDate = getDateTimeProperty(json, REQUEST_DATE);
@@ -53,7 +55,9 @@ public class RequestByInstanceIdRequest {
     final DateTime requestExpirationDate = getDateTimeProperty(json, REQUEST_EXPIRATION_DATE);
     final UUID pickupServicePointId = getUUIDProperty(json, PICKUP_SERVICE_POINT_ID);
 
+    final String fulfilmentPreference = getProperty(json, FULFILMENT_PREFERENCE);
+
     return succeeded(new RequestByInstanceIdRequest(requestDate, requesterId, instanceId,
-        requestExpirationDate, pickupServicePointId, getProperty(json, "patronComments")));
+        requestExpirationDate, pickupServicePointId, getProperty(json, "patronComments"), fulfilmentPreference));
   }
 }

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -326,8 +326,6 @@ public class RequestByInstanceIdResource extends Resource {
     RequestType[] types = RequestType.values();
     LinkedList<JsonObject> requests = new LinkedList<>();
 
-    final String defaultFulfilmentPreference = "Hold Shelf";
-
     for (Item item: combinedItems) {
       for (RequestType reqType : types) {
         if (reqType != RequestType.NONE) {
@@ -340,12 +338,12 @@ public class RequestByInstanceIdResource extends Resource {
           write(requestBody, REQUESTER_ID, requestByInstanceIdRequest.getRequesterId().toString());
           write(requestBody, "pickupServicePointId",
             requestByInstanceIdRequest.getPickupServicePointId().toString());
-          write(requestBody, "fulfilmentPreference", defaultFulfilmentPreference);
           write(requestBody, "requestType", reqType.getValue());
           if (requestByInstanceIdRequest.getRequestExpirationDate() != null) {
             write(requestBody, "requestExpirationDate",
               requestByInstanceIdRequest.getRequestExpirationDate());
           }
+          write(requestBody, "fulfilmentPreference", requestByInstanceIdRequest.getPatronComments());
           write(requestBody, "patronComments", requestByInstanceIdRequest.getPatronComments());
           requests.add(requestBody);
         }

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -343,7 +343,7 @@ public class RequestByInstanceIdResource extends Resource {
             write(requestBody, "requestExpirationDate",
               requestByInstanceIdRequest.getRequestExpirationDate());
           }
-          write(requestBody, "fulfilmentPreference", requestByInstanceIdRequest.getPatronComments());
+          write(requestBody, "fulfilmentPreference", requestByInstanceIdRequest.getfulfilmentPreference());
           write(requestBody, "patronComments", requestByInstanceIdRequest.getPatronComments());
           requests.add(requestBody);
         }

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -343,7 +343,7 @@ public class RequestByInstanceIdResource extends Resource {
             write(requestBody, "requestExpirationDate",
               requestByInstanceIdRequest.getRequestExpirationDate());
           }
-          write(requestBody, "fulfilmentPreference", requestByInstanceIdRequest.getfulfilmentPreference());
+          write(requestBody, "fulfilmentPreference", requestByInstanceIdRequest.getFulfilmentPreference());
           write(requestBody, "patronComments", requestByInstanceIdRequest.getPatronComments());
           requests.add(requestBody);
         }


### PR DESCRIPTION
## Purpose

Massey University are implementing FOLIO and identified that the circulation module does not support making an instance request with a fulfilment preference. I have proposed this PR to adjust the existing instance request endpoint by adding support for an optional fulfilment preference.

## Approach
I adjusted the RAML JSON to allow "Hold Shelf" or "Delivery". If a delivery preference was not specified, it is defaulted to "Hold Shelf" to matching existing expectations.

#### TODOS and Open Questions
[ ] Confirm PR follows FOLIO Java conventions (I haven't written Java in years)