### PR TITLE
CIRC-1326: RMB 33.1.1, Vert.x 4.2.1, PubSub 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
   <properties>
     <antlr4.version>4.7.2</antlr4.version>
     <drools.version>7.53.0.Final</drools.version>
-    <rmb.version>31.1.0</rmb.version>
-    <vertx.version>4.1.1</vertx.version>
+    <rmb.version>33.1.1</rmb.version>
+    <vertx.version>4.2.1</vertx.version>
     <log4j2.version>2.13.3</log4j2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -145,7 +145,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.0.7</version>
+      <version>2.4.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.hamcrest</groupId>

--- a/src/main/java/org/folio/circulation/services/PubSubPublishingService.java
+++ b/src/main/java/org/folio/circulation/services/PubSubPublishingService.java
@@ -41,7 +41,7 @@ public class PubSubPublishingService {
       .withEventType(eventType)
       .withEventPayload(payload)
       .withEventMetadata(new EventMetadata()
-        .withPublishedBy(PubSubClientUtils.constructModuleName())
+        .withPublishedBy(PubSubClientUtils.getModuleId())
         .withTenantId(okapiHeaders.get(OKAPI_TENANT_HEADER))
         .withEventTTL(1));
 

--- a/src/test/java/api/support/fixtures/TenantActivationFixture.java
+++ b/src/test/java/api/support/fixtures/TenantActivationFixture.java
@@ -1,9 +1,9 @@
 package api.support.fixtures;
 
 import static api.support.APITestContext.circulationModuleUrl;
+import static org.folio.util.pubsub.PubSubClientUtils.getModuleId;
 
 import org.folio.circulation.support.http.client.Response;
-import org.folio.rest.tools.PomReader;
 
 import api.support.RestAssuredClient;
 import io.vertx.core.json.JsonObject;
@@ -16,11 +16,8 @@ public class TenantActivationFixture {
   }
 
   public Response postTenant() {
-    String moduleName = PomReader.INSTANCE.getModuleName();
-    String currentVersion = PomReader.INSTANCE.getVersion();
-
     return restAssuredClient.post(
-      new JsonObject().put("id", String.format("%s-%s", moduleName, currentVersion)),
+      new JsonObject().put("id", getModuleId()),
       circulationModuleUrl("/_/tenant"), "tenant-api-post-test-request");
   }
 

--- a/src/test/java/api/support/matchers/PubSubRegistrationMatchers.java
+++ b/src/test/java/api/support/matchers/PubSubRegistrationMatchers.java
@@ -1,7 +1,7 @@
 package api.support.matchers;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
-import static org.folio.util.pubsub.PubSubClientUtils.constructModuleName;
+import static org.folio.util.pubsub.PubSubClientUtils.getModuleId;
 import static org.hamcrest.core.Is.is;
 
 import org.hamcrest.Matcher;
@@ -11,7 +11,7 @@ import io.vertx.core.json.JsonObject;
 public class PubSubRegistrationMatchers {
   public static Matcher<JsonObject> isValidPublishersRegistration() {
     return JsonObjectMatcher.allOfPaths(
-      hasJsonPath("moduleId", is(constructModuleName())),
+      hasJsonPath("moduleId", is(getModuleId())),
       hasJsonPath("eventDescriptors[0].eventType", is("ITEM_CHECKED_OUT")),
       hasJsonPath("eventDescriptors[1].eventType", is("ITEM_CHECKED_IN")),
       hasJsonPath("eventDescriptors[2].eventType", is("ITEM_DECLARED_LOST")),
@@ -25,7 +25,7 @@ public class PubSubRegistrationMatchers {
 
   public static Matcher<JsonObject> isValidSubscribersRegistration() {
     return JsonObjectMatcher.allOfPaths(
-      hasJsonPath("moduleId", is(constructModuleName())),
+      hasJsonPath("moduleId", is(getModuleId())),
       hasJsonPath("subscriptionDefinitions[0].eventType",
         is("LOAN_RELATED_FEE_FINE_CLOSED"))
     );


### PR DESCRIPTION
Upgrade raml-module-builder (RMB) from 31.1.0 to 33.1.1.
Upgrade Vert.x from 4.1.1 to 4.2.1.
Upgrade mod-pubsub-client from 2.0.7 to 2.4.0.

The new mod-pubsub-client has renamed PubSubClientUtils.constructModuleName()
to PubSubClientUtils.getModuleId() resulting in code changes in mod-circulation.