### PR TITLE
Remove json from instance in domain CIRC-1366

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Contributor.java
+++ b/src/main/java/org/folio/circulation/domain/Contributor.java
@@ -1,0 +1,9 @@
+package org.folio.circulation.domain;
+
+import lombok.Value;
+
+@Value
+public class Contributor {
+  String name;
+  Boolean primary;
+}

--- a/src/main/java/org/folio/circulation/domain/Identifier.java
+++ b/src/main/java/org/folio/circulation/domain/Identifier.java
@@ -1,0 +1,9 @@
+package org.folio.circulation.domain;
+
+import lombok.Value;
+
+@Value
+public class Identifier {
+  String typeId;
+  String value;
+}

--- a/src/main/java/org/folio/circulation/domain/Instance.java
+++ b/src/main/java/org/folio/circulation/domain/Instance.java
@@ -1,12 +1,17 @@
 package org.folio.circulation.domain;
 
+import java.util.Collection;
+import java.util.List;
+
+import lombok.NonNull;
 import lombok.Value;
 
 @Value
 public class Instance {
   public static Instance unknown() {
-    return new Instance(null);
+    return new Instance(null, List.of());
   }
 
   String title;
+  @NonNull Collection<Identifier> identifiers;
 }

--- a/src/main/java/org/folio/circulation/domain/Instance.java
+++ b/src/main/java/org/folio/circulation/domain/Instance.java
@@ -5,6 +5,8 @@ import lombok.Value;
 @Value
 public class Instance {
   public static Instance unknown() {
-    return new Instance();
+    return new Instance(null);
   }
+
+  String title;
 }

--- a/src/main/java/org/folio/circulation/domain/Instance.java
+++ b/src/main/java/org/folio/circulation/domain/Instance.java
@@ -1,0 +1,10 @@
+package org.folio.circulation.domain;
+
+import lombok.Value;
+
+@Value
+public class Instance {
+  public static Instance unknown() {
+    return new Instance();
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/Instance.java
+++ b/src/main/java/org/folio/circulation/domain/Instance.java
@@ -3,6 +3,7 @@ package org.folio.circulation.domain;
 import static java.util.Collections.emptyList;
 
 import java.util.Collection;
+import java.util.stream.Stream;
 
 import lombok.NonNull;
 import lombok.Value;
@@ -16,4 +17,17 @@ public class Instance {
   String title;
   @NonNull Collection<Identifier> identifiers;
   @NonNull Collection<Contributor> contributors;
+
+  public Stream<String> getContributorNames() {
+    return contributors.stream()
+      .map(Contributor::getName);
+  }
+
+  public String getPrimaryContributorName() {
+    return contributors.stream()
+      .filter(Contributor::getPrimary)
+      .findFirst()
+      .map(Contributor::getName)
+      .orElse(null);
+  }
 }

--- a/src/main/java/org/folio/circulation/domain/Instance.java
+++ b/src/main/java/org/folio/circulation/domain/Instance.java
@@ -1,7 +1,8 @@
 package org.folio.circulation.domain;
 
+import static java.util.Collections.emptyList;
+
 import java.util.Collection;
-import java.util.List;
 
 import lombok.NonNull;
 import lombok.Value;
@@ -9,9 +10,10 @@ import lombok.Value;
 @Value
 public class Instance {
   public static Instance unknown() {
-    return new Instance(null, List.of());
+    return new Instance(null, emptyList(), emptyList());
   }
 
   String title;
   @NonNull Collection<Identifier> identifiers;
+  @NonNull Collection<Contributor> contributors;
 }

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.folio.circulation.domain.representations.ItemProperties;
-import org.folio.circulation.storage.mappers.InstanceMapper;
 
 import io.vertx.core.json.JsonObject;
 import lombok.NonNull;
@@ -416,9 +415,7 @@ public class Item {
       holdings, this.instance);
   }
 
-  public Item withInstance(JsonObject newInstanceRepresentation) {
-    final var mapper = new InstanceMapper();
-
+  public Item withInstance(Instance instance) {
     return new Item(
       this.itemRepresentation,
       this.location,
@@ -430,7 +427,7 @@ public class Item {
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
       this.changed, holdings,
-      mapper.toDomain(newInstanceRepresentation));
+      instance);
   }
 
   public Item withPrimaryServicePoint(ServicePoint servicePoint) {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -11,7 +11,6 @@ import static org.folio.circulation.domain.ItemStatus.MISSING;
 import static org.folio.circulation.domain.ItemStatus.PAGED;
 import static org.folio.circulation.domain.representations.InstanceProperties.CONTRIBUTORS;
 import static org.folio.circulation.domain.representations.ItemProperties.EFFECTIVE_LOCATION_ID;
-import static org.folio.circulation.domain.representations.ItemProperties.IDENTIFIERS;
 import static org.folio.circulation.domain.representations.ItemProperties.IN_TRANSIT_DESTINATION_SERVICE_POINT_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.ITEM_COPY_NUMBER_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.PERMANENT_LOCATION_ID;
@@ -30,7 +29,6 @@ import java.util.stream.Stream;
 
 import org.folio.circulation.domain.representations.ItemProperties;
 import org.folio.circulation.storage.mappers.ContributorMapper;
-import org.folio.circulation.storage.mappers.IdentifierMapper;
 import org.folio.circulation.storage.mappers.InstanceMapper;
 import org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher;
 
@@ -156,10 +154,7 @@ public class Item {
   }
 
   public Stream<Identifier> getIdentifiers() {
-    final var mapper = new IdentifierMapper();
-
-    return JsonObjectArrayPropertyFetcher.toStream(instanceRepresentation, IDENTIFIERS)
-      .map(mapper::toDomain);
+    return instance.getIdentifiers().stream();
   }
 
   public String getPrimaryContributorName() {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 
 import org.folio.circulation.domain.representations.ItemProperties;
 import org.folio.circulation.storage.mappers.ContributorMapper;
+import org.folio.circulation.storage.mappers.IdentifierMapper;
 import org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher;
 
 import io.vertx.core.json.JsonArray;
@@ -127,8 +128,11 @@ public class Item {
     return getProperty(instanceRepresentation, TITLE);
   }
 
-  public JsonArray getIdentifiersJson() {
-    return getArrayProperty(instanceRepresentation, IDENTIFIERS);
+  public Stream<Identifier> getIdentifiers() {
+    final var mapper = new IdentifierMapper();
+
+    return JsonObjectArrayPropertyFetcher.toStream(instanceRepresentation, IDENTIFIERS)
+      .map(mapper::toDomain);
   }
 
   public String getPrimaryContributorName() {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -16,7 +16,6 @@ import static org.folio.circulation.domain.representations.ItemProperties.IN_TRA
 import static org.folio.circulation.domain.representations.ItemProperties.ITEM_COPY_NUMBER_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.PERMANENT_LOCATION_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.STATUS_PROPERTY;
-import static org.folio.circulation.domain.representations.ItemProperties.TITLE;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.json.JsonPropertyWriter.remove;
@@ -153,7 +152,7 @@ public class Item {
   }
 
   public String getTitle() {
-    return getProperty(instanceRepresentation, TITLE);
+    return instance.getTitle();
   }
 
   public Stream<Identifier> getIdentifiers() {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -127,7 +127,7 @@ public class Item {
     return getProperty(instanceRepresentation, TITLE);
   }
 
-  public JsonArray getIdentifiers() {
+  public JsonArray getIdentifiersJson() {
     return getArrayProperty(instanceRepresentation, IDENTIFIERS);
   }
 

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -120,20 +120,16 @@ public class Item {
     return instance.getTitle();
   }
 
-  public Stream<Identifier> getIdentifiers() {
-    return instance.getIdentifiers().stream();
+  public Stream<String> getContributorNames() {
+    return instance.getContributorNames();
   }
 
   public String getPrimaryContributorName() {
-    return getContributors()
-      .filter(Contributor::getPrimary)
-      .findFirst()
-      .map(Contributor::getName)
-      .orElse(null);
+    return instance.getPrimaryContributorName();
   }
 
-  public Stream<Contributor> getContributors() {
-    return instance.getContributors().stream();
+  public Stream<Identifier> getIdentifiers() {
+    return instance.getIdentifiers().stream();
   }
 
   public String getBarcode() {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.folio.circulation.domain.representations.ItemProperties;
+import org.folio.circulation.storage.mappers.ContributorMapper;
 import org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher;
 
 import io.vertx.core.json.JsonArray;
@@ -131,11 +132,18 @@ public class Item {
   }
 
   public String getPrimaryContributorName() {
-    return getContributorsJson()
-      .filter(c -> c.getBoolean("primary", false))
+    return getContributors()
+      .filter(Contributor::getPrimary)
       .findFirst()
-      .map(c -> c.getString("name"))
+      .map(Contributor::getName)
       .orElse(null);
+  }
+
+  public Stream<Contributor> getContributors() {
+    final var mapper = new ContributorMapper();
+
+    return getContributorsJson()
+      .map(mapper::toDomain);
   }
 
   public Stream<JsonObject> getContributorsJson() {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -29,8 +29,10 @@ import java.util.stream.Stream;
 import org.folio.circulation.domain.representations.ItemProperties;
 
 import io.vertx.core.json.JsonObject;
+import lombok.AllArgsConstructor;
 import lombok.NonNull;
 
+@AllArgsConstructor
 public class Item {
   private final JsonObject itemRepresentation;
   private final Location location;
@@ -44,35 +46,8 @@ public class Item {
   private ServicePoint inTransitDestinationServicePoint;
   private boolean changed;
 
-  private final Holdings holdings;
-  private final Instance instance;
-
-  public Item(JsonObject itemRepresentation,
-    Location location,
-    JsonObject materialTypeRepresentation,
-    ServicePoint primaryServicePoint,
-    JsonObject loanTypeRepresentation,
-    LastCheckIn lastCheckIn,
-    CallNumberComponents callNumberComponents,
-    Location permanentLocation,
-    ServicePoint inTransitDestinationServicePoint,
-    boolean changed,
-    Holdings holdings,
-    Instance instance) {
-
-    this.itemRepresentation = itemRepresentation;
-    this.location = location;
-    this.materialTypeRepresentation = materialTypeRepresentation;
-    this.primaryServicePoint = primaryServicePoint;
-    this.loanTypeRepresentation = loanTypeRepresentation;
-    this.lastCheckIn = lastCheckIn;
-    this.callNumberComponents = callNumberComponents;
-    this.permanentLocation = permanentLocation;
-    this.inTransitDestinationServicePoint = inTransitDestinationServicePoint;
-    this.changed = changed;
-    this.holdings = holdings;
-    this.instance = instance;
-  }
+  @NonNull private final Holdings holdings;
+  @NonNull private final Instance instance;
 
   public static Item from(JsonObject representation) {
     return new Item(representation,
@@ -415,7 +390,7 @@ public class Item {
       holdings, this.instance);
   }
 
-  public Item withInstance(Instance instance) {
+  public Item withInstance(@NonNull Instance instance) {
     return new Item(
       this.itemRepresentation,
       this.location,

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import org.folio.circulation.domain.representations.ItemProperties;
 import org.folio.circulation.storage.mappers.ContributorMapper;
 import org.folio.circulation.storage.mappers.IdentifierMapper;
+import org.folio.circulation.storage.mappers.InstanceMapper;
 import org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher;
 
 import io.vertx.core.json.JsonObject;
@@ -52,6 +53,7 @@ public class Item {
   private boolean changed;
 
   private final Holdings holdings;
+  private final Instance instance;
 
   public Item(JsonObject itemRepresentation,
     JsonObject instanceRepresentation,
@@ -64,7 +66,8 @@ public class Item {
     Location permanentLocation,
     ServicePoint inTransitDestinationServicePoint,
     boolean changed,
-    Holdings holdings) {
+    Holdings holdings,
+    Instance instance) {
 
     this.itemRepresentation = itemRepresentation;
     this.instanceRepresentation = instanceRepresentation;
@@ -78,6 +81,7 @@ public class Item {
     this.inTransitDestinationServicePoint = inTransitDestinationServicePoint;
     this.changed = changed;
     this.holdings = holdings;
+    this.instance = instance;
   }
 
   public static Item from(JsonObject representation) {
@@ -92,7 +96,8 @@ public class Item {
       null,
       null,
       false,
-      Holdings.unknown());
+      Holdings.unknown(),
+      Instance.unknown());
   }
 
   public boolean isCheckedOut() {
@@ -396,7 +401,7 @@ public class Item {
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings);
+      this.changed, holdings, this.instance);
   }
 
   public Item withMaterialType(JsonObject newMaterialType) {
@@ -411,7 +416,7 @@ public class Item {
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings);
+      this.changed, holdings, this.instance);
   }
 
   public Item withHoldings(@NonNull Holdings holdings) {
@@ -427,10 +432,12 @@ public class Item {
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
       this.changed,
-      holdings);
+      holdings, this.instance);
   }
 
   public Item withInstance(JsonObject newInstanceRepresentation) {
+    final var mapper = new InstanceMapper();
+
     return new Item(
       this.itemRepresentation,
       newInstanceRepresentation,
@@ -442,7 +449,8 @@ public class Item {
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings);
+      this.changed, holdings,
+      mapper.toDomain(newInstanceRepresentation));
   }
 
   public Item withPrimaryServicePoint(ServicePoint servicePoint) {
@@ -457,7 +465,7 @@ public class Item {
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings);
+      this.changed, holdings, this.instance);
   }
 
   public Item withLoanType(JsonObject newLoanTypeRepresentation) {
@@ -472,7 +480,7 @@ public class Item {
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings);
+      this.changed, holdings, this.instance);
   }
 
   public Item withLastCheckIn(LastCheckIn lastCheckIn) {
@@ -487,7 +495,7 @@ public class Item {
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings);
+      this.changed, holdings, this.instance);
   }
 
   public Item withPermanentLocation(Location permanentLocation) {
@@ -502,6 +510,6 @@ public class Item {
       this.callNumberComponents,
       permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings);
+      this.changed, holdings, this.instance);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -131,14 +131,14 @@ public class Item {
   }
 
   public String getPrimaryContributorName() {
-    return getContributors()
+    return getContributorsJson()
       .filter(c -> c.getBoolean("primary", false))
       .findFirst()
       .map(c -> c.getString("name"))
       .orElse(null);
   }
 
-  public Stream<JsonObject> getContributors() {
+  public Stream<JsonObject> getContributorsJson() {
     return JsonObjectArrayPropertyFetcher.toStream(instanceRepresentation, CONTRIBUTORS);
   }
 

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -9,7 +9,6 @@ import static org.folio.circulation.domain.ItemStatus.DECLARED_LOST;
 import static org.folio.circulation.domain.ItemStatus.IN_TRANSIT;
 import static org.folio.circulation.domain.ItemStatus.MISSING;
 import static org.folio.circulation.domain.ItemStatus.PAGED;
-import static org.folio.circulation.domain.representations.InstanceProperties.CONTRIBUTORS;
 import static org.folio.circulation.domain.representations.ItemProperties.EFFECTIVE_LOCATION_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.IN_TRANSIT_DESTINATION_SERVICE_POINT_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.ITEM_COPY_NUMBER_ID;
@@ -28,9 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.folio.circulation.domain.representations.ItemProperties;
-import org.folio.circulation.storage.mappers.ContributorMapper;
 import org.folio.circulation.storage.mappers.InstanceMapper;
-import org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher;
 
 import io.vertx.core.json.JsonObject;
 import lombok.NonNull;
@@ -166,10 +163,7 @@ public class Item {
   }
 
   public Stream<Contributor> getContributors() {
-    final var mapper = new ContributorMapper();
-
-    return JsonObjectArrayPropertyFetcher.toStream(instanceRepresentation, CONTRIBUTORS)
-      .map(mapper::toDomain);
+    return instance.getContributors().stream();
   }
 
   public String getBarcode() {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -17,7 +17,6 @@ import static org.folio.circulation.domain.representations.ItemProperties.ITEM_C
 import static org.folio.circulation.domain.representations.ItemProperties.PERMANENT_LOCATION_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.STATUS_PROPERTY;
 import static org.folio.circulation.domain.representations.ItemProperties.TITLE;
-import static org.folio.circulation.support.json.JsonPropertyFetcher.getArrayProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.json.JsonPropertyWriter.remove;
@@ -35,12 +34,9 @@ import org.folio.circulation.storage.mappers.ContributorMapper;
 import org.folio.circulation.storage.mappers.IdentifierMapper;
 import org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher;
 
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import lombok.AllArgsConstructor;
 import lombok.NonNull;
 
-@AllArgsConstructor
 public class Item {
   private final JsonObject itemRepresentation;
   private final JsonObject instanceRepresentation;
@@ -56,6 +52,33 @@ public class Item {
   private boolean changed;
 
   private final Holdings holdings;
+
+  public Item(JsonObject itemRepresentation,
+    JsonObject instanceRepresentation,
+    Location location,
+    JsonObject materialTypeRepresentation,
+    ServicePoint primaryServicePoint,
+    JsonObject loanTypeRepresentation,
+    LastCheckIn lastCheckIn,
+    CallNumberComponents callNumberComponents,
+    Location permanentLocation,
+    ServicePoint inTransitDestinationServicePoint,
+    boolean changed,
+    Holdings holdings) {
+
+    this.itemRepresentation = itemRepresentation;
+    this.instanceRepresentation = instanceRepresentation;
+    this.location = location;
+    this.materialTypeRepresentation = materialTypeRepresentation;
+    this.primaryServicePoint = primaryServicePoint;
+    this.loanTypeRepresentation = loanTypeRepresentation;
+    this.lastCheckIn = lastCheckIn;
+    this.callNumberComponents = callNumberComponents;
+    this.permanentLocation = permanentLocation;
+    this.inTransitDestinationServicePoint = inTransitDestinationServicePoint;
+    this.changed = changed;
+    this.holdings = holdings;
+  }
 
   public static Item from(JsonObject representation) {
     return new Item(representation,

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -142,12 +142,8 @@ public class Item {
   public Stream<Contributor> getContributors() {
     final var mapper = new ContributorMapper();
 
-    return getContributorsJson()
+    return JsonObjectArrayPropertyFetcher.toStream(instanceRepresentation, CONTRIBUTORS)
       .map(mapper::toDomain);
-  }
-
-  public Stream<JsonObject> getContributorsJson() {
-    return JsonObjectArrayPropertyFetcher.toStream(instanceRepresentation, CONTRIBUTORS);
   }
 
   public String getBarcode() {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -34,7 +34,6 @@ import lombok.NonNull;
 
 public class Item {
   private final JsonObject itemRepresentation;
-  private final JsonObject instanceRepresentation;
   private final Location location;
   private final JsonObject materialTypeRepresentation;
   private final ServicePoint primaryServicePoint;
@@ -50,7 +49,6 @@ public class Item {
   private final Instance instance;
 
   public Item(JsonObject itemRepresentation,
-    JsonObject instanceRepresentation,
     Location location,
     JsonObject materialTypeRepresentation,
     ServicePoint primaryServicePoint,
@@ -64,7 +62,6 @@ public class Item {
     Instance instance) {
 
     this.itemRepresentation = itemRepresentation;
-    this.instanceRepresentation = instanceRepresentation;
     this.location = location;
     this.materialTypeRepresentation = materialTypeRepresentation;
     this.primaryServicePoint = primaryServicePoint;
@@ -80,7 +77,6 @@ public class Item {
 
   public static Item from(JsonObject representation) {
     return new Item(representation,
-      null,
       null,
       null,
       null,
@@ -380,7 +376,6 @@ public class Item {
   public Item withLocation(Location newLocation) {
     return new Item(
       this.itemRepresentation,
-      this.instanceRepresentation,
       newLocation,
       this.materialTypeRepresentation,
       this.primaryServicePoint,
@@ -395,7 +390,6 @@ public class Item {
   public Item withMaterialType(JsonObject newMaterialType) {
     return new Item(
       this.itemRepresentation,
-      this.instanceRepresentation,
       this.location,
       newMaterialType,
       this.primaryServicePoint,
@@ -410,7 +404,6 @@ public class Item {
   public Item withHoldings(@NonNull Holdings holdings) {
     return new Item(
       this.itemRepresentation,
-      this.instanceRepresentation,
       this.location,
       this.materialTypeRepresentation,
       this.primaryServicePoint,
@@ -428,7 +421,6 @@ public class Item {
 
     return new Item(
       this.itemRepresentation,
-      newInstanceRepresentation,
       this.location,
       this.materialTypeRepresentation,
       this.primaryServicePoint,
@@ -444,7 +436,6 @@ public class Item {
   public Item withPrimaryServicePoint(ServicePoint servicePoint) {
     return new Item(
       this.itemRepresentation,
-      this.instanceRepresentation,
       this.location,
       this.materialTypeRepresentation,
       servicePoint,
@@ -459,7 +450,6 @@ public class Item {
   public Item withLoanType(JsonObject newLoanTypeRepresentation) {
     return new Item(
       this.itemRepresentation,
-      this.instanceRepresentation,
       this.location,
       this.materialTypeRepresentation,
       this.primaryServicePoint,
@@ -474,7 +464,6 @@ public class Item {
   public Item withLastCheckIn(LastCheckIn lastCheckIn) {
     return new Item(
       this.itemRepresentation,
-      this.instanceRepresentation,
       this.location,
       this.materialTypeRepresentation,
       this.primaryServicePoint,
@@ -489,7 +478,6 @@ public class Item {
   public Item withPermanentLocation(Location permanentLocation) {
     return new Item(
       this.itemRepresentation,
-      this.instanceRepresentation,
       this.location,
       this.materialTypeRepresentation,
       this.primaryServicePoint,

--- a/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
@@ -3,7 +3,6 @@ package org.folio.circulation.domain;
 import static java.util.Objects.isNull;
 import static java.util.Optional.ofNullable;
 import static org.folio.circulation.domain.representations.CallNumberComponentsRepresentation.createCallNumberComponents;
-import static org.folio.circulation.domain.representations.ContributorsToNamesMapper.mapContributorsToNamesOnly;
 import static org.folio.circulation.domain.representations.ItemProperties.CALL_NUMBER_COMPONENTS;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.copyProperty;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
@@ -13,6 +12,7 @@ import java.lang.invoke.MethodHandles;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.circulation.domain.representations.ContributorsToNamesMapper;
 
 import io.vertx.core.json.JsonObject;
 
@@ -74,7 +74,7 @@ public class RequestRepresentation {
       write(itemSummary, "location", locationSummary(location));
     }
 
-    itemSummary.put("contributorNames", mapContributorsToNamesOnly(item.getContributors()));
+    itemSummary.put("contributorNames", ContributorsToNamesMapper.mapContributorNamesToJson(item));
 
     String enumeration = item.getEnumeration();
     if (enumeration != null) {

--- a/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
@@ -75,7 +75,7 @@ public class RequestRepresentation {
       write(itemSummary, "location", locationSummary(location));
     }
 
-    JsonArray contributorNames = mapContributorsToNamesOnly(item.getContributors());
+    JsonArray contributorNames = mapContributorsToNamesOnly(item.getContributorsJson());
 
     if (contributorNames != null) {
       itemSummary.put("contributorNames", contributorNames);

--- a/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
@@ -14,7 +14,6 @@ import java.lang.invoke.MethodHandles;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class RequestRepresentation {
@@ -75,11 +74,7 @@ public class RequestRepresentation {
       write(itemSummary, "location", locationSummary(location));
     }
 
-    JsonArray contributorNames = mapContributorsToNamesOnly(item.getContributorsJson());
-
-    if (contributorNames != null) {
-      itemSummary.put("contributorNames", contributorNames);
-    }
+    itemSummary.put("contributorNames", mapContributorsToNamesOnly(item.getContributors()));
 
     String enumeration = item.getEnumeration();
     if (enumeration != null) {

--- a/src/main/java/org/folio/circulation/domain/StoredRequestRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/StoredRequestRepresentation.java
@@ -35,7 +35,7 @@ public class StoredRequestRepresentation {
 
     write(itemSummary, "title", item.getTitle());
     write(itemSummary, "barcode", item.getBarcode());
-    write(itemSummary, "identifiers", item.getIdentifiers());
+    write(itemSummary, "identifiers", item.getIdentifiersJson());
 
     request.put("item", itemSummary);
   }

--- a/src/main/java/org/folio/circulation/domain/StoredRequestRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/StoredRequestRepresentation.java
@@ -4,6 +4,7 @@ import static java.util.Objects.isNull;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
 import java.lang.invoke.MethodHandles;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -35,9 +36,22 @@ public class StoredRequestRepresentation {
 
     write(itemSummary, "title", item.getTitle());
     write(itemSummary, "barcode", item.getBarcode());
-    write(itemSummary, "identifiers", item.getIdentifiersJson());
+
+    write(itemSummary, "identifiers",
+      item.getIdentifiers()
+        .map(StoredRequestRepresentation::identifierToJson)
+        .collect(Collectors.toList()));
 
     request.put("item", itemSummary);
+  }
+
+  private static JsonObject identifierToJson(Identifier identifier) {
+    final var representation = new JsonObject();
+
+    write(representation, "identifierTypeId", identifier.getTypeId());
+    write(representation, "value", identifier.getValue());
+
+    return representation;
   }
 
   private static void addStoredRequesterProperties(JsonObject request, User requester) {
@@ -67,6 +81,7 @@ public class StoredRequestRepresentation {
     write(userSummary, "firstName", user.getFirstName());
     write(userSummary, "middleName", user.getMiddleName());
     write(userSummary, "barcode", user.getBarcode());
+
     return userSummary;
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -14,7 +14,6 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.folio.circulation.domain.Account;
 import org.folio.circulation.domain.CallNumberComponents;
 import org.folio.circulation.domain.CheckInContext;
-import org.folio.circulation.domain.Contributor;
 import org.folio.circulation.domain.FeeFineAction;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Loan;
@@ -156,8 +155,7 @@ public class TemplateContextUtil {
   }
 
   private static JsonObject createItemContext(Item item) {
-    String contributorNamesToken = item.getContributors()
-      .map(Contributor::getName)
+    String contributorNamesToken = item.getContributorNames()
       .collect(joining("; "));
 
     String yearCaptionsToken = String.join("; ", item.getYearCaption());

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -155,7 +155,7 @@ public class TemplateContextUtil {
   }
 
   private static JsonObject createItemContext(Item item) {
-    String contributorNamesToken = item.getContributors()
+    String contributorNamesToken = item.getContributorsJson()
       .map(o -> o.getString("name"))
       .collect(joining("; "));
 

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.folio.circulation.domain.Account;
 import org.folio.circulation.domain.CallNumberComponents;
 import org.folio.circulation.domain.CheckInContext;
+import org.folio.circulation.domain.Contributor;
 import org.folio.circulation.domain.FeeFineAction;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Loan;
@@ -155,8 +156,8 @@ public class TemplateContextUtil {
   }
 
   private static JsonObject createItemContext(Item item) {
-    String contributorNamesToken = item.getContributorsJson()
-      .map(o -> o.getString("name"))
+    String contributorNamesToken = item.getContributors()
+      .map(Contributor::getName)
       .collect(joining("; "));
 
     String yearCaptionsToken = String.join("; ", item.getYearCaption());

--- a/src/main/java/org/folio/circulation/domain/representations/ContributorsToNamesMapper.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ContributorsToNamesMapper.java
@@ -1,7 +1,10 @@
 package org.folio.circulation.domain.representations;
 
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.folio.circulation.domain.Contributor;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -9,9 +12,11 @@ import io.vertx.core.json.JsonObject;
 public class ContributorsToNamesMapper {
   private ContributorsToNamesMapper() { }
 
-  public static JsonArray mapContributorsToNamesOnly(Stream<JsonObject> contributors) {
+  public static JsonArray mapContributorsToNamesOnly(Stream<Contributor> contributors) {
     return new JsonArray(contributors
-      .map(contributor -> new JsonObject().put("name", contributor.getString("name")))
+      .map(Contributor::getName)
+      .filter(Objects::nonNull)
+      .map(name -> new JsonObject().put("name", name))
       .collect(Collectors.toList()));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/representations/ContributorsToNamesMapper.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ContributorsToNamesMapper.java
@@ -1,10 +1,8 @@
 package org.folio.circulation.domain.representations;
 
-import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.folio.circulation.domain.Contributor;
+import org.folio.circulation.domain.Item;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -12,10 +10,8 @@ import io.vertx.core.json.JsonObject;
 public class ContributorsToNamesMapper {
   private ContributorsToNamesMapper() { }
 
-  public static JsonArray mapContributorsToNamesOnly(Stream<Contributor> contributors) {
-    return new JsonArray(contributors
-      .map(Contributor::getName)
-      .filter(Objects::nonNull)
+  public static JsonArray mapContributorNamesToJson(Item item) {
+    return new JsonArray(item.getContributorNames()
       .map(name -> new JsonObject().put("name", name))
       .collect(Collectors.toList()));
   }

--- a/src/main/java/org/folio/circulation/domain/representations/InstanceProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/InstanceProperties.java
@@ -1,8 +1,0 @@
-package org.folio.circulation.domain.representations;
-
-public class InstanceProperties {
-  private InstanceProperties() { }
-
-  public static final String CONTRIBUTORS = "contributors";
-
-}

--- a/src/main/java/org/folio/circulation/domain/representations/ItemProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemProperties.java
@@ -3,7 +3,6 @@ package org.folio.circulation.domain.representations;
 public class ItemProperties {
   private ItemProperties() { }
 
-  public static final String TITLE = "title";
   public static final String IDENTIFIERS = "identifiers";
   public static final String PERMANENT_LOCATION_ID = "permanentLocationId";
   public static final String TEMPORARY_LOCATION_ID = "temporaryLocationId";

--- a/src/main/java/org/folio/circulation/domain/representations/ItemProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemProperties.java
@@ -3,7 +3,6 @@ package org.folio.circulation.domain.representations;
 public class ItemProperties {
   private ItemProperties() { }
 
-  public static final String IDENTIFIERS = "identifiers";
   public static final String PERMANENT_LOCATION_ID = "permanentLocationId";
   public static final String TEMPORARY_LOCATION_ID = "temporaryLocationId";
   public static final String TEMPORARY_LOAN_TYPE_ID = "temporaryLoanTypeId";

--- a/src/main/java/org/folio/circulation/domain/representations/ItemReportRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemReportRepresentation.java
@@ -37,7 +37,7 @@ public class ItemReportRepresentation {
     write(itemReport, "title", item.getTitle());
     write(itemReport, "barcode", item.getBarcode());
     write(itemReport, "contributors",
-      mapContributorsToNamesOnly(item.getContributors()));
+      mapContributorsToNamesOnly(item.getContributorsJson()));
     write(itemReport, "callNumber", item.getCallNumber());
     write(itemReport, "enumeration", item.getEnumeration());
     write(itemReport, "volume", item.getVolume());

--- a/src/main/java/org/folio/circulation/domain/representations/ItemReportRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemReportRepresentation.java
@@ -37,7 +37,7 @@ public class ItemReportRepresentation {
     write(itemReport, "title", item.getTitle());
     write(itemReport, "barcode", item.getBarcode());
     write(itemReport, "contributors",
-      mapContributorsToNamesOnly(item.getContributorsJson()));
+      mapContributorsToNamesOnly(item.getContributors()));
     write(itemReport, "callNumber", item.getCallNumber());
     write(itemReport, "enumeration", item.getEnumeration());
     write(itemReport, "volume", item.getVolume());

--- a/src/main/java/org/folio/circulation/domain/representations/ItemReportRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemReportRepresentation.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.domain.representations;
 
 import static org.folio.circulation.domain.representations.CallNumberComponentsRepresentation.createCallNumberComponents;
-import static org.folio.circulation.domain.representations.ContributorsToNamesMapper.mapContributorsToNamesOnly;
+import static org.folio.circulation.domain.representations.ContributorsToNamesMapper.mapContributorNamesToJson;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.folio.circulation.support.json.JsonPropertyWriter.writeNamedObject;
 
@@ -36,8 +36,7 @@ public class ItemReportRepresentation {
     write(itemReport, "id", item.getItemId());
     write(itemReport, "title", item.getTitle());
     write(itemReport, "barcode", item.getBarcode());
-    write(itemReport, "contributors",
-      mapContributorsToNamesOnly(item.getContributors()));
+    write(itemReport, "contributors", mapContributorNamesToJson(item));
     write(itemReport, "callNumber", item.getCallNumber());
     write(itemReport, "enumeration", item.getEnumeration());
     write(itemReport, "volume", item.getVolume());

--- a/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
@@ -9,11 +9,11 @@ import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import java.lang.invoke.MethodHandles;
 import java.util.Objects;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.ServicePoint;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.json.JsonObject;
 
@@ -33,7 +33,7 @@ public class ItemSummaryRepresentation {
     write(itemSummary, "title", item.getTitle());
     write(itemSummary, "barcode", item.getBarcode());
     write(itemSummary, "contributors",
-      mapContributorsToNamesOnly(item.getContributorsJson()));
+      mapContributorsToNamesOnly(item.getContributors()));
     write(itemSummary, "callNumber", item.getCallNumber());
     write(itemSummary, "enumeration", item.getEnumeration());
     write(itemSummary, "chronology", item.getChronology());

--- a/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
@@ -33,7 +33,7 @@ public class ItemSummaryRepresentation {
     write(itemSummary, "title", item.getTitle());
     write(itemSummary, "barcode", item.getBarcode());
     write(itemSummary, "contributors",
-      mapContributorsToNamesOnly(item.getContributors()));
+      mapContributorsToNamesOnly(item.getContributorsJson()));
     write(itemSummary, "callNumber", item.getCallNumber());
     write(itemSummary, "enumeration", item.getEnumeration());
     write(itemSummary, "chronology", item.getChronology());

--- a/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.domain.representations;
 
 import static org.folio.circulation.domain.representations.CallNumberComponentsRepresentation.createCallNumberComponents;
-import static org.folio.circulation.domain.representations.ContributorsToNamesMapper.mapContributorsToNamesOnly;
+import static org.folio.circulation.domain.representations.ContributorsToNamesMapper.mapContributorNamesToJson;
 import static org.folio.circulation.domain.representations.ItemProperties.CALL_NUMBER_COMPONENTS;
 import static org.folio.circulation.domain.representations.ItemProperties.LAST_CHECK_IN;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
@@ -32,8 +32,7 @@ public class ItemSummaryRepresentation {
     write(itemSummary, "instanceId", item.getInstanceId());
     write(itemSummary, "title", item.getTitle());
     write(itemSummary, "barcode", item.getBarcode());
-    write(itemSummary, "contributors",
-      mapContributorsToNamesOnly(item.getContributors()));
+    write(itemSummary, "contributors", mapContributorNamesToJson(item));
     write(itemSummary, "callNumber", item.getCallNumber());
     write(itemSummary, "enumeration", item.getEnumeration());
     write(itemSummary, "chronology", item.getChronology());

--- a/src/main/java/org/folio/circulation/domain/representations/StoredAccount.java
+++ b/src/main/java/org/folio/circulation/domain/representations/StoredAccount.java
@@ -53,8 +53,8 @@ public class StoredAccount extends JsonObject {
     this.put("paymentStatus", createNamedObject("Outstanding"));
     this.put("status", createNamedObject("Open"));
 
-    if (item.getContributors() != null) {
-      this.put("contributors", item.getContributors()
+    if (item.getContributorsJson() != null) {
+      this.put("contributors", item.getContributorsJson()
         .map(contributor -> new JsonObject().put("name", contributor.getString("name")))
         .filter(Objects::nonNull)
         .collect(Collectors.toList()));

--- a/src/main/java/org/folio/circulation/domain/representations/StoredAccount.java
+++ b/src/main/java/org/folio/circulation/domain/representations/StoredAccount.java
@@ -1,6 +1,6 @@
 package org.folio.circulation.domain.representations;
 
-import static org.folio.circulation.domain.representations.ContributorsToNamesMapper.mapContributorsToNamesOnly;
+import static org.folio.circulation.domain.representations.ContributorsToNamesMapper.mapContributorNamesToJson;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
 import java.util.UUID;
@@ -52,7 +52,7 @@ public class StoredAccount extends JsonObject {
     this.put("paymentStatus", createNamedObject("Outstanding"));
     this.put("status", createNamedObject("Open"));
 
-    this.put("contributors", mapContributorsToNamesOnly(item.getContributors()));
+    this.put("contributors", mapContributorNamesToJson(item));
   }
 
   private StoredAccount(JsonObject json) {

--- a/src/main/java/org/folio/circulation/domain/representations/StoredAccount.java
+++ b/src/main/java/org/folio/circulation/domain/representations/StoredAccount.java
@@ -1,10 +1,9 @@
 package org.folio.circulation.domain.representations;
 
+import static org.folio.circulation.domain.representations.ContributorsToNamesMapper.mapContributorsToNamesOnly;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
-import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.folio.circulation.domain.Account;
 import org.folio.circulation.domain.FeeAmount;
@@ -53,12 +52,7 @@ public class StoredAccount extends JsonObject {
     this.put("paymentStatus", createNamedObject("Outstanding"));
     this.put("status", createNamedObject("Open"));
 
-    if (item.getContributorsJson() != null) {
-      this.put("contributors", item.getContributorsJson()
-        .map(contributor -> new JsonObject().put("name", contributor.getString("name")))
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList()));
-    }
+    this.put("contributors", mapContributorsToNamesOnly(item.getContributors()));
   }
 
   private StoredAccount(JsonObject json) {

--- a/src/main/java/org/folio/circulation/storage/mappers/ContributorMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/ContributorMapper.java
@@ -1,0 +1,15 @@
+package org.folio.circulation.storage.mappers;
+
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getBooleanProperty;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+
+import org.folio.circulation.domain.Contributor;
+
+import io.vertx.core.json.JsonObject;
+
+public class ContributorMapper {
+  public Contributor toDomain(JsonObject representation) {
+    return new Contributor(getProperty(representation, "name"),
+      getBooleanProperty(representation, "primary"));
+  }
+}

--- a/src/main/java/org/folio/circulation/storage/mappers/IdentifierMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/IdentifierMapper.java
@@ -1,0 +1,14 @@
+package org.folio.circulation.storage.mappers;
+
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+
+import org.folio.circulation.domain.Identifier;
+
+import io.vertx.core.json.JsonObject;
+
+public class IdentifierMapper {
+  public Identifier toDomain(JsonObject representation) {
+    return new Identifier(getProperty(representation,"identifierTypeId"),
+      getProperty(representation, "value"));
+  }
+}

--- a/src/main/java/org/folio/circulation/storage/mappers/InstanceMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/InstanceMapper.java
@@ -1,0 +1,11 @@
+package org.folio.circulation.storage.mappers;
+
+import org.folio.circulation.domain.Instance;
+
+import io.vertx.core.json.JsonObject;
+
+public class InstanceMapper {
+  public Instance toDomain(JsonObject representation) {
+    return new Instance();
+  }
+}

--- a/src/main/java/org/folio/circulation/storage/mappers/InstanceMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/InstanceMapper.java
@@ -1,13 +1,22 @@
 package org.folio.circulation.storage.mappers;
 
+import static org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher.mapToList;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 
+import java.util.List;
+
+import org.folio.circulation.domain.Identifier;
 import org.folio.circulation.domain.Instance;
 
 import io.vertx.core.json.JsonObject;
 
 public class InstanceMapper {
   public Instance toDomain(JsonObject representation) {
-    return new Instance(getProperty(representation, "title"));
+    return new Instance(getProperty(representation, "title"),
+      mapIdentifiers(representation));
+  }
+
+  private List<Identifier> mapIdentifiers(JsonObject representation) {
+    return mapToList(representation, "identifiers", new IdentifierMapper()::toDomain);
   }
 }

--- a/src/main/java/org/folio/circulation/storage/mappers/InstanceMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/InstanceMapper.java
@@ -5,6 +5,7 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty
 
 import java.util.List;
 
+import org.folio.circulation.domain.Contributor;
 import org.folio.circulation.domain.Identifier;
 import org.folio.circulation.domain.Instance;
 
@@ -13,10 +14,14 @@ import io.vertx.core.json.JsonObject;
 public class InstanceMapper {
   public Instance toDomain(JsonObject representation) {
     return new Instance(getProperty(representation, "title"),
-      mapIdentifiers(representation));
+      mapIdentifiers(representation), mapContributors(representation));
   }
 
   private List<Identifier> mapIdentifiers(JsonObject representation) {
     return mapToList(representation, "identifiers", new IdentifierMapper()::toDomain);
+  }
+
+  private List<Contributor> mapContributors(JsonObject representation) {
+    return mapToList(representation, "contributors", new ContributorMapper()::toDomain);
   }
 }

--- a/src/main/java/org/folio/circulation/storage/mappers/InstanceMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/InstanceMapper.java
@@ -1,11 +1,13 @@
 package org.folio.circulation.storage.mappers;
 
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+
 import org.folio.circulation.domain.Instance;
 
 import io.vertx.core.json.JsonObject;
 
 public class InstanceMapper {
   public Instance toDomain(JsonObject representation) {
-    return new Instance();
+    return new Instance(getProperty(representation, "title"));
   }
 }

--- a/src/main/java/org/folio/circulation/support/json/JsonPropertyWriter.java
+++ b/src/main/java/org/folio/circulation/support/json/JsonPropertyWriter.java
@@ -2,9 +2,9 @@ package org.folio.circulation.support.json;
 
 import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTime;
 
-
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
@@ -38,6 +38,12 @@ public class JsonPropertyWriter {
     JsonArray value) {
 
     if(value != null && !value.isEmpty()) {
+      to.put(propertyName, value);
+    }
+  }
+
+  public static <T> void write(JsonObject to, String propertyName, Collection<T> value) {
+    if (value != null && !value.isEmpty()) {
       to.put(propertyName, value);
     }
   }

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -172,7 +172,7 @@ class PickSlipsTests extends APITests {
     Item item = Item.from(itemResource.getJson())
       .withInstance(itemResource.getInstance().getJson());
 
-    String contributorNames = item.getContributors()
+    String contributorNames = item.getContributorsJson()
       .map(this::getName)
       .collect(joining("; "));
 

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.folio.circulation.domain.CallNumberComponents;
+import org.folio.circulation.domain.Contributor;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.Location;
@@ -172,8 +173,8 @@ class PickSlipsTests extends APITests {
     Item item = Item.from(itemResource.getJson())
       .withInstance(itemResource.getInstance().getJson());
 
-    String contributorNames = item.getContributorsJson()
-      .map(this::getName)
+    String contributorNames = item.getContributors()
+      .map(Contributor::getName)
       .collect(joining("; "));
 
     String yearCaptionsToken = String.join("; ", item.getYearCaption());

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -27,6 +27,7 @@ import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.domain.User;
+import org.folio.circulation.storage.mappers.InstanceMapper;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.json.JsonObjectArrayPropertyFetcher;
 import org.folio.circulation.support.utils.ClockUtil;
@@ -171,7 +172,7 @@ class PickSlipsTests extends APITests {
     JsonObject itemContext = pickSlip.getJsonObject(ITEM_KEY);
 
     Item item = Item.from(itemResource.getJson())
-      .withInstance(itemResource.getInstance().getJson());
+      .withInstance(new InstanceMapper().toDomain(itemResource.getInstance().getJson()));
 
     String contributorNames = item.getContributors()
       .map(Contributor::getName)

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.folio.circulation.domain.CallNumberComponents;
-import org.folio.circulation.domain.Contributor;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.Location;
@@ -174,9 +173,7 @@ class PickSlipsTests extends APITests {
     Item item = Item.from(itemResource.getJson())
       .withInstance(new InstanceMapper().toDomain(itemResource.getInstance().getJson()));
 
-    String contributorNames = item.getContributors()
-      .map(Contributor::getName)
-      .collect(joining("; "));
+    String contributorNames = item.getContributorNames().collect(joining("; "));
 
     String yearCaptionsToken = String.join("; ", item.getYearCaption());
     String copyNumber = item.getCopyNumber() != null ? item.getCopyNumber() : "";
@@ -187,8 +184,7 @@ class PickSlipsTests extends APITests {
     assertEquals(item.getTitle(), itemContext.getString("title"));
     assertEquals(item.getBarcode(), itemContext.getString("barcode"));
     assertEquals(ItemStatus.PAGED.getValue(), itemContext.getString("status"));
-    assertEquals(item.getPrimaryContributorName(),
-      itemContext.getString("primaryContributor"));
+    assertEquals(item.getPrimaryContributorName(), itemContext.getString("primaryContributor"));
     assertEquals(contributorNames, itemContext.getString("allContributors"));
     assertEquals(item.getEnumeration(), itemContext.getString("enumeration"));
     assertEquals(item.getVolume(), itemContext.getString("volume"));

--- a/src/test/java/org/folio/circulation/domain/InstanceTests.java
+++ b/src/test/java/org/folio/circulation/domain/InstanceTests.java
@@ -1,0 +1,12 @@
+package org.folio.circulation.domain;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class InstanceTests {
+  @Test
+  void cannotHaveANullCollectionOfIdentifiers() {
+    assertThrows(NullPointerException.class, () -> new Instance("Title", null));
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/InstanceTests.java
+++ b/src/test/java/org/folio/circulation/domain/InstanceTests.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain;
 
+import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -7,6 +8,11 @@ import org.junit.jupiter.api.Test;
 class InstanceTests {
   @Test
   void cannotHaveANullCollectionOfIdentifiers() {
-    assertThrows(NullPointerException.class, () -> new Instance("Title", null));
+    assertThrows(NullPointerException.class, () -> new Instance("Title", null, emptyList()));
+  }
+
+  @Test
+  void cannotHaveANullCollectionOfContributors() {
+    assertThrows(NullPointerException.class, () -> new Instance("Title", emptyList(), null));
   }
 }

--- a/src/test/java/org/folio/circulation/domain/ItemTests.java
+++ b/src/test/java/org/folio/circulation/domain/ItemTests.java
@@ -14,4 +14,11 @@ class ItemTests {
 
     assertThrows(NullPointerException.class, () -> item.withHoldings(null));
   }
+
+  @Test
+  void cannotHaveANullInstance() {
+    val item = Item.from(new ItemBuilder().create());
+
+    assertThrows(NullPointerException.class, () -> item.withInstance(null));
+  }
 }

--- a/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
@@ -1,6 +1,7 @@
 package org.folio.circulation.domain;
 
 import static java.time.ZoneOffset.UTC;
+import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.resources.context.RenewalContext.create;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTimeProperty;
@@ -16,7 +17,6 @@ import static org.mockito.Mockito.when;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +34,6 @@ import org.folio.circulation.infrastructure.storage.feesandfines.FeeFineActionRe
 import org.folio.circulation.infrastructure.storage.feesandfines.FeeFineOwnerRepository;
 import org.folio.circulation.infrastructure.storage.feesandfines.FeeFineRepository;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
-import org.folio.circulation.infrastructure.storage.loans.LostItemPolicyRepository;
 import org.folio.circulation.infrastructure.storage.loans.OverdueFinePolicyRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
@@ -51,7 +50,6 @@ import api.support.builders.CheckInByBarcodeRequestBuilder;
 import api.support.builders.FeeFineBuilder;
 import api.support.builders.FeeFineOwnerBuilder;
 import api.support.builders.FeefineActionsBuilder;
-import api.support.builders.InstanceBuilder;
 import api.support.builders.ItemBuilder;
 import api.support.builders.LoanBuilder;
 import api.support.builders.LocationBuilder;
@@ -82,9 +80,6 @@ class OverdueFineServiceTest {
     new User(new UserBuilder().withUsername("admin").create());
   private static final String LOGGED_IN_USER_ID = LOGGED_IN_USER.getId();
   private static final String CHECK_IN_SERVICE_POINT_NAME = "test service point";
-  private static final List<JsonObject> CONTRIBUTORS = List.of(
-    new JsonObject().put("name", "Contributor 1"),
-    new JsonObject().put("name", "Contributor 2"));
 
   private static final Map<String, Integer> MINUTES_IN_INTERVAL = new HashMap<>();
   static {
@@ -103,13 +98,9 @@ class OverdueFineServiceTest {
   private ItemRepository itemRepository;
   private FeeFineOwnerRepository feeFineOwnerRepository;
   private FeeFineRepository feeFineRepository;
-  private UserRepository userRepository;
   private FeeFineActionRepository feeFineActionRepository;
-  private LostItemPolicyRepository lostItemPolicyRepository;
   private ScheduledNoticesRepository scheduledNoticesRepository;
   private ServicePointRepository servicePointRepository;
-  private FeeFineFacade feeFineFacade;
-  private FeeFineService feeFineService;
 
   @BeforeEach
   public void setUp() {
@@ -119,13 +110,14 @@ class OverdueFineServiceTest {
     feeFineOwnerRepository = mock(FeeFineOwnerRepository.class);
     feeFineRepository = mock(FeeFineRepository.class);
     overduePeriodCalculatorService = mock(OverduePeriodCalculatorService.class);
-    userRepository = mock(UserRepository.class);
+    UserRepository userRepository = mock(UserRepository.class);
     feeFineActionRepository = mock(FeeFineActionRepository.class);
-    lostItemPolicyRepository = mock(LostItemPolicyRepository.class);
     scheduledNoticesRepository = mock(ScheduledNoticesRepository.class);
     servicePointRepository = mock(ServicePointRepository.class);
-    feeFineService = mock(FeeFineService.class);
-    feeFineFacade = new FeeFineFacade(accountRepository, feeFineActionRepository, userRepository,
+    FeeFineService feeFineService = mock(FeeFineService.class);
+    FeeFineFacade feeFineFacade = new FeeFineFacade(accountRepository,
+      feeFineActionRepository,
+      userRepository,
       servicePointRepository, feeFineService);
 
     overdueFineService = new OverdueFineService(
@@ -226,10 +218,10 @@ class OverdueFineServiceTest {
     assertEquals(DUE_DATE, getDateTimeProperty(account.getValue(), "dueDate"));
     assertEquals(RETURNED_DATE, getDateTimeProperty(account.getValue(), "returnedDate"));
 
-    assertEquals(CONTRIBUTORS.size(), account.getValue().getJsonArray("contributors").size());
-    assertEquals(CONTRIBUTORS.get(0).getString("name"),
+    assertEquals(2, account.getValue().getJsonArray("contributors").size());
+    assertEquals("Contributor 1",
       account.getValue().getJsonArray("contributors").getJsonObject(0).getString("name"));
-    assertEquals(CONTRIBUTORS.get(1).getString("name"),
+    assertEquals("Contributor 2",
       account.getValue().getJsonArray("contributors").getJsonObject(1).getString("name"));
 
     ArgumentCaptor<StoredFeeFineAction> feeFineAction =
@@ -618,14 +610,17 @@ class OverdueFineServiceTest {
       .put("id", ITEM_MATERIAL_TYPE_ID.toString())
       .put("name", ITEM_MATERIAL_TYPE_NAME);
 
+    final var contributors = List.of(
+      new Contributor("Contributor 1", false),
+      new Contributor("Contributor 2", false));
+
     return Item.from(item)
       .withLocation(
         Location.from(new LocationBuilder()
           .withName(LOCATION_NAME)
           .withPrimaryServicePoint(SERVICE_POINT_ID)
           .create()))
-      .withInstance(new InstanceBuilder(TITLE, UUID.randomUUID()).create()
-        .put("contributors", CONTRIBUTORS))
+      .withInstance(new Instance(TITLE, emptyList(), contributors))
       .withMaterialType(materialType);
   }
 
@@ -694,7 +689,7 @@ class OverdueFineServiceTest {
           LOCATION_NAME, ITEM_MATERIAL_TYPE_ID.toString())
       ),
       new FeeAmount(correctOverdueFine), new FeeAmount(correctOverdueFine), "Open", "Outstanding",
-      Collections.emptyList(),
+      emptyList(),
       ClockUtil.getZonedDateTime()
     );
   }

--- a/src/test/java/org/folio/circulation/support/JsonPropertyWriterTest.java
+++ b/src/test/java/org/folio/circulation/support/JsonPropertyWriterTest.java
@@ -1,9 +1,18 @@
 package org.folio.circulation.support;
 
 import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
+import static org.folio.circulation.support.StreamToListMapper.toList;
+import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.folio.circulation.support.json.JsonPropertyWriter.writeByPath;
+import static org.folio.circulation.support.json.JsonStringArrayPropertyFetcher.toStream;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,5 +37,37 @@ class JsonPropertyWriterTest {
       hasJsonPath("11", "1.1"),
       hasJsonPath("1.21", 2.1)
     ));
+  }
+
+  @Test
+  void shouldWriteCollection() {
+    final var json = new JsonObject();
+    final var value = List.of("foo", "bar");
+
+    write(json, "collection", value);
+
+    final var collection = toList(toStream(json, "collection"));
+
+    assertThat(collection, contains("foo", "bar"));
+  }
+
+  @Test
+  void shouldNotWriteEmptyCollection() {
+    final var json = new JsonObject();
+
+    write(json, "collection", Collections.emptyList());
+
+    assertThat("collection property should not be present",
+      json.containsKey("collection"), is(false));
+  }
+
+  @Test
+  void shouldNotWriteNullCollection() {
+    final var json = new JsonObject();
+
+    write(json, "collection", (Collection<String>)null);
+
+    assertThat("collection property should not be present",
+      json.containsKey("collection"), is(false));
   }
 }


### PR DESCRIPTION
## Purpose

In order to reduce the coupling on the storage representations within the domain model e.g. to allow for instantiating it from other sources / representations, the use of a JSON object for the instance related to an item should be removed

## Approach

* Introduce basic domain model for contributors
* Introduce basic domain model for identifiers
* Introduce basic domain model for instances
* Move information about contributors and identifiers to instance domain class
* Remove JSON representations
