### PR TITLE
Remove json from loan type in domain CIRC-1368

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -38,7 +38,6 @@ public class Item {
   private final JsonObject itemRepresentation;
   private final Location location;
   private final ServicePoint primaryServicePoint;
-  private final JsonObject loanTypeRepresentation;
   private final LastCheckIn lastCheckIn;
   private final CallNumberComponents callNumberComponents;
   private final Location permanentLocation;
@@ -49,10 +48,10 @@ public class Item {
   @NonNull private final Holdings holdings;
   @NonNull private final Instance instance;
   @NonNull private final MaterialType materialType;
+  @NonNull private final LoanType loanType;
 
   public static Item from(JsonObject representation) {
     return new Item(representation,
-      null,
       null,
       null,
       LastCheckIn.fromItemJson(representation),
@@ -62,7 +61,8 @@ public class Item {
       false,
       Holdings.unknown(),
       Instance.unknown(),
-      MaterialType.unknown());
+      MaterialType.unknown(),
+      LoanType.unknown());
   }
 
   public boolean isCheckedOut() {
@@ -256,7 +256,7 @@ public class Item {
   }
 
   public String getLoanTypeName() {
-    return getProperty(loanTypeRepresentation, "name");
+    return loanType.getName();
   }
 
   public Item changeStatus(ItemStatus newStatus) {
@@ -276,6 +276,7 @@ public class Item {
       return this;
     }
   }
+
 
   Item available() {
     return changeStatus(AVAILABLE)
@@ -348,12 +349,11 @@ public class Item {
       this.itemRepresentation,
       newLocation,
       this.primaryServicePoint,
-      this.loanTypeRepresentation,
       this.lastCheckIn,
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings, this.instance, this.materialType);
+      this.changed, holdings, this.instance, this.materialType, loanType);
   }
 
   public Item withMaterialType(MaterialType materialType) {
@@ -361,13 +361,12 @@ public class Item {
       this.itemRepresentation,
       this.location,
       this.primaryServicePoint,
-      this.loanTypeRepresentation,
       this.lastCheckIn,
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
       this.changed, holdings, this.instance,
-      materialType);
+      materialType, loanType);
   }
 
   public Item withHoldings(@NonNull Holdings holdings) {
@@ -375,13 +374,12 @@ public class Item {
       this.itemRepresentation,
       this.location,
       this.primaryServicePoint,
-      this.loanTypeRepresentation,
       this.lastCheckIn,
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
       this.changed,
-      holdings, this.instance, this.materialType);
+      holdings, this.instance, this.materialType, loanType);
   }
 
   public Item withInstance(@NonNull Instance instance) {
@@ -389,13 +387,12 @@ public class Item {
       this.itemRepresentation,
       this.location,
       this.primaryServicePoint,
-      this.loanTypeRepresentation,
       this.lastCheckIn,
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
       this.changed, holdings,
-      instance, this.materialType);
+      instance, this.materialType, loanType);
   }
 
   public Item withPrimaryServicePoint(ServicePoint servicePoint) {
@@ -403,25 +400,25 @@ public class Item {
       this.itemRepresentation,
       this.location,
       servicePoint,
-      this.loanTypeRepresentation,
       this.lastCheckIn,
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings, this.instance, this.materialType);
+      this.changed, holdings, this.instance, this.materialType, loanType);
   }
 
-  public Item withLoanType(JsonObject newLoanTypeRepresentation) {
+
+  public Item withLoanType(LoanType loanType) {
     return new Item(
       this.itemRepresentation,
       this.location,
       this.primaryServicePoint,
-      newLoanTypeRepresentation,
       this.lastCheckIn,
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings, this.instance, this.materialType);
+      this.changed, holdings, this.instance, this.materialType,
+      loanType);
   }
 
   public Item withLastCheckIn(LastCheckIn lastCheckIn) {
@@ -429,12 +426,11 @@ public class Item {
       this.itemRepresentation,
       this.location,
       this.primaryServicePoint,
-      this.loanTypeRepresentation,
       lastCheckIn,
       this.callNumberComponents,
       this.permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings, this.instance, this.materialType);
+      this.changed, holdings, this.instance, this.materialType, loanType);
   }
 
   public Item withPermanentLocation(Location permanentLocation) {
@@ -442,11 +438,10 @@ public class Item {
       this.itemRepresentation,
       this.location,
       this.primaryServicePoint,
-      this.loanTypeRepresentation,
       this.lastCheckIn,
       this.callNumberComponents,
       permanentLocation,
       this.inTransitDestinationServicePoint,
-      this.changed, holdings, this.instance, this.materialType);
+      this.changed, holdings, this.instance, this.materialType, loanType);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/LoanType.java
+++ b/src/main/java/org/folio/circulation/domain/LoanType.java
@@ -1,0 +1,12 @@
+package org.folio.circulation.domain;
+
+import lombok.Value;
+
+@Value
+public class LoanType {
+  public static LoanType unknown() {
+    return new LoanType(null);
+  }
+
+  String name;
+}

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -38,6 +38,7 @@ import org.folio.circulation.domain.ServicePoint;
 import org.folio.circulation.infrastructure.storage.ServicePointRepository;
 import org.folio.circulation.storage.mappers.HoldingsMapper;
 import org.folio.circulation.storage.mappers.InstanceMapper;
+import org.folio.circulation.storage.mappers.LoanTypeMapper;
 import org.folio.circulation.storage.mappers.MaterialTypeMapper;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FindWithCqlQuery;
@@ -140,7 +141,10 @@ public class ItemRepository {
     if (!fetchLoanType) {
       return completedFuture(result);
     }
-    return result.combineAfter(this::getLoanType, Item::withLoanType);
+
+    return result.combineAfter(this::getLoanType,
+      (item, newLoanTypeRepresentation) -> item.withLoanType(
+        new LoanTypeMapper().toDomain(newLoanTypeRepresentation)));
   }
 
   private CompletableFuture<Result<JsonObject>> getLoanType(Item item) {
@@ -223,11 +227,13 @@ public class ItemRepository {
   private Result<Collection<Item>> matchLoanTypesToItems(
     Map<Item, String> itemToLoanTypeId, Map<String, JsonObject> loanTypes) {
 
+    final var mapper = new LoanTypeMapper();
+
     return succeeded(
       itemToLoanTypeId.entrySet().stream()
-        .map(e -> e.getKey().withLoanType(loanTypes.get(e.getValue())))
-        .collect(Collectors.toList())
-    );
+        .map(e -> e.getKey().withLoanType(
+          mapper.toDomain(loanTypes.get(e.getValue()))))
+        .collect(Collectors.toList()));
   }
 
   private CompletableFuture<Result<Collection<Item>>> fetchInstances(

--- a/src/main/java/org/folio/circulation/storage/mappers/LoanTypeMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/LoanTypeMapper.java
@@ -1,0 +1,13 @@
+package org.folio.circulation.storage.mappers;
+
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+
+import org.folio.circulation.domain.LoanType;
+
+import io.vertx.core.json.JsonObject;
+
+public class LoanTypeMapper {
+  public LoanType toDomain(JsonObject representation) {
+    return new LoanType(getProperty(representation, "name"));
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/ItemTests.java
+++ b/src/test/java/org/folio/circulation/domain/ItemTests.java
@@ -28,4 +28,11 @@ class ItemTests {
 
     assertThrows(NullPointerException.class, () -> item.withMaterialType(null));
   }
+
+  @Test
+  void cannotHaveANullLoanType() {
+    val item = Item.from(new ItemBuilder().create());
+
+    assertThrows(NullPointerException.class, () -> item.withLoanType(null));
+  }
 }


### PR DESCRIPTION
## Purpose

In order to reduce the coupling on the storage representations within the domain model e.g. to allow for instantiating it from other sources / representations, the use of a JSON object for the loan type related to an item should be removed

## Approach
* Introduce basic domain model for loan type
* Move mapping from JSON to domain model out of the domain
* Remove JSON representations
* Disallow null loan type (in order to avoid null checks on every usage)