### PR TITLE
CIRC-1402: Extend requests returned by queue API with additional fields

### DIFF
--- a/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestRepository.java
@@ -1,14 +1,14 @@
 package org.folio.circulation.infrastructure.storage.requests;
 
 import static java.util.Objects.isNull;
+import static org.folio.circulation.support.http.ResponseMapping.forwardOnFailure;
+import static org.folio.circulation.support.http.ResponseMapping.mapUsingJson;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.of;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
 import static org.folio.circulation.support.results.ResultBinding.flatMapResult;
 import static org.folio.circulation.support.results.ResultBinding.mapResult;
-import static org.folio.circulation.support.http.ResponseMapping.forwardOnFailure;
-import static org.folio.circulation.support.http.ResponseMapping.mapUsingJson;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -19,22 +19,22 @@ import org.folio.circulation.domain.RequestAndRelatedRecords;
 import org.folio.circulation.domain.ServicePoint;
 import org.folio.circulation.domain.StoredRequestRepresentation;
 import org.folio.circulation.domain.User;
-import org.folio.circulation.infrastructure.storage.inventory.InstanceRepository;
-import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.ServicePointRepository;
+import org.folio.circulation.infrastructure.storage.inventory.InstanceRepository;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.users.PatronGroupRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.storage.RequestBatch;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FetchSingleRecord;
 import org.folio.circulation.support.RecordNotFoundFailure;
-import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.SingleRecordFetcher;
 import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.client.ResponseInterpreter;
+import org.folio.circulation.support.results.Result;
 
 import io.vertx.core.json.JsonObject;
 import lombok.AllArgsConstructor;
@@ -92,8 +92,8 @@ public class RequestRepository {
     return findByWithoutItems(query, pageLimit).thenComposeAsync(this::fetchFields);
   }
 
-  private CompletableFuture<Result<MultipleRecords<Request>>> fetchFields(Result<MultipleRecords<Request>> coreResult) {
-    return itemRepository.fetchItemsFor(coreResult, Request::withItem)
+  private CompletableFuture<Result<MultipleRecords<Request>>> fetchFields(Result<MultipleRecords<Request>> recordsWithoutFetchedFields) {
+    return itemRepository.fetchItemsFor(recordsWithoutFetchedFields, Request::withItem)
       .thenComposeAsync(result -> result.after(loanRepository::findOpenLoansFor))
       .thenComposeAsync(result -> result.after(servicePointRepository::findServicePointsForRequests))
       .thenComposeAsync(result -> result.after(userRepository::findUsersForRequests))

--- a/src/test/java/api/queue/RequestQueueResourceTest.java
+++ b/src/test/java/api/queue/RequestQueueResourceTest.java
@@ -13,6 +13,7 @@ import static org.folio.circulation.domain.representations.logs.LogEventType.REQ
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -30,7 +31,6 @@ import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
 import org.folio.circulation.support.http.client.Response;
 import org.hamcrest.Matcher;
-import org.hamcrest.core.Is;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,7 +45,6 @@ import api.support.builders.RequestBuilder;
 import api.support.fakes.FakePubSub;
 import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
-import api.support.matchers.UUIDMatcher;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -275,22 +274,11 @@ class RequestQueueResourceTest extends APITests {
 
     assertThat(request.containsKey("instance"), is(true));
     JsonObject instance = request.getJsonObject("instance");
-    assertThat(instance.containsKey("title"), is(true));
-    assertThat(instance.containsKey("identifiers"), is(true));
-    assertThat(instance.containsKey("contributorNames"), is(true));
-    assertThat(instance.containsKey("publication"), is(true));
-    assertThat(instance.containsKey("editions"), is(true));
+    assertThat(instance.fieldNames(), contains("title", "identifiers", "contributorNames", "publication", "editions"));
 
     assertThat(request.containsKey("item"), is(true));
     JsonObject item = request.getJsonObject("item");
-    assertThat(item.containsKey("barcode"), is(true));
-    assertThat(item.containsKey("location"), is(true));
-    assertThat(item.containsKey("enumeration"), is(true));
-    assertThat(item.containsKey("volume"), is(true));
-    assertThat(item.containsKey("chronology"), is(true));
-    assertThat(item.containsKey("status"), is(true));
-    assertThat(item.containsKey("callNumber"), is(true));
-    assertThat(item.containsKey("copyNumber"), is(true));
+    assertThat(item.fieldNames(), contains("barcode", "location", "enumeration", "volume", "chronology", "status", "callNumber", "callNumberComponents", "copyNumber"));
 
     assertThat(request.containsKey("loan"), is(true));
     JsonObject loan = request.getJsonObject("loan");
@@ -298,25 +286,18 @@ class RequestQueueResourceTest extends APITests {
 
     assertThat(request.containsKey("requester"), is(true));
     JsonObject requester = request.getJsonObject("requester");
-    assertThat(requester.containsKey("lastName"), is(true));
-    assertThat(requester.containsKey("firstName"), is(true));
-    assertThat(requester.containsKey("middleName"), is(false));
-    assertThat(requester.containsKey("barcode"), is(true));
-    assertThat(requester.containsKey("patronGroup"), is(true));
+    assertThat(requester.fieldNames(), contains("lastName", "firstName", "barcode", "patronGroup", "patronGroupId"));
 
     assertThat(request.containsKey("proxy"), is(true));
     final JsonObject proxySummary = request.getJsonObject("proxy");
-    assertThat(proxySummary.containsKey("patronGroup"), is(true));
+    assertThat(proxySummary.fieldNames(), contains("lastName", "firstName", "barcode", "patronGroup", "patronGroupId"));
     assertThat(proxySummary.getString("patronGroupId"), is(staffGroupId));
     assertThat(proxySummary.getJsonObject("patronGroup").getString("id"),
       is(staffGroupId));
 
     assertThat(request.containsKey("pickupServicePoint"), is(true));
     final JsonObject pickupServicePoint = request.getJsonObject("pickupServicePoint");
-    assertThat(pickupServicePoint.containsKey("name"), is(true));
-    assertThat(pickupServicePoint.containsKey("code"), is(true));
-    assertThat(pickupServicePoint.containsKey("discoveryDisplayName"), is(true));
-    assertThat(pickupServicePoint.containsKey("pickupLocation"), is(true));
+    assertThat(pickupServicePoint.fieldNames(), contains("name", "code", "discoveryDisplayName", "description" ,"shelvingLagTime", "pickupLocation"));
   }
 
   @Test
@@ -657,7 +638,7 @@ class RequestQueueResourceTest extends APITests {
 
   @ParameterizedTest
   @ArgumentsSource(ReorderQueueTestDataSource.class)
-  public void canReorderQueueTwice(Integer[] initialState, Integer[] targetState) {
+  void canReorderQueueTwice(Integer[] initialState, Integer[] targetState) {
     checkOutFixture.checkOutByBarcode(item, rebecca);
 
     IndividualResource firstHoldRequest = holdRequestForDefaultItem(steve);
@@ -692,7 +673,7 @@ class RequestQueueResourceTest extends APITests {
 
   @ParameterizedTest
   @ArgumentsSource(ReorderQueueTestDataSource.class)
-  public void canReorderUnifiedQueueTwice(Integer[] initialState, Integer[] targetState) {
+  void canReorderUnifiedQueueTwice(Integer[] initialState, Integer[] targetState) {
     reconfigureTlrFeature(TlrFeatureStatus.ENABLED);
 
     checkOutFixture.checkOutByBarcode(items.get(0), rebecca);

--- a/src/test/java/api/support/fixtures/ItemExamples.java
+++ b/src/test/java/api/support/fixtures/ItemExamples.java
@@ -18,6 +18,17 @@ public class ItemExamples {
   public static ItemBuilder basedUponSmallAngryPlanet(
     UUID bookMaterialTypeId,
     UUID loanTypeId,
+    String barcode) {
+
+    return new ItemBuilder()
+      .withPermanentLoanType(loanTypeId)
+      .withMaterialType(bookMaterialTypeId)
+      .withBarcode(barcode);
+  }
+
+  public static ItemBuilder basedUponSmallAngryPlanet(
+    UUID bookMaterialTypeId,
+    UUID loanTypeId,
     String callNumber,
     String callNumberPrefix,
     String callNumberSuffix,

--- a/src/test/java/api/support/fixtures/ItemsFixture.java
+++ b/src/test/java/api/support/fixtures/ItemsFixture.java
@@ -164,6 +164,23 @@ public class ItemsFixture {
         loanTypesFixture.canCirculate().getId()));
   }
 
+  public ItemResource basedUponSmallAngryPlanet(
+    Function<HoldingBuilder, HoldingBuilder> additionalHoldingsRecordProperties,
+    Function<InstanceBuilder, InstanceBuilder> additionalInstanceProperties,
+    Function<ItemBuilder, ItemBuilder> additionalItemProperties,
+    String barcode) {
+
+    return applyAdditionalProperties(
+      additionalHoldingsRecordProperties,
+      additionalInstanceProperties,
+      additionalItemProperties,
+      InstanceExamples.basedUponSmallAngryPlanet(booksInstanceTypeId(),
+        getPersonalContributorNameTypeId()),
+      thirdFloorHoldings(),
+      ItemExamples.basedUponSmallAngryPlanet(materialTypesFixture.book().getId(),
+        loanTypesFixture.canCirculate().getId(), barcode));
+  }
+
   public ItemResource basedUponNod() {
     return basedUponNod(identity());
   }


### PR DESCRIPTION
## Purpose
[CIRC-1402](https://issues.folio.org/browse/CIRC-1402)
_Extend requests returned by queue API with additional fields_