### PR TITLE
Circ 1112 reset due date changed flag during loan replacement

### DIFF
--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -49,7 +49,7 @@ public class RequestQueue {
     return requests.stream().anyMatch(request -> request.getRequestType() == type);
   }
 
-  public Boolean hasOpenRecalls() {
+  public boolean hasOpenRecalls() {
     return requests.stream()
         .anyMatch(request -> request.getRequestType() == RequestType.RECALL && request.isNotYetFilled());
   }

--- a/src/test/java/api/loans/scenarios/ChangeDueDateAPITests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateAPITests.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.awaitility.Awaitility;
-import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.support.http.client.Response;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
@@ -341,7 +340,6 @@ class ChangeDueDateAPITests extends APITests {
 
   @Test
   void dueDateChangeShouldClearRenewalFlagWhenSetAndNoOpenRecallsInQueue() {
-
     IndividualResource loanPolicy = loanPoliciesFixture.create(
       new LoanPolicyBuilder()
         .withName("loan policy")
@@ -357,12 +355,12 @@ class ChangeDueDateAPITests extends APITests {
     ItemBuilder itemBuilder = ItemExamples.basedUponSmallAngryPlanet(
       materialTypesFixture.book().getId(), loanTypesFixture.canCirculate().getId(),
       EMPTY, "ItemPrefix", "ItemSuffix", "");
-  
+
     ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet(
       itemBuilder, itemsFixture.thirdFloorHoldings());
-  
+
     IndividualResource steve = usersFixture.steve();
-  
+
     IndividualResource initialLoan = checkOutFixture.checkOutByBarcode(smallAngryPlanet, steve);
 
     ZonedDateTime initialDueDate = ZonedDateTime.parse(initialLoan.getJson().getString("dueDate"));
@@ -389,7 +387,7 @@ class ChangeDueDateAPITests extends APITests {
       .withDueDate(newDueDate));
 
     JsonObject dueDateChangedLoan = loansClient.getById(initialLoan.getId()).getJson();
-    
+
     assertThat(dueDateChangedLoan.getBoolean("dueDateChangedByRecall"), equalTo(false));
     assertThat("due date should be provided new due date",
     dueDateChangedLoan.getString("dueDate"), isEquivalentTo(newDueDate));

--- a/src/test/java/api/loans/scenarios/ChangeDueDateByReplacingLoanTests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateByReplacingLoanTests.java
@@ -308,7 +308,7 @@ class ChangeDueDateByReplacingLoanTests extends APITests {
   }
 
   @Test
-  void dueDateChangeShouldClearRenewalFlagWhenSetAndNoOpenRecallsInQueue() {
+  void dueDateChangeShouldResetDueDateChangedFlagWhenNoOpenRecallsInQueue() {
     final var loanPolicy = loanPoliciesFixture.create(
       new LoanPolicyBuilder()
         .withName("loan policy")
@@ -358,7 +358,7 @@ class ChangeDueDateByReplacingLoanTests extends APITests {
   }
 
   @Test
-  void dueDateChangedFlagShouldNotBeResetWhenDueDateDoesNotChange() {
+  void dueDateChangedFlagShouldNotBeResetWhenDueDateHasNotChanged() {
     final var loanPolicy = loanPoliciesFixture.create(
       new LoanPolicyBuilder()
         .withName("loan policy")

--- a/src/test/java/api/loans/scenarios/ChangeDueDateByReplacingLoanTests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateByReplacingLoanTests.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 
 import org.folio.circulation.support.http.client.Response;
 import org.hamcrest.Matcher;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 
 import api.support.APITests;
@@ -308,7 +307,6 @@ class ChangeDueDateByReplacingLoanTests extends APITests {
       loanInStorage.containsKey("checkoutServicePoint"), is(false));
   }
 
-  @Ignore("WIP")
   @Test
   void dueDateChangeShouldClearRenewalFlagWhenSetAndNoOpenRecallsInQueue() {
     final var loanPolicy = loanPoliciesFixture.create(

--- a/src/test/java/api/loans/scenarios/ChangeDueDateByReplacingLoanTests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateByReplacingLoanTests.java
@@ -357,6 +357,57 @@ class ChangeDueDateByReplacingLoanTests extends APITests {
       dueDateChangedLoan.getString("dueDate"), isEquivalentTo(newDueDate));
   }
 
+  @Test
+  void dueDateChangedFlagShouldNotBeResetWhenDueDateDoesNotChange() {
+    final var loanPolicy = loanPoliciesFixture.create(
+      new LoanPolicyBuilder()
+        .withName("loan policy")
+        .withRecallsMinimumGuaranteedLoanPeriod(org.folio.circulation.domain.policy.Period.weeks(2))
+        .rolling(org.folio.circulation.domain.policy.Period.months(1)));
+
+    useFallbackPolicies(loanPolicy.getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.activeNotice().getId(),
+      overdueFinePoliciesFixture.facultyStandardDoNotCountClosed().getId(),
+      lostItemFeePoliciesFixture.facultyStandard().getId());
+
+    final var itemBuilder = ItemExamples.basedUponSmallAngryPlanet(
+      materialTypesFixture.book().getId(), loanTypesFixture.canCirculate().getId(),
+      EMPTY, "ItemPrefix", "ItemSuffix", "");
+
+    final var smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet(
+      itemBuilder, itemsFixture.thirdFloorHoldings());
+
+    final var steve = usersFixture.steve();
+
+    final var initialLoan = checkOutFixture.checkOutByBarcode(smallAngryPlanet, steve);
+    final var loanId = initialLoan.getId();
+    final var initialDueDate = ZonedDateTime.parse(initialLoan.getJson().getString("dueDate"));
+
+    final var recall = requestsFixture.place(new RequestBuilder()
+      .recall()
+      .forItem(smallAngryPlanet)
+      .by(usersFixture.charlotte())
+      .fulfilToHoldShelf(servicePointsFixture.cd1()));
+
+    Response recalledLoan = loansClient.getById(loanId);
+
+    assertThat(recalledLoan.getJson().getBoolean("dueDateChangedByRecall"), equalTo(true));
+
+    requestsFixture.cancelRequest(recall);
+
+    final var newDueDate = initialDueDate.plusMonths(1);
+
+    // Intended to represent a replacement of a loan that does not change the due date
+    // If checks are added later for identical loan representations,
+    // this may provide false positive
+    loansClient.replace(loanId, recalledLoan.getJson());
+
+    final var dueDateChangedLoan = loansClient.getById(loanId).getJson();
+
+    assertThat(dueDateChangedLoan.getBoolean("dueDateChangedByRecall"), equalTo(true));
+  }
+
   private JsonObject loanForDueDateChangeRequest(Response fetchedLoan, ZonedDateTime newDueDate) {
     JsonObject loanToChange = fetchedLoan.getJson().copy();
 


### PR DESCRIPTION
## Purpose

Apply the same due date changed by recall flag resetting logic as renewal and explicit change due date operations when changing a loan via replacement (PUT)

## Approach
* Uses the same logic as for the other places where the flag is reset

#### TODOS and Open Questions
* There is some duplication between the three places where this flag is reset when a due date is changed
