### PR TITLE
CIRC-1427 update removing scheduled notices logic

### DIFF
--- a/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
@@ -151,9 +151,7 @@ public class LoanScheduledNoticeHandler extends ScheduledNoticeHandler {
     if (noticeConfig.hasBeforeTiming() && isBeforeMillis(dueDate, systemTime)) {
       logMessages.add("Loan is overdue");
     }
-    if (isRecurringAfterNotice(notice) &&
-      loan.hasItemWithAnyStatus(DECLARED_LOST, ItemStatus.AGED_TO_LOST, CLAIMED_RETURNED)) {
-
+    if (loan.hasItemWithAnyStatus(DECLARED_LOST, ItemStatus.AGED_TO_LOST, CLAIMED_RETURNED)) {
       logMessages.add(String.format("Recurring overdue notice for item in status \"%s\"",
         loan.getItemStatus()));
     }


### PR DESCRIPTION
## Purpose
- Scheduled notices with the time triggers: before once, before recurring, after once should be included in the removing list as not relevant;

Resolves: [CIRC-1427](https://issues.folio.org/browse/CIRC-1427)

## Approach
- update LoanScheduledNoticeHandler;
- add test;
- fix broken tests;