### PR TITLE
Remove json from service point in domain CIRC-1369

### DIFF
--- a/src/main/java/org/folio/circulation/domain/ServicePoint.java
+++ b/src/main/java/org/folio/circulation/domain/ServicePoint.java
@@ -1,12 +1,5 @@
 package org.folio.circulation.domain;
 
-import static org.folio.circulation.support.json.JsonPropertyFetcher.getBooleanProperty;
-import static org.folio.circulation.support.json.JsonPropertyFetcher.getIntegerProperty;
-import static org.folio.circulation.support.json.JsonPropertyFetcher.getObjectProperty;
-import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
-
-import io.vertx.core.json.JsonObject;
-
 public class ServicePoint {
   private final String name;
   private final String id;
@@ -17,17 +10,19 @@ public class ServicePoint {
   private final TimePeriod holdShelfExpiryPeriod;
   private final boolean pickupLocation;
 
-  public ServicePoint(JsonObject representation) {
-    name = getProperty(representation, "name");
-    id = getProperty(representation, "id");
-    code = getProperty(representation, "code");
-    pickupLocation = getBooleanProperty(representation, "pickupLocation");
-    discoveryDisplayName = getProperty(representation, "discoveryDisplayName");
-    description = getProperty(representation, "description");
-    shelvingLagTime = getIntegerProperty(representation, "shelvingLagTime",
-      null);
-    holdShelfExpiryPeriod = TimePeriod.from(
-      getObjectProperty(representation, "holdShelfExpiryPeriod"));
+  public ServicePoint(String id, String name,
+    String code, boolean pickupLocation, String discoveryDisplayName,
+    String description, Integer shelvingLagTime,
+    TimePeriod holdShelfExpiryPeriod) {
+
+    this.name = name;
+    this.id = id;
+    this.code = code;
+    this.pickupLocation = pickupLocation;
+    this.discoveryDisplayName = discoveryDisplayName;
+    this.description = description;
+    this.shelvingLagTime = shelvingLagTime;
+    this.holdShelfExpiryPeriod = holdShelfExpiryPeriod;
   }
 
   public boolean isPickupLocation() {

--- a/src/main/java/org/folio/circulation/domain/ServicePoint.java
+++ b/src/main/java/org/folio/circulation/domain/ServicePoint.java
@@ -45,8 +45,4 @@ public class ServicePoint {
   public TimePeriod getHoldShelfExpiryPeriod() {
     return TimePeriod.from(getObjectProperty(representation, "holdShelfExpiryPeriod"));
   }
-
-  public static ServicePoint from(JsonObject representation) {
-    return new ServicePoint(representation);
-  }
 }

--- a/src/main/java/org/folio/circulation/domain/ServicePoint.java
+++ b/src/main/java/org/folio/circulation/domain/ServicePoint.java
@@ -1,29 +1,17 @@
 package org.folio.circulation.domain;
 
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
 public class ServicePoint {
-  private final String name;
   private final String id;
+  private final String name;
   private final String code;
+  private final boolean pickupLocation;
   private final String discoveryDisplayName;
   private final String description;
   private final Integer shelvingLagTime;
   private final TimePeriod holdShelfExpiryPeriod;
-  private final boolean pickupLocation;
-
-  public ServicePoint(String id, String name,
-    String code, boolean pickupLocation, String discoveryDisplayName,
-    String description, Integer shelvingLagTime,
-    TimePeriod holdShelfExpiryPeriod) {
-
-    this.name = name;
-    this.id = id;
-    this.code = code;
-    this.pickupLocation = pickupLocation;
-    this.discoveryDisplayName = discoveryDisplayName;
-    this.description = description;
-    this.shelvingLagTime = shelvingLagTime;
-    this.holdShelfExpiryPeriod = holdShelfExpiryPeriod;
-  }
 
   public boolean isPickupLocation() {
     return pickupLocation;

--- a/src/main/java/org/folio/circulation/domain/ServicePoint.java
+++ b/src/main/java/org/folio/circulation/domain/ServicePoint.java
@@ -8,41 +8,57 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty
 import io.vertx.core.json.JsonObject;
 
 public class ServicePoint {
-  private final JsonObject representation;
+  private final String name;
+  private final String id;
+  private final String code;
+  private final String discoveryDisplayName;
+  private final String description;
+  private final Integer shelvingLagTime;
+  private final TimePeriod holdShelfExpiryPeriod;
+  private final boolean pickupLocation;
 
   public ServicePoint(JsonObject representation) {
-    this.representation = representation;
+    name = getProperty(representation, "name");
+    id = getProperty(representation, "id");
+    code = getProperty(representation, "code");
+    pickupLocation = getBooleanProperty(representation, "pickupLocation");
+    discoveryDisplayName = getProperty(representation, "discoveryDisplayName");
+    description = getProperty(representation, "description");
+    shelvingLagTime = getIntegerProperty(representation, "shelvingLagTime",
+      null);
+    holdShelfExpiryPeriod = TimePeriod.from(
+      getObjectProperty(representation, "holdShelfExpiryPeriod"));
   }
 
   public boolean isPickupLocation() {
-    return getBooleanProperty(representation, "pickupLocation");
+    return pickupLocation;
   }
 
   public String getName() {
-    return getProperty(representation, "name");
+    return name;
   }
 
   public String getId() {
-    return getProperty(representation, "id");
+    return id;
   }
 
   public String getCode() {
-    return getProperty(representation, "code");
+    return code;
   }
 
   public String getDiscoveryDisplayName() {
-    return getProperty(representation, "discoveryDisplayName");
+    return discoveryDisplayName;
   }
 
   public String getDescription() {
-    return getProperty(representation, "description");
+    return description;
   }
 
   public Integer getShelvingLagTime() {
-    return getIntegerProperty(representation, "shelvingLagTime", null);
+    return shelvingLagTime;
   }
 
   public TimePeriod getHoldShelfExpiryPeriod() {
-    return TimePeriod.from(getObjectProperty(representation, "holdShelfExpiryPeriod"));
+    return holdShelfExpiryPeriod;
   }
 }

--- a/src/main/java/org/folio/circulation/domain/ServicePoint.java
+++ b/src/main/java/org/folio/circulation/domain/ServicePoint.java
@@ -1,47 +1,15 @@
 package org.folio.circulation.domain;
 
-import lombok.AllArgsConstructor;
+import lombok.Value;
 
-@AllArgsConstructor
+@Value
 public class ServicePoint {
-  private final String id;
-  private final String name;
-  private final String code;
-  private final boolean pickupLocation;
-  private final String discoveryDisplayName;
-  private final String description;
-  private final Integer shelvingLagTime;
-  private final TimePeriod holdShelfExpiryPeriod;
-
-  public boolean isPickupLocation() {
-    return pickupLocation;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public String getId() {
-    return id;
-  }
-
-  public String getCode() {
-    return code;
-  }
-
-  public String getDiscoveryDisplayName() {
-    return discoveryDisplayName;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public Integer getShelvingLagTime() {
-    return shelvingLagTime;
-  }
-
-  public TimePeriod getHoldShelfExpiryPeriod() {
-    return holdShelfExpiryPeriod;
-  }
+  String id;
+  String name;
+  String code;
+  boolean pickupLocation;
+  String discoveryDisplayName;
+  String description;
+  Integer shelvingLagTime;
+  TimePeriod holdShelfExpiryPeriod;
 }

--- a/src/main/java/org/folio/circulation/domain/TimePeriod.java
+++ b/src/main/java/org/folio/circulation/domain/TimePeriod.java
@@ -3,22 +3,12 @@ package org.folio.circulation.domain;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 
+import lombok.Value;
+
+@Value
 public class TimePeriod {
-  private final int duration;
-  private final String intervalId;
-
-  public TimePeriod(int duration, String intervalId) {
-    this.duration = duration;
-    this.intervalId = intervalId;
-  }
-
-  public int getDuration() {
-    return duration;
-  }
-
-  public String getIntervalId() {
-    return intervalId;
-  }
+  int duration;
+  String intervalId;
 
   public ChronoUnit getInterval() {
     final String id = getIntervalId();

--- a/src/main/java/org/folio/circulation/domain/TimePeriod.java
+++ b/src/main/java/org/folio/circulation/domain/TimePeriod.java
@@ -1,12 +1,7 @@
 package org.folio.circulation.domain;
 
-import static org.folio.circulation.support.json.JsonPropertyFetcher.getIntegerProperty;
-import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
-
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-
-import io.vertx.core.json.JsonObject;
 
 public class TimePeriod {
   private final int duration;
@@ -44,12 +39,5 @@ public class TimePeriod {
 
     return chronoUnit == ChronoUnit.DAYS || chronoUnit == ChronoUnit.WEEKS
       || chronoUnit == ChronoUnit.MONTHS;
-  }
-
-  public static TimePeriod from(JsonObject representation) {
-    final int duration = getIntegerProperty(representation, "duration", 0);
-    final String intervalId = getProperty(representation, "intervalId");
-
-    return new TimePeriod(duration, intervalId);
   }
 }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
@@ -19,6 +19,7 @@ import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.ServicePoint;
+import org.folio.circulation.storage.mappers.ServicePointMapper;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FetchSingleRecord;
@@ -49,9 +50,11 @@ public class ServicePointRepository {
       return ofAsync(() -> null);
     }
 
+    final var mapper = new ServicePointMapper();
+
     return FetchSingleRecord.<ServicePoint>forRecord("service point")
         .using(servicePointsStorageClient)
-        .mapTo(ServicePoint::new)
+        .mapTo(mapper::toDomain)
         .whenNotFound(succeeded(null))
         .fetch(id);
   }
@@ -175,7 +178,9 @@ public class ServicePointRepository {
   }
 
   private FindWithMultipleCqlIndexValues<ServicePoint> createServicePointsFetcher() {
+    final var mapper = new ServicePointMapper();
+
     return findWithMultipleCqlIndexValues(servicePointsStorageClient,
-      "servicepoints", ServicePoint::from);
+      "servicepoints", mapper::toDomain);
   }
 }

--- a/src/main/java/org/folio/circulation/storage/mappers/ServicePointMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/ServicePointMapper.java
@@ -1,11 +1,25 @@
 package org.folio.circulation.storage.mappers;
 
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getBooleanProperty;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getIntegerProperty;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getObjectProperty;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+
 import org.folio.circulation.domain.ServicePoint;
+import org.folio.circulation.domain.TimePeriod;
 
 import io.vertx.core.json.JsonObject;
 
 public class ServicePointMapper {
   public ServicePoint toDomain(JsonObject representation) {
-    return new ServicePoint(representation);
+    return new ServicePoint(getProperty(representation, "id"),
+      getProperty(representation, "name"),
+      getProperty(representation, "code"),
+      getBooleanProperty(representation, "pickupLocation"),
+      getProperty(representation, "discoveryDisplayName"),
+      getProperty(representation, "description"),
+      getIntegerProperty(representation, "shelvingLagTime",
+        null),
+      TimePeriod.from(getObjectProperty(representation, "holdShelfExpiryPeriod")));
   }
 }

--- a/src/main/java/org/folio/circulation/storage/mappers/ServicePointMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/ServicePointMapper.java
@@ -1,0 +1,11 @@
+package org.folio.circulation.storage.mappers;
+
+import org.folio.circulation.domain.ServicePoint;
+
+import io.vertx.core.json.JsonObject;
+
+public class ServicePointMapper {
+  public ServicePoint toDomain(JsonObject representation) {
+    return new ServicePoint(representation);
+  }
+}

--- a/src/main/java/org/folio/circulation/storage/mappers/ServicePointMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/ServicePointMapper.java
@@ -6,12 +6,13 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getObjectPr
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 
 import org.folio.circulation.domain.ServicePoint;
-import org.folio.circulation.domain.TimePeriod;
 
 import io.vertx.core.json.JsonObject;
 
 public class ServicePointMapper {
   public ServicePoint toDomain(JsonObject representation) {
+    final var timePeriodMapper = new TimePeriodMapper();
+
     return new ServicePoint(getProperty(representation, "id"),
       getProperty(representation, "name"),
       getProperty(representation, "code"),
@@ -20,6 +21,7 @@ public class ServicePointMapper {
       getProperty(representation, "description"),
       getIntegerProperty(representation, "shelvingLagTime",
         null),
-      TimePeriod.from(getObjectProperty(representation, "holdShelfExpiryPeriod")));
+      timePeriodMapper.toDomain(
+        getObjectProperty(representation, "holdShelfExpiryPeriod")));
   }
 }

--- a/src/main/java/org/folio/circulation/storage/mappers/TimePeriodMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/TimePeriodMapper.java
@@ -1,0 +1,15 @@
+package org.folio.circulation.storage.mappers;
+
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getIntegerProperty;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+
+import org.folio.circulation.domain.TimePeriod;
+
+import io.vertx.core.json.JsonObject;
+
+public class TimePeriodMapper {
+  public TimePeriod toDomain(JsonObject representation) {
+    return new TimePeriod(getIntegerProperty(representation, "duration", 0),
+      getProperty(representation, "intervalId"));
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
@@ -40,7 +40,6 @@ import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.context.RenewalContext;
 import org.folio.circulation.services.FeeFineFacade;
 import org.folio.circulation.services.feefine.FeeFineService;
-import org.folio.circulation.storage.mappers.ServicePointMapper;
 import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -692,9 +691,8 @@ class OverdueFineServiceTest {
   }
 
   private ServicePoint createServicePoint() {
-    return new ServicePointMapper().toDomain(new JsonObject()
-      .put("id", CHECK_IN_SERVICE_POINT_ID)
-      .put("name", CHECK_IN_SERVICE_POINT_NAME));
+    return new ServicePoint(CHECK_IN_SERVICE_POINT_ID.toString(), CHECK_IN_SERVICE_POINT_NAME,
+      null, false, null, null, null, null);
   }
 
   private static Collection<Object[]> testParameters() {

--- a/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
@@ -40,6 +40,7 @@ import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.context.RenewalContext;
 import org.folio.circulation.services.FeeFineFacade;
 import org.folio.circulation.services.feefine.FeeFineService;
+import org.folio.circulation.storage.mappers.ServicePointMapper;
 import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -691,10 +692,9 @@ class OverdueFineServiceTest {
   }
 
   private ServicePoint createServicePoint() {
-    return new ServicePoint(new JsonObject()
+    return new ServicePointMapper().toDomain(new JsonObject()
       .put("id", CHECK_IN_SERVICE_POINT_ID)
-      .put("name", CHECK_IN_SERVICE_POINT_NAME)
-    );
+      .put("name", CHECK_IN_SERVICE_POINT_NAME));
   }
 
   private static Collection<Object[]> testParameters() {

--- a/src/test/java/org/folio/circulation/domain/RequestRepresentationTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestRepresentationTests.java
@@ -1,6 +1,5 @@
 package org.folio.circulation.domain;
 
-import static java.lang.Boolean.TRUE;
 import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -9,12 +8,10 @@ import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
-import org.folio.circulation.storage.mappers.ServicePointMapper;
 import org.junit.jupiter.api.Test;
 
 import api.support.builders.Address;
 import api.support.builders.RequestBuilder;
-import api.support.builders.ServicePointBuilder;
 import api.support.builders.UserBuilder;
 import io.vertx.core.json.JsonObject;
 
@@ -76,11 +73,9 @@ class RequestRepresentationTests {
 
     final ZonedDateTime requestDate = ZonedDateTime.of(2017, 7, 22, 10, 22, 54, 0, UTC);
 
-    final ServicePointBuilder servicePointBuilder = new ServicePointBuilder("Circ Desk", "cd1", "Circulation Desk")
-      .withId(SERVICE_POINT_ID)
-      .withPickupLocation(TRUE);
-
-    final var servicePoint = new ServicePointMapper().toDomain(servicePointBuilder.create());
+    final var servicePoint
+      = new ServicePoint(SERVICE_POINT_ID.toString(), "Circ Desk", "cd1", true,
+      "Circulation Desk", null, null, null);
 
     JsonObject requestJsonObject = new RequestBuilder()
       .recall()

--- a/src/test/java/org/folio/circulation/domain/RequestRepresentationTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestRepresentationTests.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
+import org.folio.circulation.storage.mappers.ServicePointMapper;
 import org.junit.jupiter.api.Test;
 
 import api.support.builders.Address;
@@ -79,7 +80,7 @@ class RequestRepresentationTests {
       .withId(SERVICE_POINT_ID)
       .withPickupLocation(TRUE);
 
-    final ServicePoint servicePoint = new ServicePoint(servicePointBuilder.create());
+    final var servicePoint = new ServicePointMapper().toDomain(servicePointBuilder.create());
 
     JsonObject requestJsonObject = new RequestBuilder()
       .recall()


### PR DESCRIPTION
## Purpose

In order to reduce the coupling on the storage representations within the domain model e.g. to allow for instantiating it from other sources / representations, the use of a JSON object for the service point related to an item should be removed

## Approach
* Remove JSON representations from service point domain class
* Remove JSON representations from time period domain class
* Move mapping from JSON to domain model out of the domain