### PR TITLE
CIRC-1331 Add rule for checking ':' before policy

### DIFF
--- a/src/main/antlr4/org/folio/circulation/rules/CirculationRules.g4
+++ b/src/main/antlr4/org/folio/circulation/rules/CirculationRules.g4
@@ -149,7 +149,7 @@ all : 'all';
 
 fallbackpolicy : 'fallback-policy'
                 ( policies NEWLINE
-                | NEWLINE { notifyErrorListeners("':' symbol is missing"); }
+                | NEWLINE { notifyErrorListeners("Policy missing"); }
                 )
                ;
 

--- a/src/main/antlr4/org/folio/circulation/rules/CirculationRules.g4
+++ b/src/main/antlr4/org/folio/circulation/rules/CirculationRules.g4
@@ -147,7 +147,10 @@ criterium : CRITERIUM_LETTER
 
 all : 'all';
 
-fallbackpolicy : 'fallback-policy' policies NEWLINE
+fallbackpolicy : 'fallback-policy'
+                ( policies NEWLINE
+                | NEWLINE { notifyErrorListeners("Policy missing."); }
+                )
                ;
 
 policies : ':' policy+

--- a/src/main/antlr4/org/folio/circulation/rules/CirculationRules.g4
+++ b/src/main/antlr4/org/folio/circulation/rules/CirculationRules.g4
@@ -149,7 +149,7 @@ all : 'all';
 
 fallbackpolicy : 'fallback-policy'
                 ( policies NEWLINE
-                | NEWLINE { notifyErrorListeners("Policy missing."); }
+                | NEWLINE { notifyErrorListeners("':' symbol is missing"); }
                 )
                ;
 

--- a/src/main/java/org/folio/circulation/rules/Text2Drools.java
+++ b/src/main/java/org/folio/circulation/rules/Text2Drools.java
@@ -164,7 +164,7 @@ public class Text2Drools extends CirculationRulesBaseListener {
     Token token = ctx.getStart();
     if (expr.criterium() != null && expr.policies() == null) {
       throw new CirculationRulesException(
-        "':' symbol is missing", token.getLine(), token.getCharPositionInLine() + 1);
+        "Policy missing", token.getLine(), token.getCharPositionInLine() + 1);
     }
   }
 

--- a/src/main/java/org/folio/circulation/rules/Text2Drools.java
+++ b/src/main/java/org/folio/circulation/rules/Text2Drools.java
@@ -159,6 +159,16 @@ public class Text2Drools extends CirculationRulesBaseListener {
   }
 
   @Override
+  public void enterSimpleStatement(CirculationRulesParser.SimpleStatementContext ctx) {
+    ExprContext expr = ctx.expr();
+    Token token = ctx.getStart();
+    if (expr.criterium() != null && expr.policies() == null) {
+      throw new org.folio.circulation.rules.CirculationRulesException(
+        "Policy missing.", token.getLine(), token.getCharPositionInLine() + 1);
+    }
+  }
+
+  @Override
   public void exitIndent(IndentContext indent) {
     setIndentation(indent.INDENT());
   }

--- a/src/main/java/org/folio/circulation/rules/Text2Drools.java
+++ b/src/main/java/org/folio/circulation/rules/Text2Drools.java
@@ -163,8 +163,8 @@ public class Text2Drools extends CirculationRulesBaseListener {
     ExprContext expr = ctx.expr();
     Token token = ctx.getStart();
     if (expr.criterium() != null && expr.policies() == null) {
-      throw new org.folio.circulation.rules.CirculationRulesException(
-        "Policy missing.", token.getLine(), token.getCharPositionInLine() + 1);
+      throw new CirculationRulesException(
+        "':' symbol is missing", token.getLine(), token.getCharPositionInLine() + 1);
     }
   }
 

--- a/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
+++ b/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
@@ -486,7 +486,7 @@ class Text2DroolsTest {
   void missingColonAfterCriteriaAndBeforePolicy() {
     int unused = 0;
     expectException(HEADER + "g visitor\n   m book",
-      matches("':' symbol is missing", unused, unused));
+      matches("Policy missing", unused, unused));
   }
 
   @Test
@@ -497,7 +497,7 @@ class Text2DroolsTest {
       "fallback-policy");
 
     expectException(rulesText,
-      matches("':' symbol is missing", unused, unused));
+      matches("Policy missing", unused, unused));
   }
 
   @Test

--- a/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
+++ b/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
@@ -692,8 +692,7 @@ class Text2DroolsTest {
   }
 
   private void expectException(String rulesText, Matcher<CirculationRulesException> matches) {
-    assertThat(
-      assertThrows(CirculationRulesException.class, () -> Text2Drools.convert(rulesText)),
+    assertThat(assertThrows(CirculationRulesException.class, () -> Text2Drools.convert(rulesText)),
       matches);
   }
 }

--- a/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
+++ b/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
@@ -483,10 +483,10 @@ class Text2DroolsTest {
   }
 
   @Test
-  void missingColonAfterPolicy() {
+  void missingColonAfterCriteriaAndBeforePolicy() {
     int unused = 0;
     expectException(HEADER + "g visitor\n   m book",
-      matches("Policy missing", unused, unused));
+      matches("':' symbol is missing", unused, unused));
   }
 
   @Test
@@ -497,7 +497,7 @@ class Text2DroolsTest {
       "fallback-policy");
 
     expectException(rulesText,
-      matches("Policy missing", unused, unused));
+      matches("':' symbol is missing", unused, unused));
   }
 
   @Test

--- a/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
+++ b/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
@@ -484,20 +484,17 @@ class Text2DroolsTest {
 
   @Test
   void missingColonAfterCriteriaAndBeforePolicy() {
-    int unused = 0;
     expectException(HEADER + "g visitor\n   m book",
-      matches("Policy missing", unused, unused));
+      matches("Policy missing", 4, 4));
   }
 
   @Test
   void missingColonAfterFallbackPolicy() {
-    int unused = 0;
     String rulesText = String.join("\n",
       "priority: t, s, c, b, a, m, g",
       "fallback-policy");
-
     expectException(rulesText,
-      matches("Policy missing", unused, unused));
+      matches("Policy missing", 2, 16));
   }
 
   @Test
@@ -695,8 +692,8 @@ class Text2DroolsTest {
   }
 
   private void expectException(String rulesText, Matcher<CirculationRulesException> matches) {
-    assertThrows(CirculationRulesException.class, () -> {
-      Text2Drools.convert(rulesText);
-    });
+    assertThat(
+      assertThrows(CirculationRulesException.class, () -> Text2Drools.convert(rulesText)),
+      matches);
   }
 }

--- a/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
+++ b/src/test/java/org/folio/circulation/rules/Text2DroolsTest.java
@@ -483,6 +483,24 @@ class Text2DroolsTest {
   }
 
   @Test
+  void missingColonAfterPolicy() {
+    int unused = 0;
+    expectException(HEADER + "g visitor\n   m book",
+      matches("Policy missing", unused, unused));
+  }
+
+  @Test
+  void missingColonAfterFallbackPolicy() {
+    int unused = 0;
+    String rulesText = String.join("\n",
+      "priority: t, s, c, b, a, m, g",
+      "fallback-policy");
+
+    expectException(rulesText,
+      matches("Policy missing", unused, unused));
+  }
+
+  @Test
   void duplicateLoanPolicy() {
     expectException(HEADER + "m book: l policy-a l policy-b r no-hold n basic-notice o overdue i lost-item",
       matches("Only one policy of type l allowed", 3, 6));


### PR DESCRIPTION
## Purpose
The goal is to fix saving rules when they have unfinished criteria ( without ':' and without policies )

[CIRC-1331](https://issues.folio.org/browse/CIRC-1331)

## Approach
Add rule for fallback-policy and add handler for checking stetements

#### TODOS and Open Questions

## Learning
