### PR TITLE
CIRC-1397 Disable request queue validation for page requests always being at the top

### DIFF
--- a/src/main/java/org/folio/circulation/domain/validation/RequestQueueValidation.java
+++ b/src/main/java/org/folio/circulation/domain/validation/RequestQueueValidation.java
@@ -86,25 +86,15 @@ public class RequestQueueValidation {
       return result;
     }
 
-    return result.value().isQueueForInstance()
-      ? pageRequestsHaveTopPositions(result)
-      : pageRequestHasFirstPosition(result);
+    return pageRequestHasFirstPosition(result);
   }
 
   /**
-   * Makes sure that all Page requests are always at the top of the unified queue (TLR feature
-   * enabled).
+   * Makes sure that all Page requests are always at the first position of the unified queue.
    *
    * @param result - Context
    * @return New result, failed if validation has failed
    */
-  private static Result<ReorderRequestContext> pageRequestsHaveTopPositions(
-    Result<ReorderRequestContext> result) {
-
-    return validateRequestsAtTopPositions(result, RequestHelper::isPageRequest,
-      "Page requests can not be displaced from top positions.");
-  }
-
   private static Result<ReorderRequestContext> pageRequestHasFirstPosition(Result<ReorderRequestContext> result) {
     return validateRequestAtFirstPosition(result, RequestHelper::isPageRequest,
       "Page requests can not be displaced from position 1.");

--- a/src/main/java/org/folio/circulation/domain/validation/RequestQueueValidation.java
+++ b/src/main/java/org/folio/circulation/domain/validation/RequestQueueValidation.java
@@ -86,7 +86,9 @@ public class RequestQueueValidation {
       return result;
     }
 
-    return pageRequestHasFirstPosition(result);
+    return result.value().isQueueForInstance()
+    ? result
+    : pageRequestHasFirstPosition(result);
   }
 
   /**

--- a/src/main/java/org/folio/circulation/domain/validation/RequestQueueValidation.java
+++ b/src/main/java/org/folio/circulation/domain/validation/RequestQueueValidation.java
@@ -87,16 +87,10 @@ public class RequestQueueValidation {
     }
 
     return result.value().isQueueForInstance()
-    ? result
-    : pageRequestHasFirstPosition(result);
+      ? result
+      : pageRequestHasFirstPosition(result);
   }
 
-  /**
-   * Makes sure that all Page requests are always at the first position of the unified queue.
-   *
-   * @param result - Context
-   * @return New result, failed if validation has failed
-   */
   private static Result<ReorderRequestContext> pageRequestHasFirstPosition(Result<ReorderRequestContext> result) {
     return validateRequestAtFirstPosition(result, RequestHelper::isPageRequest,
       "Page requests can not be displaced from position 1.");


### PR DESCRIPTION
### Purpose
Change requests queue behavior to place the page requests at the queue top 
### Approach
Moved condition which allowed to place the page requests at the queue top.
### Learning
https://issues.folio.org/browse/CIRC-1397