### PR TITLE
CIRC-1169 an error creation was removed if location doesn't exist by …

### DIFF
--- a/src/main/java/org/folio/circulation/rules/CirculationRulesProcessor.java
+++ b/src/main/java/org/folio/circulation/rules/CirculationRulesProcessor.java
@@ -121,8 +121,7 @@ public class CirculationRulesProcessor {
       .using(locationStorageClient)
       .mapTo(Location::from)
       .fetch(params.getLocationId())
-      .thenApply(r -> r.failed()
-        ? Result.succeeded(params)
-        : r.map(params::withLocation));
+      .thenApply(r -> r.map(params::withLocation))
+      .thenApply(r -> r.mapFailure(failure -> succeeded(params)));
   }
 }

--- a/src/main/java/org/folio/circulation/rules/CirculationRulesProcessor.java
+++ b/src/main/java/org/folio/circulation/rules/CirculationRulesProcessor.java
@@ -1,6 +1,5 @@
 package org.folio.circulation.rules;
 
-import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.results.Result.combined;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
@@ -121,8 +120,9 @@ public class CirculationRulesProcessor {
     return FetchSingleRecord.<Location>forRecord("location")
       .using(locationStorageClient)
       .mapTo(Location::from)
-      .whenNotFound(failedValidation("Cannot find location", "location_id", params.getLocationId()))
       .fetch(params.getLocationId())
-      .thenApply(r -> r.map(params::withLocation));
+      .thenApply(r -> r.failed()
+        ? Result.succeeded(params)
+        : r.map(params::withLocation));
   }
 }

--- a/src/main/java/org/folio/circulation/rules/Drools.java
+++ b/src/main/java/org/folio/circulation/rules/Drools.java
@@ -64,9 +64,11 @@ public class Drools {
     kieSession.insert(new LoanType(loanTypeId));
     kieSession.insert(new PatronGroup(patronGroupId));
     kieSession.insert(new ItemLocation(locationId));
-    kieSession.insert(new Institution(location.getInstitutionId()));
-    kieSession.insert(new Campus(location.getCampusId()));
-    kieSession.insert(new Library(location.getLibraryId()));
+    if (location != null) {
+      kieSession.insert(new Institution(location.getInstitutionId()));
+      kieSession.insert(new Campus(location.getCampusId()));
+      kieSession.insert(new Library(location.getLibraryId()));
+    }
 
     return kieSession;
   }

--- a/src/test/java/api/CirculationRulesEngineAPITests.java
+++ b/src/test/java/api/CirculationRulesEngineAPITests.java
@@ -1,11 +1,7 @@
 package api;
 
-import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
-import static api.support.matchers.ValidationErrorMatchers.hasMessage;
-import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
@@ -355,22 +351,16 @@ class CirculationRulesEngineAPITests extends APITests {
   }
 
   @Test
-  void rulesEvaluationFailsWhenTheProvidedLocationDoesNotExist() {
+  void rulesEvaluationPassesWhenTheProvidedLocationDoesNotExist() {
     // The underlying rules are irrelevant
-    setRules(rules1);
+    setRules(rulesWithInstitution);
 
-    final var itemType = new ItemType(UUID.randomUUID().toString());
+    final var itemType = m2;
     final var loanType = new LoanType(UUID.randomUUID().toString());
     final var patronGroup = new PatronGroup(UUID.randomUUID().toString());
     final var locationThatDoesNotExist = new ItemLocation(UUID.randomUUID().toString());
 
-    final var response = circulationRulesFixture
-      .attemptToApplyRulesForRequestPolicy(itemType, loanType,
-        patronGroup, locationThatDoesNotExist);
-
-    assertThat(response.getJson(), hasErrorWith(allOf(
-      hasMessage("Cannot find location"),
-      hasParameter("location_id", locationThatDoesNotExist.id))));
+    assertThat(applyRequestPolicy(itemType, loanType, patronGroup, locationThatDoesNotExist), is(rp2));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
This PR is aimed to achieving consistency by avoiding creating an error when unreal locationId are passed
using /circulation/rules/request-policy endpoint

[CIRC-1169](https://issues.folio.org/browse/CIRC-1169)
 -->

## Approach
remove error creating if location doesn't exist

#### TODOS and Open Questions

## Learning
