### PR TITLE
CIRC-1403 add filtering by itemId, create test

### DIFF
--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -63,9 +63,11 @@ public class RequestQueue {
     if (request.getRequestLevel() == RequestLevel.TITLE) {
       String itemInstanceId = item.getInstanceId();
       String requestInstanceId = request.getInstanceId();
+      String requestItemId = request.getItemId();
+      String itemId = item.getItemId();
 
       return itemInstanceId != null && itemInstanceId.equals(requestInstanceId)
-        && (request.getItemId() == null ^ item.getItemId().equals(request.getItemId()));
+        && (requestItemId == null ^ (item.isFound() && itemId.equals(requestItemId)));
     }
     else if (request.getRequestLevel() == RequestLevel.ITEM) {
       String itemId = item.getItemId();

--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -64,7 +64,8 @@ public class RequestQueue {
       String itemInstanceId = item.getInstanceId();
       String requestInstanceId = request.getInstanceId();
 
-      return itemInstanceId != null && itemInstanceId.equals(requestInstanceId);
+      return itemInstanceId != null && itemInstanceId.equals(requestInstanceId)
+        && item.getItemId().equals(request.getItemId());
     }
     else if (request.getRequestLevel() == RequestLevel.ITEM) {
       String itemId = item.getItemId();

--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -65,7 +65,7 @@ public class RequestQueue {
       String requestInstanceId = request.getInstanceId();
 
       return itemInstanceId != null && itemInstanceId.equals(requestInstanceId)
-        && item.getItemId().equals(request.getItemId());
+        && (request.getItemId() == null ^ item.getItemId().equals(request.getItemId()));
     }
     else if (request.getRequestLevel() == RequestLevel.ITEM) {
       String itemId = item.getItemId();

--- a/src/test/java/api/support/http/CqlQuery.java
+++ b/src/test/java/api/support/http/CqlQuery.java
@@ -17,6 +17,10 @@ public class CqlQuery implements QueryStringParameter {
     return queryFromTemplate("%s==\"%s\"", indexName, value);
   }
 
+  public static CqlQuery notEqual(String indexName, Object value) {
+    return queryFromTemplate("%s<>\"%s\"", indexName, value);
+  }
+
   public static CqlQuery noQuery() {
     return new CqlQuery(null);
   }


### PR DESCRIPTION
## Purpose
Scenario:

One instance with two items (item1 and item2), both "Available" or "In transit".
Two TLR page requests created (request1 for item1 and request2 for item2), both of them are linked to items, which means that items become "Paged" and requests now have itemIds and status "Open - not yet filled".
Now, when item2 is checked in, request2 should become either "Open - awaiting pickup" or "Open - in transit" depending on the item's status, but request1 shouldn't be updated because it's linked to another item.

## Approach
- update filtering of existing request fulfillment with item;
- create tests;

Resolves: [CIRC-1403](https://issues.folio.org/browse/CIRC-1403)