### PR TITLE
FOLIO-3231 Use api-doc CI facility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,13 @@
 
 buildMvn {
   publishModDescriptor = true
-  publishAPI = true
   mvnDeploy = true
   doKubeDeploy = true
   publishPreview = false
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-circulation
 
-Copyright (C) 2017-2020 The Open Library Foundation
+Copyright (C) 2017-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.


### PR DESCRIPTION
Adds the `doApiDoc` configuration to Jenkinsfile, which enables the [api-doc](https://dev.folio.org/guides/api-doc/) CI facility. This generates and publishes the API documentation during a merge to mainline and on release.

The `doApiLint` ([api-lint](https://dev.folio.org/guides/api-lint/)) was already configured.

The https://dev.folio.org/reference/api/#mod-circulation section of API documentation will be automatically reconfigured tomorrow:
https://dev.folio.org/reference/api/#explain-gather-config
