### PR TITLE
CIRC-1327: Tests fail if build server time zone is not UTC

### DIFF
--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -49,7 +49,6 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
@@ -283,7 +282,7 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
     assertThat(requestContext.getString("deliveryAddressType"), is(addressTypesFixture.home().getJson().getString("addressType")));
     assertThat(requestContext.getString("requestExpirationDate"), isEquivalentTo(
       ZonedDateTime.of(requestExpiration.atTime(23, 59, 59), ZoneOffset.UTC)));
-    assertThat(requestContext.getString("holdShelfExpirationDate"), isEquivalentTo(toZonedStartOfDay(holdShelfExpiration)));
+    assertThat(requestContext.getString("holdShelfExpirationDate"), isEquivalentTo(holdShelfExpiration.atStartOfDay(UTC)));
     assertThat(requestContext.getString("requestID"), is(request.getId()));
     assertThat(requestContext.getString("servicePointPickup"), is(servicePoint.getJson().getString("name")));
     assertThat(requestContext.getString("patronComments"), is("I need the book"));
@@ -1481,12 +1480,6 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
       assertThat(checkInOperation.getString("servicePointId"), is(servicePoint.toString()));
       assertThat(checkInOperation.getString("performedByUserId"), is(getUserId()));
     });
-  }
-
-  private ZonedDateTime toZonedStartOfDay(LocalDate date) {
-    final var startOfDay = date.atStartOfDay();
-
-    return ZonedDateTime.of(startOfDay, ZoneId.systemDefault().normalized());
   }
 
   private LocalDate toLocalDate(ZonedDateTime dateTime) {

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -12,8 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -225,10 +223,10 @@ class PickSlipsTests extends APITests {
 
     assertThat(requestContext.getString("deliveryAddressType"),
       is(addressTypeResource.getJson().getString("addressType")));
-    assertThat(requestContext.getString("requestExpirationDate"), isEquivalentTo(ZonedDateTime.of(
-      requestExpiration.atTime(23, 59, 59), ZoneOffset.UTC)));
+    assertThat(requestContext.getString("requestExpirationDate"),
+      isEquivalentTo(requestExpiration.atTime(23, 59, 59).atZone(UTC)));
     assertThat(requestContext.getString("holdShelfExpirationDate"),
-      isEquivalentTo(toZonedStartOfDay(holdShelfExpiration)));
+      isEquivalentTo(holdShelfExpiration.atStartOfDay(UTC)));
     assertThat(requestContext.getString("requestID"),
       UUIDMatcher.is(requestResource.getId()));
     assertThat(requestContext.getString("servicePointPickup"),
@@ -455,11 +453,5 @@ class PickSlipsTests extends APITests {
 
   private String getName(JsonObject jsonObject) {
     return jsonObject.getString("name");
-  }
-
-  private ZonedDateTime toZonedStartOfDay(LocalDate date) {
-    final var startOfDay = date.atStartOfDay();
-
-    return ZonedDateTime.of(startOfDay, ZoneId.systemDefault().normalized());
   }
 }


### PR DESCRIPTION
Replace ZoneId.systemDefault() by UTC to make the test independent
of the build server time zone.