### PR TITLE
CIRC-1417: Fix dueDate comparison in LoanDueDatesAfterRecallTests

### DIFF
--- a/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
+++ b/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
@@ -395,7 +395,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
 
     final String expectedDueDate = formatDateTime(ZonedDateTime
       .of(getZonedDateTime().plusMonths(2).toLocalDate(),
-        LocalTime.MIDNIGHT.minusSeconds(1),getZoneId())); 
+        LocalTime.MIDNIGHT.minusSeconds(1),getZoneId()));
 
     assertThat("due date should be in 2 months (recall return interval)",
         storedLoan.getString("dueDate"), is(expectedDueDate));
@@ -812,7 +812,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
       .withPickupServicePointId(servicePointsFixture.cd1().getId()));
 
     assertThat(loansStorageClient.getById(loan.getId()).getJson(),
-      hasJsonPath("dueDate", expectedLoanDueDate.toString()));
+      hasJsonPath("dueDate", isEquivalentTo(expectedLoanDueDate)));
 
     // verify that loan action is recorder even though due date is not changed
     final MultipleJsonRecords loanHistory = loanHistoryClient


### PR DESCRIPTION
Use isEquivalentTo matcher to fix this error:

LoanDueDatesAfterRecallTests.shouldNotExtendLoanDueDateIfOverdueLoanIsRecalled:814
Expected: Json path ["dueDate"] is "2022-01-13T10:12:02Z"
but: Expected json path ["dueDate"] evaluated to is "2022-01-13T10:12:02Z" but actual ["2022-01-13T10:12:02.000Z"]