### PR TITLE
CIRC-1412 - Requests should change position when they go in fulfilment on check-in

### DIFF
--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -166,9 +166,11 @@ public class RequestQueue {
     int newIndex = -1;
 
     for (int i = 0; i < requests.size(); i++) {
-      boolean isSameRequest = StringUtils.equals(requestId, requests.get(i).getId());
+      var currentRequest = requests.get(i);
+      boolean isSameRequest = StringUtils.equals(requestId, currentRequest.getId());
+
       if (newIndex == -1) {
-        if (!isSameRequest && requests.get(i).isNotYetFilled()) {
+        if (!isSameRequest && currentRequest.isNotYetFilled()) {
           newIndex = i;
         }
       } else if (isSameRequest) {

--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -166,17 +166,18 @@ public class RequestQueue {
     int newIndex = -1;
 
     for (int i = 0; i < requests.size(); i++) {
+      boolean isSameRequest = StringUtils.equals(requestId, requests.get(i).getId());
       if (newIndex == -1) {
-        if (requests.get(i).isNotYetFilled()) {
+        if (!isSameRequest && requests.get(i).isNotYetFilled()) {
           newIndex = i;
         }
-      } else if (StringUtils.equals(requestId, requests.get(i).getId())) {
-        var requestToMove = requests.remove(i);
-        requests.add(newIndex, requestToMove);
+      } else if (isSameRequest) {
+        requests.add(newIndex, requests.remove(i));
         reSequenceRequests();
         return;
       }
     }
   }
+
 
 }

--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -124,6 +124,16 @@ public class RequestQueue {
     reSequenceRequests();
   }
 
+  public void setRequestToPositionOne(Request request) {
+    if (requests.size() > 1) {
+      requests = requests.stream()
+        .filter(r -> !r.getId().equals(request.getId()))
+        .collect(Collectors.toList());
+      requests.add(0, request);
+      reSequenceRequests();
+    }
+  }
+
   private void reSequenceRequests() {
     final AtomicInteger position = new AtomicInteger(1);
     requests.forEach(req -> req.changePosition(position.getAndIncrement()));

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -85,8 +85,8 @@ public class UpdateRequestQueue {
     if (requestBeingFulfilled.getItemId() == null) {
       requestBeingFulfilled = requestBeingFulfilled.withItem(item);
     }
-    //request's position needs to be changed to 1
-    requestQueue.setRequestToPositionOne(requestBeingFulfilled);
+
+    requestQueue.updateRequestPositionOnCheckIn(requestBeingFulfilled.getId());
 
     Request originalRequest = Request.from(requestBeingFulfilled.asJson());
 

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -85,6 +85,9 @@ public class UpdateRequestQueue {
     if (requestBeingFulfilled.getItemId() == null) {
       requestBeingFulfilled = requestBeingFulfilled.withItem(item);
     }
+    //request's position needs to be changed to 1
+    requestQueue.setRequestToPositionOne(requestBeingFulfilled);
+
     Request originalRequest = Request.from(requestBeingFulfilled.asJson());
 
     CompletableFuture<Result<Request>> updatedReq;
@@ -111,7 +114,7 @@ public class UpdateRequestQueue {
 
     return updatedReq
       .thenComposeAsync(r -> r.after(requestRepository::update))
-      .thenApply(result -> result.map(v -> requestQueue));
+      .thenComposeAsync(result -> result.after(v -> requestQueueRepository.updateRequestsWithChangedPositions(requestQueue)));
   }
 
   private CompletableFuture<Result<Request>> awaitPickup(Request request) {

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -1491,7 +1491,7 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
     UUID instanceId = instancesFixture.basedUponDunkirk().getId();
     IndividualResource defaultWithHoldings = holdingsFixture.defaultWithHoldings(instanceId);
     IndividualResource checkedOutItem = itemsClient.create(buildCheckedOutItemWithHoldingRecordsId(defaultWithHoldings.getId()));
-    IndividualResource holdRequestBeforeFulfilled = requestsClient.create(buildHoldTLRWithHoldShelfFulfilmentPreference(instanceId, usersFixture.charlotte().getId()));
+    IndividualResource holdRequestBeforeFulfilled = requestsClient.create(buildHoldTLRWithHoldShelfFulfilmentPreference(instanceId));
 
     checkInFixture.checkInByBarcode(checkedOutItem, servicePointsFixture.cd1().getId());
 
@@ -1598,7 +1598,7 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
       .create();
   }
 
-  private JsonObject buildHoldTLRWithHoldShelfFulfilmentPreference(UUID instanceId, UUID requesterId) {
+  private JsonObject buildHoldTLRWithHoldShelfFulfilmentPreference(UUID instanceId) {
     return new RequestBuilder()
       .hold()
       .fulfilToHoldShelf()
@@ -1607,8 +1607,7 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
       .withNoItemId()
       .withNoHoldingsRecordId()
       .withPickupServicePointId(servicePointsFixture.cd1().getId())
-      .withRequesterId(requesterId)
-      .create();
+      .withRequesterId(usersFixture.charlotte().getId()).create();
   }
 
   private JsonObject buildHoldTLRWithDeliveryFulfilmentPreference(UUID instanceId) {

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -1589,20 +1589,6 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
       allOf(isOpenAwaitingPickup(), hasPosition(2)));
   }
 
-  private JsonObject createTitleLevelPageRequestObject(UUID instanceId,
-    UUID requesterId, UUID pickupServicePointId, ZonedDateTime requestDate) {
-    return new RequestBuilder()
-      .withInstanceId(instanceId)
-      .withNoItemId()
-      .withNoHoldingsRecordId()
-      .withRequesterId(requesterId)
-      .withRequestDate(requestDate)
-      .withPickupServicePointId(pickupServicePointId)
-      .titleRequestLevel()
-      .page()
-      .create();
-  }
-
   private JsonObject buildCheckedOutItemWithHoldingRecordsId(UUID holdingRecordsId) {
     return new ItemBuilder()
       .forHolding(holdingRecordsId)

--- a/src/test/java/api/requests/scenarios/HoldShelfFulfillmentTests.java
+++ b/src/test/java/api/requests/scenarios/HoldShelfFulfillmentTests.java
@@ -156,8 +156,7 @@ class HoldShelfFulfillmentTests extends APITests {
     }
 
     if (checkedInItemNumber == 2) {
-      // Jessica's request should be fulfilled. All requests should keep their positions until
-      // re-positioning is triggered by check-out, cancellation etc.
+      // Jessica's request should be fulfilled and moved to the first position in queue
 
       Response updatedRequestBySteve = requestsClient.getById(requestBySteve.getId());
       assertThat(updatedRequestBySteve.getJson(), isItemLevel());

--- a/src/test/java/api/requests/scenarios/HoldShelfFulfillmentTests.java
+++ b/src/test/java/api/requests/scenarios/HoldShelfFulfillmentTests.java
@@ -162,12 +162,12 @@ class HoldShelfFulfillmentTests extends APITests {
       Response updatedRequestBySteve = requestsClient.getById(requestBySteve.getId());
       assertThat(updatedRequestBySteve.getJson(), isItemLevel());
       assertThat(updatedRequestBySteve.getJson(), isOpenNotYetFilled());
-      assertThat(updatedRequestBySteve.getJson(), hasPosition(1));
+      assertThat(updatedRequestBySteve.getJson(), hasPosition(2));
 
       Response updatedRequestByJessica = requestsClient.getById(requestByJessica.getId());
       assertThat(updatedRequestByJessica.getJson(), isTitleLevel());
       assertThat(updatedRequestByJessica.getJson(), isOpenAwaitingPickup());
-      assertThat(updatedRequestByJessica.getJson(), hasPosition(2));
+      assertThat(updatedRequestByJessica.getJson(), hasPosition(1));
 
       Response updatedRequestByCharlotte = requestsClient.getById(requestByCharlotte.getId());
       assertThat(updatedRequestByCharlotte.getJson(), isItemLevel());

--- a/src/test/java/api/support/fixtures/RequestsFixture.java
+++ b/src/test/java/api/support/fixtures/RequestsFixture.java
@@ -69,6 +69,19 @@ public class RequestsFixture {
       .withPickupServicePointId(servicePointsFixture.cd1().getId()));
   }
 
+  public IndividualResource placeItemLevelPageRequest(IndividualResource item, UUID instanceId,
+    IndividualResource by) {
+
+    return place(new RequestBuilder()
+      .page()
+      .fulfilToHoldShelf()
+      .withItemId(item.getId())
+      .withInstanceId(instanceId)
+      .withRequestDate(ZonedDateTime.now())
+      .withRequesterId(by.getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId()));
+  }
+
   public IndividualResource placeItemLevelHoldShelfRequest(IndividualResource item,
     IndividualResource by) {
 

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -1,0 +1,92 @@
+package org.folio.circulation.domain;
+
+import static org.folio.circulation.domain.RequestStatus.OPEN_AWAITING_PICKUP;
+import static org.folio.circulation.domain.RequestStatus.OPEN_NOT_YET_FILLED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.vertx.core.json.JsonObject;
+
+class RequestQueueTests {
+  private static final String TOP_FULFILLABLE_REQUEST_ID = randomId();
+
+  @ParameterizedTest
+  @MethodSource("argumentsForUpdateRequestPositionOnCheckIn")
+  void updateRequestPositionOnCheckIn(List<Request> requests, int[] expectedPositions) {
+    List<Request> requestsBeforeUpdate = new ArrayList<>(requests);
+    assertEquals(requestsBeforeUpdate.size(), expectedPositions.length);
+
+    RequestQueue requestQueue = new RequestQueue(requests);
+    requestQueue.updateRequestPositionOnCheckIn(TOP_FULFILLABLE_REQUEST_ID);
+
+    List<Request> requestsAfterUpdate = new ArrayList<>(requestQueue.getRequests());
+
+    assertEquals(requestsAfterUpdate.size(), expectedPositions.length);
+
+    for (int i = 0; i < expectedPositions.length; i++) {
+      int expectedPosition = expectedPositions[i];
+      Request requestBeforeUpdate = requestsBeforeUpdate.get(i);
+      Request requestAfterUpdate = requestsAfterUpdate.get(expectedPosition - 1);
+      assertEquals(requestAfterUpdate.getPosition(), expectedPosition);
+      assertEquals(requestBeforeUpdate.getId(), requestAfterUpdate.getId());
+    }
+  }
+
+  private static Stream<Arguments> argumentsForUpdateRequestPositionOnCheckIn() {
+    return Stream.of(
+      Arguments.of(List.of(
+          buildRequest(1, OPEN_NOT_YET_FILLED, TOP_FULFILLABLE_REQUEST_ID)),
+        new int[] { 1 }),
+
+      Arguments.of(List.of(
+          buildRequest(1, OPEN_NOT_YET_FILLED, TOP_FULFILLABLE_REQUEST_ID),
+          buildRequest(2, OPEN_NOT_YET_FILLED, randomId())),
+        new int[] { 1, 2 }),
+
+      Arguments.of(List.of(
+          buildRequest(1, OPEN_AWAITING_PICKUP, randomId()),
+          buildRequest(2, OPEN_AWAITING_PICKUP, randomId()),
+          buildRequest(3, OPEN_NOT_YET_FILLED, TOP_FULFILLABLE_REQUEST_ID)),
+        new int[] { 1, 2, 3 }),
+
+      Arguments.of(List.of(
+          buildRequest(1, OPEN_NOT_YET_FILLED, randomId()),
+          buildRequest(2, OPEN_NOT_YET_FILLED, TOP_FULFILLABLE_REQUEST_ID),
+          buildRequest(3, OPEN_NOT_YET_FILLED, randomId())),
+        new int[] { 2, 1, 3 }),
+
+      Arguments.of(List.of(
+          buildRequest(1, OPEN_NOT_YET_FILLED, randomId()),
+          buildRequest(2, OPEN_NOT_YET_FILLED, randomId()),
+          buildRequest(3, OPEN_NOT_YET_FILLED, TOP_FULFILLABLE_REQUEST_ID)),
+        new int[] { 2, 3, 1 }),
+
+      Arguments.of(List.of(
+          buildRequest(1, OPEN_AWAITING_PICKUP, randomId()),
+          buildRequest(2, OPEN_NOT_YET_FILLED, randomId()),
+          buildRequest(3, OPEN_NOT_YET_FILLED, TOP_FULFILLABLE_REQUEST_ID)),
+        new int[] { 1, 3, 2 })
+    );
+  }
+
+  private static Request buildRequest(int position, RequestStatus status, String requestId) {
+    JsonObject json = new JsonObject()
+      .put("id", requestId)
+      .put("status", status.getValue())
+      .put("position", position);
+
+    return new Request(null, null, json, null, null, null, null, null, null, null, null, false, null, false);
+  }
+
+  private static String randomId() {
+    return UUID.randomUUID().toString();
+  }
+}


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-1412

When an item is checked in and it fulfils a request, this request's position needs to be changed to 1 and the whole request queue should be updated accordingly. This logic was already implemented for item-level requests, it now needs to be supported by the unified queue.