### PR TITLE
CIRC-1100 provide notice-policy access in order to send certain notices

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -747,6 +747,7 @@
             "accounts.collection.get",
             "feefineactions.item.get",
             "feefineactions.collection.get",
+            "circulation.rules.notice-policy.get",
             "circulation-storage.loans.item.get",
             "circulation-storage.loans.collection.get",
             "circulation-storage.circulation-rules.get",


### PR DESCRIPTION
## Purpose

`circulation.rules.notice-policy.get` was missing from the module
permissions for the endpoint
`/circulation/fee-fine-scheduled-notices-processing`, causing certain
notices such as those with a trigger-event of "overdue fine returned"
not be sent.

## Approach

Add the missing permission.

Refs [CIRC-1100](https://issues.folio.org/browse/CIRC-1100)
