### PR TITLE
CIRC-1414: Remove org.apache.httpcomponents:httpclient-*

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,16 +102,6 @@
       <version>4.4</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient-osgi</artifactId>
-      <version>4.5.8</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient-cache</artifactId>
-      <version>4.5.8</version>
-    </dependency>
-    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-core</artifactId>
       <version>${drools.version}</version>

--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticeService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticeService.java
@@ -1,9 +1,9 @@
 package org.folio.circulation.domain.notice;
 
-import static org.apache.http.HttpStatus.SC_OK;
+import static org.folio.HttpStatus.HTTP_OK;
 
+import io.vertx.core.json.JsonObject;
 import java.util.concurrent.CompletableFuture;
-
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.support.Clients;
@@ -12,8 +12,6 @@ import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.client.ResponseInterpreter;
 import org.folio.circulation.support.logging.PatronNoticeLogHelper;
 import org.folio.circulation.support.results.Result;
-
-import io.vertx.core.json.JsonObject;
 
 public abstract class PatronNoticeService {
 
@@ -37,7 +35,7 @@ public abstract class PatronNoticeService {
   private CompletableFuture<Result<Void>> logResult(PatronNotice patronNotice,
     NoticeLogContext noticeLogContext, Result<Response> result, Throwable throwable) {
 
-    PatronNoticeLogHelper.logResponse(result, throwable, SC_OK, patronNotice);
+    PatronNoticeLogHelper.logResponse(result, throwable, HTTP_OK.toInt(), patronNotice);
 
     return eventPublisher.publishNoticeLogEvent(noticeLogContext, result, throwable);
   }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/notices/ScheduledNoticesRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/notices/ScheduledNoticesRepository.java
@@ -5,9 +5,6 @@ import static io.vertx.core.http.HttpMethod.GET;
 import static io.vertx.core.http.HttpMethod.POST;
 import static io.vertx.core.http.HttpMethod.PUT;
 import static java.util.function.Function.identity;
-import static org.apache.http.HttpStatus.SC_CREATED;
-import static org.apache.http.HttpStatus.SC_NO_CONTENT;
-import static org.apache.http.HttpStatus.SC_OK;
 import static org.folio.circulation.domain.notice.NoticeTiming.AFTER;
 import static org.folio.circulation.domain.notice.NoticeTiming.UPON_AT;
 import static org.folio.circulation.domain.notice.schedule.TriggeringEvent.DUE_DATE;
@@ -24,6 +21,9 @@ import static org.folio.circulation.support.http.client.CqlQuery.exactMatchAny;
 import static org.folio.circulation.support.logging.PatronNoticeLogHelper.logResponse;
 import static org.folio.circulation.support.results.ResultBinding.flatMapResult;
 import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTime;
+import static org.folio.HttpStatus.HTTP_CREATED;
+import static org.folio.HttpStatus.HTTP_NO_CONTENT;
+import static org.folio.HttpStatus.HTTP_OK;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -70,7 +70,7 @@ public class ScheduledNoticesRepository {
       .flatMapOn(201, flatMapUsingJson(JsonScheduledNoticeMapper::mapFromJson));
 
     return scheduledNoticesStorageClient.post(representation)
-      .whenComplete((r, t) -> logResponse(r, t, SC_CREATED, POST, scheduledNotice))
+      .whenComplete((r, t) -> logResponse(r, t, HTTP_CREATED.toInt(), POST, scheduledNotice))
       .thenApply(interpreter::flatMap);
   }
 
@@ -93,7 +93,7 @@ public class ScheduledNoticesRepository {
     CqlQuery cqlQuery, PageLimit pageLimit) {
 
     return scheduledNoticesStorageClient.getMany(cqlQuery, pageLimit)
-      .whenComplete((r, t) -> logResponse(r, t, SC_OK, GET, cqlQuery))
+      .whenComplete((r, t) -> logResponse(r, t, HTTP_OK.toInt(), GET, cqlQuery))
       .thenApply(r -> r.next(response ->
         MultipleRecords.from(response, identity(), "scheduledNotices")))
       .thenApply(r -> r.next(records -> records.flatMapRecords(
@@ -105,7 +105,7 @@ public class ScheduledNoticesRepository {
 
     return scheduledNoticesStorageClient.put(scheduledNotice.getId(),
         mapToJson(scheduledNotice))
-      .whenComplete((r, t) -> logResponse(r, t, SC_NO_CONTENT, PUT, scheduledNotice))
+      .whenComplete((r, t) -> logResponse(r, t, HTTP_NO_CONTENT.toInt(), PUT, scheduledNotice))
       .thenApply(noContentRecordInterpreter(scheduledNotice)::flatMap);
   }
 
@@ -117,7 +117,7 @@ public class ScheduledNoticesRepository {
       .otherwise(forwardOnFailure());
 
     return scheduledNoticesStorageClient.delete(scheduledNotice.getId())
-      .whenComplete((r, t) -> logResponse(r, t, SC_NO_CONTENT, DELETE, scheduledNotice))
+      .whenComplete((r, t) -> logResponse(r, t, HTTP_NO_CONTENT.toInt(), DELETE, scheduledNotice))
       .thenApply(flatMapResult(interpreter::apply));
   }
 
@@ -147,7 +147,7 @@ public class ScheduledNoticesRepository {
       .otherwise(forwardOnFailure());
 
     return scheduledNoticesStorageClient.deleteMany(cqlQuery)
-      .whenComplete((r, t) -> logResponse(r, t, SC_NO_CONTENT, DELETE, cqlQuery))
+      .whenComplete((r, t) -> logResponse(r, t, HTTP_NO_CONTENT.toInt(), DELETE, cqlQuery))
       .thenApply(responseResult -> responseResult.next(interpreter::apply));
   }
 }

--- a/src/main/java/org/folio/circulation/support/http/ContentType.java
+++ b/src/main/java/org/folio/circulation/support/http/ContentType.java
@@ -3,8 +3,12 @@ package org.folio.circulation.support.http;
 /**
  * Strings for HTTP content-type header.
  */
-public class ContentType {
+public final class ContentType {
   public static final String CONTENT_TYPE = "Content-Type";
   public static final String APPLICATION_JSON = "application/json; charset=UTF-8";
   public static final String TEXT_PLAIN = "text/plain; ISO_8859_1";
+
+  private ContentType() {
+    throw new UnsupportedOperationException("Can't instantiate utility class");
+  }
 }

--- a/src/main/java/org/folio/circulation/support/http/ContentType.java
+++ b/src/main/java/org/folio/circulation/support/http/ContentType.java
@@ -1,0 +1,10 @@
+package org.folio.circulation.support.http;
+
+/**
+ * Strings for HTTP content-type header.
+ */
+public class ContentType {
+  public static final String CONTENT_TYPE = "Content-Type";
+  public static final String APPLICATION_JSON = "application/json; charset=UTF-8";
+  public static final String TEXT_PLAIN = "text/plain; ISO_8859_1";
+}

--- a/src/main/java/org/folio/circulation/support/http/client/Response.java
+++ b/src/main/java/org/folio/circulation/support/http/client/Response.java
@@ -3,14 +3,13 @@ package org.folio.circulation.support.http.client;
 import static io.vertx.core.MultiMap.caseInsensitiveMultiMap;
 import static java.lang.String.format;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpHeaders;
-
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
 import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.circulation.support.http.ContentType;
 
 public class Response {
   protected final String body;
@@ -39,7 +38,7 @@ public class Response {
     headers.addAll(response.headers());
 
     return new Response(response.statusCode(), response.bodyAsString(),
-      headers.get(HttpHeaders.CONTENT_TYPE), headers, url);
+      headers.get(ContentType.CONTENT_TYPE), headers, url);
   }
 
   public boolean hasBody() {

--- a/src/main/java/org/folio/circulation/support/http/client/VertxWebClientOkapiHttpClient.java
+++ b/src/main/java/org/folio/circulation/support/http/client/VertxWebClientOkapiHttpClient.java
@@ -1,7 +1,6 @@
 package org.folio.circulation.support.http.client;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.apache.http.HttpHeaders.ACCEPT;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.succeeded;
 import static org.folio.circulation.support.http.OkapiHeader.OKAPI_URL;
@@ -19,6 +18,7 @@ import java.util.stream.Stream;
 import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.ServerErrorFailure;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
@@ -30,6 +30,7 @@ import io.vertx.core.http.HttpMethod;
 
 public class VertxWebClientOkapiHttpClient implements OkapiHttpClient {
   private static final Duration DEFAULT_TIMEOUT = Duration.of(20, SECONDS);
+  private static final String ACCEPT = HttpHeaderNames.ACCEPT.toString();
 
   private final WebClient webClient;
   private final URL okapiUrl;

--- a/src/main/java/org/folio/circulation/support/http/server/ClientErrorResponse.java
+++ b/src/main/java/org/folio/circulation/support/http/server/ClientErrorResponse.java
@@ -1,6 +1,6 @@
 package org.folio.circulation.support.http.server;
 
-import org.apache.http.entity.ContentType;
+import org.folio.circulation.support.http.ContentType;
 
 import io.vertx.core.http.HttpServerResponse;
 
@@ -18,7 +18,7 @@ public class ClientErrorResponse {
 
   public static void badRequest(HttpServerResponse response, String reason) {
     response.setStatusCode(400);
-    response.putHeader("content-type", ContentType.TEXT_PLAIN.toString());
+    response.putHeader("content-type", ContentType.TEXT_PLAIN);
     response.end(reason);
   }
 }

--- a/src/main/java/org/folio/circulation/support/http/server/ServerErrorResponse.java
+++ b/src/main/java/org/folio/circulation/support/http/server/ServerErrorResponse.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.support.http.server;
 
 import io.vertx.core.http.HttpServerResponse;
-import org.apache.http.entity.ContentType;
+import org.folio.circulation.support.http.ContentType;
 
 public class ServerErrorResponse {
   private ServerErrorResponse() { }
@@ -9,7 +9,7 @@ public class ServerErrorResponse {
   public static void internalError(HttpServerResponse response, String reason) {
     response.setStatusCode(500);
 
-    response.putHeader("content-type", ContentType.TEXT_PLAIN.toString());
+    response.putHeader("content-type", ContentType.TEXT_PLAIN);
 
     if(reason != null) {
       response.end(reason);

--- a/src/test/java/org/folio/circulation/support/http/ContentTypeTest.java
+++ b/src/test/java/org/folio/circulation/support/http/ContentTypeTest.java
@@ -1,0 +1,13 @@
+package org.folio.circulation.support.http;
+
+import org.folio.rest.testing.UtilityClassTester;
+import org.junit.jupiter.api.Test;
+
+class ContentTypeTest {
+
+  @Test
+  void utilityClass() {
+    UtilityClassTester.assertUtilityClass(ContentType.class);
+  }
+
+}

--- a/src/test/java/org/folio/circulation/support/http/client/ResponseInterpretationTests.java
+++ b/src/test/java/org/folio/circulation/support/http/client/ResponseInterpretationTests.java
@@ -2,8 +2,8 @@ package org.folio.circulation.support.http.client;
 
 import static io.vertx.core.MultiMap.caseInsensitiveMultiMap;
 import static java.util.function.Function.identity;
-import static org.apache.http.entity.ContentType.APPLICATION_JSON;
-import static org.apache.http.entity.ContentType.TEXT_PLAIN;
+import static org.folio.circulation.support.http.ContentType.APPLICATION_JSON;
+import static org.folio.circulation.support.http.ContentType.TEXT_PLAIN;
 import static org.folio.circulation.support.http.ResponseMapping.mapUsingJson;
 import static org.folio.circulation.support.results.Result.of;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -26,7 +26,7 @@ class ResponseInterpretationTests {
 
     Result<JsonObject> result = new ResponseInterpreter<JsonObject>()
       .flatMapOn(200, mapUsingJson(identity()))
-      .apply(new Response(200, body.toString(), APPLICATION_JSON.toString()));
+      .apply(new Response(200, body.toString(), APPLICATION_JSON));
 
     assertThat(result.succeeded(), is(true));
     assertThat(result.value(), is(body));
@@ -84,7 +84,7 @@ class ResponseInterpretationTests {
     Result<String> result = new ResponseInterpreter<String>()
       .flatMapOn(200, response -> of(response::getBody))
       .otherwise(response -> of(() -> "unexpected response"))
-      .apply(new Response(200, "ok", TEXT_PLAIN.toString()));
+      .apply(new Response(200, "ok", TEXT_PLAIN));
 
     assertThat(result.succeeded(), is(true));
     assertThat(result.value(), is("ok"));


### PR DESCRIPTION
pom.xml adds org.apache.httpcomponents:httpclient-osgi and org.apache.httpcomponents:httpclient-cache as runtime dependencies.

They result in 1.2 MB of code in the final mod-circulation.jar because of indirect dependencies:

* org.apache.httpcomponents:fluent-hc:jar:4.5.8
* org.apache.httpcomponents:httpclient-cache:jar:4.5.8
* org.apache.httpcomponents:httpclient-osgi:jar:4.5.8
* org.apache.httpcomponents:httpclient:jar:4.5.8
* org.apache.httpcomponents:httpcore:jar:4.4.11
* org.apache.httpcomponents:httpmime:jar:4.5.8

These libraries are deprecated: "Users of HttpCore 4.x are strongly encouraged to migrate to HttpCore 5.x" https://hc.apache.org/status.html

The libraries are needed for 6 String constants only.

To avoid bloating the final jar these 6 String contstants are taken from other sources and the org.apache.httpcomponents are removed.