### PR TITLE
CIRC-1046 add handling for not critical errors for check-out

### DIFF
--- a/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeService.java
@@ -67,11 +67,6 @@ public class LoanScheduledNoticeService {
   private CompletableFuture<Result<List<ScheduledNotice>>> scheduleLoanNoticesBasedOnPolicy(Loan loan,
      NoticeEventType eventType, ZonedDateTime eventTime, PatronNoticePolicy noticePolicy) {
 
-    noticePolicy.getNoticeConfigurations().stream()
-      .filter(config -> config.getNoticeEventType() == eventType)
-      .map(config -> createScheduledNotice(config, loan, eventType, eventTime))
-      .forEach(scheduledNoticesRepository::create);
-
     List<ScheduledNotice> scheduledNotices = noticePolicy.getNoticeConfigurations().stream()
       .filter(config -> config.getNoticeEventType() == eventType)
       .map(config -> createScheduledNotice(config, loan, eventType, eventTime))

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeService.java
@@ -132,7 +132,7 @@ public class LoanScheduledNoticeService {
 
     if (!loan.isClosed()) {
       scheduledNoticesRepository.deleteByLoanIdAndTriggeringEvent(loan.getId(), triggeringEvent)
-        .thenAccept(r -> r.map(v -> scheduleLoanNotices(loan, eventType, eventTime)));
+        .thenAccept(r -> r.after(v -> scheduleLoanNotices(loan, eventType, eventTime)));
     }
 
     return succeeded(mapTo);

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -149,7 +149,7 @@ public class CheckOutByBarcodeResource extends Resource {
       .thenApplyAsync(r -> r.map(records -> records.withLoggedInUserId(context.getUserId())))
       .thenComposeAsync(r -> r.after(l -> publishItemCheckedOutEvent(l, eventPublisher,
         userRepository, errorHandler)))
-      .thenCompose(r -> r.after(l -> scheduleNoticesForLoanDueDate(l, scheduledNoticeService,
+      .thenComposeAsync(r -> r.after(l -> scheduleNoticesForLoanDueDate(l, scheduledNoticeService,
         errorHandler)))
       .thenApply(r -> r.map(LoanAndRelatedRecords::getLoan))
       .thenApply(r -> r.map(loanRepresentation::extendedLoan))

--- a/src/main/java/org/folio/circulation/resources/handlers/error/CirculationErrorType.java
+++ b/src/main/java/org/folio/circulation/resources/handlers/error/CirculationErrorType.java
@@ -57,6 +57,5 @@ public enum CirculationErrorType {
 
   // Acceptable errors for checkout with partial success
   FAILED_TO_SAVE_SESSION_RECORD,
-  FAILED_TO_PUBLISH_CHECKOUT_EVENT,
-  FAILED_TO_SCHEDULE_NOTICE_FOR_LOAN_DUE_DATE
+  FAILED_TO_PUBLISH_CHECKOUT_EVENT
 }

--- a/src/main/java/org/folio/circulation/resources/handlers/error/CirculationErrorType.java
+++ b/src/main/java/org/folio/circulation/resources/handlers/error/CirculationErrorType.java
@@ -55,7 +55,7 @@ public enum CirculationErrorType {
   // Errors related to block overrides
   INSUFFICIENT_OVERRIDE_PERMISSIONS,
 
-  // Errors that do not affect a loan creation
+  // Acceptable errors for checkout with partial success
   FAILED_TO_SAVE_SESSION_RECORD,
   FAILED_TO_PUBLISH_CHECKOUT_EVENT,
   FAILED_TO_SCHEDULE_NOTICE_FOR_LOAN_DUE_DATE

--- a/src/main/java/org/folio/circulation/resources/handlers/error/CirculationErrorType.java
+++ b/src/main/java/org/folio/circulation/resources/handlers/error/CirculationErrorType.java
@@ -53,5 +53,10 @@ public enum CirculationErrorType {
   RENEWAL_IS_NOT_POSSIBLE,
 
   // Errors related to block overrides
-  INSUFFICIENT_OVERRIDE_PERMISSIONS
+  INSUFFICIENT_OVERRIDE_PERMISSIONS,
+
+  // Errors that do not affect a loan creation
+  FAILED_TO_SAVE_SESSION_RECORD,
+  FAILED_TO_PUBLISH_CHECKOUT_EVENT,
+  FAILED_TO_SCHEDULE_NOTICE_FOR_LOAN_DUE_DATE
 }

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -46,7 +46,9 @@ import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static api.support.matchers.ValidationErrorMatchers.hasUUIDParameter;
 import static api.support.utl.BlockOverridesUtils.getMissingPermissions;
 import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfScheduledNotices;
+import static io.vertx.core.http.HttpMethod.POST;
 import static java.time.ZoneOffset.UTC;
+import static org.folio.HttpStatus.HTTP_INTERNAL_SERVER_ERROR;
 import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
 import static org.folio.circulation.domain.EventType.ITEM_CHECKED_OUT;
 import static org.folio.circulation.domain.policy.DueDateManagement.KEEP_THE_CURRENT_DUE_DATE;
@@ -112,7 +114,6 @@ import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
 import api.support.http.OkapiHeaders;
 import api.support.http.UserResource;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import lombok.val;
@@ -1471,7 +1472,7 @@ class CheckOutByBarcodeTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    FakeStorageModule.addFailure(HttpMethod.POST, PATRON_ACTION_SESSION_STORAGE_PATH, 500);
+    FakeStorageModule.addFailureConfig(POST, PATRON_ACTION_SESSION_STORAGE_PATH, HTTP_INTERNAL_SERVER_ERROR);
     checkOutFixture.attemptCheckOutByBarcode(200,
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
@@ -1498,7 +1499,7 @@ class CheckOutByBarcodeTests extends APITests {
       .withLoanNotices(List.of(uponAtDueDateNoticeConfiguration));
     use(noticePolicy);
 
-    FakeStorageModule.addFailure(HttpMethod.POST, SCHEDULED_NOTICE_STORAGE_PATH, 500);
+    FakeStorageModule.addFailureConfig(POST, SCHEDULED_NOTICE_STORAGE_PATH, HTTP_INTERNAL_SERVER_ERROR);
     checkOutFixture.attemptCheckOutByBarcode(200,
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -1472,7 +1472,7 @@ class CheckOutByBarcodeTests extends APITests {
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
 
-    FakeStorageModule.addFailureConfig(POST, PATRON_ACTION_SESSION_STORAGE_PATH, HTTP_INTERNAL_SERVER_ERROR);
+    FakeStorageModule.addRequestMapping(POST, PATRON_ACTION_SESSION_STORAGE_PATH, HTTP_INTERNAL_SERVER_ERROR);
     checkOutFixture.attemptCheckOutByBarcode(200,
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
@@ -1499,7 +1499,7 @@ class CheckOutByBarcodeTests extends APITests {
       .withLoanNotices(List.of(uponAtDueDateNoticeConfiguration));
     use(noticePolicy);
 
-    FakeStorageModule.addFailureConfig(POST, SCHEDULED_NOTICE_STORAGE_PATH, HTTP_INTERNAL_SERVER_ERROR);
+    FakeStorageModule.addRequestMapping(POST, SCHEDULED_NOTICE_STORAGE_PATH, HTTP_INTERNAL_SERVER_ERROR);
     checkOutFixture.attemptCheckOutByBarcode(200,
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 import api.support.fakes.FakeModNotify;
 import api.support.fakes.FakePubSub;
+import api.support.fakes.FakeStorageModule;
 import api.support.fixtures.AddressTypesFixture;
 import api.support.fixtures.AgeToLostFixture;
 import api.support.fixtures.AutomatedPatronBlocksFixture;
@@ -312,6 +313,7 @@ public abstract class APITests {
 
     FakeModNotify.clearSentPatronNotices();
     FakeModNotify.setFailPatronNoticesWithBadRequest(false);
+    FakeStorageModule.cleanUpFailure();
   }
 
   @AfterEach

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -313,7 +313,7 @@ public abstract class APITests {
 
     FakeModNotify.clearSentPatronNotices();
     FakeModNotify.setFailPatronNoticesWithBadRequest(false);
-    FakeStorageModule.cleanUpFailure();
+    FakeStorageModule.cleanUpFailureConfigs();
   }
 
   @AfterEach

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -313,7 +313,7 @@ public abstract class APITests {
 
     FakeModNotify.clearSentPatronNotices();
     FakeModNotify.setFailPatronNoticesWithBadRequest(false);
-    FakeStorageModule.cleanUpFailureConfigs();
+    FakeStorageModule.cleanUpRequestMappings();
   }
 
   @AfterEach


### PR DESCRIPTION
## Purpose
Check out should respond with 200 in case of partially successful checkout. For full successful checkout, the status code should not be changed.

## Approach
Implement error handling for all actions that follow after creating a loan in the storage. After creating it, an item status should be "checked out" and these not critical issues should be handled with 200 status.

Resolves: [CIRC-1046](https://issues.folio.org/browse/CIRC-1046)
