### PR TITLE
CIRC-1373 - Add new Action when an automated fee/fine is charged if item is aged to lost

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -664,9 +664,8 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
       AGED_TO_LOST_DATE);
   }
 
-  public Loan removePreviousAction() {
-    representation.put(LoanProperties.ACTION, "");
-
+  public Loan setLostItemFees() {
+    representation.put(LoanProperties.ACTION, LoanAction.LOST_FEES_CHARGED.getValue());
     return this;
   }
 

--- a/src/main/java/org/folio/circulation/domain/LoanAction.java
+++ b/src/main/java/org/folio/circulation/domain/LoanAction.java
@@ -19,6 +19,7 @@ public enum LoanAction {
   CLOSED_LOAN("closedLoan"),
   ITEM_AGED_TO_LOST("itemAgedToLost"),
   DUE_DATE_CHANGED("dueDateChanged"),
+  LOST_FEES_CHARGED("lostFeesCharged"),
 
   RESOLVE_CLAIM_AS_RETURNED_BY_PATRON("checkedInReturnedByPatron"),
   RESOLVE_CLAIM_AS_FOUND_BY_LIBRARY("checkedInFoundByLibrary");

--- a/src/main/java/org/folio/circulation/domain/representations/logs/LogContextActionResolver.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/LogContextActionResolver.java
@@ -12,6 +12,7 @@ import static org.folio.circulation.domain.LoanAction.MISSING;
 import static org.folio.circulation.domain.LoanAction.RECALLREQUESTED;
 import static org.folio.circulation.domain.LoanAction.RENEWED;
 import static org.folio.circulation.domain.LoanAction.RENEWED_THROUGH_OVERRIDE;
+import static org.folio.circulation.domain.LoanAction.LOST_FEES_CHARGED;
 
 import java.util.HashMap;
 
@@ -30,6 +31,7 @@ public class LogContextActionResolver {
     loanLogActions.put(CLOSED_LOAN.getValue(), "Closed loan");
     loanLogActions.put(ITEM_AGED_TO_LOST.getValue(), "Age to lost");
     loanLogActions.put(DUE_DATE_CHANGED.getValue(), "Changed due date");
+    loanLogActions.put(LOST_FEES_CHARGED.getValue(), "Charge lost fees");
   }
 
   public static String resolveAction(String action) {

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -139,7 +139,7 @@ public class ChargeLostFeesWhenAgedToLostService {
   private CompletableFuture<Result<Loan>> updateLoanBillingInfo(LoanToChargeFees loanToChargeFees) {
     final Loan updatedLoan = loanToChargeFees.getLoan()
       .setLostItemHasBeenBilled()
-      .removePreviousAction();
+      .setLostItemFees();
 
     return loanRepository.updateLoan(updatedLoan);
   }

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
@@ -90,7 +90,7 @@ class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
     assertThat(result.getLoan(), hasLostItemFeeCreatedBySystemAction());
 
     assertThat(result.getLoan(), hasLoanHistoryInOrder(
-      hasJsonPath("loan.action", ""),
+      hasJsonPath("loan.action", "lostFeesCharged"),
       hasJsonPath("loan.action", "itemAgedToLost"),
       hasJsonPath("loan.action", "checkedout")
     ));


### PR DESCRIPTION
[CIRC-1373](https://issues.folio.org/browse/CIRC-1373) - Add new Action when an automated fee/fine is charged if item is aged to lost

## Purpose
Add new Action after starting aged to lost items charging process if item aged to lost, and if there is Lost item fee policy with Items aged to lost after overdue setting, and if there is fee/fine owner for service point.
