### PR TITLE
CIRC-1421 - During check-in only update fulfillable request if it's for the same item

### DIFF
--- a/src/main/java/org/folio/circulation/domain/CheckInContext.java
+++ b/src/main/java/org/folio/circulation/domain/CheckInContext.java
@@ -94,7 +94,7 @@ public class CheckInContext {
   public CheckInContext withRequestQueue(RequestQueue requestQueue) {
     Request firstRequest = null;
 
-    if (requestQueue.hasOutstandingFulfillableRequests()) {
+    if (requestQueue.hasOutstandingFulfillableByItemRequests(item)) {
       firstRequest = requestQueue.getHighestPriorityRequestFulfillableByItem(item);
     }
 

--- a/src/main/java/org/folio/circulation/domain/CheckInContext.java
+++ b/src/main/java/org/folio/circulation/domain/CheckInContext.java
@@ -94,7 +94,7 @@ public class CheckInContext {
   public CheckInContext withRequestQueue(RequestQueue requestQueue) {
     Request firstRequest = null;
 
-    if (requestQueue.hasOutstandingFulfillableByItemRequests(item)) {
+    if (requestQueue.hasOutstandingRequestsFulfillableByItem(item)) {
       firstRequest = requestQueue.getHighestPriorityRequestFulfillableByItem(item);
     }
 

--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -41,7 +41,7 @@ public class RequestQueue {
   }
 
   ItemStatus checkedInItemStatus(Item item) {
-    return hasOutstandingFulfillableByItemRequests(item)
+    return hasOutstandingRequestsFulfillableByItem(item)
       ? getHighestPriorityRequestFulfillableByItem(item).checkedInItemStatus()
       : AVAILABLE;
   }
@@ -50,7 +50,7 @@ public class RequestQueue {
     return !fulfillableRequests().isEmpty();
   }
 
-  boolean hasOutstandingFulfillableByItemRequests(Item item) {
+  boolean hasOutstandingRequestsFulfillableByItem(Item item) {
     return  fulfillableRequests().stream()
       .anyMatch(request -> requestIsFulfillableByItem(request, item));
   }

--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -41,13 +41,18 @@ public class RequestQueue {
   }
 
   ItemStatus checkedInItemStatus(Item item) {
-    return hasOutstandingFulfillableRequests()
+    return hasOutstandingFulfillableByItemRequests(item)
       ? getHighestPriorityRequestFulfillableByItem(item).checkedInItemStatus()
       : AVAILABLE;
   }
 
   boolean hasOutstandingFulfillableRequests() {
     return !fulfillableRequests().isEmpty();
+  }
+
+  boolean hasOutstandingFulfillableByItemRequests(Item item) {
+    return  fulfillableRequests().stream()
+      .anyMatch(request -> requestIsFulfillableByItem(request, item));
   }
 
   Request getHighestPriorityFulfillableRequest() {

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -44,7 +44,7 @@ public class UpdateItem {
   private Result<Item> changeItemOnCheckIn(Item item, RequestQueue requestQueue,
     UUID checkInServicePointId) {
 
-    if (requestQueue.hasOutstandingFulfillableByItemRequests(item)) {
+    if (requestQueue.hasOutstandingRequestsFulfillableByItem(item)) {
       return changeItemWithOutstandingRequest(item, requestQueue, checkInServicePointId);
     } else {
       if(Optional.ofNullable(item.getLocation())

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -44,7 +44,7 @@ public class UpdateItem {
   private Result<Item> changeItemOnCheckIn(Item item, RequestQueue requestQueue,
     UUID checkInServicePointId) {
 
-    if (requestQueue.hasOutstandingFulfillableRequests()) {
+    if (requestQueue.hasOutstandingFulfillableByItemRequests(item)) {
       return changeItemWithOutstandingRequest(item, requestQueue, checkInServicePointId);
     } else {
       if(Optional.ofNullable(item.getLocation())

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -71,7 +71,7 @@ public class UpdateRequestQueue {
   public CompletableFuture<Result<RequestQueue>> onCheckIn(
     RequestQueue requestQueue, Item item, String checkInServicePointId) {
 
-    if (requestQueue.hasOutstandingFulfillableByItemRequests(item)) {
+    if (requestQueue.hasOutstandingRequestsFulfillableByItem(item)) {
       return updateOutstandingRequestOnCheckIn(requestQueue, item, checkInServicePointId);
     } else {
       return completedFuture(succeeded(requestQueue));

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -71,7 +71,7 @@ public class UpdateRequestQueue {
   public CompletableFuture<Result<RequestQueue>> onCheckIn(
     RequestQueue requestQueue, Item item, String checkInServicePointId) {
 
-    if (requestQueue.hasOutstandingFulfillableRequests()) {
+    if (requestQueue.hasOutstandingFulfillableByItemRequests(item)) {
       return updateOutstandingRequestOnCheckIn(requestQueue, item, checkInServicePointId);
     } else {
       return completedFuture(succeeded(requestQueue));


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-1421
NPE thrown when an item is checked in and there are fulfillable requests in the unified queue (TLR is enabled), but they are not fulfillable by the item that is checked in. The reason is that item-specific method updateOutstandingRequestOnCheckIn() is called when requestQueue.hasOutstandingFulfillableRequests() (that checks for fulfillable items, not necessarily fulfillable by the same item) returns true.
Another item-specific method hasOutstandingFulfillableByItemRequests() needs to be added.