### PR TITLE
CIRC-1387 Upgrade Log4j to v2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <drools.version>7.53.0.Final</drools.version>
     <rmb.version>33.1.1</rmb.version>
     <vertx.version>4.2.1</vertx.version>
-    <log4j2.version>2.13.3</log4j2.version>
+    <log4j2.version>2.16.0</log4j2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <lombok.version>1.18.16</lombok.version>


### PR DESCRIPTION
[CIRC-1387](https://issues.folio.org/browse/CIRC-1387)

## Purpose
Update Log4j to a newer version with CVE-2021-44228 vulnerability fixed.

## Approach
Update version in pom

