### PR TITLE
CIRC-1300 add permission

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1507,7 +1507,8 @@
         "scheduled-notice-storage.scheduled-notices.item.post",
         "accounts.refund.post",
         "accounts.cancel.post",
-        "configuration.entries.collection.get"
+        "configuration.entries.collection.get",
+        "calendar.opening-hours.collection.get"
       ],
       "visible": false
     },


### PR DESCRIPTION
Link to [ticket](https://issues.folio.org/browse/CIRC-1300)

## Purpose
Warner University had noticed that when their student workers checked in overdue materials, fines were not calculating as expected. When staff did, the fine calculated. Research found that this was due to the Student Worker permission set missing calendar.opening-hours.collection.get permission

## Approach
add necessary permissions

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
