### PR TITLE
CIRC-1362 Consider TLR when changing loan due date

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -114,7 +114,8 @@
           "methods": ["POST"],
           "pathPattern": "/circulation/loans/{id}/change-due-date",
           "permissionsRequired": [
-            "circulation.loans.change-due-date.post"
+            "circulation.loans.change-due-date.post",
+            "configuration.entries.collection.get"
           ],
           "modulePermissions": [
             "modperms.circulation.loans.change-due-date.post"

--- a/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
+++ b/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
@@ -10,6 +10,7 @@ import static org.folio.circulation.support.results.Result.succeeded;
 
 import java.lang.invoke.MethodHandles;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.logging.log4j.LogManager;
@@ -102,7 +103,8 @@ public class ChangeDueDateResource extends Resource {
     RequestQueue queue = loanAndRelatedRecords.getRequestQueue();
     Loan loan = loanAndRelatedRecords.getLoan();
     log.info("Loan {} prior to flag check: {}", loan.getId(), loan.asJson().toString());
-    if (loan.wasDueDateChangedByRecall() && !queue.hasOpenRecalls()) {
+    if (loan.wasDueDateChangedByRecall() && !queue.hasOpenRecalls() && (Objects.isNull(loanAndRelatedRecords.getTlrSettings())
+    || Objects.nonNull(loanAndRelatedRecords.getTlrSettings()) && !loanAndRelatedRecords.getTlrSettings().isTitleLevelRequestsFeatureEnabled())) {
       log.info("Loan {} registers as having due date change flag set to true and no open recalls in queue.", loan.getId());
       return loanAndRelatedRecords.withLoan(loan.unsetDueDateChangedByRecall());
     } else {

--- a/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
+++ b/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
@@ -10,7 +10,6 @@ import static org.folio.circulation.support.results.Result.succeeded;
 
 import java.lang.invoke.MethodHandles;
 import java.time.ZonedDateTime;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
+++ b/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
@@ -103,8 +103,7 @@ public class ChangeDueDateResource extends Resource {
     RequestQueue queue = loanAndRelatedRecords.getRequestQueue();
     Loan loan = loanAndRelatedRecords.getLoan();
     log.info("Loan {} prior to flag check: {}", loan.getId(), loan.asJson().toString());
-    if (loan.wasDueDateChangedByRecall() && !queue.hasOpenRecalls() && (Objects.isNull(loanAndRelatedRecords.getTlrSettings())
-    || Objects.nonNull(loanAndRelatedRecords.getTlrSettings()) && !loanAndRelatedRecords.getTlrSettings().isTitleLevelRequestsFeatureEnabled())) {
+    if (loan.wasDueDateChangedByRecall() && !queue.hasOpenRecalls()) {
       log.info("Loan {} registers as having due date change flag set to true and no open recalls in queue.", loan.getId());
       return loanAndRelatedRecords.withLoan(loan.unsetDueDateChangedByRecall());
     } else {

--- a/src/test/java/api/loans/scenarios/ChangeDueDateAPITests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateAPITests.java
@@ -433,7 +433,7 @@ class ChangeDueDateAPITests extends APITests {
 
     configurationsFixture.enableTlrFeature();
     requestsClient.create(new RequestBuilder()
-      .page()
+      .recall()
       .titleRequestLevel()
       .withInstanceId(smallAngryPlanet.getInstanceId())
       .withPickupServicePointId(servicePointsFixture.cd1().getId())
@@ -489,7 +489,7 @@ class ChangeDueDateAPITests extends APITests {
     configurationsFixture.enableTlrFeature();
 
     requestsClient.create(new RequestBuilder()
-      .page()
+      .recall()
       .titleRequestLevel()
       .withInstanceId(smallAngryPlanet.getInstanceId())
       .withPickupServicePointId(servicePointsFixture.cd1().getId())

--- a/src/test/java/api/loans/scenarios/ChangeDueDateAPITests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateAPITests.java
@@ -346,8 +346,8 @@ class ChangeDueDateAPITests extends APITests {
     IndividualResource loanPolicy = loanPoliciesFixture.create(
       new LoanPolicyBuilder()
         .withName("loan policy")
-        .withRecallsMinimumGuaranteedLoanPeriod(org.folio.circulation.domain.policy.Period.weeks(2))
-        .rolling(org.folio.circulation.domain.policy.Period.months(1)));
+        .withRecallsMinimumGuaranteedLoanPeriod(org.folio.circulation.domain.policy.Period.days(3))
+        .rolling(org.folio.circulation.domain.policy.Period.days(7)));
 
     useFallbackPolicies(loanPolicy.getId(),
       requestPoliciesFixture.allowAllRequestPolicy().getId(),
@@ -380,7 +380,7 @@ class ChangeDueDateAPITests extends APITests {
     ZonedDateTime recalledLoanDueDate = ZonedDateTime.parse(recalledLoan.getJson().getString("dueDate"));
 
     assertThat(recalledLoan.getJson().getBoolean("dueDateChangedByRecall"), equalTo(true));
-    assertThat(calculateDaysBetween(initialDueDate, recalledLoanDueDate), equalTo(16));
+    assertThat(calculateDaysBetween(initialDueDate, recalledLoanDueDate), equalTo(4));
 
     requestsFixture.cancelRequest(recall);
 

--- a/src/test/java/api/loans/scenarios/ChangeDueDateAPITests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateAPITests.java
@@ -45,8 +45,11 @@ import org.folio.circulation.support.http.client.Response;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import api.support.APITests;
+import api.support.TlrFeatureStatus;
 import api.support.builders.ChangeDueDateRequestBuilder;
 import api.support.builders.ClaimItemReturnedRequestBuilder;
 import api.support.builders.ItemBuilder;
@@ -391,6 +394,118 @@ class ChangeDueDateAPITests extends APITests {
     assertThat(dueDateChangedLoan.getBoolean("dueDateChangedByRecall"), equalTo(false));
     assertThat("due date should be provided new due date",
     dueDateChangedLoan.getString("dueDate"), isEquivalentTo(newDueDate));
+  }
+
+  @Test
+  void dueDateChangeShouldNotUnsetRenewalFlagValueWhenTlrFeatureEnabled() {
+    IndividualResource loanPolicy = loanPoliciesFixture.create(
+      new LoanPolicyBuilder()
+        .withName("loan policy")
+        .withRecallsMinimumGuaranteedLoanPeriod(org.folio.circulation.domain.policy.Period.weeks(2))
+        .rolling(org.folio.circulation.domain.policy.Period.months(1)));
+
+    useFallbackPolicies(loanPolicy.getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.activeNotice().getId(),
+      overdueFinePoliciesFixture.facultyStandardDoNotCountClosed().getId(),
+      lostItemFeePoliciesFixture.facultyStandard().getId());
+
+    ItemBuilder itemBuilder = ItemExamples.basedUponSmallAngryPlanet(
+      materialTypesFixture.book().getId(), loanTypesFixture.canCirculate().getId(),
+      EMPTY, "ItemPrefix", "ItemSuffix", "");
+
+    ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet(
+      itemBuilder, itemsFixture.thirdFloorHoldings());
+    IndividualResource steve = usersFixture.steve();
+    IndividualResource initialLoan = checkOutFixture.checkOutByBarcode(smallAngryPlanet, steve);
+    ZonedDateTime initialDueDate = ZonedDateTime.parse(initialLoan.getJson().getString("dueDate"));
+
+    assertThat(initialLoan.getJson().containsKey("dueDateChangedByRecall"), equalTo(false));
+
+    IndividualResource recall = requestsFixture.place(new RequestBuilder()
+      .recall()
+      .forItem(smallAngryPlanet)
+      .by(usersFixture.charlotte())
+      .fulfilToHoldShelf(servicePointsFixture.cd1()));
+    Response recalledLoan = loansClient.getById(initialLoan.getId());
+
+    assertThat(recalledLoan.getJson().getBoolean("dueDateChangedByRecall"), equalTo(true));
+
+    configurationsFixture.enableTlrFeature();
+    requestsClient.create(new RequestBuilder()
+      .page()
+      .titleRequestLevel()
+      .withInstanceId(smallAngryPlanet.getInstanceId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
+      .withRequesterId(usersFixture.jessica().getId()));
+
+    requestsFixture.cancelRequest(recall);
+    final ZonedDateTime newDueDate = initialDueDate.plusMonths(1);
+    changeDueDateFixture.changeDueDate(new ChangeDueDateRequestBuilder()
+      .forLoan(recalledLoan.getJson().getString("id"))
+      .withDueDate(newDueDate));
+    JsonObject dueDateChangedLoan = loansClient.getById(initialLoan.getId()).getJson();
+
+    assertThat(recalledLoan.getJson().containsKey("dueDateChangedByRecall"), equalTo(true));
+    assertThat(dueDateChangedLoan.getBoolean("dueDateChangedByRecall"), equalTo(true));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = TlrFeatureStatus.class, names = {"DISABLED", "NOT_CONFIGURED"})
+  void dueDateChangeShouldUnsetRenewalFlagValueWhenTlrFeatureDisabledOrNotConfigured(TlrFeatureStatus tlrFeatureStatus) {
+    IndividualResource loanPolicy = loanPoliciesFixture.create(
+      new LoanPolicyBuilder()
+        .withName("loan policy")
+        .withRecallsMinimumGuaranteedLoanPeriod(org.folio.circulation.domain.policy.Period.weeks(2))
+        .rolling(org.folio.circulation.domain.policy.Period.months(1)));
+
+    useFallbackPolicies(loanPolicy.getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.activeNotice().getId(),
+      overdueFinePoliciesFixture.facultyStandardDoNotCountClosed().getId(),
+      lostItemFeePoliciesFixture.facultyStandard().getId());
+
+    ItemBuilder itemBuilder = ItemExamples.basedUponSmallAngryPlanet(
+      materialTypesFixture.book().getId(), loanTypesFixture.canCirculate().getId(),
+      EMPTY, "ItemPrefix", "ItemSuffix", "");
+
+    ItemResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet(
+      itemBuilder, itemsFixture.thirdFloorHoldings());
+    IndividualResource steve = usersFixture.steve();
+    IndividualResource initialLoan = checkOutFixture.checkOutByBarcode(smallAngryPlanet, steve);
+    ZonedDateTime initialDueDate = ZonedDateTime.parse(initialLoan.getJson().getString("dueDate"));
+
+    assertThat(initialLoan.getJson().containsKey("dueDateChangedByRecall"), equalTo(false));
+
+    IndividualResource recall = requestsFixture.place(new RequestBuilder()
+      .recall()
+      .forItem(smallAngryPlanet)
+      .by(usersFixture.charlotte())
+      .fulfilToHoldShelf(servicePointsFixture.cd1()));
+    Response recalledLoan = loansClient.getById(initialLoan.getId());
+
+    assertThat(recalledLoan.getJson().getBoolean("dueDateChangedByRecall"), equalTo(true));
+
+    configurationsFixture.enableTlrFeature();
+
+    requestsClient.create(new RequestBuilder()
+      .page()
+      .titleRequestLevel()
+      .withInstanceId(smallAngryPlanet.getInstanceId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
+      .withRequesterId(usersFixture.jessica().getId()));
+
+    requestsFixture.cancelRequest(recall);
+    reconfigureTlrFeature(tlrFeatureStatus);
+
+    final ZonedDateTime newDueDate = initialDueDate.plusMonths(1);
+    changeDueDateFixture.changeDueDate(new ChangeDueDateRequestBuilder()
+      .forLoan(recalledLoan.getJson().getString("id"))
+      .withDueDate(newDueDate));
+    JsonObject dueDateChangedLoan = loansClient.getById(initialLoan.getId()).getJson();
+
+    assertThat(recalledLoan.getJson().containsKey("dueDateChangedByRecall"), equalTo(true));
+    assertThat(dueDateChangedLoan.getBoolean("dueDateChangedByRecall"), equalTo(false));
   }
 
   private Integer calculateDaysBetween(ZonedDateTime initialDate, ZonedDateTime secondDate) {


### PR DESCRIPTION
### Purpose
Consider title-level requests and TLR feature settings when performing the following validation during due date change
### Approach

- Added logic to ChangeDueDateResource and unsetDueDateChangedByRecallIfNoOpenRecallsInQueue with purpose to get tlr settings and according to their values fulfill unsetting of dueDateChangedByRecall property;
- Added tests;

### Learning
https://issues.folio.org/browse/CIRC-1362