### PR TITLE
CIRC-1386 fix NPE for age-to-lost charging

### DIFF
--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -222,8 +222,15 @@ public class ChargeLostFeesWhenAgedToLostService {
     MultipleRecords<Loan> loans) {
 
     return itemRepository.fetchItemsFor(succeeded(loans), Loan::withItem)
-      .thenCompose(r -> r.after(multipleLoans -> userRepository.findUsersForLoans(multipleLoans)))
+      .thenApply(r -> r.next(this::excludeLoansWithNonExistentItems))
+      .thenCompose(r -> r.after(userRepository::findUsersForLoans))
       .thenComposeAsync(r -> r.after(lostItemPolicyRepository::findLostItemPoliciesForLoans));
+  }
+
+  private Result<MultipleRecords<Loan>> excludeLoansWithNonExistentItems(
+    MultipleRecords<Loan> loans) {
+
+    return succeeded(loans.filter(loan -> loan.getItem().isFound()));
   }
 
   private Result<CqlQuery> loanFetchQuery() {

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -222,12 +222,12 @@ public class ChargeLostFeesWhenAgedToLostService {
     MultipleRecords<Loan> loans) {
 
     return itemRepository.fetchItemsFor(succeeded(loans), Loan::withItem)
-      .thenApply(r -> r.next(this::excludeLoansWithNonExistentItems))
+      .thenApply(r -> r.next(this::excludeLoansWithNonexistentItems))
       .thenCompose(r -> r.after(userRepository::findUsersForLoans))
       .thenComposeAsync(r -> r.after(lostItemPolicyRepository::findLostItemPoliciesForLoans));
   }
 
-  private Result<MultipleRecords<Loan>> excludeLoansWithNonExistentItems(
+  private Result<MultipleRecords<Loan>> excludeLoansWithNonexistentItems(
     MultipleRecords<Loan> loans) {
 
     return succeeded(loans.filter(loan -> loan.getItem().isFound()));

--- a/src/main/java/org/folio/circulation/services/agedtolost/LoanToChargeFees.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/LoanToChargeFees.java
@@ -49,7 +49,7 @@ public final class LoanToChargeFees {
     try {
       return loan.getItem().getPermanentLocation().getPrimaryServicePointId().toString();
     } catch (RuntimeException e) {
-      log.error(format("Failed to get service pointId for the loanId: \"%s\"", loan.getId()));
+      log.error(format("Failed to get servicePointId for the loanId: \"%s\"", loan.getId()));
       return null;
     }
   }

--- a/src/main/java/org/folio/circulation/services/agedtolost/LoanToChargeFees.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/LoanToChargeFees.java
@@ -46,15 +46,11 @@ final class LoanToChargeFees {
   }
 
   String getOwnerServicePointId() {
-    if (loan.getItem() != null && loan.getItem().getPermanentLocation() != null &&
-      loan.getItem().getPermanentLocation().getPrimaryServicePointId() != null) {
-
+    try {
       return loan.getItem().getPermanentLocation().getPrimaryServicePointId().toString();
-    } else {
-      String errorMessage = format("Failed to get service point id for loanId: \"%s\"",
-        loan.getId());
-      log.error(errorMessage);
-      throw new IllegalStateException(errorMessage);
+    } catch (RuntimeException e) {
+      log.error(format("Failed to get service pointId for the loanId: \"%s\"", loan.getId()));
+      return null;
     }
   }
 

--- a/src/main/java/org/folio/circulation/services/agedtolost/LoanToChargeFees.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/LoanToChargeFees.java
@@ -1,9 +1,11 @@
 package org.folio.circulation.services.agedtolost;
 
+import static java.lang.String.format;
 import static java.util.function.Function.identity;
 import static org.folio.circulation.domain.FeeFine.LOST_ITEM_FEE_TYPE;
 import static org.folio.circulation.domain.FeeFine.LOST_ITEM_PROCESSING_FEE_TYPE;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -15,6 +17,8 @@ import org.folio.circulation.domain.FeeFineOwner;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.policy.lostitem.LostItemPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -23,6 +27,8 @@ import lombok.Getter;
 @Getter(AccessLevel.PACKAGE)
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 final class LoanToChargeFees {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   private final Loan loan;
   private final FeeFineOwner owner;
   private final Map<String, FeeFine> feeFineTypes;
@@ -40,7 +46,16 @@ final class LoanToChargeFees {
   }
 
   String getOwnerServicePointId() {
-    return loan.getItem().getPermanentLocation().getPrimaryServicePointId().toString();
+    if (loan.getItem() != null && loan.getItem().getPermanentLocation() != null &&
+      loan.getItem().getPermanentLocation().getPrimaryServicePointId() != null) {
+
+      return loan.getItem().getPermanentLocation().getPrimaryServicePointId().toString();
+    } else {
+      String errorMessage = format("Failed to get service point id for loanId: \"%s\"",
+        loan.getId());
+      log.error(errorMessage);
+      throw new IllegalStateException(errorMessage);
+    }
   }
 
   FeeFine getLostItemFeeType() {

--- a/src/main/java/org/folio/circulation/services/agedtolost/LoanToChargeFees.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/LoanToChargeFees.java
@@ -26,7 +26,7 @@ import lombok.Getter;
 
 @Getter(AccessLevel.PACKAGE)
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
-final class LoanToChargeFees {
+public final class LoanToChargeFees {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private final Loan loan;
@@ -45,7 +45,7 @@ final class LoanToChargeFees {
     return owner == null;
   }
 
-  String getOwnerServicePointId() {
+  public String getOwnerServicePointId() {
     try {
       return loan.getItem().getPermanentLocation().getPrimaryServicePointId().toString();
     } catch (RuntimeException e) {
@@ -82,7 +82,7 @@ final class LoanToChargeFees {
       && !getLostItemPolicy().getAgeToLostProcessingFee().isChargeable();
   }
 
-  static LoanToChargeFees usingLoan(Loan loan) {
+  public static LoanToChargeFees usingLoan(Loan loan) {
     return new LoanToChargeFees(loan, null, Collections.emptyMap());
   }
 

--- a/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
+++ b/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
@@ -7,9 +7,13 @@ import static api.support.matchers.LoanMatchers.isClosed;
 import static api.support.matchers.LoanMatchers.isOpen;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getUUIDProperty;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import api.support.http.IndividualResource;
+import java.util.UUID;
+
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.services.agedtolost.LoanToChargeFees;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -117,6 +121,13 @@ class CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests extends APITests {
     JsonObject loanById = loansFixture.getLoanById(loan.getId()).getJson();
     assertThat(loanById, isOpen());
     assertThat(loanById.getString("itemId"), is(item.getId().toString()));
+  }
+
+  @Test
+  public void getOwnerServicePointIdShouldNotFailIfItemDoesNotExist() {
+    JsonObject loanJson = new JsonObject().put("id", UUID.randomUUID().toString());
+    assertThat(LoanToChargeFees.usingLoan(Loan.from(loanJson)).getOwnerServicePointId(),
+      nullValue());
   }
 
   @Test

--- a/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
+++ b/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
@@ -116,7 +116,7 @@ class CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests extends APITests {
 
     JsonObject loanById = loansFixture.getLoanById(loan.getId()).getJson();
     assertThat(loanById, isOpen());
-    assertThat(loanById.getString("itemId"), is(item.getId()));
+    assertThat(loanById.getString("itemId"), is(item.getId().toString()));
   }
 
   @Test

--- a/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
+++ b/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
@@ -1,5 +1,6 @@
 package api.handlers;
 
+import static api.support.http.CqlQuery.exactMatch;
 import static api.support.matchers.ItemMatchers.isAgedToLost;
 import static api.support.matchers.ItemMatchers.isCheckedOut;
 import static api.support.matchers.ItemMatchers.isLostAndPaid;
@@ -110,7 +111,7 @@ class CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests extends APITests {
   }
 
   @Test
-  public void shouldNotFailWhenAgedToLostLoanHasNonExistentItem() {
+  public void shouldNotFailWhenAgedToLostLoanHasNonexistentItem() {
     var item = itemsFixture.basedUponNod(ItemBuilder::withRandomBarcode);
     var loan = checkOutFixture.checkOutByBarcode(item, usersFixture.steve());
     ageToLostFixture.ageToLost();
@@ -121,6 +122,8 @@ class CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests extends APITests {
     JsonObject loanById = loansFixture.getLoanById(loan.getId()).getJson();
     assertThat(loanById, isOpen());
     assertThat(loanById.getString("itemId"), is(item.getId().toString()));
+    assertThat(accountsClient.getMany(exactMatch("loanId", loan.getId().toString())).size(),
+      is(0));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Fix NPE for the loans which have nonexistent an item and handle a situation when it happens;

## Approach
NPE happens during owners fetching. The loans with nonexistent items should be excluded from age-to-lost charging processing;

Resolves: [CIRC-1386](https://issues.folio.org/browse/CIRC-1386)
