### PR TITLE
Remove unnecessary assertions for intermediary step CIRC-1365

### DIFF
--- a/src/test/java/api/loans/scenarios/ChangeDueDateAPITests.java
+++ b/src/test/java/api/loans/scenarios/ChangeDueDateAPITests.java
@@ -32,11 +32,10 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-import java.time.Period;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -377,10 +376,6 @@ class ChangeDueDateAPITests extends APITests {
       .fulfilToHoldShelf(servicePointsFixture.cd1()));
 
     Response recalledLoan = loansClient.getById(initialLoan.getId());
-    ZonedDateTime recalledLoanDueDate = ZonedDateTime.parse(recalledLoan.getJson().getString("dueDate"));
-
-    assertThat(recalledLoan.getJson().getBoolean("dueDateChangedByRecall"), equalTo(true));
-    assertThat(calculateDaysBetween(initialDueDate, recalledLoanDueDate), equalTo(16));
 
     requestsFixture.cancelRequest(recall);
 
@@ -392,13 +387,9 @@ class ChangeDueDateAPITests extends APITests {
     JsonObject dueDateChangedLoan = loansClient.getById(initialLoan.getId()).getJson();
 
     assertThat(dueDateChangedLoan.getBoolean("dueDateChangedByRecall"), equalTo(false));
-    assertThat("due date should be provided new due date",
-    dueDateChangedLoan.getString("dueDate"), isEquivalentTo(newDueDate));
-  }
 
-  private Integer calculateDaysBetween(ZonedDateTime initialDate, ZonedDateTime secondDate) {
-    Period period = Period.between(initialDate.toLocalDate(), secondDate.toLocalDate());
-    return Math.abs(period.getDays());
+    assertThat("due date should be provided new due date",
+      dueDateChangedLoan.getString("dueDate"), isEquivalentTo(newDueDate));
   }
 
   private void chargeFeesForLostItemToKeepLoanOpen() {


### PR DESCRIPTION
The changes in the previous pull request did not remove the possibility of erroneous failures in this test, caused by mismatches in accuracy in due date comparisons.

Rather than change the assertion to be more reliable, it has been removed as it was for details about an
intermediary step that is unimportant for this test.