### PR TITLE
CIRC-1413 Inline higher limit variable

### DIFF
--- a/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
+++ b/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
@@ -33,8 +33,6 @@ import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonObject;
 
 class InstanceRequestsAPICreationTests extends APITests {
-  private static final int ITEM_COPIES_NUMBER = 20;
-
   @Test
   void canCreateATitleLevelRequestForMultipleAvailableItemsAndAMatchingPickupLocationId() {
     UUID pickupServicePointId = servicePointsFixture.cd1().getId();
@@ -315,7 +313,7 @@ class InstanceRequestsAPICreationTests extends APITests {
     IndividualResource holdings = holdingsFixture.defaultWithHoldings(instance.getId());
     IndividualResource locationsResource = locationsFixture.mainFloor();
 
-    IntStream.range(0, ITEM_COPIES_NUMBER)
+    IntStream.range(0, 20)
       .forEach(index -> itemsFixture.basedUponDunkirkWithCustomHoldingAndLocationAndCheckedOut(
         holdings.getId(), locationsResource.getId()));
     var availableItem = itemsFixture.basedUponDunkirkWithCustomHoldingAndLocation(


### PR DESCRIPTION
### Purpose
When creating a request using the basic TLR implementation, more then ten items associated with an instance should be checked for availability. And if such items are available, page request should be created via  /patron/account/<userId>/instance/<instanceId>/hold
### Approach

- Test refactoring (Inline higher limit variable)

### Learning
https://issues.folio.org/browse/CIRC-1413