### PR TITLE
CIRC-1424 Fetch request queue by instance ID if TLR is enabled

### DIFF
--- a/src/main/java/org/folio/circulation/domain/MoveRequestRecord.java
+++ b/src/main/java/org/folio/circulation/domain/MoveRequestRecord.java
@@ -1,13 +1,30 @@
 package org.folio.circulation.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.With;
+
+@AllArgsConstructor
 public class MoveRequestRecord {
 
   private final String sourceItemId;
   private final String destinationItemId;
+  @With
+  private String destinationItemInstanceId;
+  private final String sourceItemInstanceId;
 
-  public MoveRequestRecord(String sourceItemId, String destinationItemId) {
+  public String getDestinationItemInstanceId() {
+    return destinationItemInstanceId;
+  }
+
+  public String getSourceItemInstanceId() {
+    return sourceItemInstanceId;
+  }
+
+  public MoveRequestRecord(String sourceItemId, String destinationItemId,
+    String sourceItemInstanceId) {
     this.sourceItemId = sourceItemId;
     this.destinationItemId = destinationItemId;
+    this.sourceItemInstanceId = sourceItemInstanceId;
   }
 
   public String getSourceItemId() {
@@ -17,9 +34,10 @@ public class MoveRequestRecord {
   public String getDestinationItemId() {
     return destinationItemId;
   }
-  
-  public static MoveRequestRecord with(String sourceItemId, String destinationItemId) {
-    return new MoveRequestRecord(sourceItemId, destinationItemId);
+
+  public static MoveRequestRecord with(String sourceItemId, String destinationItemId,
+    String sourceItemInstanceId) {
+    return new MoveRequestRecord(sourceItemId, destinationItemId, sourceItemInstanceId);
   }
 
 }

--- a/src/main/java/org/folio/circulation/domain/MoveRequestService.java
+++ b/src/main/java/org/folio/circulation/domain/MoveRequestService.java
@@ -14,6 +14,8 @@ import org.folio.circulation.resources.RequestNoticeSender;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.support.results.Result;
 
+import io.vertx.core.json.JsonObject;
+
 public class MoveRequestService {
   private final RequestRepository requestRepository;
   private final RequestPolicyRepository requestPolicyRepository;

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -167,6 +167,12 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
     return requestRepresentation.getString(HOLDINGS_RECORD_ID);
   }
 
+  public Request withTlrSettings(TlrSettingsConfiguration tlrSettingsConfiguration) {
+    return new Request(tlrSettingsConfiguration, operation, requestRepresentation,
+      cancellationReasonRepresentation, instance, item, requester, proxy, addressType,
+      loan, pickupServicePoint, changedPosition, previousPosition, changedStatus);
+  }
+
   public Request withItem(Item newItem) {
     // NOTE: this is null in RequestsAPIUpdatingTests.replacingAnExistingRequestRemovesItemInformationWhenItemDoesNotExist test
     if (newItem != null && newItem.getItemId() != null && newItem.getHoldingsRecordId() != null) {

--- a/src/main/java/org/folio/circulation/domain/RequestAndRelatedRecords.java
+++ b/src/main/java/org/folio/circulation/domain/RequestAndRelatedRecords.java
@@ -42,6 +42,13 @@ public class RequestAndRelatedRecords implements UserRelatedRecord, ItemRelatedR
     );
   }
 
+  public RequestAndRelatedRecords withDestinationItemInstanceId(String destinationItemInstanceId) {
+    return new RequestAndRelatedRecords(
+      request, requestQueue, requestPolicy,
+      moveRequestRecord.withDestinationItemInstanceId(destinationItemInstanceId), timeZone
+    );
+  }
+
   public RequestAndRelatedRecords withRequestPolicy(RequestPolicy newRequestPolicy) {
     return new RequestAndRelatedRecords(
       this.request,
@@ -97,12 +104,13 @@ public class RequestAndRelatedRecords implements UserRelatedRecord, ItemRelatedR
       moveRequestRecord, newTimeZone);
   }
 
-  public RequestAndRelatedRecords asMove(String originalItemId, String destinationItemId) {
+  public RequestAndRelatedRecords asMove(String originalItemId, String destinationItemId,
+    String originalItemInstanceId) {
     return new RequestAndRelatedRecords(
       this.request,
       this.requestQueue,
       this.requestPolicy,
-      MoveRequestRecord.with(originalItemId, destinationItemId), timeZone
+      MoveRequestRecord.with(originalItemId, destinationItemId, originalItemInstanceId), timeZone
     );
   }
 
@@ -122,6 +130,14 @@ public class RequestAndRelatedRecords implements UserRelatedRecord, ItemRelatedR
 
   String getDestinationItemId() {
     return moveRequestRecord != null ? moveRequestRecord.getDestinationItemId() : null;
+  }
+
+  String getDestinationItemInstanceId() {
+    return moveRequestRecord != null ? moveRequestRecord.getDestinationItemInstanceId() : null;
+  }
+
+  String getSourceItemInstanceId() {
+    return moveRequestRecord != null ? moveRequestRecord.getSourceItemInstanceId() : null;
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/RequestServiceUtility.java
+++ b/src/main/java/org/folio/circulation/domain/RequestServiceUtility.java
@@ -64,6 +64,9 @@ public class RequestServiceUtility {
 
     Request request = requestAndRelatedRecords.getRequest();
 
+    System.out.println("!!!!!!!!!!!!");
+    System.out.println(request.getItem().getStatus());
+
     if (request.getItem().isNotFound() || request.allowedForItem()) {
       return succeeded(requestAndRelatedRecords);
     } else {

--- a/src/test/java/org/folio/circulation/domain/UpdateRequestQueueTest.java
+++ b/src/test/java/org/folio/circulation/domain/UpdateRequestQueueTest.java
@@ -142,9 +142,10 @@ class UpdateRequestQueueTest {
 
     String newOriginalItemId = UUID.randomUUID().toString();
     String newDestinationItemId = UUID.randomUUID().toString();
+    String newDestinationInstanceId = UUID.randomUUID().toString();
 
     RequestAndRelatedRecords moveFromRequestContext = createMoveRequestContext()
-      .asMove(newOriginalItemId, newDestinationItemId);
+      .asMove(newOriginalItemId, newDestinationItemId, newDestinationInstanceId);
 
     CompletableFuture<Result<RequestAndRelatedRecords>> completableFuture =
       updateRequestQueue.onMovedFrom(moveFromRequestContext);
@@ -162,9 +163,10 @@ class UpdateRequestQueueTest {
 
     String newOriginalItemId = UUID.randomUUID().toString();
     String newDestinationItemId = UUID.randomUUID().toString();
+    String newDestinationInstanceId = UUID.randomUUID().toString();
 
     RequestAndRelatedRecords moveFromRequestContext = createMoveRequestContext()
-      .asMove(newOriginalItemId, newDestinationItemId);
+      .asMove(newOriginalItemId, newDestinationItemId, newDestinationInstanceId);
 
     CompletableFuture<Result<RequestAndRelatedRecords>> completableFuture =
       updateRequestQueue.onMovedTo(moveFromRequestContext);
@@ -231,6 +233,7 @@ class UpdateRequestQueueTest {
 
   private RequestAndRelatedRecords createMoveRequestContext() {
     UUID itemId = UUID.randomUUID();
+    String instanceId = UUID.randomUUID().toString();
 
     RequestQueue requestQueue = createRequestQueue(itemId, 4);
     Request request = requestQueue.getRequests().iterator().next();
@@ -239,7 +242,7 @@ class UpdateRequestQueueTest {
       .withRequestQueue(requestQueue)
       // setting destination == source, to handle both moveTo and moveFrom cases
       // it does not matter for tests
-      .asMove(itemId.toString(), itemId.toString());
+      .asMove(itemId.toString(), itemId.toString(), instanceId);
   }
 
   private RequestAndRelatedRecords createCancellationContext() {


### PR DESCRIPTION
Resolves: https://issues.folio.org/browse/CIRC-1424

## Purpose
Currently, if we move ILR to an available item in a unified queue it gets wrong position. 

## Approach
If TLR is enabled, fetch the queue by instance ID.
