### PR TITLE
CIRC-1407 require request-storage 4.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -967,7 +967,7 @@
     },
     {
       "id": "request-storage",
-      "version": "3.4"
+      "version": "4.0"
     },
     {
       "id": "request-storage-batch",


### PR DESCRIPTION
This should have been part of #1022 but was missed.

In fact, it appears there were no changes to the `request-storage` API from `3.4` to `4.0` so it is not clear to me why the interface version changed. Maybe, since the shape of a `request` is changing to handle TLR fields, that transitive change bubbles up to the interface version? Anyway, just bumping the interface feels a bit naive, but it isn't clear to me what else I should investigate to make sure this change is sufficient 😬. 

Refs [CIRC-1407](https://issues.folio.org/browse/CIRC-1407), [FOLIO-3376](https://issues.folio.org/browse/CIRC-1407)