### PR TITLE
Remove json from material type in domain CIRC-1367

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -29,10 +29,8 @@ import java.util.stream.Stream;
 import org.folio.circulation.domain.representations.ItemProperties;
 
 import io.vertx.core.json.JsonObject;
-import lombok.AllArgsConstructor;
 import lombok.NonNull;
 
-@AllArgsConstructor
 public class Item {
   private final JsonObject itemRepresentation;
   private final Location location;
@@ -48,6 +46,32 @@ public class Item {
 
   @NonNull private final Holdings holdings;
   @NonNull private final Instance instance;
+
+  public Item(JsonObject itemRepresentation,
+    Location location, JsonObject materialTypeRepresentation,
+    ServicePoint primaryServicePoint,
+    JsonObject loanTypeRepresentation,
+    LastCheckIn lastCheckIn,
+    CallNumberComponents callNumberComponents,
+    Location permanentLocation,
+    ServicePoint inTransitDestinationServicePoint,
+    boolean changed,
+    @NonNull Holdings holdings,
+    @NonNull Instance instance) {
+
+    this.itemRepresentation = itemRepresentation;
+    this.location = location;
+    this.materialTypeRepresentation = materialTypeRepresentation;
+    this.primaryServicePoint = primaryServicePoint;
+    this.loanTypeRepresentation = loanTypeRepresentation;
+    this.lastCheckIn = lastCheckIn;
+    this.callNumberComponents = callNumberComponents;
+    this.permanentLocation = permanentLocation;
+    this.inTransitDestinationServicePoint = inTransitDestinationServicePoint;
+    this.changed = changed;
+    this.holdings = holdings;
+    this.instance = instance;
+  }
 
   public static Item from(JsonObject representation) {
     return new Item(representation,

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -36,7 +36,6 @@ import lombok.NonNull;
 public class Item {
   private final JsonObject itemRepresentation;
   private final Location location;
-  private final JsonObject materialTypeRepresentation;
   private final ServicePoint primaryServicePoint;
   private final JsonObject loanTypeRepresentation;
   private final LastCheckIn lastCheckIn;
@@ -51,7 +50,7 @@ public class Item {
   @NonNull private final MaterialType materialType;
 
   public Item(JsonObject itemRepresentation,
-    Location location, JsonObject materialTypeRepresentation,
+    Location location,
     ServicePoint primaryServicePoint,
     JsonObject loanTypeRepresentation,
     LastCheckIn lastCheckIn,
@@ -65,7 +64,6 @@ public class Item {
 
     this.itemRepresentation = itemRepresentation;
     this.location = location;
-    this.materialTypeRepresentation = materialTypeRepresentation;
     this.primaryServicePoint = primaryServicePoint;
     this.loanTypeRepresentation = loanTypeRepresentation;
     this.lastCheckIn = lastCheckIn;
@@ -80,7 +78,6 @@ public class Item {
 
   public static Item from(JsonObject representation) {
     return new Item(representation,
-      null,
       null,
       null,
       null,
@@ -376,7 +373,6 @@ public class Item {
     return new Item(
       this.itemRepresentation,
       newLocation,
-      this.materialTypeRepresentation,
       this.primaryServicePoint,
       this.loanTypeRepresentation,
       this.lastCheckIn,
@@ -390,7 +386,6 @@ public class Item {
     return new Item(
       this.itemRepresentation,
       this.location,
-      newMaterialType,
       this.primaryServicePoint,
       this.loanTypeRepresentation,
       this.lastCheckIn,
@@ -405,7 +400,6 @@ public class Item {
     return new Item(
       this.itemRepresentation,
       this.location,
-      this.materialTypeRepresentation,
       this.primaryServicePoint,
       this.loanTypeRepresentation,
       this.lastCheckIn,
@@ -420,7 +414,6 @@ public class Item {
     return new Item(
       this.itemRepresentation,
       this.location,
-      this.materialTypeRepresentation,
       this.primaryServicePoint,
       this.loanTypeRepresentation,
       this.lastCheckIn,
@@ -435,7 +428,6 @@ public class Item {
     return new Item(
       this.itemRepresentation,
       this.location,
-      this.materialTypeRepresentation,
       servicePoint,
       this.loanTypeRepresentation,
       this.lastCheckIn,
@@ -449,7 +441,6 @@ public class Item {
     return new Item(
       this.itemRepresentation,
       this.location,
-      this.materialTypeRepresentation,
       this.primaryServicePoint,
       newLoanTypeRepresentation,
       this.lastCheckIn,
@@ -463,7 +454,6 @@ public class Item {
     return new Item(
       this.itemRepresentation,
       this.location,
-      this.materialTypeRepresentation,
       this.primaryServicePoint,
       this.loanTypeRepresentation,
       lastCheckIn,
@@ -477,7 +467,6 @@ public class Item {
     return new Item(
       this.itemRepresentation,
       this.location,
-      this.materialTypeRepresentation,
       this.primaryServicePoint,
       this.loanTypeRepresentation,
       this.lastCheckIn,

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -12,6 +12,7 @@ import static org.folio.circulation.domain.ItemStatus.PAGED;
 import static org.folio.circulation.domain.representations.ItemProperties.EFFECTIVE_LOCATION_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.IN_TRANSIT_DESTINATION_SERVICE_POINT_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.ITEM_COPY_NUMBER_ID;
+import static org.folio.circulation.domain.representations.ItemProperties.MATERIAL_TYPE_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.PERMANENT_LOCATION_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.STATUS_PROPERTY;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
@@ -218,7 +219,7 @@ public class Item {
   }
 
   public String getMaterialTypeName() {
-    return getProperty(materialTypeRepresentation, "name");
+    return materialType.getName();
   }
 
   public String getCopyNumber() {
@@ -228,7 +229,7 @@ public class Item {
   }
 
   public String getMaterialTypeId() {
-    return getProperty(getItem(), ItemProperties.MATERIAL_TYPE_ID);
+    return getProperty(getItem(), MATERIAL_TYPE_ID);
   }
 
   public String getLocationId() {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -28,11 +28,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.folio.circulation.domain.representations.ItemProperties;
-import org.folio.circulation.storage.mappers.MaterialTypeMapper;
 
 import io.vertx.core.json.JsonObject;
+import lombok.AllArgsConstructor;
 import lombok.NonNull;
 
+@AllArgsConstructor
 public class Item {
   private final JsonObject itemRepresentation;
   private final Location location;
@@ -48,33 +49,6 @@ public class Item {
   @NonNull private final Holdings holdings;
   @NonNull private final Instance instance;
   @NonNull private final MaterialType materialType;
-
-  public Item(JsonObject itemRepresentation,
-    Location location,
-    ServicePoint primaryServicePoint,
-    JsonObject loanTypeRepresentation,
-    LastCheckIn lastCheckIn,
-    CallNumberComponents callNumberComponents,
-    Location permanentLocation,
-    ServicePoint inTransitDestinationServicePoint,
-    boolean changed,
-    @NonNull Holdings holdings,
-    @NonNull Instance instance,
-    @NonNull MaterialType materialType) {
-
-    this.itemRepresentation = itemRepresentation;
-    this.location = location;
-    this.primaryServicePoint = primaryServicePoint;
-    this.loanTypeRepresentation = loanTypeRepresentation;
-    this.lastCheckIn = lastCheckIn;
-    this.callNumberComponents = callNumberComponents;
-    this.permanentLocation = permanentLocation;
-    this.inTransitDestinationServicePoint = inTransitDestinationServicePoint;
-    this.changed = changed;
-    this.holdings = holdings;
-    this.instance = instance;
-    this.materialType = materialType;
-  }
 
   public static Item from(JsonObject representation) {
     return new Item(representation,

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -214,8 +214,8 @@ public class Item {
     return permanentLocation;
   }
 
-  public JsonObject getMaterialType() {
-    return materialTypeRepresentation;
+  public MaterialType getMaterialType() {
+    return materialType;
   }
 
   public String getMaterialTypeName() {
@@ -287,7 +287,6 @@ public class Item {
   public String getLoanTypeName() {
     return getProperty(loanTypeRepresentation, "name");
   }
-
 
   public Item changeStatus(ItemStatus newStatus) {
     if (isNotSameStatus(newStatus)) {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -382,7 +382,7 @@ public class Item {
       this.changed, holdings, this.instance, this.materialType);
   }
 
-  public Item withMaterialType(JsonObject newMaterialType) {
+  public Item withMaterialType(MaterialType materialType) {
     return new Item(
       this.itemRepresentation,
       this.location,
@@ -393,7 +393,7 @@ public class Item {
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
       this.changed, holdings, this.instance,
-      new MaterialTypeMapper().toDomain(newMaterialType));
+      materialType);
   }
 
   public Item withHoldings(@NonNull Holdings holdings) {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.folio.circulation.domain.representations.ItemProperties;
+import org.folio.circulation.storage.mappers.MaterialTypeMapper;
 
 import io.vertx.core.json.JsonObject;
 import lombok.NonNull;
@@ -46,6 +47,7 @@ public class Item {
 
   @NonNull private final Holdings holdings;
   @NonNull private final Instance instance;
+  @NonNull private final MaterialType materialType;
 
   public Item(JsonObject itemRepresentation,
     Location location, JsonObject materialTypeRepresentation,
@@ -57,7 +59,8 @@ public class Item {
     ServicePoint inTransitDestinationServicePoint,
     boolean changed,
     @NonNull Holdings holdings,
-    @NonNull Instance instance) {
+    @NonNull Instance instance,
+    @NonNull MaterialType materialType) {
 
     this.itemRepresentation = itemRepresentation;
     this.location = location;
@@ -71,6 +74,7 @@ public class Item {
     this.changed = changed;
     this.holdings = holdings;
     this.instance = instance;
+    this.materialType = materialType;
   }
 
   public static Item from(JsonObject representation) {
@@ -85,7 +89,8 @@ public class Item {
       null,
       false,
       Holdings.unknown(),
-      Instance.unknown());
+      Instance.unknown(),
+      MaterialType.unknown());
   }
 
   public boolean isCheckedOut() {
@@ -378,7 +383,7 @@ public class Item {
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings, this.instance);
+      this.changed, holdings, this.instance, this.materialType);
   }
 
   public Item withMaterialType(JsonObject newMaterialType) {
@@ -392,7 +397,8 @@ public class Item {
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings, this.instance);
+      this.changed, holdings, this.instance,
+      new MaterialTypeMapper().toDomain(newMaterialType));
   }
 
   public Item withHoldings(@NonNull Holdings holdings) {
@@ -407,7 +413,7 @@ public class Item {
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
       this.changed,
-      holdings, this.instance);
+      holdings, this.instance, this.materialType);
   }
 
   public Item withInstance(@NonNull Instance instance) {
@@ -422,7 +428,7 @@ public class Item {
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
       this.changed, holdings,
-      instance);
+      instance, this.materialType);
   }
 
   public Item withPrimaryServicePoint(ServicePoint servicePoint) {
@@ -436,7 +442,7 @@ public class Item {
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings, this.instance);
+      this.changed, holdings, this.instance, this.materialType);
   }
 
   public Item withLoanType(JsonObject newLoanTypeRepresentation) {
@@ -450,7 +456,7 @@ public class Item {
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings, this.instance);
+      this.changed, holdings, this.instance, this.materialType);
   }
 
   public Item withLastCheckIn(LastCheckIn lastCheckIn) {
@@ -464,7 +470,7 @@ public class Item {
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings, this.instance);
+      this.changed, holdings, this.instance, this.materialType);
   }
 
   public Item withPermanentLocation(Location permanentLocation) {
@@ -478,6 +484,6 @@ public class Item {
       this.callNumberComponents,
       permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings, this.instance);
+      this.changed, holdings, this.instance, this.materialType);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/MaterialType.java
+++ b/src/main/java/org/folio/circulation/domain/MaterialType.java
@@ -1,0 +1,10 @@
+package org.folio.circulation.domain;
+
+import lombok.Value;
+
+@Value
+public class MaterialType {
+  public static MaterialType unknown() {
+    return new MaterialType();
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/MaterialType.java
+++ b/src/main/java/org/folio/circulation/domain/MaterialType.java
@@ -5,6 +5,8 @@ import lombok.Value;
 @Value
 public class MaterialType {
   public static MaterialType unknown() {
-    return new MaterialType();
+    return new MaterialType(null);
   }
+
+  String name;
 }

--- a/src/main/java/org/folio/circulation/domain/MaterialType.java
+++ b/src/main/java/org/folio/circulation/domain/MaterialType.java
@@ -5,8 +5,9 @@ import lombok.Value;
 @Value
 public class MaterialType {
   public static MaterialType unknown() {
-    return new MaterialType(null);
+    return new MaterialType(null, null);
   }
 
   String name;
+  String source;
 }

--- a/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
@@ -7,11 +7,8 @@ import static org.folio.circulation.domain.representations.ItemProperties.LAST_C
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.folio.circulation.support.json.JsonPropertyWriter.writeByPath;
 
-import java.lang.invoke.MethodHandles;
 import java.util.Objects;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.ServicePoint;
@@ -19,8 +16,6 @@ import org.folio.circulation.domain.ServicePoint;
 import io.vertx.core.json.JsonObject;
 
 public class ItemSummaryRepresentation {
-  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
-
   public JsonObject createItemSummary(Item item) {
     if(item == null || item.isNotFound()) {
       return new JsonObject();

--- a/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
@@ -5,6 +5,7 @@ import static org.folio.circulation.domain.representations.ContributorsToNamesMa
 import static org.folio.circulation.domain.representations.ItemProperties.CALL_NUMBER_COMPONENTS;
 import static org.folio.circulation.domain.representations.ItemProperties.LAST_CHECK_IN;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
+import static org.folio.circulation.support.json.JsonPropertyWriter.writeByPath;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Objects;
@@ -76,29 +77,12 @@ public class ItemSummaryRepresentation {
         .put("name", location.getName()));
     }
 
-    final String materialTypeProperty = "materialType";
-
-    final JsonObject materialType = item.getMaterialType();
-
-    if(materialType != null) {
-      if(materialType.containsKey("name") && materialType.getString("name") != null) {
-        itemSummary.put(materialTypeProperty, new JsonObject()
-          .put("name", materialType.getString("name")));
-      } else {
-        log.warn("Missing or null property for material type for item id {}",
-          item.getItemId());
-      }
-    } else {
-      log.warn("No material type {} found for item {}", item.getMaterialTypeId(),
-        item.getItemId());
-    }
+    writeByPath(itemSummary, item.getMaterialTypeName(), "materialType", "name");
 
     return itemSummary;
   }
 
-
   public JsonObject createItemStorageRepresentation(Item item) {
-
     JsonObject summary = item.getItem().copy();
     if (item.getLastCheckIn() != null) {
       write(summary, LAST_CHECK_IN, item.getLastCheckIn().toJson());
@@ -106,5 +90,4 @@ public class ItemSummaryRepresentation {
 
     return summary;
   }
-
 }

--- a/src/main/java/org/folio/circulation/domain/representations/logs/RequestUpdateLogEventMapper.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/RequestUpdateLogEventMapper.java
@@ -20,10 +20,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class RequestUpdateLogEventMapper {
-  public static final String ITEM_SOURCE = "source";
-
-  private RequestUpdateLogEventMapper() {
-  }
+  private RequestUpdateLogEventMapper() {}
 
   public static JsonObject mapToRequestLogEventJson(Request request) {
     JsonObject logEventPayload = new JsonObject();
@@ -60,7 +57,7 @@ public class RequestUpdateLogEventMapper {
       write(logEventPayload, ITEM_STATUS_NAME.value(), item.getStatusName());
       ofNullable(item.getInTransitDestinationServicePoint())
         .ifPresent(sp -> write(logEventPayload, DESTINATION_SERVICE_POINT.value(), sp.getName()));
-      ofNullable(item.getMaterialType()).ifPresent(mt -> write(logEventPayload, SOURCE.value(), mt.getString(ITEM_SOURCE)));
+      write(logEventPayload, SOURCE.value(), item.getMaterialType().getSource());
     });
   }
 

--- a/src/main/java/org/folio/circulation/domain/validation/ItemLimitValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ItemLimitValidator.java
@@ -66,9 +66,6 @@ public class ItemLimitValidator {
     }
 
     Item item = records.getLoan().getItem();
-    String materialTypeId = item.getMaterialType() != null
-      ? item.getMaterialTypeId()
-      : null;
     String loanTypeId = item.determineLoanTypeForItem();
     Integer itemLimit = records.getLoan().getLoanPolicy().getItemLimit();
     AppliedRuleConditions ruleConditions = records.getLoan().getLoanPolicy().getRuleConditions();
@@ -77,7 +74,7 @@ public class ItemLimitValidator {
       .thenApply(r -> r.map(loanRecords -> loanRecords.getRecords().stream()
         .filter(loanRecord -> !loanRecord.getItem().isClaimedReturned())
         .filter(loanRecord -> isMaterialTypeMatchInRetrievedLoan(
-          materialTypeId, loanRecord, ruleConditions))
+          item.getMaterialTypeId(), loanRecord, ruleConditions))
         .filter(loanRecord -> isLoanTypeMatchInRetrievedLoan(
           loanTypeId, loanRecord, ruleConditions))
         .count()))

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -38,6 +38,7 @@ import org.folio.circulation.domain.ServicePoint;
 import org.folio.circulation.infrastructure.storage.ServicePointRepository;
 import org.folio.circulation.storage.mappers.HoldingsMapper;
 import org.folio.circulation.storage.mappers.InstanceMapper;
+import org.folio.circulation.storage.mappers.MaterialTypeMapper;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FindWithCqlQuery;
 import org.folio.circulation.support.FindWithMultipleCqlIndexValues;
@@ -184,12 +185,14 @@ public class ItemRepository {
   private CompletableFuture<Result<Collection<Item>>> fetchMaterialTypes(
     Result<Collection<Item>> result) {
 
-    if(fetchMaterialType) {
+    final var mapper = new MaterialTypeMapper();
+
+    if (fetchMaterialType) {
       return result.after(items ->
         materialTypeRepository.getMaterialTypes(items)
           .thenApply(r -> r.map(materialTypes -> items.stream()
-              .map(item -> item.withMaterialType(materialTypes
-                .getOrDefault(item.getMaterialTypeId(), null)))
+              .map(item -> item.withMaterialType(mapper.toDomain(materialTypes
+                .getOrDefault(item.getMaterialTypeId(), null))))
               .collect(Collectors.toList()))));
     }
     else {

--- a/src/main/java/org/folio/circulation/storage/mappers/MaterialTypeMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/MaterialTypeMapper.java
@@ -1,11 +1,13 @@
 package org.folio.circulation.storage.mappers;
 
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+
 import org.folio.circulation.domain.MaterialType;
 
 import io.vertx.core.json.JsonObject;
 
 public class MaterialTypeMapper {
   public MaterialType toDomain(JsonObject representation) {
-    return new MaterialType();
+    return new MaterialType(getProperty(representation, "name"));
   }
 }

--- a/src/main/java/org/folio/circulation/storage/mappers/MaterialTypeMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/MaterialTypeMapper.java
@@ -8,6 +8,7 @@ import io.vertx.core.json.JsonObject;
 
 public class MaterialTypeMapper {
   public MaterialType toDomain(JsonObject representation) {
-    return new MaterialType(getProperty(representation, "name"));
+    return new MaterialType(getProperty(representation, "name"),
+      getProperty(representation, "source"));
   }
 }

--- a/src/main/java/org/folio/circulation/storage/mappers/MaterialTypeMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/MaterialTypeMapper.java
@@ -1,0 +1,11 @@
+package org.folio.circulation.storage.mappers;
+
+import org.folio.circulation.domain.MaterialType;
+
+import io.vertx.core.json.JsonObject;
+
+public class MaterialTypeMapper {
+  public MaterialType toDomain(JsonObject representation) {
+    return new MaterialType();
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/ItemTests.java
+++ b/src/test/java/org/folio/circulation/domain/ItemTests.java
@@ -21,4 +21,11 @@ class ItemTests {
 
     assertThrows(NullPointerException.class, () -> item.withInstance(null));
   }
+
+  @Test
+  void cannotHaveANullMaterialType() {
+    val item = Item.from(new ItemBuilder().create());
+
+    assertThrows(NullPointerException.class, () -> item.withMaterialType(null));
+  }
 }

--- a/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
@@ -606,10 +606,6 @@ class OverdueFineServiceTest {
       .create();
     item.put("effectiveCallNumberComponents", new JsonObject().put("callNumber", CALL_NUMBER));
 
-    JsonObject materialType = new JsonObject()
-      .put("id", ITEM_MATERIAL_TYPE_ID.toString())
-      .put("name", ITEM_MATERIAL_TYPE_NAME);
-
     final var contributors = List.of(
       new Contributor("Contributor 1", false),
       new Contributor("Contributor 2", false));
@@ -621,7 +617,7 @@ class OverdueFineServiceTest {
           .withPrimaryServicePoint(SERVICE_POINT_ID)
           .create()))
       .withInstance(new Instance(TITLE, emptyList(), contributors))
-      .withMaterialType(materialType);
+      .withMaterialType(new MaterialType(ITEM_MATERIAL_TYPE_NAME, null));
   }
 
   private OverdueFinePolicy createOverdueFinePolicy(


### PR DESCRIPTION
## Purpose

In order to reduce the coupling on the storage representations within the domain model e.g. to allow for instantiating it from other sources / representations, the use of a JSON object for the material type related to an item should be removed

## Approach

* Introduce basic domain model for material type
* Move mapping from JSON to domain model out of the domain
* Remove JSON representations