### PR TITLE
Pull item repository dependency up CIRC-1418

### DIFF
--- a/src/main/java/org/folio/circulation/StoreLoanAndItem.java
+++ b/src/main/java/org/folio/circulation/StoreLoanAndItem.java
@@ -11,7 +11,6 @@ import org.folio.circulation.domain.Loan;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.resources.context.RenewalContext;
-import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 
 public class StoreLoanAndItem {
@@ -21,11 +20,6 @@ public class StoreLoanAndItem {
   public StoreLoanAndItem(LoanRepository loanRepository, ItemRepository itemRepository) {
     this.loanRepository = loanRepository;
     this.itemRepository = itemRepository;
-  }
-
-  public StoreLoanAndItem(Clients clients) {
-    this(new LoanRepository(clients),
-      new ItemRepository(clients, false, false, false));
   }
 
   public CompletableFuture<Result<RenewalContext>> updateLoanAndItemInStorage(

--- a/src/main/java/org/folio/circulation/StoreLoanAndItem.java
+++ b/src/main/java/org/folio/circulation/StoreLoanAndItem.java
@@ -1,7 +1,6 @@
 package org.folio.circulation;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.folio.circulation.infrastructure.storage.inventory.ItemRepository.noLocationMaterialTypeAndLoanTypeInstance;
 import static org.folio.circulation.support.results.Result.succeeded;
 import static org.folio.circulation.support.results.ResultBinding.mapResult;
 
@@ -25,7 +24,8 @@ public class StoreLoanAndItem {
   }
 
   public StoreLoanAndItem(Clients clients) {
-    this(new LoanRepository(clients), noLocationMaterialTypeAndLoanTypeInstance(clients));
+    this(new LoanRepository(clients),
+      new ItemRepository(clients, false, false, false));
   }
 
   public CompletableFuture<Result<RenewalContext>> updateLoanAndItemInStorage(

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -12,6 +12,7 @@ import static org.folio.circulation.domain.ItemStatus.PAGED;
 import static org.folio.circulation.domain.representations.ItemProperties.EFFECTIVE_LOCATION_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.IN_TRANSIT_DESTINATION_SERVICE_POINT_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.ITEM_COPY_NUMBER_ID;
+import static org.folio.circulation.domain.representations.ItemProperties.LAST_CHECK_IN;
 import static org.folio.circulation.domain.representations.ItemProperties.MATERIAL_TYPE_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.PERMANENT_LOCATION_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.STATUS_PROPERTY;
@@ -434,8 +435,17 @@ public class Item {
   }
 
   public Item withLastCheckIn(LastCheckIn lastCheckIn) {
+    final var changedItemRepresentation= itemRepresentation.copy();
+
+    if (lastCheckIn == null) {
+      itemRepresentation.remove(LAST_CHECK_IN);
+    }
+    else {
+      write(changedItemRepresentation, LAST_CHECK_IN, lastCheckIn.toJson());
+    }
+
     return new Item(
-      this.itemRepresentation,
+      changedItemRepresentation,
       this.location,
       this.primaryServicePoint,
       lastCheckIn,

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -14,8 +14,10 @@ import static org.folio.circulation.domain.representations.ItemProperties.IN_TRA
 import static org.folio.circulation.domain.representations.ItemProperties.ITEM_COPY_NUMBER_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.LAST_CHECK_IN;
 import static org.folio.circulation.domain.representations.ItemProperties.MATERIAL_TYPE_ID;
+import static org.folio.circulation.domain.representations.ItemProperties.PERMANENT_LOAN_TYPE_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.PERMANENT_LOCATION_ID;
 import static org.folio.circulation.domain.representations.ItemProperties.STATUS_PROPERTY;
+import static org.folio.circulation.domain.representations.ItemProperties.TEMPORARY_LOAN_TYPE_ID;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.json.JsonPropertyWriter.remove;
@@ -27,8 +29,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.folio.circulation.domain.representations.ItemProperties;
 
 import io.vertx.core.json.JsonObject;
 import lombok.AllArgsConstructor;
@@ -258,14 +258,8 @@ public class Item {
   }
 
   public String getLoanTypeId() {
-    if (itemRepresentation == null) {
-      return null;
-    }
-
-    return itemRepresentation.containsKey(ItemProperties.TEMPORARY_LOAN_TYPE_ID)
-      && !itemRepresentation.getString(ItemProperties.TEMPORARY_LOAN_TYPE_ID).isEmpty()
-      ? itemRepresentation.getString(ItemProperties.TEMPORARY_LOAN_TYPE_ID)
-      : itemRepresentation.getString(ItemProperties.PERMANENT_LOAN_TYPE_ID);
+    return firstNonBlank(getProperty(itemRepresentation, TEMPORARY_LOAN_TYPE_ID),
+      getProperty(itemRepresentation, PERMANENT_LOAN_TYPE_ID));
   }
 
   public String getLoanTypeName() {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -134,15 +134,15 @@ public class Item {
   }
 
   public String getBarcode() {
-    return getProperty(getItem(), "barcode");
+    return getProperty(itemRepresentation, "barcode");
   }
 
   public String getItemId() {
-    return getProperty(getItem(), "id");
+    return getProperty(itemRepresentation, "id");
   }
 
   public String getHoldingsRecordId() {
-    return getProperty(getItem(), "holdingsRecordId");
+    return getProperty(itemRepresentation, "holdingsRecordId");
   }
 
   public String getInstanceId() {
@@ -178,11 +178,11 @@ public class Item {
   }
 
   public String getStatusName() {
-    return getNestedStringProperty(getItem(), STATUS_PROPERTY, "name");
+    return getNestedStringProperty(itemRepresentation, STATUS_PROPERTY, "name");
   }
 
   private String getStatusDate() {
-    return getNestedStringProperty(getItem(), STATUS_PROPERTY, "date");
+    return getNestedStringProperty(itemRepresentation, STATUS_PROPERTY, "date");
   }
 
   public Location getLocation() {
@@ -203,20 +203,20 @@ public class Item {
 
   public String getCopyNumber() {
     return firstNonBlank(
-      getProperty(getItem(), ITEM_COPY_NUMBER_ID),
+      getProperty(itemRepresentation, ITEM_COPY_NUMBER_ID),
       holdings.getCopyNumber());
   }
 
   public String getMaterialTypeId() {
-    return getProperty(getItem(), MATERIAL_TYPE_ID);
+    return getProperty(itemRepresentation, MATERIAL_TYPE_ID);
   }
 
   public String getLocationId() {
-    return getProperty(getItem(), EFFECTIVE_LOCATION_ID);
+    return getProperty(itemRepresentation, EFFECTIVE_LOCATION_ID);
   }
 
   public String getEnumeration() {
-    return getProperty(getItem(), "enumeration");
+    return getProperty(itemRepresentation, "enumeration");
   }
 
   public String getInTransitDestinationServicePointId() {
@@ -232,19 +232,19 @@ public class Item {
   }
 
   public String getVolume() {
-    return getProperty(getItem(), "volume");
+    return getProperty(itemRepresentation, "volume");
   }
 
   public String getChronology() {
-    return getProperty(getItem(), "chronology");
+    return getProperty(itemRepresentation, "chronology");
   }
 
   public String getNumberOfPieces() {
-    return getProperty(getItem(), "numberOfPieces");
+    return getProperty(itemRepresentation, "numberOfPieces");
   }
 
   public String getDescriptionOfPieces() {
-    return getProperty(getItem(), "descriptionOfPieces");
+    return getProperty(itemRepresentation, "descriptionOfPieces");
   }
 
   public List<String> getYearCaption() {
@@ -257,10 +257,10 @@ public class Item {
   }
 
   public String determineLoanTypeForItem() {
-    return getItem().containsKey(ItemProperties.TEMPORARY_LOAN_TYPE_ID)
-      && !getItem().getString(ItemProperties.TEMPORARY_LOAN_TYPE_ID).isEmpty()
-      ? getItem().getString(ItemProperties.TEMPORARY_LOAN_TYPE_ID)
-      : getItem().getString(ItemProperties.PERMANENT_LOAN_TYPE_ID);
+    return itemRepresentation.containsKey(ItemProperties.TEMPORARY_LOAN_TYPE_ID)
+      && !itemRepresentation.getString(ItemProperties.TEMPORARY_LOAN_TYPE_ID).isEmpty()
+      ? itemRepresentation.getString(ItemProperties.TEMPORARY_LOAN_TYPE_ID)
+      : itemRepresentation.getString(ItemProperties.PERMANENT_LOAN_TYPE_ID);
   }
 
   public String getLoanTypeName() {
@@ -339,7 +339,7 @@ public class Item {
   }
 
   public boolean isFound() {
-    return getItem() != null;
+    return itemRepresentation != null;
   }
 
   public LastCheckIn getLastCheckIn() {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -256,7 +256,11 @@ public class Item {
     return primaryServicePoint;
   }
 
-  public String determineLoanTypeForItem() {
+  public String getLoanTypeId() {
+    if (itemRepresentation == null) {
+      return null;
+    }
+
     return itemRepresentation.containsKey(ItemProperties.TEMPORARY_LOAN_TYPE_ID)
       && !itemRepresentation.getString(ItemProperties.TEMPORARY_LOAN_TYPE_ID).isEmpty()
       ? itemRepresentation.getString(ItemProperties.TEMPORARY_LOAN_TYPE_ID)

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -428,15 +428,10 @@ public class Item {
       loanType);
   }
 
-  public Item withLastCheckIn(LastCheckIn lastCheckIn) {
+  public Item withLastCheckIn(@NonNull LastCheckIn lastCheckIn) {
     final var changedItemRepresentation = itemRepresentation.copy();
 
-    if (lastCheckIn == null) {
-      itemRepresentation.remove(LAST_CHECK_IN);
-    }
-    else {
-      write(changedItemRepresentation, LAST_CHECK_IN, lastCheckIn.toJson());
-    }
+    write(changedItemRepresentation, LAST_CHECK_IN, lastCheckIn.toJson());
 
     return new Item(
       changedItemRepresentation,

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -429,7 +429,7 @@ public class Item {
   }
 
   public Item withLastCheckIn(LastCheckIn lastCheckIn) {
-    final var changedItemRepresentation= itemRepresentation.copy();
+    final var changedItemRepresentation = itemRepresentation.copy();
 
     if (lastCheckIn == null) {
       itemRepresentation.remove(LAST_CHECK_IN);

--- a/src/main/java/org/folio/circulation/domain/OverdueFineService.java
+++ b/src/main/java/org/folio/circulation/domain/OverdueFineService.java
@@ -22,17 +22,14 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.folio.circulation.domain.policy.OverdueFineCalculationParameters;
 import org.folio.circulation.domain.policy.OverdueFineInterval;
 import org.folio.circulation.domain.policy.OverdueFinePolicy;
-import org.folio.circulation.infrastructure.storage.CalendarRepository;
 import org.folio.circulation.infrastructure.storage.feesandfines.FeeFineOwnerRepository;
 import org.folio.circulation.infrastructure.storage.feesandfines.FeeFineRepository;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
-import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
 import org.folio.circulation.infrastructure.storage.loans.OverdueFinePolicyRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.resources.context.RenewalContext;
 import org.folio.circulation.services.FeeFineFacade;
 import org.folio.circulation.services.support.CreateAccountCommand;
-import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.utils.ClockUtil;
 
@@ -48,21 +45,6 @@ public class OverdueFineService {
   private final ScheduledNoticesRepository scheduledNoticesRepository;
   private final OverduePeriodCalculatorService overduePeriodCalculatorService;
   private final FeeFineFacade feeFineFacade;
-
-  public static OverdueFineService using(Clients clients) {
-    return new OverdueFineService(clients,
-      new ItemRepository(clients, true, false, false));
-  }
-
-  private OverdueFineService(Clients clients, ItemRepository itemRepository) {
-    this(new OverdueFinePolicyRepository(clients), itemRepository,
-      new FeeFineOwnerRepository(clients),
-      new FeeFineRepository(clients),
-      ScheduledNoticesRepository.using(clients),
-      new OverduePeriodCalculatorService(new CalendarRepository(clients),
-        new LoanPolicyRepository(clients)),
-      new FeeFineFacade(clients));
-  }
 
   public CompletableFuture<Result<RenewalContext>> createOverdueFineIfNecessary(
     RenewalContext context) {

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -16,15 +16,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
-import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
 public class UpdateItem {
   private final ItemRepository itemRepository;
-
-  public UpdateItem(Clients clients) {
-    itemRepository = new ItemRepository(clients, false, false, false);
-  }
 
   public CompletableFuture<Result<Item>> onCheckIn(Item item, RequestQueue requestQueue,
       UUID checkInServicePointId, String loggedInUserId, ZonedDateTime dateTime) {

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -55,8 +55,7 @@ public class UpdateRequestQueue {
     final var requestRepository = RequestRepository.using(clients, itemRepository,
       userRepository, loanRepository);
 
-    return new UpdateRequestQueue(
-      RequestQueueRepository.using(clients),
+    return new UpdateRequestQueue(new RequestQueueRepository(requestRepository),
       requestRepository,
       new ServicePointRepository(clients),
       new ConfigurationRepository(clients));

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -18,11 +18,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.ServicePointRepository;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
-import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestQueueRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
-import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.context.ReorderRequestContext;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
@@ -47,17 +44,12 @@ public class UpdateRequestQueue {
     this.configurationRepository = configurationRepository;
   }
 
-  public static UpdateRequestQueue using(Clients clients) {
-    final var itemRepository = new ItemRepository(clients);
-    final var userRepository = new UserRepository(clients);
-    final var loanRepository = new LoanRepository(clients, itemRepository,
-      userRepository);
-    final var requestRepository = RequestRepository.using(clients, itemRepository,
-      userRepository, loanRepository);
+  public static UpdateRequestQueue using(Clients clients,
+    RequestRepository requestRepository,
+    RequestQueueRepository requestQueueRepository) {
 
-    return new UpdateRequestQueue(new RequestQueueRepository(requestRepository),
-      requestRepository,
-      new ServicePointRepository(clients),
+    return new UpdateRequestQueue(requestQueueRepository,
+      requestRepository, new ServicePointRepository(clients),
       new ConfigurationRepository(clients));
   }
 

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -18,8 +18,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.ServicePointRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestQueueRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.context.ReorderRequestContext;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
@@ -45,9 +48,16 @@ public class UpdateRequestQueue {
   }
 
   public static UpdateRequestQueue using(Clients clients) {
+    final var itemRepository = new ItemRepository(clients);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository,
+      userRepository);
+    final var requestRepository = RequestRepository.using(clients, itemRepository,
+      userRepository, loanRepository);
+
     return new UpdateRequestQueue(
       RequestQueueRepository.using(clients),
-      RequestRepository.using(clients),
+      requestRepository,
       new ServicePointRepository(clients),
       new ConfigurationRepository(clients));
   }

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
@@ -15,6 +15,7 @@ import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
 import org.folio.circulation.infrastructure.storage.feesandfines.FeeFineActionRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 
@@ -23,8 +24,8 @@ import io.vertx.core.json.JsonObject;
 public class FeeFineScheduledNoticeHandler extends ScheduledNoticeHandler {
   private final FeeFineActionRepository actionRepository;
 
-  public FeeFineScheduledNoticeHandler(Clients clients) {
-    super(clients);
+  public FeeFineScheduledNoticeHandler(Clients clients, ItemRepository itemRepository) {
+    super(clients, itemRepository);
     this.actionRepository = new FeeFineActionRepository(clients);
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
@@ -15,7 +15,7 @@ import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
 import org.folio.circulation.infrastructure.storage.feesandfines.FeeFineActionRepository;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 
@@ -24,8 +24,8 @@ import io.vertx.core.json.JsonObject;
 public class FeeFineScheduledNoticeHandler extends ScheduledNoticeHandler {
   private final FeeFineActionRepository actionRepository;
 
-  public FeeFineScheduledNoticeHandler(Clients clients, ItemRepository itemRepository) {
-    super(clients, itemRepository);
+  public FeeFineScheduledNoticeHandler(Clients clients, LoanRepository loanRepository) {
+    super(clients, loanRepository);
     this.actionRepository = new FeeFineActionRepository(clients);
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedLoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedLoanScheduledNoticeHandler.java
@@ -21,10 +21,9 @@ import org.folio.circulation.domain.notice.ScheduledPatronNoticeService;
 import org.folio.circulation.domain.notice.schedule.ScheduledNoticeHandler.ScheduledNoticeContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.HttpFailure;
-import org.folio.circulation.support.RecordNotFoundFailure;
 import org.folio.circulation.support.results.Result;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,9 +34,11 @@ public class GroupedLoanScheduledNoticeHandler {
   private final LoanScheduledNoticeHandler loanScheduledNoticeHandler;
   private final ScheduledPatronNoticeService patronNoticeService;
 
-  public GroupedLoanScheduledNoticeHandler(Clients clients, ZonedDateTime systemTime) {
+  public GroupedLoanScheduledNoticeHandler(Clients clients,
+    LoanRepository loanRepository, ZonedDateTime systemTime) {
+
     this.loanScheduledNoticeHandler = new LoanScheduledNoticeHandler(clients,
-      new ItemRepository(clients), systemTime);
+      loanRepository, systemTime);
 
     this.patronNoticeService = new ScheduledPatronNoticeService(clients);
   }

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedLoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedLoanScheduledNoticeHandler.java
@@ -21,6 +21,7 @@ import org.folio.circulation.domain.notice.ScheduledPatronNoticeService;
 import org.folio.circulation.domain.notice.schedule.ScheduledNoticeHandler.ScheduledNoticeContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.RecordNotFoundFailure;
@@ -35,7 +36,9 @@ public class GroupedLoanScheduledNoticeHandler {
   private final ScheduledPatronNoticeService patronNoticeService;
 
   public GroupedLoanScheduledNoticeHandler(Clients clients, ZonedDateTime systemTime) {
-    this.loanScheduledNoticeHandler = new LoanScheduledNoticeHandler(clients, systemTime);
+    this.loanScheduledNoticeHandler = new LoanScheduledNoticeHandler(clients,
+      new ItemRepository(clients), systemTime);
+
     this.patronNoticeService = new ScheduledPatronNoticeService(clients);
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ItemLevelRequestScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ItemLevelRequestScheduledNoticeHandler.java
@@ -5,14 +5,17 @@ import static org.folio.circulation.support.results.ResultBinding.mapResult;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 
 public class ItemLevelRequestScheduledNoticeHandler extends RequestScheduledNoticeHandler {
 
-  public ItemLevelRequestScheduledNoticeHandler(Clients clients, ItemRepository itemRepository) {
-    super(clients, itemRepository);
+  public ItemLevelRequestScheduledNoticeHandler(Clients clients,
+    RequestRepository requestRepository, LoanRepository loanRepository) {
+
+    super(clients, loanRepository, requestRepository);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ItemLevelRequestScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ItemLevelRequestScheduledNoticeHandler.java
@@ -5,13 +5,14 @@ import static org.folio.circulation.support.results.ResultBinding.mapResult;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 
 public class ItemLevelRequestScheduledNoticeHandler extends RequestScheduledNoticeHandler {
 
-  public ItemLevelRequestScheduledNoticeHandler(Clients clients) {
-    super(clients);
+  public ItemLevelRequestScheduledNoticeHandler(Clients clients, ItemRepository itemRepository) {
+    super(clients, itemRepository);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
@@ -26,6 +26,7 @@ import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.RecordNotFoundFailure;
@@ -38,8 +39,10 @@ public class LoanScheduledNoticeHandler extends ScheduledNoticeHandler {
   private final LoanPolicyRepository loanPolicyRepository;
   private final ZonedDateTime systemTime;
 
-  public LoanScheduledNoticeHandler(Clients clients, ZonedDateTime systemTime) {
-    super(clients);
+  public LoanScheduledNoticeHandler(Clients clients,
+    ItemRepository itemRepository, ZonedDateTime systemTime) {
+
+    super(clients, itemRepository);
     this.systemTime = systemTime;
     this.loanPolicyRepository = new LoanPolicyRepository(clients);
   }

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
@@ -26,8 +26,8 @@ import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.RecordNotFoundFailure;
 import org.folio.circulation.support.http.client.CqlQuery;
@@ -40,9 +40,9 @@ public class LoanScheduledNoticeHandler extends ScheduledNoticeHandler {
   private final ZonedDateTime systemTime;
 
   public LoanScheduledNoticeHandler(Clients clients,
-    ItemRepository itemRepository, ZonedDateTime systemTime) {
+    LoanRepository loanRepository, ZonedDateTime systemTime) {
 
-    super(clients, itemRepository);
+    super(clients, loanRepository);
     this.systemTime = systemTime;
     this.loanPolicyRepository = new LoanPolicyRepository(clients);
   }

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
@@ -16,10 +16,8 @@ import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.notice.NoticeTiming;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
-import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.rules.CirculationRuleMatch;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
@@ -30,14 +28,11 @@ import io.vertx.core.json.JsonObject;
 public abstract class RequestScheduledNoticeHandler extends ScheduledNoticeHandler {
   protected final RequestRepository requestRepository;
 
-  public RequestScheduledNoticeHandler(Clients clients, ItemRepository itemRepository) {
-    super(clients, itemRepository);
-    final var userRepository = new UserRepository(clients);
-    final var loanRepository = new LoanRepository(clients, itemRepository,
-      userRepository);
+  public RequestScheduledNoticeHandler(Clients clients,
+    LoanRepository loanRepository, RequestRepository requestRepository) {
 
-    this.requestRepository = RequestRepository.using(clients,
-      itemRepository, userRepository, loanRepository);
+    super(clients, loanRepository);
+    this.requestRepository = requestRepository;
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
@@ -29,7 +29,7 @@ public abstract class RequestScheduledNoticeHandler extends ScheduledNoticeHandl
 
   public RequestScheduledNoticeHandler(Clients clients) {
     super(clients);
-    this.requestRepository = RequestRepository.using(clients, true);
+    this.requestRepository = RequestRepository.using(clients);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
@@ -17,7 +17,9 @@ import org.folio.circulation.domain.notice.NoticeTiming;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.rules.CirculationRuleMatch;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
@@ -30,7 +32,12 @@ public abstract class RequestScheduledNoticeHandler extends ScheduledNoticeHandl
 
   public RequestScheduledNoticeHandler(Clients clients, ItemRepository itemRepository) {
     super(clients, itemRepository);
-    this.requestRepository = RequestRepository.using(clients);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository,
+      userRepository);
+
+    this.requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/RequestScheduledNoticeHandler.java
@@ -16,6 +16,7 @@ import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.notice.NoticeTiming;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.rules.CirculationRuleMatch;
 import org.folio.circulation.support.Clients;
@@ -27,8 +28,8 @@ import io.vertx.core.json.JsonObject;
 public abstract class RequestScheduledNoticeHandler extends ScheduledNoticeHandler {
   protected final RequestRepository requestRepository;
 
-  public RequestScheduledNoticeHandler(Clients clients) {
-    super(clients);
+  public RequestScheduledNoticeHandler(Clients clients, ItemRepository itemRepository) {
+    super(clients, itemRepository);
     this.requestRepository = RequestRepository.using(clients);
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
@@ -22,11 +22,9 @@ import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.notice.ScheduledPatronNoticeService;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.infrastructure.storage.feesandfines.AccountRepository;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.PatronNoticePolicyRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
-import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.rules.CirculationRuleMatch;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.support.Clients;
@@ -53,11 +51,9 @@ public abstract class ScheduledNoticeHandler {
   protected final ScheduledPatronNoticeService patronNoticeService;
   protected final EventPublisher eventPublisher;
 
-  protected ScheduledNoticeHandler(Clients clients, ItemRepository itemRepository) {
-    final var userRepository = new UserRepository(clients);
-
+  protected ScheduledNoticeHandler(Clients clients, LoanRepository loanRepository) {
     this.scheduledNoticesRepository = ScheduledNoticesRepository.using(clients);
-    this.loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    this.loanRepository = loanRepository;
     this.accountRepository = new AccountRepository(clients);
     this.patronNoticePolicyRepository = new PatronNoticePolicyRepository(clients);
     this.templateNoticesClient = clients.noticeTemplatesClient();

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
@@ -22,9 +22,11 @@ import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.notice.ScheduledPatronNoticeService;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.infrastructure.storage.feesandfines.AccountRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.PatronNoticePolicyRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.rules.CirculationRuleMatch;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.support.Clients;
@@ -52,8 +54,11 @@ public abstract class ScheduledNoticeHandler {
   protected final EventPublisher eventPublisher;
 
   protected ScheduledNoticeHandler(Clients clients) {
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var userRepository = new UserRepository(clients);
+
     this.scheduledNoticesRepository = ScheduledNoticesRepository.using(clients);
-    this.loanRepository = new LoanRepository(clients);
+    this.loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     this.accountRepository = new AccountRepository(clients);
     this.patronNoticePolicyRepository = new PatronNoticePolicyRepository(clients);
     this.templateNoticesClient = clients.noticeTemplatesClient();

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
@@ -53,8 +53,7 @@ public abstract class ScheduledNoticeHandler {
   protected final ScheduledPatronNoticeService patronNoticeService;
   protected final EventPublisher eventPublisher;
 
-  protected ScheduledNoticeHandler(Clients clients) {
-    final var itemRepository = new ItemRepository(clients);
+  protected ScheduledNoticeHandler(Clients clients, ItemRepository itemRepository) {
     final var userRepository = new UserRepository(clients);
 
     this.scheduledNoticesRepository = ScheduledNoticesRepository.using(clients);

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
@@ -54,7 +54,7 @@ public abstract class ScheduledNoticeHandler {
   protected final EventPublisher eventPublisher;
 
   protected ScheduledNoticeHandler(Clients clients) {
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
 
     this.scheduledNoticesRepository = ScheduledNoticesRepository.using(clients);

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/TitleLevelRequestScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/TitleLevelRequestScheduledNoticeHandler.java
@@ -5,13 +5,14 @@ import static org.folio.circulation.support.results.ResultBinding.mapResult;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 
 public class TitleLevelRequestScheduledNoticeHandler extends RequestScheduledNoticeHandler {
 
-  public TitleLevelRequestScheduledNoticeHandler(Clients clients) {
-    super(clients);
+  public TitleLevelRequestScheduledNoticeHandler(Clients clients, ItemRepository itemRepository) {
+    super(clients, itemRepository);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/TitleLevelRequestScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/TitleLevelRequestScheduledNoticeHandler.java
@@ -5,14 +5,17 @@ import static org.folio.circulation.support.results.ResultBinding.mapResult;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 
 public class TitleLevelRequestScheduledNoticeHandler extends RequestScheduledNoticeHandler {
 
-  public TitleLevelRequestScheduledNoticeHandler(Clients clients, ItemRepository itemRepository) {
-    super(clients, itemRepository);
+  public TitleLevelRequestScheduledNoticeHandler(Clients clients,
+    RequestRepository requestRepository, LoanRepository loanRepository) {
+
+    super(clients, loanRepository, requestRepository);
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionService.java
@@ -56,9 +56,10 @@ public class PatronActionSessionService {
   private final ImmediatePatronNoticeService patronNoticeService;
   protected final EventPublisher eventPublisher;
 
-  public static PatronActionSessionService using(Clients clients) {
-    return new PatronActionSessionService(
-      PatronActionSessionRepository.using(clients),
+  public static PatronActionSessionService using(Clients clients,
+    PatronActionSessionRepository patronActionSessionRepository) {
+
+    return new PatronActionSessionService(patronActionSessionRepository,
       new ImmediatePatronNoticeService(clients, new LoanNoticeContextCombiner()),
       new EventPublisher(clients.pubSubPublishingService()));
   }

--- a/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
@@ -3,7 +3,6 @@ package org.folio.circulation.domain.representations;
 import static org.folio.circulation.domain.representations.CallNumberComponentsRepresentation.createCallNumberComponents;
 import static org.folio.circulation.domain.representations.ContributorsToNamesMapper.mapContributorNamesToJson;
 import static org.folio.circulation.domain.representations.ItemProperties.CALL_NUMBER_COMPONENTS;
-import static org.folio.circulation.domain.representations.ItemProperties.LAST_CHECK_IN;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.folio.circulation.support.json.JsonPropertyWriter.writeByPath;
 
@@ -75,14 +74,5 @@ public class ItemSummaryRepresentation {
     writeByPath(itemSummary, item.getMaterialTypeName(), "materialType", "name");
 
     return itemSummary;
-  }
-
-  public JsonObject createItemStorageRepresentation(Item item) {
-    JsonObject summary = item.getItem().copy();
-    if (item.getLastCheckIn() != null) {
-      write(summary, LAST_CHECK_IN, item.getLastCheckIn().toJson());
-    }
-
-    return summary;
   }
 }

--- a/src/main/java/org/folio/circulation/domain/validation/CheckOutValidators.java
+++ b/src/main/java/org/folio/circulation/domain/validation/CheckOutValidators.java
@@ -67,7 +67,7 @@ public class CheckOutValidators {
 
     this.errorHandler = errorHandler;
 
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
 

--- a/src/main/java/org/folio/circulation/domain/validation/CheckOutValidators.java
+++ b/src/main/java/org/folio/circulation/domain/validation/CheckOutValidators.java
@@ -36,9 +36,7 @@ import org.folio.circulation.domain.representations.CheckOutByBarcodeRequest;
 import org.folio.circulation.domain.validation.overriding.BlockValidator;
 import org.folio.circulation.domain.validation.overriding.OverridingLoanValidator;
 import org.folio.circulation.infrastructure.storage.AutomatedPatronBlocksRepository;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
-import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.handlers.error.CirculationErrorHandler;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.ValidationErrorFailure;
@@ -63,13 +61,10 @@ public class CheckOutValidators {
   private final CirculationErrorHandler errorHandler;
 
   public CheckOutValidators(CheckOutByBarcodeRequest request, Clients clients,
-    CirculationErrorHandler errorHandler, OkapiPermissions permissions) {
+    CirculationErrorHandler errorHandler, OkapiPermissions permissions,
+    LoanRepository loanRepository) {
 
     this.errorHandler = errorHandler;
-
-    final var itemRepository = new ItemRepository(clients);
-    final var userRepository = new UserRepository(clients);
-    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
 
     final AutomatedPatronBlocksRepository automatedPatronBlocksRepository =
       new AutomatedPatronBlocksRepository(clients);
@@ -100,7 +95,8 @@ public class CheckOutValidators {
     openLoanValidator = new ExistingOpenLoanValidator(loanRepository,
       message -> singleValidationError(message, ITEM_BARCODE, request.getItemBarcode()));
 
-    itemLimitValidator = createItemLimitValidator(request, permissions, loanRepository);
+    itemLimitValidator = createItemLimitValidator(request, permissions,
+      loanRepository);
 
     automatedPatronBlocksValidator = createAutomatedPatronBlocksValidator(request, permissions,
       automatedPatronBlocksRepository);

--- a/src/main/java/org/folio/circulation/domain/validation/CheckOutValidators.java
+++ b/src/main/java/org/folio/circulation/domain/validation/CheckOutValidators.java
@@ -36,7 +36,9 @@ import org.folio.circulation.domain.representations.CheckOutByBarcodeRequest;
 import org.folio.circulation.domain.validation.overriding.BlockValidator;
 import org.folio.circulation.domain.validation.overriding.OverridingLoanValidator;
 import org.folio.circulation.infrastructure.storage.AutomatedPatronBlocksRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.handlers.error.CirculationErrorHandler;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.ValidationErrorFailure;
@@ -65,7 +67,9 @@ public class CheckOutValidators {
 
     this.errorHandler = errorHandler;
 
-    final LoanRepository loanRepository = new LoanRepository(clients);
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
 
     final AutomatedPatronBlocksRepository automatedPatronBlocksRepository =
       new AutomatedPatronBlocksRepository(clients);

--- a/src/main/java/org/folio/circulation/domain/validation/ItemLimitValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ItemLimitValidator.java
@@ -66,7 +66,7 @@ public class ItemLimitValidator {
     }
 
     Item item = records.getLoan().getItem();
-    String loanTypeId = item.determineLoanTypeForItem();
+    String loanTypeId = item.getLoanTypeId();
     Integer itemLimit = records.getLoan().getLoanPolicy().getItemLimit();
     AppliedRuleConditions ruleConditions = records.getLoan().getLoanPolicy().getRuleConditions();
 
@@ -100,7 +100,7 @@ public class ItemLimitValidator {
     }
 
     return expectedLoanType != null
-      && expectedLoanType.equals(loanRecord.getItem().determineLoanTypeForItem());
+      && expectedLoanType.equals(loanRecord.getItem().getLoanTypeId());
   }
 
   private String getErrorMessage(AppliedRuleConditions ruleConditionsEntity) {

--- a/src/main/java/org/folio/circulation/infrastructure/storage/CirculationPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/CirculationPolicyRepository.java
@@ -109,7 +109,7 @@ public abstract class CirculationPolicyRepository<T> {
       return completedFuture(failedDueToServerError("Unable to apply circulation rules to an item with null value as locationId"));
     }
 
-    if (item.determineLoanTypeForItem() == null) {
+    if (item.getLoanTypeId() == null) {
       log.error("LoanTypeId is null for item {}", item.getItemId());
       return completedFuture(failedDueToServerError("Unable to apply circulation rules to an item which loan type can not be determined"));
     }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/CirculationPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/CirculationPolicyRepository.java
@@ -126,8 +126,6 @@ public abstract class CirculationPolicyRepository<T> {
 
   protected abstract Result<T> toPolicy(JsonObject representation, AppliedRuleConditions ruleConditionsEntity);
 
-  protected abstract String fetchPolicyId(JsonObject jsonObject);
-
   protected abstract CompletableFuture<Result<CirculationRuleMatch>> getPolicyAndMatch(
     RulesExecutionParameters rulesExecutionParameters);
 }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -46,6 +46,7 @@ import org.folio.circulation.storage.mappers.HoldingsMapper;
 import org.folio.circulation.storage.mappers.InstanceMapper;
 import org.folio.circulation.storage.mappers.LoanTypeMapper;
 import org.folio.circulation.storage.mappers.MaterialTypeMapper;
+import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FindWithCqlQuery;
 import org.folio.circulation.support.FindWithMultipleCqlIndexValues;
@@ -76,7 +77,7 @@ public class ItemRepository {
 
   private static final String ITEMS_COLLECTION_PROPERTY_NAME = "items";
 
-  public ItemRepository(org.folio.circulation.support.Clients clients,
+  public ItemRepository(Clients clients,
     boolean fetchLocation, boolean fetchMaterialType, boolean fetchLoanType) {
 
     this(clients.itemsStorage(), clients.holdingsStorage(),

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -500,8 +500,4 @@ public class ItemRepository {
       .thenComposeAsync(this::fetchMaterialType)
       .thenComposeAsync(this::fetchLoanType);
   }
-
-  public static ItemRepository noLocationMaterialTypeAndLoanTypeInstance(org.folio.circulation.support.Clients clients) {
-    return new ItemRepository(clients, false, false, false);
-  }
 }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanPolicyRepository.java
@@ -171,11 +171,6 @@ public class LoanPolicyRepository extends CirculationPolicyRepository<LoanPolicy
   }
 
   @Override
-  protected String fetchPolicyId(JsonObject jsonObject) {
-    return jsonObject.getString("loanPolicyId");
-  }
-
-  @Override
   protected CompletableFuture<Result<CirculationRuleMatch>> getPolicyAndMatch(
     RulesExecutionParameters rulesExecutionParameters) {
 

--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
@@ -79,10 +79,12 @@ public class LoanRepository implements GetManyRecordsRepository<Loan> {
   private static final String ITEM_ID = "itemId";
   private static final String USER_ID = "userId";
 
-  public LoanRepository(Clients clients) {
+  public LoanRepository(Clients clients, ItemRepository itemRepository,
+    UserRepository userRepository) {
+
     loansStorageClient = clients.loansStorage();
-    itemRepository = new ItemRepository(clients, true, true, true);
-    userRepository = new UserRepository(clients);
+    this.itemRepository = itemRepository;
+    this.userRepository = userRepository;
   }
 
   public CompletableFuture<Result<LoanAndRelatedRecords>> createLoan(

--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/LostItemPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/LostItemPolicyRepository.java
@@ -53,11 +53,6 @@ public class LostItemPolicyRepository extends CirculationPolicyRepository<LostIt
     return succeeded(LostItemPolicy.from(representation));
   }
 
-  @Override
-  protected String fetchPolicyId(JsonObject jsonObject) {
-    return jsonObject.getString("lostItemPolicyId");
-  }
-
   public CompletableFuture<Result<MultipleRecords<Loan>>> findLostItemPoliciesForLoans(
     MultipleRecords<Loan> multipleLoans) {
 

--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/OverdueFinePolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/OverdueFinePolicyRepository.java
@@ -53,11 +53,6 @@ public class OverdueFinePolicyRepository extends CirculationPolicyRepository<Ove
     return succeeded(OverdueFinePolicy.from((representation)));
   }
 
-  @Override
-  protected String fetchPolicyId(JsonObject jsonObject) {
-    return jsonObject.getString("overdueFinePolicyId");
-  }
-
   public CompletableFuture<Result<MultipleRecords<Loan>>>
     findOverdueFinePoliciesForLoans(MultipleRecords<Loan> multipleLoans) {
 

--- a/src/main/java/org/folio/circulation/infrastructure/storage/notices/PatronNoticePolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/notices/PatronNoticePolicyRepository.java
@@ -40,11 +40,6 @@ public class PatronNoticePolicyRepository extends CirculationPolicyRepository<Pa
   }
 
   @Override
-  protected String fetchPolicyId(JsonObject jsonObject) {
-    return jsonObject.getString("noticePolicyId");
-  }
-
-  @Override
   protected CompletableFuture<Result<CirculationRuleMatch>> getPolicyAndMatch(
     RulesExecutionParameters rulesExecutionParameters) {
 

--- a/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestPolicyRepository.java
@@ -71,7 +71,7 @@ public class RequestPolicyRepository {
 
     String materialTypeId = item.getMaterialTypeId();
     String patronGroupId = user.getPatronGroupId();
-    String loanTypeId = item.determineLoanTypeForItem();
+    String loanTypeId = item.getLoanTypeId();
     String locationId = item.getLocationId();
 
     log.info(

--- a/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestQueueRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestQueueRepository.java
@@ -24,6 +24,9 @@ import org.folio.circulation.domain.RequestAndRelatedRecords;
 import org.folio.circulation.domain.RequestQueue;
 import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.domain.configuration.TlrSettingsConfiguration;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.context.RenewalContext;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.http.client.CqlQuery;
@@ -41,7 +44,11 @@ public class RequestQueueRepository {
   }
 
   public static RequestQueueRepository using(Clients clients) {
-    return new RequestQueueRepository(RequestRepository.using(clients));
+    final ItemRepository itemRepository = new ItemRepository(clients);
+    final UserRepository userRepository = new UserRepository(clients);
+    return new RequestQueueRepository(RequestRepository.using(clients,
+      itemRepository, userRepository, new LoanRepository(clients,
+        itemRepository, userRepository)));
   }
 
   public CompletableFuture<Result<LoanAndRelatedRecords>> get(LoanAndRelatedRecords records) {

--- a/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestQueueRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestQueueRepository.java
@@ -24,32 +24,19 @@ import org.folio.circulation.domain.RequestAndRelatedRecords;
 import org.folio.circulation.domain.RequestQueue;
 import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.domain.configuration.TlrSettingsConfiguration;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
-import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
-import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.context.RenewalContext;
-import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.results.Result;
 
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
 public class RequestQueueRepository {
   private static final Logger LOG = LogManager.getLogger(RequestQueueRepository.class);
 
   private static final PageLimit MAXIMUM_SUPPORTED_REQUEST_QUEUE_SIZE = oneThousand();
   private final RequestRepository requestRepository;
-
-  private RequestQueueRepository(RequestRepository requestRepository) {
-    this.requestRepository = requestRepository;
-  }
-
-  public static RequestQueueRepository using(Clients clients) {
-    final ItemRepository itemRepository = new ItemRepository(clients);
-    final UserRepository userRepository = new UserRepository(clients);
-    return new RequestQueueRepository(RequestRepository.using(clients,
-      itemRepository, userRepository, new LoanRepository(clients,
-        itemRepository, userRepository)));
-  }
 
   public CompletableFuture<Result<LoanAndRelatedRecords>> get(LoanAndRelatedRecords records) {
     Item item = records.getItem();

--- a/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestRepository.java
@@ -84,7 +84,7 @@ public class RequestRepository {
   }
 
   public static RequestRepository using(org.folio.circulation.support.Clients clients) {
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
 

--- a/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestRepository.java
@@ -84,16 +84,14 @@ public class RequestRepository {
   }
 
   public static RequestRepository using(org.folio.circulation.support.Clients clients) {
-    return using(clients, false);
-  }
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
 
-  public static RequestRepository using(org.folio.circulation.support.Clients clients, boolean fetchMaterialType) {
     return new RequestRepository(
       new Clients(clients.requestsStorage(), clients.requestsBatchStorage(),
         clients.cancellationReasonStorage()),
-      new ItemRepository(clients, true, fetchMaterialType, true),
-      new UserRepository(clients),
-      new LoanRepository(clients),
+      itemRepository, userRepository, loanRepository,
       new ServicePointRepository(clients),
       new PatronGroupRepository(clients),
       new InstanceRepository(clients));

--- a/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestRepository.java
@@ -83,10 +83,10 @@ public class RequestRepository {
     this.instanceRepository = instanceRepository;
   }
 
-  public static RequestRepository using(org.folio.circulation.support.Clients clients) {
-    final var itemRepository = new ItemRepository(clients);
-    final var userRepository = new UserRepository(clients);
-    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+  public static RequestRepository using(
+    org.folio.circulation.support.Clients clients,
+    ItemRepository itemRepository, UserRepository userRepository,
+    LoanRepository loanRepository) {
 
     return new RequestRepository(
       new Clients(clients.requestsStorage(), clients.requestsBatchStorage(),

--- a/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
@@ -68,7 +68,7 @@ public class PatronActionSessionRepository {
   public static PatronActionSessionRepository using(Clients clients) {
     return new PatronActionSessionRepository(
       clients.patronActionSessionsStorageClient(),
-      new LoanRepository(clients, new ItemRepository(clients, true, true, true),
+      new LoanRepository(clients, new ItemRepository(clients),
         new UserRepository(clients)),
       new UserRepository(clients),
       new LoanPolicyRepository(clients),

--- a/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
@@ -41,7 +41,6 @@ import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.notice.session.ExpiredSession;
 import org.folio.circulation.domain.notice.session.PatronActionType;
 import org.folio.circulation.domain.notice.session.PatronSessionRecord;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.inventory.LocationRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
@@ -65,12 +64,12 @@ public class PatronActionSessionRepository {
   private final UserRepository userRepository;
   private final LocationRepository locationRepository;
 
-  public static PatronActionSessionRepository using(Clients clients) {
+  public static PatronActionSessionRepository using(Clients clients,
+    LoanRepository loanRepository, UserRepository userRepository) {
+
     return new PatronActionSessionRepository(
       clients.patronActionSessionsStorageClient(),
-      new LoanRepository(clients, new ItemRepository(clients),
-        new UserRepository(clients)),
-      new UserRepository(clients),
+      loanRepository, userRepository,
       new LoanPolicyRepository(clients),
       LocationRepository.using(clients));
   }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
@@ -41,6 +41,7 @@ import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.notice.session.ExpiredSession;
 import org.folio.circulation.domain.notice.session.PatronActionType;
 import org.folio.circulation.domain.notice.session.PatronSessionRecord;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.inventory.LocationRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
@@ -67,7 +68,8 @@ public class PatronActionSessionRepository {
   public static PatronActionSessionRepository using(Clients clients) {
     return new PatronActionSessionRepository(
       clients.patronActionSessionsStorageClient(),
-      new LoanRepository(clients),
+      new LoanRepository(clients, new ItemRepository(clients, true, true, true),
+        new UserRepository(clients)),
       new UserRepository(clients),
       new LoanPolicyRepository(clients),
       LocationRepository.using(clients));

--- a/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
+++ b/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
@@ -26,6 +26,7 @@ import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestQueueRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.support.Clients;
@@ -66,11 +67,13 @@ public class ChangeDueDateResource extends Resource {
     final WebContext context = new WebContext(routingContext);
     final Clients clients = Clients.create(context, client);
 
-    final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
-
-    final LoanRepository loanRepository = new LoanRepository(clients,
-      new ItemRepository(clients),
-      new UserRepository(clients));
+    final var itemRepository = new ItemRepository(clients);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients,
+      new ItemRepository(clients), new UserRepository(clients));
+    final var requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
+    final var requestQueueRepository = new RequestQueueRepository(requestRepository);
 
     final LoanScheduledNoticeService scheduledNoticeService
       = LoanScheduledNoticeService.using(clients);

--- a/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
+++ b/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
@@ -69,7 +69,7 @@ public class ChangeDueDateResource extends Resource {
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
 
     final LoanRepository loanRepository = new LoanRepository(clients,
-      new ItemRepository(clients, true, true, true),
+      new ItemRepository(clients),
       new UserRepository(clients));
 
     final LoanScheduledNoticeService scheduledNoticeService

--- a/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
+++ b/src/main/java/org/folio/circulation/resources/ChangeDueDateResource.java
@@ -69,8 +69,7 @@ public class ChangeDueDateResource extends Resource {
 
     final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
-    final var loanRepository = new LoanRepository(clients,
-      new ItemRepository(clients), new UserRepository(clients));
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final var requestRepository = RequestRepository.using(clients,
       itemRepository, userRepository, loanRepository);
     final var requestQueueRepository = new RequestQueueRepository(requestRepository);

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -6,13 +6,15 @@ import static org.folio.circulation.support.ValidationErrorFailure.singleValidat
 
 import org.folio.circulation.domain.CheckInContext;
 import org.folio.circulation.domain.Item;
-import org.folio.circulation.domain.RequestAndRelatedRecords;
 import org.folio.circulation.domain.notice.schedule.RequestScheduledNoticeService;
 import org.folio.circulation.domain.notice.session.PatronActionSessionService;
 import org.folio.circulation.domain.representations.CheckInByBarcodeRequest;
 import org.folio.circulation.domain.representations.CheckInByBarcodeResponse;
 import org.folio.circulation.domain.validation.CheckInValidators;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.sessions.PatronActionSessionRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.support.Clients;
@@ -43,6 +45,10 @@ public class CheckInByBarcodeResource extends Resource {
 
     final Clients clients = Clients.create(context, client);
 
+    final var userRepository = new UserRepository(clients);
+    final var itemRepository = new ItemRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+
     final Result<CheckInByBarcodeRequest> checkInRequestResult
       = CheckInByBarcodeRequest.from(routingContext.getBodyAsJson());
 
@@ -55,9 +61,8 @@ public class CheckInByBarcodeResource extends Resource {
       RequestScheduledNoticeService.using(clients);
 
     final PatronActionSessionService patronActionSessionService =
-      PatronActionSessionService.using(clients);
-
-    final UserRepository userRepository = new UserRepository(clients);
+      PatronActionSessionService.using(clients,
+        PatronActionSessionRepository.using(clients, loanRepository, userRepository));
 
     final RequestNoticeSender requestNoticeSender = RequestNoticeSender.using(clients);
 

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -50,6 +50,8 @@ public class CheckInByBarcodeResource extends Resource {
     final var userRepository = new UserRepository(clients);
     final var itemRepository = new ItemRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final var requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
 
     final Result<CheckInByBarcodeRequest> checkInRequestResult
       = CheckInByBarcodeRequest.from(routingContext.getBodyAsJson());
@@ -58,11 +60,8 @@ public class CheckInByBarcodeResource extends Resource {
 
     final var checkInValidators = new CheckInValidators(this::errorWhenInIncorrectStatus);
     final CheckInProcessAdapter processAdapter = CheckInProcessAdapter.newInstance(clients,
-      itemRepository, userRepository,
-      loanRepository, RequestRepository.using(clients,
-        itemRepository, userRepository, loanRepository), new RequestQueueRepository(
-        RequestRepository.using(clients,
-            itemRepository, userRepository, loanRepository)));
+      itemRepository, userRepository, loanRepository, requestRepository,
+      new RequestQueueRepository(requestRepository));
 
     final RequestScheduledNoticeService requestScheduledNoticeService =
       RequestScheduledNoticeService.using(clients);

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -14,6 +14,8 @@ import org.folio.circulation.domain.validation.CheckInValidators;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestQueueRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.infrastructure.storage.sessions.PatronActionSessionRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.services.EventPublisher;
@@ -55,7 +57,12 @@ public class CheckInByBarcodeResource extends Resource {
     final EventPublisher eventPublisher = new EventPublisher(routingContext);
 
     final var checkInValidators = new CheckInValidators(this::errorWhenInIncorrectStatus);
-    final CheckInProcessAdapter processAdapter = CheckInProcessAdapter.newInstance(clients);
+    final CheckInProcessAdapter processAdapter = CheckInProcessAdapter.newInstance(clients,
+      itemRepository, userRepository,
+      loanRepository, RequestRepository.using(clients,
+        itemRepository, userRepository, loanRepository), new RequestQueueRepository(
+        RequestRepository.using(clients,
+            itemRepository, userRepository, loanRepository)));
 
     final RequestScheduledNoticeService requestScheduledNoticeService =
       RequestScheduledNoticeService.using(clients);

--- a/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
@@ -94,10 +94,9 @@ class CheckInProcessAdapter {
   }
 
   public static CheckInProcessAdapter newInstance(Clients clients) {
-    final LoanRepository loanRepository = new LoanRepository(clients);
-    final UserRepository userRepository = new UserRepository(clients);
-
-    final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
 
     final ItemByBarcodeInStorageFinder itemFinder =
       new ItemByBarcodeInStorageFinder(itemRepository);

--- a/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
@@ -118,7 +118,7 @@ class CheckInProcessAdapter {
       singleOpenLoanFinder,
       new LoanCheckInService(),
       RequestQueueRepository.using(clients),
-      new UpdateItem(clients),
+      new UpdateItem(itemRepository),
       UpdateRequestQueue.using(clients),
       loanRepository,
       new ServicePointRepository(clients),

--- a/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
@@ -94,7 +94,7 @@ class CheckInProcessAdapter {
   }
 
   public static CheckInProcessAdapter newInstance(Clients clients) {
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
 

--- a/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
@@ -115,6 +115,7 @@ class CheckInProcessAdapter {
       new OverduePeriodCalculatorService(new CalendarRepository(clients),
         new LoanPolicyRepository(clients)),
       new FeeFineFacade(clients));
+
     return new CheckInProcessAdapter(itemFinder,
       singleOpenLoanFinder,
       new LoanCheckInService(),
@@ -129,7 +130,8 @@ class CheckInProcessAdapter {
       new LogCheckInService(clients),
       overdueFineService,
       FeeFineScheduledNoticeService.using(clients),
-      new LostItemFeeRefundService(clients),
+      new LostItemFeeRefundService(clients, itemRepository,
+        userRepository, loanRepository),
       new EventPublisher(clients.pubSubPublishingService()));
   }
 

--- a/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
@@ -100,9 +100,9 @@ class CheckInProcessAdapter {
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final var requestRepository = RequestRepository.using(clients,
       itemRepository, userRepository, loanRepository);
+    final var requestQueueRepository = new RequestQueueRepository(requestRepository);
 
-    final ItemByBarcodeInStorageFinder itemFinder =
-      new ItemByBarcodeInStorageFinder(itemRepository);
+    final var itemFinder = new ItemByBarcodeInStorageFinder(itemRepository);
 
     final SingleOpenLoanForItemInStorageFinder singleOpenLoanFinder
       = new SingleOpenLoanForItemInStorageFinder(loanRepository, userRepository, true);
@@ -115,13 +115,13 @@ class CheckInProcessAdapter {
       new OverduePeriodCalculatorService(new CalendarRepository(clients),
         new LoanPolicyRepository(clients)),
       new FeeFineFacade(clients));
-
     return new CheckInProcessAdapter(itemFinder,
       singleOpenLoanFinder,
       new LoanCheckInService(),
-      new RequestQueueRepository(requestRepository),
+      requestQueueRepository,
       new UpdateItem(itemRepository),
-      UpdateRequestQueue.using(clients),
+      UpdateRequestQueue.using(clients, requestRepository,
+        requestQueueRepository),
       loanRepository,
       new ServicePointRepository(clients),
       userRepository,

--- a/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
@@ -31,6 +31,7 @@ import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.loans.OverdueFinePolicyRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestQueueRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.infrastructure.storage.users.AddressTypeRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.services.EventPublisher;
@@ -97,6 +98,8 @@ class CheckInProcessAdapter {
     final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final var requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
 
     final ItemByBarcodeInStorageFinder itemFinder =
       new ItemByBarcodeInStorageFinder(itemRepository);
@@ -116,7 +119,7 @@ class CheckInProcessAdapter {
     return new CheckInProcessAdapter(itemFinder,
       singleOpenLoanFinder,
       new LoanCheckInService(),
-      RequestQueueRepository.using(clients),
+      new RequestQueueRepository(requestRepository),
       new UpdateItem(itemRepository),
       UpdateRequestQueue.using(clients),
       loanRepository,

--- a/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
@@ -14,19 +14,27 @@ import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanCheckInService;
 import org.folio.circulation.domain.OverdueFineService;
+import org.folio.circulation.domain.OverduePeriodCalculatorService;
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestQueue;
 import org.folio.circulation.domain.ServicePoint;
 import org.folio.circulation.domain.UpdateItem;
 import org.folio.circulation.domain.UpdateRequestQueue;
 import org.folio.circulation.domain.notice.schedule.FeeFineScheduledNoticeService;
+import org.folio.circulation.infrastructure.storage.CalendarRepository;
 import org.folio.circulation.infrastructure.storage.ServicePointRepository;
+import org.folio.circulation.infrastructure.storage.feesandfines.FeeFineOwnerRepository;
+import org.folio.circulation.infrastructure.storage.feesandfines.FeeFineRepository;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.loans.OverdueFinePolicyRepository;
+import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestQueueRepository;
 import org.folio.circulation.infrastructure.storage.users.AddressTypeRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.services.EventPublisher;
+import org.folio.circulation.services.FeeFineFacade;
 import org.folio.circulation.services.LogCheckInService;
 import org.folio.circulation.services.LostItemFeeRefundService;
 import org.folio.circulation.storage.ItemByBarcodeInStorageFinder;
@@ -97,6 +105,15 @@ class CheckInProcessAdapter {
     final SingleOpenLoanForItemInStorageFinder singleOpenLoanFinder
       = new SingleOpenLoanForItemInStorageFinder(loanRepository, userRepository, true);
 
+    final var overdueFineService = new OverdueFineService(
+      new OverdueFinePolicyRepository(clients), itemRepository,
+      new FeeFineOwnerRepository(clients),
+      new FeeFineRepository(clients),
+      ScheduledNoticesRepository.using(clients),
+      new OverduePeriodCalculatorService(new CalendarRepository(clients),
+        new LoanPolicyRepository(clients)),
+      new FeeFineFacade(clients));
+
     return new CheckInProcessAdapter(itemFinder,
       singleOpenLoanFinder,
       new LoanCheckInService(),
@@ -108,7 +125,7 @@ class CheckInProcessAdapter {
       userRepository,
       new AddressTypeRepository(clients),
       new LogCheckInService(clients),
-      OverdueFineService.using(clients),
+      overdueFineService,
       FeeFineScheduledNoticeService.using(clients),
       new LostItemFeeRefundService(clients),
       new EventPublisher(clients.pubSubPublishingService()));

--- a/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
@@ -94,13 +94,10 @@ class CheckInProcessAdapter {
     this.eventPublisher = eventPublisher;
   }
 
-  public static CheckInProcessAdapter newInstance(Clients clients) {
-    final var itemRepository = new ItemRepository(clients);
-    final var userRepository = new UserRepository(clients);
-    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
-    final var requestRepository = RequestRepository.using(clients,
-      itemRepository, userRepository, loanRepository);
-    final var requestQueueRepository = new RequestQueueRepository(requestRepository);
+  public static CheckInProcessAdapter newInstance(Clients clients,
+    ItemRepository itemRepository, UserRepository userRepository,
+    LoanRepository loanRepository, RequestRepository requestRepository,
+    RequestQueueRepository requestQueueRepository) {
 
     final var itemFinder = new ItemByBarcodeInStorageFinder(itemRepository);
 

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -85,7 +85,7 @@ public class CheckOutByBarcodeResource extends Resource {
     final UserRepository userRepository = new UserRepository(clients);
     final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
-    final LoanRepository loanRepository = new LoanRepository(clients);
+    final LoanRepository loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final LoanService loanService = new LoanService(clients);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final OverdueFinePolicyRepository overdueFinePolicyRepository = new OverdueFinePolicyRepository(clients);

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -105,7 +105,8 @@ public class CheckOutByBarcodeResource extends Resource {
     CheckOutValidators validators = new CheckOutValidators(request, clients, errorHandler,
       permissions, loanRepository);
 
-    final UpdateRequestQueue requestQueueUpdate = UpdateRequestQueue.using(clients);
+    final var requestQueueUpdate = UpdateRequestQueue.using(clients,
+      requestRepository, requestQueueRepository);
 
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
 

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -37,6 +37,7 @@ import org.folio.circulation.infrastructure.storage.loans.OverdueFinePolicyRepos
 import org.folio.circulation.infrastructure.storage.notices.PatronNoticePolicyRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestQueueRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.infrastructure.storage.users.PatronGroupRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.handlers.error.CirculationErrorHandler;
@@ -82,10 +83,12 @@ public class CheckOutByBarcodeResource extends Resource {
 
     final Clients clients = Clients.create(context, client);
 
-    final UserRepository userRepository = new UserRepository(clients);
-    final ItemRepository itemRepository = new ItemRepository(clients);
-    final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
-    final LoanRepository loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final var userRepository = new UserRepository(clients);
+    final var itemRepository = new ItemRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final var requestRepository = RequestRepository.using(clients, itemRepository,
+      userRepository, loanRepository);
+    final var requestQueueRepository = new RequestQueueRepository(requestRepository);
     final LoanService loanService = new LoanService(clients);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final OverdueFinePolicyRepository overdueFinePolicyRepository = new OverdueFinePolicyRepository(clients);

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -38,6 +38,7 @@ import org.folio.circulation.infrastructure.storage.notices.PatronNoticePolicyRe
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestQueueRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
+import org.folio.circulation.infrastructure.storage.sessions.PatronActionSessionRepository;
 import org.folio.circulation.infrastructure.storage.users.PatronGroupRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.handlers.error.CirculationErrorHandler;
@@ -113,7 +114,9 @@ public class CheckOutByBarcodeResource extends Resource {
     final EventPublisher eventPublisher = new EventPublisher(routingContext);
 
     final PatronActionSessionService patronActionSessionService =
-      PatronActionSessionService.using(clients);
+      PatronActionSessionService.using(clients,
+        PatronActionSessionRepository.using(clients, loanRepository,
+          userRepository));
 
     ofAsync(() -> new LoanAndRelatedRecords(request.toLoan()))
       .thenApply(validators::refuseCheckOutWhenServicePointIsNotPresent)

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -83,7 +83,7 @@ public class CheckOutByBarcodeResource extends Resource {
     final Clients clients = Clients.create(context, client);
 
     final UserRepository userRepository = new UserRepository(clients);
-    final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
+    final ItemRepository itemRepository = new ItemRepository(clients);
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
     final LoanRepository loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final LoanService loanService = new LoanService(clients);

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -100,7 +100,7 @@ public class CheckOutByBarcodeResource extends Resource {
     OkapiPermissions permissions = OkapiPermissions.from(new WebContext(routingContext).getHeaders());
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(permissions);
     CheckOutValidators validators = new CheckOutValidators(request, clients, errorHandler,
-      permissions);
+      permissions, loanRepository);
 
     final UpdateRequestQueue requestQueueUpdate = UpdateRequestQueue.using(clients);
 

--- a/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
+++ b/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
@@ -71,7 +71,7 @@ public class DeclareLostResource extends Resource {
   private CompletableFuture<Result<Loan>> declareItemLost(DeclareItemLostRequest request,
     Clients clients, WebContext context) {
 
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository,
       new UserRepository(clients));
     final var storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);

--- a/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
+++ b/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
@@ -73,13 +73,11 @@ public class DeclareLostResource extends Resource {
     Clients clients, WebContext context) {
 
     final var itemRepository = new ItemRepository(clients);
-    final UserRepository userRepository = new UserRepository(clients);
-    final var loanRepository = new LoanRepository(clients, itemRepository,
-      new UserRepository(clients));
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final var storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
     final var lostItemFeeService = new LostItemFeeChargingService(clients, storeLoanAndItem,
-      new LostItemFeeRefundService(clients,
-        itemRepository, userRepository, loanRepository));
+      new LostItemFeeRefundService(clients, itemRepository, userRepository, loanRepository));
 
     return loanRepository.getById(request.getLoanId())
       .thenApply(LoanValidator::refuseWhenLoanIsClosed)

--- a/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
+++ b/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
@@ -23,6 +23,7 @@ import org.folio.circulation.infrastructure.storage.notes.NotesRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.services.LostItemFeeChargingService;
+import org.folio.circulation.services.LostItemFeeRefundService;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.http.server.NoContentResponse;
 import org.folio.circulation.support.http.server.WebContext;
@@ -72,10 +73,13 @@ public class DeclareLostResource extends Resource {
     Clients clients, WebContext context) {
 
     final var itemRepository = new ItemRepository(clients);
+    final UserRepository userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository,
       new UserRepository(clients));
     final var storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
-    final var lostItemFeeService = new LostItemFeeChargingService(clients, storeLoanAndItem);
+    final var lostItemFeeService = new LostItemFeeChargingService(clients, storeLoanAndItem,
+      new LostItemFeeRefundService(clients,
+        itemRepository, userRepository, loanRepository));
 
     return loanRepository.getById(request.getLoanId())
       .thenApply(LoanValidator::refuseWhenLoanIsClosed)

--- a/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
+++ b/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
@@ -20,6 +20,7 @@ import org.folio.circulation.domain.validation.LoanValidator;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notes.NotesRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.services.LostItemFeeChargingService;
 import org.folio.circulation.support.Clients;
@@ -70,8 +71,9 @@ public class DeclareLostResource extends Resource {
   private CompletableFuture<Result<Loan>> declareItemLost(DeclareItemLostRequest request,
     Clients clients, WebContext context) {
 
-    final var loanRepository = new LoanRepository(clients);
     final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var loanRepository = new LoanRepository(clients, itemRepository,
+      new UserRepository(clients));
     final var storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
     final var lostItemFeeService = new LostItemFeeChargingService(clients, storeLoanAndItem);
 

--- a/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
+++ b/src/main/java/org/folio/circulation/resources/DeclareLostResource.java
@@ -70,10 +70,10 @@ public class DeclareLostResource extends Resource {
   private CompletableFuture<Result<Loan>> declareItemLost(DeclareItemLostRequest request,
     Clients clients, WebContext context) {
 
-    final LoanRepository loanRepository = new LoanRepository(clients);
-    final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
-    final StoreLoanAndItem storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
-    final LostItemFeeChargingService lostItemFeeService = new LostItemFeeChargingService(clients);
+    final var loanRepository = new LoanRepository(clients);
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
+    final var lostItemFeeService = new LostItemFeeChargingService(clients, storeLoanAndItem);
 
     return loanRepository.getById(request.getLoanId())
       .thenApply(LoanValidator::refuseWhenLoanIsClosed)

--- a/src/main/java/org/folio/circulation/resources/DueDateNotRealTimeScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/DueDateNotRealTimeScheduledNoticeProcessingResource.java
@@ -21,6 +21,7 @@ import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.domain.notice.schedule.ScheduledNoticeGroupDefinition;
 import org.folio.circulation.domain.notice.schedule.TriggeringEvent;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CqlSortBy;
@@ -72,7 +73,8 @@ public class DueDateNotRealTimeScheduledNoticeProcessingResource extends Schedul
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> handleNotices(
-    Clients clients, MultipleRecords<ScheduledNotice> notices) {
+    Clients clients, ItemRepository itemRepository,
+    MultipleRecords<ScheduledNotice> notices) {
 
     Map<ScheduledNoticeGroupDefinition, List<ScheduledNotice>> orderedGroups =
       notices.getRecords().stream().collect(Collectors.groupingBy(

--- a/src/main/java/org/folio/circulation/resources/DueDateNotRealTimeScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/DueDateNotRealTimeScheduledNoticeProcessingResource.java
@@ -21,8 +21,9 @@ import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.domain.notice.schedule.ScheduledNoticeGroupDefinition;
 import org.folio.circulation.domain.notice.schedule.TriggeringEvent;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CqlSortBy;
 import org.folio.circulation.support.CqlSortClause;
@@ -73,8 +74,8 @@ public class DueDateNotRealTimeScheduledNoticeProcessingResource extends Schedul
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> handleNotices(
-    Clients clients, ItemRepository itemRepository,
-    MultipleRecords<ScheduledNotice> notices) {
+    Clients clients, RequestRepository requestRepository,
+    LoanRepository loanRepository, MultipleRecords<ScheduledNotice> notices) {
 
     Map<ScheduledNoticeGroupDefinition, List<ScheduledNotice>> orderedGroups =
       notices.getRecords().stream().collect(Collectors.groupingBy(
@@ -95,7 +96,7 @@ public class DueDateNotRealTimeScheduledNoticeProcessingResource extends Schedul
       .map(Map.Entry::getValue)
       .collect(Collectors.toList());
 
-    return new GroupedLoanScheduledNoticeHandler(clients, getZonedDateTime())
+    return new GroupedLoanScheduledNoticeHandler(clients, loanRepository, getZonedDateTime())
       .handleNotices(noticeGroups)
       .thenApply(mapResult(v -> notices));
   }

--- a/src/main/java/org/folio/circulation/resources/EndPatronActionSessionResource.java
+++ b/src/main/java/org/folio/circulation/resources/EndPatronActionSessionResource.java
@@ -6,6 +6,10 @@ import java.util.List;
 
 import org.folio.circulation.domain.notice.session.PatronActionSessionService;
 import org.folio.circulation.domain.representations.EndPatronSessionRequest;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.sessions.PatronActionSessionRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.server.WebContext;
@@ -32,8 +36,12 @@ public class EndPatronActionSessionResource extends Resource {
     WebContext context = new WebContext(routingContext);
     Clients clients = Clients.create(context, client);
 
+    final var userRepository = new UserRepository(clients);
+    final var itemRepository = new ItemRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     PatronActionSessionService patronActionSessionService =
-      PatronActionSessionService.using(clients);
+      PatronActionSessionService.using(clients,
+        PatronActionSessionRepository.using(clients, loanRepository, userRepository));
 
     List<Result<EndPatronSessionRequest>> resultListOfEndSessionRequestResult =
       EndPatronSessionRequest.from(routingContext.getBodyAsJson());

--- a/src/main/java/org/folio/circulation/resources/ExpiredSessionProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ExpiredSessionProcessingResource.java
@@ -14,7 +14,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.notice.session.ExpiredSession;
 import org.folio.circulation.domain.notice.session.PatronActionSessionService;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.sessions.PatronActionSessionRepository;
 import org.folio.circulation.infrastructure.storage.sessions.PatronExpiredSessionRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.server.NoContentResponse;
@@ -48,8 +52,12 @@ public class ExpiredSessionProcessingResource extends Resource {
     final ConfigurationRepository configurationRepository
       = new ConfigurationRepository(clients);
 
+    final var userRepository = new UserRepository(clients);
+    final var itemRepository = new ItemRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final PatronActionSessionService patronSessionService
-      = PatronActionSessionService.using(clients);
+      = PatronActionSessionService.using(clients,
+      PatronActionSessionRepository.using(clients, loanRepository, userRepository));
 
     final PatronExpiredSessionRepository patronExpiredSessionRepository
       = PatronExpiredSessionRepository.using(clients);

--- a/src/main/java/org/folio/circulation/resources/FeeFineScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/FeeFineScheduledNoticeProcessingResource.java
@@ -14,8 +14,9 @@ import org.folio.circulation.domain.notice.schedule.FeeFineScheduledNoticeHandle
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.domain.notice.schedule.TriggeringEvent;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CqlSortBy;
 import org.folio.circulation.support.http.client.PageLimit;
@@ -48,10 +49,12 @@ public class FeeFineScheduledNoticeProcessingResource extends ScheduledNoticePro
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> handleNotices(
-    Clients clients, ItemRepository itemRepository,
+    Clients clients,
+    RequestRepository requestRepository,
+    LoanRepository loanRepository,
     MultipleRecords<ScheduledNotice> scheduledNotices) {
 
-    return new FeeFineScheduledNoticeHandler(clients, new ItemRepository(clients))
+    return new FeeFineScheduledNoticeHandler(clients, loanRepository)
       .handleNotices(scheduledNotices.getRecords())
       .thenApply(mapResult(v -> scheduledNotices));
   }

--- a/src/main/java/org/folio/circulation/resources/FeeFineScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/FeeFineScheduledNoticeProcessingResource.java
@@ -14,6 +14,7 @@ import org.folio.circulation.domain.notice.schedule.FeeFineScheduledNoticeHandle
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.domain.notice.schedule.TriggeringEvent;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CqlSortBy;
@@ -47,9 +48,10 @@ public class FeeFineScheduledNoticeProcessingResource extends ScheduledNoticePro
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> handleNotices(
-    Clients clients, MultipleRecords<ScheduledNotice> scheduledNotices) {
+    Clients clients, ItemRepository itemRepository,
+    MultipleRecords<ScheduledNotice> scheduledNotices) {
 
-    return new FeeFineScheduledNoticeHandler(clients)
+    return new FeeFineScheduledNoticeHandler(clients, new ItemRepository(clients))
       .handleNotices(scheduledNotices.getRecords())
       .thenApply(mapResult(v -> scheduledNotices));
   }

--- a/src/main/java/org/folio/circulation/resources/LoanAnonymizationResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanAnonymizationResource.java
@@ -9,8 +9,10 @@ import org.folio.circulation.domain.anonymization.service.AnonymizationCheckersS
 import org.folio.circulation.domain.anonymization.service.LoansForBorrowerFinder;
 import org.folio.circulation.domain.representations.anonymization.AnonymizeLoansRepresentation;
 import org.folio.circulation.infrastructure.storage.feesandfines.AccountRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.AnonymizeStorageLoansRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.RouteRegistration;
@@ -40,7 +42,9 @@ public class LoanAnonymizationResource extends Resource {
 
     String borrowerId = routingContext.request().getParam("userId");
 
-    final var loanRepository = new LoanRepository(clients);
+    final var loanRepository = new LoanRepository(clients,
+      new ItemRepository(clients, true, true, true),
+      new UserRepository(clients));
     final var accountRepository = new AccountRepository(clients);
 
     final var loansFinder = new LoansForBorrowerFinder(borrowerId,

--- a/src/main/java/org/folio/circulation/resources/LoanAnonymizationResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanAnonymizationResource.java
@@ -43,7 +43,7 @@ public class LoanAnonymizationResource extends Resource {
     String borrowerId = routingContext.request().getParam("userId");
 
     final var loanRepository = new LoanRepository(clients,
-      new ItemRepository(clients, true, true, true),
+      new ItemRepository(clients),
       new UserRepository(clients));
     final var accountRepository = new AccountRepository(clients);
 

--- a/src/main/java/org/folio/circulation/resources/LoanAnonymizationResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanAnonymizationResource.java
@@ -42,8 +42,7 @@ public class LoanAnonymizationResource extends Resource {
 
     String borrowerId = routingContext.request().getParam("userId");
 
-    final var loanRepository = new LoanRepository(clients,
-      new ItemRepository(clients),
+    final var loanRepository = new LoanRepository(clients, new ItemRepository(clients),
       new UserRepository(clients));
     final var accountRepository = new AccountRepository(clients);
 

--- a/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
@@ -74,10 +74,11 @@ public class LoanCollectionResource extends CollectionResource {
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final var servicePointRepository = new ServicePointRepository(clients);
-    final var requestQueueRepository = new RequestQueueRepository(
-      RequestRepository.using(clients, itemRepository, userRepository, loanRepository));
-
-    final UpdateRequestQueue requestQueueUpdate = UpdateRequestQueue.using(clients);
+    final var requestRepository = RequestRepository.using(clients, itemRepository,
+      userRepository, loanRepository);
+    final var requestQueueRepository = new RequestQueueRepository(requestRepository);
+    final var requestQueueUpdate = UpdateRequestQueue.using(clients,
+      requestRepository, requestQueueRepository);
     final UpdateItem updateItem = new UpdateItem(itemRepository);
     final LoanService loanService = new LoanService(clients);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
@@ -141,15 +142,17 @@ public class LoanCollectionResource extends CollectionResource {
     final Loan loan = Loan.from(incomingRepresentation);
 
     final Clients clients = Clients.create(context, client);
-    final ItemRepository itemRepository = new ItemRepository(clients);
-    final UserRepository userRepository = new UserRepository(clients);
-    final LoanRepository loanRepository = new LoanRepository(clients,
+    final var itemRepository = new ItemRepository(clients);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients,
       itemRepository, userRepository);
-    final RequestQueueRepository requestQueueRepository = new RequestQueueRepository(
-      RequestRepository.using(clients, itemRepository, userRepository, loanRepository));
+    final var requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
+    final var requestQueueRepository = new RequestQueueRepository(requestRepository);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
 
-    final UpdateRequestQueue requestQueueUpdate = UpdateRequestQueue.using(clients);
+    final var requestQueueUpdate = UpdateRequestQueue.using(clients,
+      requestRepository, requestQueueRepository);
     final UpdateItem updateItem = new UpdateItem(itemRepository);
 
     final ProxyRelationshipValidator proxyRelationshipValidator = new ProxyRelationshipValidator(

--- a/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
@@ -75,7 +75,7 @@ public class LoanCollectionResource extends CollectionResource {
     final UserRepository userRepository = new UserRepository(clients);
 
     final UpdateRequestQueue requestQueueUpdate = UpdateRequestQueue.using(clients);
-    final UpdateItem updateItem = new UpdateItem(clients);
+    final UpdateItem updateItem = new UpdateItem(itemRepository);
     final LoanRepository loanRepository = new LoanRepository(clients);
     final LoanService loanService = new LoanService(clients);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
@@ -145,7 +145,7 @@ public class LoanCollectionResource extends CollectionResource {
     final UserRepository userRepository = new UserRepository(clients);
 
     final UpdateRequestQueue requestQueueUpdate = UpdateRequestQueue.using(clients);
-    final UpdateItem updateItem = new UpdateItem(clients);
+    final UpdateItem updateItem = new UpdateItem(itemRepository);
     final LoanRepository loanRepository = new LoanRepository(clients);
 
     final ProxyRelationshipValidator proxyRelationshipValidator = new ProxyRelationshipValidator(

--- a/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
@@ -69,7 +69,7 @@ public class LoanCollectionResource extends CollectionResource {
 
     final Clients clients = Clients.create(context, client);
 
-    final ItemRepository itemRepository = new ItemRepository(clients, true, true, false);
+    final ItemRepository itemRepository = new ItemRepository(clients);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
     final UserRepository userRepository = new UserRepository(clients);
@@ -142,7 +142,7 @@ public class LoanCollectionResource extends CollectionResource {
     final Clients clients = Clients.create(context, client);
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
-    final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
+    final ItemRepository itemRepository = new ItemRepository(clients);
     final UserRepository userRepository = new UserRepository(clients);
 
     final UpdateRequestQueue requestQueueUpdate = UpdateRequestQueue.using(clients);
@@ -202,7 +202,7 @@ public class LoanCollectionResource extends CollectionResource {
     final Clients clients = Clients.create(context, client);
 
     final var loanRepository = new LoanRepository(clients,
-      new ItemRepository(clients, true, true, true),
+      new ItemRepository(clients),
       new UserRepository(clients));
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
@@ -246,7 +246,7 @@ public class LoanCollectionResource extends CollectionResource {
     Clients clients = Clients.create(context, client);
 
     final var userRepository = new UserRepository(clients);
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
     final LoanRepresentation loanRepresentation = new LoanRepresentation();

--- a/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
@@ -76,7 +76,8 @@ public class LoanCollectionResource extends CollectionResource {
 
     final UpdateRequestQueue requestQueueUpdate = UpdateRequestQueue.using(clients);
     final UpdateItem updateItem = new UpdateItem(itemRepository);
-    final LoanRepository loanRepository = new LoanRepository(clients);
+    final LoanRepository loanRepository = new LoanRepository(clients,
+      itemRepository, userRepository);
     final LoanService loanService = new LoanService(clients);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final EventPublisher eventPublisher = new EventPublisher(routingContext);
@@ -146,7 +147,8 @@ public class LoanCollectionResource extends CollectionResource {
 
     final UpdateRequestQueue requestQueueUpdate = UpdateRequestQueue.using(clients);
     final UpdateItem updateItem = new UpdateItem(itemRepository);
-    final LoanRepository loanRepository = new LoanRepository(clients);
+    final LoanRepository loanRepository = new LoanRepository(clients,
+      itemRepository, userRepository);
 
     final ProxyRelationshipValidator proxyRelationshipValidator = new ProxyRelationshipValidator(
       clients, () -> singleValidationError("proxyUserId is not valid", "proxyUserId",
@@ -199,7 +201,9 @@ public class LoanCollectionResource extends CollectionResource {
     final WebContext context = new WebContext(routingContext);
     final Clients clients = Clients.create(context, client);
 
-    final LoanRepository loanRepository = new LoanRepository(clients);
+    final var loanRepository = new LoanRepository(clients,
+      new ItemRepository(clients, true, true, true),
+      new UserRepository(clients));
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
     final UserRepository userRepository = new UserRepository(clients);
@@ -241,10 +245,11 @@ public class LoanCollectionResource extends CollectionResource {
     WebContext context = new WebContext(routingContext);
     Clients clients = Clients.create(context, client);
 
-    final LoanRepository loanRepository = new LoanRepository(clients);
+    final var userRepository = new UserRepository(clients);
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
-    final UserRepository userRepository = new UserRepository(clients);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final OverdueFinePolicyRepository overdueFinePolicyRepository = new OverdueFinePolicyRepository(clients);
     final LostItemPolicyRepository lostItemPolicyRepository = new LostItemPolicyRepository(clients);

--- a/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanCollectionResource.java
@@ -205,12 +205,11 @@ public class LoanCollectionResource extends CollectionResource {
     final WebContext context = new WebContext(routingContext);
     final Clients clients = Clients.create(context, client);
 
+    final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients,
-      new ItemRepository(clients),
-      new UserRepository(clients));
+      new ItemRepository(clients), userRepository);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
-    final UserRepository userRepository = new UserRepository(clients);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final OverdueFinePolicyRepository overdueFinePolicyRepository = new OverdueFinePolicyRepository(clients);
     final LostItemPolicyRepository lostItemPolicyRepository = new LostItemPolicyRepository(clients);

--- a/src/main/java/org/folio/circulation/resources/LoanScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanScheduledNoticeProcessingResource.java
@@ -11,8 +11,9 @@ import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.notice.schedule.LoanScheduledNoticeHandler;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CqlSortBy;
 import org.folio.circulation.support.http.client.PageLimit;
@@ -40,11 +41,12 @@ public class LoanScheduledNoticeProcessingResource extends ScheduledNoticeProces
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> handleNotices(
-    Clients clients, ItemRepository itemRepository,
+    Clients clients,
+    RequestRepository requestRepository,
+    LoanRepository loanRepository,
     MultipleRecords<ScheduledNotice> noticesResult) {
 
-    return new LoanScheduledNoticeHandler(clients, itemRepository,
-        ClockUtil.getZonedDateTime())
+    return new LoanScheduledNoticeHandler(clients, loanRepository, ClockUtil.getZonedDateTime())
       .handleNotices(noticesResult.getRecords())
       .thenApply(mapResult(v -> noticesResult));
   }

--- a/src/main/java/org/folio/circulation/resources/LoanScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanScheduledNoticeProcessingResource.java
@@ -11,6 +11,7 @@ import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.notice.schedule.LoanScheduledNoticeHandler;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CqlSortBy;
@@ -39,9 +40,11 @@ public class LoanScheduledNoticeProcessingResource extends ScheduledNoticeProces
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> handleNotices(
-    Clients clients, MultipleRecords<ScheduledNotice> noticesResult) {
+    Clients clients, ItemRepository itemRepository,
+    MultipleRecords<ScheduledNotice> noticesResult) {
 
-    return new LoanScheduledNoticeHandler(clients, ClockUtil.getZonedDateTime())
+    return new LoanScheduledNoticeHandler(clients, itemRepository,
+        ClockUtil.getZonedDateTime())
       .handleNotices(noticesResult.getRecords())
       .thenApply(mapResult(v -> noticesResult));
   }

--- a/src/main/java/org/folio/circulation/resources/PickSlipsResource.java
+++ b/src/main/java/org/folio/circulation/resources/PickSlipsResource.java
@@ -79,7 +79,8 @@ public class PickSlipsResource extends Resource {
     final WebContext context = new WebContext(routingContext);
     final Clients clients = Clients.create(context, client);
 
-    final UserRepository userRepository = new UserRepository(clients);
+    final var userRepository = new UserRepository(clients);
+    final var itemRepository = new ItemRepository(clients);
     final AddressTypeRepository addressTypeRepository = new AddressTypeRepository(clients);
     final ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
 
@@ -87,7 +88,8 @@ public class PickSlipsResource extends Resource {
       routingContext.request().getParam(SERVICE_POINT_ID_PARAM));
 
     fetchLocationsForServicePoint(servicePointId, clients)
-      .thenComposeAsync(r -> r.after(locations -> fetchPagedItemsForLocations(locations, clients)))
+      .thenComposeAsync(r -> r.after(locations -> fetchPagedItemsForLocations(locations,
+        clients, itemRepository)))
       .thenComposeAsync(r -> r.after(items -> fetchOpenPageRequestsForItems(items, clients)))
       .thenComposeAsync(r -> r.after(userRepository::findUsersForRequests))
       .thenComposeAsync(r -> r.after(addressTypeRepository::findAddressTypesForRequests))
@@ -105,7 +107,8 @@ public class PickSlipsResource extends Resource {
   }
 
   private CompletableFuture<Result<Collection<Item>>> fetchPagedItemsForLocations(
-    MultipleRecords<Location> multipleLocations, Clients clients) {
+    MultipleRecords<Location> multipleLocations, Clients clients,
+    ItemRepository itemRepository) {
 
     Collection<Location> locations = multipleLocations.getRecords();
 
@@ -118,7 +121,6 @@ public class PickSlipsResource extends Resource {
       return completedFuture(succeeded(emptyList()));
     }
 
-    final ItemRepository itemRepository = new ItemRepository(clients);
     Result<CqlQuery> statusQuery = exactMatch(STATUS_NAME_KEY, ItemStatus.PAGED.getValue());
 
     return itemRepository.findByIndexNameAndQuery(locationIds, EFFECTIVE_LOCATION_ID_KEY, statusQuery)

--- a/src/main/java/org/folio/circulation/resources/PickSlipsResource.java
+++ b/src/main/java/org/folio/circulation/resources/PickSlipsResource.java
@@ -118,7 +118,7 @@ public class PickSlipsResource extends Resource {
       return completedFuture(succeeded(emptyList()));
     }
 
-    final ItemRepository itemRepository = new ItemRepository(clients, false, true, true);
+    final ItemRepository itemRepository = new ItemRepository(clients);
     Result<CqlQuery> statusQuery = exactMatch(STATUS_NAME_KEY, ItemStatus.PAGED.getValue());
 
     return itemRepository.findByIndexNameAndQuery(locationIds, EFFECTIVE_LOCATION_ID_KEY, statusQuery)

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -55,7 +55,6 @@ import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestPolicyRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestQueueRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
-import org.folio.circulation.infrastructure.storage.users.PatronGroupRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.handlers.error.FailFastErrorHandler;
 import org.folio.circulation.services.EventPublisher;

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -232,15 +232,16 @@ public class RequestByInstanceIdResource extends Resource {
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
-
+    final var requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
+    final var requestQueueRepository = new RequestQueueRepository(requestRepository);
     final UpdateUponRequest updateUponRequest = new UpdateUponRequest(
         new UpdateItem(itemRepository),
         new UpdateLoan(clients, loanRepository, loanPolicyRepository),
-        UpdateRequestQueue.using(clients));
+        UpdateRequestQueue.using(clients, requestRepository, requestQueueRepository));
 
     final CreateRequestService createRequestService = new CreateRequestService(
-      new CreateRequestRepositories(RequestRepository.using(clients,
-        itemRepository, userRepository, loanRepository),
+      new CreateRequestRepositories(requestRepository,
         new RequestPolicyRepository(clients), configurationRepository),
       updateUponRequest,
       new RequestLoanValidator(null, loanRepository),

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -221,11 +221,12 @@ public class RequestByInstanceIdResource extends Resource {
 
     final RequestNoticeSender requestNoticeSender = new ItemLevelRequestNoticeSender(clients);
     final LoanRepository loanRepository = new LoanRepository(clients);
+    final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
 
     final UpdateUponRequest updateUponRequest = new UpdateUponRequest(
-        new UpdateItem(clients),
+        new UpdateItem(itemRepository),
         new UpdateLoan(clients, loanRepository, loanPolicyRepository),
         UpdateRequestQueue.using(clients));
 

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -98,7 +98,7 @@ public class RequestByInstanceIdResource extends Resource {
     final WebContext context = new WebContext(routingContext);
     final Clients clients = Clients.create(context, client);
 
-    final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
+    final ItemRepository itemRepository = new ItemRepository(clients);
     final ItemByInstanceIdFinder finder = new ItemByInstanceIdFinder(clients.holdingsStorage(), itemRepository);
 
     final Result<RequestByInstanceIdRequest> requestByInstanceIdRequestResult =
@@ -146,7 +146,7 @@ public class RequestByInstanceIdResource extends Resource {
       return CompletableFuture.completedFuture(succeeded(null));
     }
 
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     LoanRepository loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     Map<Item, CompletableFuture<Result<Loan>>> itemLoanFuturesMap = new HashMap<>();
@@ -220,9 +220,9 @@ public class RequestByInstanceIdResource extends Resource {
 
   private CompletableFuture<Result<RequestAndRelatedRecords>> placeRequests(
     List<JsonObject> itemRequestRepresentations, Clients clients, EventPublisher eventPublisher) {
-
+    
     final RequestNoticeSender requestNoticeSender = new ItemLevelRequestNoticeSender(clients);
-    final var itemRepository = new ItemRepository(clients, false, false, false);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
@@ -263,7 +263,7 @@ public class RequestByInstanceIdResource extends Resource {
     }
 
     JsonObject currentItemRequest = itemRequests.get(startIndex);
-    ItemRepository itemRepository = new ItemRepository(clients, true, false, false);
+    ItemRepository itemRepository = new ItemRepository(clients);
     final RequestFromRepresentationService requestFromRepresentationService =
       new RequestFromRepresentationService(
         new InstanceRepository(clients),

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -146,7 +146,9 @@ public class RequestByInstanceIdResource extends Resource {
       return CompletableFuture.completedFuture(succeeded(null));
     }
 
-    LoanRepository loanRepository = new LoanRepository(clients);
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var userRepository = new UserRepository(clients);
+    LoanRepository loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     Map<Item, CompletableFuture<Result<Loan>>> itemLoanFuturesMap = new HashMap<>();
 
     //Find request queues and loan items for each item
@@ -220,8 +222,9 @@ public class RequestByInstanceIdResource extends Resource {
     List<JsonObject> itemRequestRepresentations, Clients clients, EventPublisher eventPublisher) {
 
     final RequestNoticeSender requestNoticeSender = new ItemLevelRequestNoticeSender(clients);
-    final LoanRepository loanRepository = new LoanRepository(clients);
-    final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients, false, false, false);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
 

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -119,7 +119,7 @@ public class RequestByInstanceIdResource extends Resource {
       .thenApply( r -> r.next(RequestByInstanceIdResource::instanceToItemRequests))
       .thenCompose( r -> r.after(requests -> placeRequests(requests, clients, eventPublisher,
         itemRepository, loanRepository, requestRepository, requestQueueRepository,
-        new UserRepository(clients))))
+        userRepository)))
       .thenApply(r -> r.map(RequestAndRelatedRecords::getRequest))
       .thenApply(r -> r.map(new RequestRepresentation()::extendedRepresentation))
       .thenApply(r -> r.map(JsonHttpResponse::created))

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -234,7 +234,8 @@ public class RequestByInstanceIdResource extends Resource {
         UpdateRequestQueue.using(clients));
 
     final CreateRequestService createRequestService = new CreateRequestService(
-      new CreateRequestRepositories(RequestRepository.using(clients),
+      new CreateRequestRepositories(RequestRepository.using(clients,
+        itemRepository, userRepository, loanRepository),
         new RequestPolicyRepository(clients), configurationRepository),
       updateUponRequest,
       new RequestLoanValidator(null, loanRepository),

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -82,10 +82,10 @@ public class RequestCollectionResource extends CollectionResource {
     final var loanPolicyRepository = new LoanPolicyRepository(clients);
     final var requestNoticeSender = createRequestNoticeSender(clients, representation);
     final var configurationRepository = new ConfigurationRepository(clients);
-
     final var updateUponRequest = new UpdateUponRequest(new UpdateItem(itemRepository),
       new UpdateLoan(clients, loanRepository, loanPolicyRepository),
-      UpdateRequestQueue.using(clients));
+      UpdateRequestQueue.using(clients, requestRepository,
+        new RequestQueueRepository(requestRepository)));
 
     final var okapiPermissions = OkapiPermissions.from(context.getHeaders());
     final var blockOverrides = BlockOverrides.fromRequest(representation);
@@ -138,7 +138,9 @@ public class RequestCollectionResource extends CollectionResource {
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final var requestRepository = RequestRepository.using(clients,
       itemRepository, userRepository, loanRepository);
-    final var updateRequestQueue = UpdateRequestQueue.using(clients);
+    final var requestQueueRepository = new RequestQueueRepository(requestRepository);
+    final var updateRequestQueue = UpdateRequestQueue.using(clients,
+      requestRepository, requestQueueRepository);
     final var loanPolicyRepository = new LoanPolicyRepository(clients);
     final var eventPublisher = new EventPublisher(routingContext);
     final var requestNoticeSender = createRequestNoticeSender(clients, representation);
@@ -279,7 +281,7 @@ public class RequestCollectionResource extends CollectionResource {
 
     final var updateUponRequest = new UpdateUponRequest(new UpdateItem(itemRepository),
       new UpdateLoan(clients, loanRepository, loanPolicyRepository),
-      UpdateRequestQueue.using(clients));
+      UpdateRequestQueue.using(clients, requestRepository, requestQueueRepository));
 
     final var moveRequestProcessAdapter = new MoveRequestProcessAdapter(itemRepository,
       loanRepository, requestRepository);

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -96,7 +96,8 @@ public class RequestCollectionResource extends CollectionResource {
       loanRepository);
 
     final var createRequestService = new CreateRequestService(
-      new CreateRequestRepositories(RequestRepository.using(clients),
+      new CreateRequestRepositories(RequestRepository.using(clients,
+        itemRepository, userRepository, loanRepository),
         new RequestPolicyRepository(clients), configurationRepository),
       updateUponRequest, requestLoanValidator, requestNoticeSender,
       requestBlocksValidators, eventPublisher, errorHandler);
@@ -132,9 +133,11 @@ public class RequestCollectionResource extends CollectionResource {
     write(representation, "id", getRequestId(routingContext));
 
     final var itemRepository = new ItemRepository(clients);
-    final var requestRepository = RequestRepository.using(clients);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final var requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
     final var updateRequestQueue = UpdateRequestQueue.using(clients);
-    final var loanRepository = new LoanRepository(clients, itemRepository, new UserRepository(clients));
     final var loanPolicyRepository = new LoanPolicyRepository(clients);
     final var eventPublisher = new EventPublisher(routingContext);
     final var requestNoticeSender = createRequestNoticeSender(clients, representation);
@@ -184,7 +187,11 @@ public class RequestCollectionResource extends CollectionResource {
     final var context = new WebContext(routingContext);
     final var clients = Clients.create(context, client);
 
-    final var requestRepository = RequestRepository.using(clients);
+    final var itemRepository = new ItemRepository(clients);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final var requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
 
     final var id = getRequestId(routingContext);
 
@@ -201,7 +208,11 @@ public class RequestCollectionResource extends CollectionResource {
 
     final var id = getRequestId(routingContext);
 
-    final var requestRepository = RequestRepository.using(clients);
+    final var itemRepository = new ItemRepository(clients);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final var requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
 
     final var updateRequestQueue = new UpdateRequestQueue(RequestQueueRepository.using(clients),
       requestRepository, new ServicePointRepository(clients), new ConfigurationRepository(clients));
@@ -218,7 +229,11 @@ public class RequestCollectionResource extends CollectionResource {
     final var context = new WebContext(routingContext);
     final var clients = Clients.create(context, client);
 
-    final var requestRepository = RequestRepository.using(clients);
+    final var itemRepository = new ItemRepository(clients);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final var requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
 
     fromFutureResult(requestRepository.findBy(routingContext.request().query()))
       .map(this::mapToJson)
@@ -250,12 +265,13 @@ public class RequestCollectionResource extends CollectionResource {
 
     final var id = getRequestId(routingContext);
 
-    final var requestRepository = RequestRepository.using(clients);
-    final var requestQueueRepository = RequestQueueRepository.using(clients);
-
     final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final var requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
+    final var requestQueueRepository = RequestQueueRepository.using(clients);
+
     final var loanPolicyRepository = new LoanPolicyRepository(clients);
     final var configurationRepository = new ConfigurationRepository(clients);
 

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -81,7 +81,7 @@ public class RequestCollectionResource extends CollectionResource {
     final var requestNoticeSender = createRequestNoticeSender(clients, representation);
     final var configurationRepository = new ConfigurationRepository(clients);
 
-    final var updateUponRequest = new UpdateUponRequest(new UpdateItem(clients),
+    final var updateUponRequest = new UpdateUponRequest(new UpdateItem(itemRepository),
       new UpdateLoan(clients, loanRepository, loanPolicyRepository),
       UpdateRequestQueue.using(clients));
 
@@ -127,7 +127,7 @@ public class RequestCollectionResource extends CollectionResource {
     final var representation = routingContext.getBodyAsJson();
 
     write(representation, "id", getRequestId(routingContext));
-
+    
     final var itemRepository = new ItemRepository(clients, true, true, true);
     final var requestRepository = RequestRepository.using(clients);
     final var updateRequestQueue = UpdateRequestQueue.using(clients);
@@ -137,7 +137,7 @@ public class RequestCollectionResource extends CollectionResource {
     final var requestNoticeSender = createRequestNoticeSender(clients, representation);
     final var configurationRepository = new ConfigurationRepository(clients);
 
-    final var updateItem = new UpdateItem(clients);
+    final var updateItem = new UpdateItem(itemRepository);
 
     final var updateUponRequest = new UpdateUponRequest(updateItem,
       new UpdateLoan(clients, loanRepository, loanPolicyRepository), updateRequestQueue);
@@ -255,7 +255,7 @@ public class RequestCollectionResource extends CollectionResource {
     final var loanPolicyRepository = new LoanPolicyRepository(clients);
     final var configurationRepository = new ConfigurationRepository(clients);
 
-    final var updateUponRequest = new UpdateUponRequest(new UpdateItem(clients),
+    final var updateUponRequest = new UpdateUponRequest(new UpdateItem(itemRepository),
       new UpdateLoan(clients, loanRepository, loanPolicyRepository),
       UpdateRequestQueue.using(clients));
 

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -115,7 +115,7 @@ public class RequestCollectionResource extends CollectionResource {
       representation))
       .flatMapFuture(createRequestService::createRequest)
       .onSuccess(scheduledNoticeService::scheduleRequestNotices)
-      .onSuccess(records -> eventPublisher.publishDueDateChangedEvent(records, clients))
+      .onSuccess(records -> eventPublisher.publishDueDateChangedEvent(records, loanRepository))
       .map(RequestAndRelatedRecords::getRequest)
       .map(new RequestRepresentation()::extendedRepresentation)
       .map(JsonHttpResponse::created)
@@ -173,7 +173,7 @@ public class RequestCollectionResource extends CollectionResource {
       representation))
       .flatMapFuture(when(requestRepository::exists, updateRequestService::replaceRequest,
         createRequestService::createRequest))
-      .flatMapFuture(records -> eventPublisher.publishDueDateChangedEvent(records, clients))
+      .flatMapFuture(records -> eventPublisher.publishDueDateChangedEvent(records, loanRepository))
       .map(requestScheduledNoticeService::rescheduleRequestNotices)
       .map(toFixedValue(NoContentResponse::noContent))
       .onComplete(context::write, context::write);
@@ -278,7 +278,7 @@ public class RequestCollectionResource extends CollectionResource {
       .map(RequestAndRelatedRecords::new)
       .map(request -> asMove(request, representation))
       .flatMapFuture(move -> moveRequestService.moveRequest(move, move.getOriginalRequest()))
-      .onSuccess(records -> eventPublisher.publishDueDateChangedEvent(records, clients))
+      .onSuccess(records -> eventPublisher.publishDueDateChangedEvent(records, loanRepository))
       .map(RequestAndRelatedRecords::getRequest)
       .map(new RequestRepresentation()::extendedRepresentation)
       .map(JsonHttpResponse::ok)

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -74,7 +74,7 @@ public class RequestCollectionResource extends CollectionResource {
 
     final var eventPublisher = new EventPublisher(routingContext);
 
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final var loanPolicyRepository = new LoanPolicyRepository(clients);
@@ -131,7 +131,7 @@ public class RequestCollectionResource extends CollectionResource {
 
     write(representation, "id", getRequestId(routingContext));
 
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var requestRepository = RequestRepository.using(clients);
     final var updateRequestQueue = UpdateRequestQueue.using(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, new UserRepository(clients));
@@ -253,7 +253,7 @@ public class RequestCollectionResource extends CollectionResource {
     final var requestRepository = RequestRepository.using(clients);
     final var requestQueueRepository = RequestQueueRepository.using(clients);
 
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final var loanPolicyRepository = new LoanPolicyRepository(clients);

--- a/src/main/java/org/folio/circulation/resources/RequestHoldShelfClearanceResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestHoldShelfClearanceResource.java
@@ -83,7 +83,7 @@ public class RequestHoldShelfClearanceResource extends Resource {
     final WebContext context = new WebContext(routingContext);
     final Clients clients = Clients.create(context, client);
 
-    final ItemRepository itemRepository = new ItemRepository(clients, false, false, false);
+    final ItemRepository itemRepository = new ItemRepository(clients);
     final GetManyRecordsClient requestsStorage = clients.requestsStorage();
     final ItemReportRepository itemReportRepository = new ItemReportRepository(clients);
 

--- a/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
@@ -51,8 +51,8 @@ public class RequestNoticeSender {
 
     userRepository = new UserRepository(clients);
     patronNoticeService = new SingleImmediatePatronNoticeService(clients);
-    requestRepository = RequestRepository.using(clients);
     loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    requestRepository = RequestRepository.using(clients, itemRepository, userRepository, loanRepository);
     servicePointRepository = new ServicePointRepository(clients);
     eventPublisher = new EventPublisher(clients.pubSubPublishingService());
   }

--- a/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
@@ -47,7 +47,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RequestNoticeSender {
   public RequestNoticeSender(Clients clients) {
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
 
     userRepository = new UserRepository(clients);
     patronNoticeService = new SingleImmediatePatronNoticeService(clients);

--- a/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
@@ -1,7 +1,6 @@
 package org.folio.circulation.resources;
 
 import static java.util.concurrent.CompletableFuture.runAsync;
-import static org.folio.circulation.domain.RequestLevel.TITLE;
 import static org.folio.circulation.domain.notice.TemplateContextUtil.createRequestNoticeContext;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.ofAsync;
@@ -33,6 +32,7 @@ import org.folio.circulation.domain.notice.SingleImmediatePatronNoticeService;
 import org.folio.circulation.domain.notice.TemplateContextUtil;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.infrastructure.storage.ServicePointRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
@@ -47,15 +47,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RequestNoticeSender {
   public RequestNoticeSender(Clients clients) {
-    this(
-      new SingleImmediatePatronNoticeService(clients),
-      RequestRepository.using(clients),
-      new LoanRepository(clients),
-      new UserRepository(clients),
-      new ServicePointRepository(clients),
-      new EventPublisher(clients.pubSubPublishingService())
-    );
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+
+    userRepository = new UserRepository(clients);
+    patronNoticeService = new SingleImmediatePatronNoticeService(clients);
+    requestRepository = RequestRepository.using(clients);
+    loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    servicePointRepository = new ServicePointRepository(clients);
+    eventPublisher = new EventPublisher(clients.pubSubPublishingService());
   }
+
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   protected static final Map<RequestType, NoticeEventType> requestTypeToEventMap;

--- a/src/main/java/org/folio/circulation/resources/RequestQueueResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestQueueResource.java
@@ -23,8 +23,11 @@ import org.folio.circulation.domain.representations.logs.LogEventType;
 import org.folio.circulation.domain.validation.RequestQueueValidation;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.ServicePointRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestQueueRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.context.ReorderRequestContext;
 import org.folio.circulation.resources.context.RequestQueueType;
 import org.folio.circulation.services.EventPublisher;
@@ -101,7 +104,11 @@ public class RequestQueueResource extends Resource {
 
     final WebContext context = new WebContext(routingContext);
     final Clients clients = Clients.create(context, client);
-    final RequestRepository requestRepository = RequestRepository.using(clients);
+    final ItemRepository itemRepository = new ItemRepository(clients);
+    final UserRepository userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final RequestRepository requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
     final ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
 

--- a/src/main/java/org/folio/circulation/resources/RequestQueueResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestQueueResource.java
@@ -80,11 +80,19 @@ public class RequestQueueResource extends Resource {
   }
 
   private void getQueue(RoutingContext routingContext, RequestQueueType requestQueueType) {
-    final WebContext context = new WebContext(routingContext);
+    final var context = new WebContext(routingContext);
+    final var clients = Clients.create(context, client);
+
+    final var itemRepository = new ItemRepository(clients);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final var requestQueueRepository = new RequestQueueRepository(
+      RequestRepository.using(clients, itemRepository, userRepository, loanRepository));
+
     final RequestRepresentation requestRepresentation = new RequestRepresentation();
 
     CompletableFuture<Result<RequestQueue>> requestQueue = getRequestQueueByType(routingContext,
-      context, requestQueueType);
+      requestQueueType, requestQueueRepository);
 
     requestQueue
       .thenApply(r -> r.map(queue -> new MultipleRecords<>(queue.getRequests(), queue.size())))
@@ -102,25 +110,26 @@ public class RequestQueueResource extends Resource {
 
     final EventPublisher eventPublisher = new EventPublisher(routingContext);
 
-    final WebContext context = new WebContext(routingContext);
-    final Clients clients = Clients.create(context, client);
-    final ItemRepository itemRepository = new ItemRepository(clients);
-    final UserRepository userRepository = new UserRepository(clients);
+    final var context = new WebContext(routingContext);
+    final var clients = Clients.create(context, client);
+
+    final var itemRepository = new ItemRepository(clients);
+    final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
-    final RequestRepository requestRepository = RequestRepository.using(clients,
+    final var requestRepository = RequestRepository.using(clients,
       itemRepository, userRepository, loanRepository);
-    final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
-    final ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
+    final var configurationRepository = new ConfigurationRepository(clients);
+    final var requestQueueRepository = new RequestQueueRepository(requestRepository);
 
     final UpdateRequestQueue updateRequestQueue = new UpdateRequestQueue(
       requestQueueRepository, requestRepository, new ServicePointRepository(clients),
       configurationRepository);
 
-    getRequestQueueByType(routingContext, context, requestQueueType);
+    getRequestQueueByType(routingContext, requestQueueType, requestQueueRepository);
 
     validateTlrFeatureStatus(configurationRepository, requestQueueType, idParamValue)
       .thenCompose(r -> r.after(tlrSettings ->
-        getRequestQueueByType(routingContext, context, requestQueueType)))
+        getRequestQueueByType(routingContext, requestQueueType, requestQueueRepository)))
       .thenApply(r -> r.map(reorderContext::withRequestQueue))
       // Validation block
       .thenApply(RequestQueueValidation::queueIsFound)
@@ -196,10 +205,8 @@ public class RequestQueueResource extends Resource {
   }
 
   private CompletableFuture<Result<RequestQueue>> getRequestQueueByType(
-    RoutingContext routingContext, WebContext context, RequestQueueType requestQueueType) {
-
-    Clients clients = Clients.create(context, client);
-    final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
+    RoutingContext routingContext, RequestQueueType requestQueueType,
+    RequestQueueRepository requestQueueRepository) {
 
     String idParamValue = getIdParameterValueByQueueType(routingContext, requestQueueType);
 

--- a/src/main/java/org/folio/circulation/resources/RequestScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestScheduledNoticeProcessingResource.java
@@ -18,8 +18,9 @@ import org.folio.circulation.domain.notice.schedule.ItemLevelRequestScheduledNot
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.domain.notice.schedule.TitleLevelRequestScheduledNoticeHandler;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CqlSortBy;
 import org.folio.circulation.support.http.client.PageLimit;
@@ -46,7 +47,7 @@ public class RequestScheduledNoticeProcessingResource extends ScheduledNoticePro
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> handleNotices(
-    Clients clients, ItemRepository itemRepository,
+    Clients clients, RequestRepository requestRepository, LoanRepository loanRepository,
     MultipleRecords<ScheduledNotice> scheduledNotices) {
 
     Collection<ScheduledNotice> records = scheduledNotices.getRecords();
@@ -54,33 +55,36 @@ public class RequestScheduledNoticeProcessingResource extends ScheduledNoticePro
       .stream()
       .collect(Collectors.groupingBy(this::isTitleLevelRequestNotice));
 
-    return handleItemLevelRequestNotices(clients, itemRepository,
-      noticesByRequestLevel.get(false))
+    return handleItemLevelRequestNotices(clients,
+      noticesByRequestLevel.get(false), requestRepository, loanRepository)
       .thenCompose(v -> handleTitleLevelRequestNotices(clients,
-        itemRepository, noticesByRequestLevel.get(true)
-      ))
+        requestRepository, loanRepository, noticesByRequestLevel.get(true)))
       .thenApply(mapResult(v -> scheduledNotices));
   }
 
   private CompletableFuture<Result<List<ScheduledNotice>>> handleItemLevelRequestNotices(
-    Clients clients, ItemRepository itemRepository, List<ScheduledNotice> itemLevelNotices) {
+    Clients clients,
+    List<ScheduledNotice> itemLevelNotices, RequestRepository requestRepository,
+    LoanRepository loanRepository) {
 
     if (itemLevelNotices == null || itemLevelNotices.isEmpty()) {
       return ofAsync(() -> null);
     }
 
-    return new ItemLevelRequestScheduledNoticeHandler(clients, itemRepository)
+    return new ItemLevelRequestScheduledNoticeHandler(clients, requestRepository, loanRepository)
       .handleNotices(itemLevelNotices);
   }
 
   private CompletableFuture<Result<List<ScheduledNotice>>> handleTitleLevelRequestNotices(
-    Clients clients, ItemRepository itemRepository, List<ScheduledNotice> titleLevelNotices) {
+    Clients clients,
+    RequestRepository requestRepository,
+    LoanRepository loanRepository, List<ScheduledNotice> titleLevelNotices) {
 
     if (titleLevelNotices == null || titleLevelNotices.isEmpty()) {
       return ofAsync(() -> null);
     }
 
-    return new TitleLevelRequestScheduledNoticeHandler(clients, itemRepository)
+    return new TitleLevelRequestScheduledNoticeHandler(clients, requestRepository, loanRepository)
       .handleNotices(titleLevelNotices);
   }
 

--- a/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
@@ -13,8 +13,10 @@ import org.folio.circulation.domain.anonymization.service.LoansForTenantFinder;
 import org.folio.circulation.domain.representations.anonymization.AnonymizeLoansRepresentation;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.feesandfines.AccountRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.AnonymizeStorageLoansRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.RouteRegistration;
@@ -50,7 +52,9 @@ public class ScheduledAnonymizationProcessingResource extends Resource {
     final Clients clients = Clients.create(context, client);
 
     ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
-    final var loanRepository = new LoanRepository(clients);
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final var accountRepository = new AccountRepository(clients);
 
     final var anonymizeStorageLoansRepository = new AnonymizeStorageLoansRepository(clients);

--- a/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledAnonymizationProcessingResource.java
@@ -52,7 +52,7 @@ public class ScheduledAnonymizationProcessingResource extends Resource {
     final Clients clients = Clients.create(context, client);
 
     ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final var accountRepository = new AccountRepository(clients);

--- a/src/main/java/org/folio/circulation/resources/ScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledNoticeProcessingResource.java
@@ -9,7 +9,10 @@ import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.RouteRegistration;
 import org.folio.circulation.support.http.client.PageLimit;
@@ -46,11 +49,16 @@ public abstract class ScheduledNoticeProcessingResource extends Resource {
     final ConfigurationRepository configurationRepository =
       new ConfigurationRepository(clients);
     final var itemRepository = new ItemRepository(clients);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final var requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
 
     safelyInitialise(configurationRepository::lookupSchedulerNoticesProcessingLimit)
       .thenCompose(r -> r.after(limit -> findNoticesToSend(configurationRepository,
         scheduledNoticesRepository, limit)))
-      .thenCompose(r -> r.after(notices -> handleNotices(clients, itemRepository, notices)))
+      .thenCompose(r -> r.after(notices -> handleNotices(clients, requestRepository,
+        loanRepository, notices)))
       .thenApply(r -> r.map(toFixedValue(NoContentResponse::noContent)))
       .exceptionally(CommonFailures::failedDueToServerError)
       .thenAccept(context::writeResultToHttpResponse);
@@ -61,6 +69,8 @@ public abstract class ScheduledNoticeProcessingResource extends Resource {
     ScheduledNoticesRepository scheduledNoticesRepository, PageLimit pageLimit);
 
   protected abstract CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> handleNotices(
-    Clients clients, ItemRepository itemRepository,
+    Clients clients,
+    RequestRepository requestRepository,
+    LoanRepository loanRepository,
     MultipleRecords<ScheduledNotice> noticesResult);
 }

--- a/src/main/java/org/folio/circulation/resources/agedtolost/ScheduledAgeToLostFeeChargingResource.java
+++ b/src/main/java/org/folio/circulation/resources/agedtolost/ScheduledAgeToLostFeeChargingResource.java
@@ -3,6 +3,8 @@ package org.folio.circulation.resources.agedtolost;
 import static org.folio.circulation.support.Clients.create;
 import static org.folio.circulation.support.results.MappingFunctions.toFixedValue;
 
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.Resource;
 import org.folio.circulation.services.agedtolost.ChargeLostFeesWhenAgedToLostService;
 import org.folio.circulation.support.RouteRegistration;
@@ -26,8 +28,10 @@ public class ScheduledAgeToLostFeeChargingResource extends Resource {
 
   private void scheduledAgeToLostFeeCharging(RoutingContext routingContext) {
     final WebContext context = new WebContext(routingContext);
+    final var clients = create(context, client);
     final ChargeLostFeesWhenAgedToLostService chargingService =
-      new ChargeLostFeesWhenAgedToLostService(create(context, client));
+      new ChargeLostFeesWhenAgedToLostService(clients, new ItemRepository(clients),
+        new UserRepository(clients));
 
     chargingService.chargeFees()
       .thenApply(r -> r.map(toFixedValue(NoContentResponse::noContent)))

--- a/src/main/java/org/folio/circulation/resources/agedtolost/ScheduledAgeToLostResource.java
+++ b/src/main/java/org/folio/circulation/resources/agedtolost/ScheduledAgeToLostResource.java
@@ -31,7 +31,7 @@ public class ScheduledAgeToLostResource extends Resource {
     final WebContext context = new WebContext(routingContext);
     final var clients = Clients.create(context, client);
 
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
 

--- a/src/main/java/org/folio/circulation/resources/agedtolost/ScheduledAgeToLostResource.java
+++ b/src/main/java/org/folio/circulation/resources/agedtolost/ScheduledAgeToLostResource.java
@@ -4,6 +4,7 @@ import static org.folio.circulation.support.results.MappingFunctions.toFixedValu
 
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.Resource;
 import org.folio.circulation.services.agedtolost.MarkOverdueLoansAsAgedLostService;
 import org.folio.circulation.support.Clients;
@@ -30,8 +31,9 @@ public class ScheduledAgeToLostResource extends Resource {
     final WebContext context = new WebContext(routingContext);
     final var clients = Clients.create(context, client);
 
-    final var itemRepository = new ItemRepository(clients, false, false, false);
-    final var loanRepository = new LoanRepository(clients);
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
 
     final MarkOverdueLoansAsAgedLostService ageToLostService =
       new MarkOverdueLoansAsAgedLostService(clients, itemRepository, loanRepository);

--- a/src/main/java/org/folio/circulation/resources/handlers/LoanRelatedFeeFineClosedHandlerResource.java
+++ b/src/main/java/org/folio/circulation/resources/handlers/LoanRelatedFeeFineClosedHandlerResource.java
@@ -72,7 +72,7 @@ public class LoanRelatedFeeFineClosedHandlerResource extends Resource {
     WebContext context, LoanRelatedFeeFineClosedEvent event) {
 
     final Clients clients = create(context, client);
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final var accountRepository = new AccountRepository(clients);

--- a/src/main/java/org/folio/circulation/resources/handlers/LoanRelatedFeeFineClosedHandlerResource.java
+++ b/src/main/java/org/folio/circulation/resources/handlers/LoanRelatedFeeFineClosedHandlerResource.java
@@ -20,6 +20,7 @@ import org.folio.circulation.infrastructure.storage.feesandfines.AccountReposito
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.loans.LostItemPolicyRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.Resource;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.support.Clients;
@@ -71,8 +72,9 @@ public class LoanRelatedFeeFineClosedHandlerResource extends Resource {
     WebContext context, LoanRelatedFeeFineClosedEvent event) {
 
     final Clients clients = create(context, client);
-    final var loanRepository = new LoanRepository(clients);
-    final var itemRepository = new ItemRepository(clients, false, false, false);
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final var accountRepository = new AccountRepository(clients);
     final var lostItemPolicyRepository = new LostItemPolicyRepository(clients);
 

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -78,6 +78,7 @@ import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.loans.OverdueFinePolicyRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestQueueRepository;
+import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.LoanNoticeSender;
 import org.folio.circulation.resources.Resource;
@@ -139,7 +140,9 @@ public abstract class RenewalResource extends Resource {
     final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
-    final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
+    final var requestRepository = RequestRepository.using(clients,
+      itemRepository, userRepository, loanRepository);
+    final var requestQueueRepository = new RequestQueueRepository(requestRepository);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final StoreLoanAndItem storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
 

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -136,7 +136,7 @@ public abstract class RenewalResource extends Resource {
 
     final CirculationErrorHandler errorHandler = new OverridingErrorHandler(okapiPermissions);
 
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
@@ -233,7 +233,7 @@ public abstract class RenewalResource extends Resource {
 
     final var overdueFineService = new OverdueFineService(
       new OverdueFinePolicyRepository(clients),
-      new ItemRepository(clients, true, false, false),
+      new ItemRepository(clients),
       new FeeFineOwnerRepository(clients),
       new FeeFineRepository(clients),
       ScheduledNoticesRepository.using(clients),

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -136,9 +136,9 @@ public abstract class RenewalResource extends Resource {
 
     final CirculationErrorHandler errorHandler = new OverridingErrorHandler(okapiPermissions);
 
-    final LoanRepository loanRepository = new LoanRepository(clients);
-    final ItemRepository itemRepository = new ItemRepository(clients, true, true, true);
-    final UserRepository userRepository = new UserRepository(clients);
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final RequestQueueRepository requestQueueRepository = RequestQueueRepository.using(clients);
     final LoanPolicyRepository loanPolicyRepository = new LoanPolicyRepository(clients);
     final StoreLoanAndItem storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -235,7 +235,7 @@ public abstract class RenewalResource extends Resource {
 
     return lostFeeRefundService.refundLostItemFees(renewalContext, servicePointId(renewalContext))
       .thenCompose(r -> r.after(context -> processFeesFinesForRegularRenew(context, clients,
-        new ItemRepository(clients))));
+        itemRepository)));
   }
 
   private CompletableFuture<Result<RenewalContext>> processFeesFinesForRegularRenew(

--- a/src/main/java/org/folio/circulation/rules/RulesExecutionParameters.java
+++ b/src/main/java/org/folio/circulation/rules/RulesExecutionParameters.java
@@ -37,7 +37,7 @@ public final class RulesExecutionParameters {
   }
 
   public static RulesExecutionParameters forItem(Item item, User user) {
-    return new RulesExecutionParameters(item.determineLoanTypeForItem(), item.getLocationId(),
+    return new RulesExecutionParameters(item.getLoanTypeId(), item.getLocationId(),
       item.getMaterialTypeId(), user.getPatronGroupId(), item.getLocation());
   }
 

--- a/src/main/java/org/folio/circulation/services/ChangeItemStatusService.java
+++ b/src/main/java/org/folio/circulation/services/ChangeItemStatusService.java
@@ -18,7 +18,7 @@ public class ChangeItemStatusService {
   public ChangeItemStatusService(Clients clients) {
     this.loanRepository = new LoanRepository(clients);
       this.storeLoanAndItem = new StoreLoanAndItem(loanRepository,
-              new ItemRepository(clients, false, false, false));
+        new ItemRepository(clients, false, false, false));
   }
 
   public <T extends ChangeItemStatusRequest> CompletableFuture<Result<Loan>> getOpenLoan(T request) {

--- a/src/main/java/org/folio/circulation/services/ChangeItemStatusService.java
+++ b/src/main/java/org/folio/circulation/services/ChangeItemStatusService.java
@@ -17,7 +17,7 @@ public class ChangeItemStatusService {
   private final StoreLoanAndItem storeLoanAndItem;
 
   public ChangeItemStatusService(Clients clients) {
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     this.loanRepository = new LoanRepository(clients, itemRepository, userRepository);
       this.storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);

--- a/src/main/java/org/folio/circulation/services/ChangeItemStatusService.java
+++ b/src/main/java/org/folio/circulation/services/ChangeItemStatusService.java
@@ -8,6 +8,7 @@ import org.folio.circulation.domain.representations.ChangeItemStatusRequest;
 import org.folio.circulation.domain.validation.LoanValidator;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 
@@ -16,9 +17,10 @@ public class ChangeItemStatusService {
   private final StoreLoanAndItem storeLoanAndItem;
 
   public ChangeItemStatusService(Clients clients) {
-    this.loanRepository = new LoanRepository(clients);
-      this.storeLoanAndItem = new StoreLoanAndItem(loanRepository,
-        new ItemRepository(clients, false, false, false));
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var userRepository = new UserRepository(clients);
+    this.loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+      this.storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
   }
 
   public <T extends ChangeItemStatusRequest> CompletableFuture<Result<Loan>> getOpenLoan(T request) {

--- a/src/main/java/org/folio/circulation/services/ChangeItemStatusService.java
+++ b/src/main/java/org/folio/circulation/services/ChangeItemStatusService.java
@@ -6,21 +6,18 @@ import org.folio.circulation.StoreLoanAndItem;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.representations.ChangeItemStatusRequest;
 import org.folio.circulation.domain.validation.LoanValidator;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
-import org.folio.circulation.infrastructure.storage.users.UserRepository;
-import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
 
 public class ChangeItemStatusService {
   private final LoanRepository loanRepository;
   private final StoreLoanAndItem storeLoanAndItem;
 
-  public ChangeItemStatusService(Clients clients) {
-    final var itemRepository = new ItemRepository(clients);
-    final var userRepository = new UserRepository(clients);
-    this.loanRepository = new LoanRepository(clients, itemRepository, userRepository);
-      this.storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
+  public ChangeItemStatusService(LoanRepository loanRepository,
+    StoreLoanAndItem storeLoanAndItem) {
+
+    this.loanRepository = loanRepository;
+    this.storeLoanAndItem = storeLoanAndItem;
   }
 
   public <T extends ChangeItemStatusRequest> CompletableFuture<Result<Loan>> getOpenLoan(T request) {

--- a/src/main/java/org/folio/circulation/services/ChangeItemStatusService.java
+++ b/src/main/java/org/folio/circulation/services/ChangeItemStatusService.java
@@ -1,13 +1,12 @@
 package org.folio.circulation.services;
 
-import static org.folio.circulation.infrastructure.storage.inventory.ItemRepository.noLocationMaterialTypeAndLoanTypeInstance;
-
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.circulation.StoreLoanAndItem;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.representations.ChangeItemStatusRequest;
 import org.folio.circulation.domain.validation.LoanValidator;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.results.Result;
@@ -18,8 +17,8 @@ public class ChangeItemStatusService {
 
   public ChangeItemStatusService(Clients clients) {
     this.loanRepository = new LoanRepository(clients);
-    this.storeLoanAndItem = new StoreLoanAndItem(loanRepository,
-      noLocationMaterialTypeAndLoanTypeInstance(clients));
+      this.storeLoanAndItem = new StoreLoanAndItem(loanRepository,
+              new ItemRepository(clients, false, false, false));
   }
 
   public <T extends ChangeItemStatusRequest> CompletableFuture<Result<Loan>> getOpenLoan(T request) {

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -30,7 +30,6 @@ import static org.folio.circulation.support.results.Result.succeeded;
 import static org.folio.circulation.support.utils.ClockUtil.getZonedDateTime;
 import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTimeOptional;
 
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.logging.log4j.LogManager;
@@ -49,6 +48,7 @@ import org.folio.circulation.domain.representations.logs.LoanLogContext;
 import org.folio.circulation.domain.representations.logs.LogContextActionResolver;
 import org.folio.circulation.domain.representations.logs.LogEventType;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.context.RenewalContext;
@@ -232,7 +232,10 @@ public class EventPublisher {
   public CompletableFuture<Result<RequestAndRelatedRecords>> publishDueDateChangedEvent(
     RequestAndRelatedRecords requestAndRelatedRecords, Clients clients) {
 
-    LoanRepository loanRepository = new LoanRepository(clients);
+    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+
     loanRepository.findOpenLoanForRequest(requestAndRelatedRecords.getRequest())
       .thenCompose(r -> r.after(loan -> publishDueDateChangedEvent(loan, requestAndRelatedRecords)));
 

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -232,7 +232,7 @@ public class EventPublisher {
   public CompletableFuture<Result<RequestAndRelatedRecords>> publishDueDateChangedEvent(
     RequestAndRelatedRecords requestAndRelatedRecords, Clients clients) {
 
-    final var itemRepository = new ItemRepository(clients, true, true, true);
+    final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
 

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -48,11 +48,9 @@ import org.folio.circulation.domain.representations.logs.LoanLogContext;
 import org.folio.circulation.domain.representations.logs.LogContextActionResolver;
 import org.folio.circulation.domain.representations.logs.LogEventType;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
-import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.users.UserRepository;
 import org.folio.circulation.resources.context.RenewalContext;
-import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.results.Result;
 
@@ -230,11 +228,7 @@ public class EventPublisher {
   }
 
   public CompletableFuture<Result<RequestAndRelatedRecords>> publishDueDateChangedEvent(
-    RequestAndRelatedRecords requestAndRelatedRecords, Clients clients) {
-
-    final var itemRepository = new ItemRepository(clients);
-    final var userRepository = new UserRepository(clients);
-    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    RequestAndRelatedRecords requestAndRelatedRecords, LoanRepository loanRepository) {
 
     loanRepository.findOpenLoanForRequest(requestAndRelatedRecords.getRequest())
       .thenCompose(r -> r.after(loan -> publishDueDateChangedEvent(loan, requestAndRelatedRecords)));

--- a/src/main/java/org/folio/circulation/services/ItemsInTransitReportService.java
+++ b/src/main/java/org/folio/circulation/services/ItemsInTransitReportService.java
@@ -58,13 +58,13 @@ public class ItemsInTransitReportService {
 
   public ItemsInTransitReportService(Clients clients) {
     this.itemReportRepository = new ItemReportRepository(clients);
-    this.loanRepository = new LoanRepository(clients);
+    this.itemRepository = new ItemRepository(clients, true, true, true);
+    this.userRepository = new UserRepository(clients);
+    this.loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     this.locationRepository = LocationRepository.using(clients);
     this.servicePointRepository = new ServicePointRepository(clients);
     this.requestRepository = new RequestRepository(clients, itemRepository, userRepository,
       loanRepository, servicePointRepository, patronGroupRepository);
-    this.itemRepository = new ItemRepository(clients, true, true, true);
-    this.userRepository = new UserRepository(clients);
     this.patronGroupRepository = new PatronGroupRepository(clients);
   }
 

--- a/src/main/java/org/folio/circulation/services/ItemsInTransitReportService.java
+++ b/src/main/java/org/folio/circulation/services/ItemsInTransitReportService.java
@@ -58,7 +58,7 @@ public class ItemsInTransitReportService {
 
   public ItemsInTransitReportService(Clients clients) {
     this.itemReportRepository = new ItemReportRepository(clients);
-    this.itemRepository = new ItemRepository(clients, true, true, true);
+    this.itemRepository = new ItemRepository(clients);
     this.userRepository = new UserRepository(clients);
     this.loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     this.locationRepository = LocationRepository.using(clients);

--- a/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
@@ -51,8 +51,8 @@ public class LostItemFeeChargingService {
   private String servicePointId;
 
   public LostItemFeeChargingService(Clients clients,
-    StoreLoanAndItem storeLoanAndItem) {
-    
+    StoreLoanAndItem storeLoanAndItem, LostItemFeeRefundService refundService) {
+
     this.lostItemPolicyRepository = new LostItemPolicyRepository(clients);
     this.feeFineOwnerRepository = new FeeFineOwnerRepository(clients);
     this.feeFineRepository = new FeeFineRepository(clients);
@@ -60,7 +60,7 @@ public class LostItemFeeChargingService {
     this.storeLoanAndItem = storeLoanAndItem;
     this.locationRepository = LocationRepository.using(clients);
     this.eventPublisher = new EventPublisher(clients.pubSubPublishingService());
-    this.refundService = new LostItemFeeRefundService(clients);
+    this.refundService = refundService;
     this.accountRepository = new AccountRepository(clients);
   }
 

--- a/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
@@ -50,12 +50,14 @@ public class LostItemFeeChargingService {
   private String userId;
   private String servicePointId;
 
-  public LostItemFeeChargingService(Clients clients) {
+  public LostItemFeeChargingService(Clients clients,
+    StoreLoanAndItem storeLoanAndItem) {
+    
     this.lostItemPolicyRepository = new LostItemPolicyRepository(clients);
     this.feeFineOwnerRepository = new FeeFineOwnerRepository(clients);
     this.feeFineRepository = new FeeFineRepository(clients);
     this.feeFineFacade = new FeeFineFacade(clients);
-    this.storeLoanAndItem = new StoreLoanAndItem(clients);
+    this.storeLoanAndItem = storeLoanAndItem;
     this.locationRepository = LocationRepository.using(clients);
     this.eventPublisher = new EventPublisher(clients.pubSubPublishingService());
     this.refundService = new LostItemFeeRefundService(clients);

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
@@ -46,7 +46,6 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.results.CommonFailures;
 import org.folio.circulation.support.results.Result;
-import org.folio.circulation.support.utils.ClockUtil;
 import org.folio.circulation.support.utils.DateTimeUtil;
 
 public class LostItemFeeRefundService {
@@ -63,12 +62,12 @@ public class LostItemFeeRefundService {
   private final FeeFineScheduledNoticeService scheduledNoticeService;
 
   public LostItemFeeRefundService(Clients clients) {
+    this.itemRepository = new ItemRepository(clients, true, true, true);
+    this.userRepository = new UserRepository(clients);
     this.lostItemPolicyRepository = new LostItemPolicyRepository(clients);
     this.feeFineFacade = new FeeFineFacade(clients);
     this.accountRepository = new AccountRepository(clients);
-    this.loanRepository = new LoanRepository(clients);
-    this.userRepository = new UserRepository(clients);
-    this.itemRepository = new ItemRepository(clients, true, false, false);
+    this.loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     this.scheduledNoticeService = FeeFineScheduledNoticeService.using(clients);
   }
 

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
@@ -61,13 +61,16 @@ public class LostItemFeeRefundService {
   private final ItemRepository itemRepository;
   private final FeeFineScheduledNoticeService scheduledNoticeService;
 
-  public LostItemFeeRefundService(Clients clients) {
-    this.itemRepository = new ItemRepository(clients);
-    this.userRepository = new UserRepository(clients);
+  public LostItemFeeRefundService(Clients clients,
+    ItemRepository itemRepository, UserRepository userRepository,
+    LoanRepository loanRepository) {
+
+    this.itemRepository = itemRepository;
+    this.userRepository = userRepository;
     this.lostItemPolicyRepository = new LostItemPolicyRepository(clients);
     this.feeFineFacade = new FeeFineFacade(clients);
     this.accountRepository = new AccountRepository(clients);
-    this.loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    this.loanRepository = loanRepository;
     this.scheduledNoticeService = FeeFineScheduledNoticeService.using(clients);
   }
 

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundService.java
@@ -62,7 +62,7 @@ public class LostItemFeeRefundService {
   private final FeeFineScheduledNoticeService scheduledNoticeService;
 
   public LostItemFeeRefundService(Clients clients) {
-    this.itemRepository = new ItemRepository(clients, true, true, true);
+    this.itemRepository = new ItemRepository(clients);
     this.userRepository = new UserRepository(clients);
     this.lostItemPolicyRepository = new LostItemPolicyRepository(clients);
     this.feeFineFacade = new FeeFineFacade(clients);

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -74,13 +74,13 @@ public class ChargeLostFeesWhenAgedToLostService {
   private final FeeFineScheduledNoticeService feeFineScheduledNoticeService;
 
   public ChargeLostFeesWhenAgedToLostService(Clients clients) {
+    this.itemRepository = new ItemRepository(clients, true, true, true);
+    this.userRepository = new UserRepository(clients);
     this.lostItemPolicyRepository = new LostItemPolicyRepository(clients);
     this.feeFineOwnerRepository = new FeeFineOwnerRepository(clients);
     this.feeFineRepository = new FeeFineRepository(clients);
     this.feeFineFacade = new FeeFineFacade(clients);
-    this.loanRepository = new LoanRepository(clients);
-    this.itemRepository = new ItemRepository(clients, true, false, false);
-    this.userRepository = new UserRepository(clients);
+    this.loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     this.storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
     this.eventPublisher = new EventPublisher(clients.pubSubPublishingService());
     this.loanPageableFetcher = new PageableFetcher<>(loanRepository);

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -74,7 +74,7 @@ public class ChargeLostFeesWhenAgedToLostService {
   private final FeeFineScheduledNoticeService feeFineScheduledNoticeService;
 
   public ChargeLostFeesWhenAgedToLostService(Clients clients) {
-    this.itemRepository = new ItemRepository(clients, true, true, true);
+    this.itemRepository = new ItemRepository(clients);
     this.userRepository = new UserRepository(clients);
     this.lostItemPolicyRepository = new LostItemPolicyRepository(clients);
     this.feeFineOwnerRepository = new FeeFineOwnerRepository(clients);

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -73,15 +73,18 @@ public class ChargeLostFeesWhenAgedToLostService {
   private final PageableFetcher<Loan> loanPageableFetcher;
   private final FeeFineScheduledNoticeService feeFineScheduledNoticeService;
 
-  public ChargeLostFeesWhenAgedToLostService(Clients clients) {
-    this.itemRepository = new ItemRepository(clients);
-    this.userRepository = new UserRepository(clients);
+  public ChargeLostFeesWhenAgedToLostService(Clients clients,
+    ItemRepository itemRepository, UserRepository userRepository) {
+    this.itemRepository = itemRepository;
+    this.userRepository = userRepository;
     this.lostItemPolicyRepository = new LostItemPolicyRepository(clients);
     this.feeFineOwnerRepository = new FeeFineOwnerRepository(clients);
     this.feeFineRepository = new FeeFineRepository(clients);
     this.feeFineFacade = new FeeFineFacade(clients);
-    this.loanRepository = new LoanRepository(clients, itemRepository, userRepository);
-    this.storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
+    this.loanRepository = new LoanRepository(clients, itemRepository,
+      userRepository);
+    this.storeLoanAndItem = new StoreLoanAndItem(loanRepository,
+      itemRepository);
     this.eventPublisher = new EventPublisher(clients.pubSubPublishingService());
     this.loanPageableFetcher = new PageableFetcher<>(loanRepository);
     this.feeFineScheduledNoticeService = FeeFineScheduledNoticeService.using(clients);

--- a/src/main/java/org/folio/circulation/services/agedtolost/MarkOverdueLoansAsAgedLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/MarkOverdueLoansAsAgedLostService.java
@@ -3,7 +3,6 @@ package org.folio.circulation.services.agedtolost;
 import static org.folio.circulation.domain.ItemStatus.AGED_TO_LOST;
 import static org.folio.circulation.domain.ItemStatus.CLAIMED_RETURNED;
 import static org.folio.circulation.domain.ItemStatus.DECLARED_LOST;
-import static org.folio.circulation.infrastructure.storage.inventory.ItemRepository.noLocationMaterialTypeAndLoanTypeInstance;
 import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.support.CqlSortBy.ascending;
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
@@ -47,7 +46,7 @@ public class MarkOverdueLoansAsAgedLostService {
 
   public MarkOverdueLoansAsAgedLostService(Clients clients) {
     this.lostItemPolicyRepository = new LostItemPolicyRepository(clients);
-    this.itemRepository = noLocationMaterialTypeAndLoanTypeInstance(clients);
+      this.itemRepository = new ItemRepository(clients, false, false, false);
     this.storeLoanAndItem = new StoreLoanAndItem(clients);
     this.eventPublisher = new EventPublisher(clients.pubSubPublishingService());
     this.loanPageableFetcher = new PageableFetcher<>(new LoanRepository(clients));

--- a/src/main/java/org/folio/circulation/services/agedtolost/MarkOverdueLoansAsAgedLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/MarkOverdueLoansAsAgedLostService.java
@@ -44,12 +44,14 @@ public class MarkOverdueLoansAsAgedLostService {
   private final LoanScheduledNoticeService loanScheduledNoticeService;
   private final UserRepository userRepository;
 
-  public MarkOverdueLoansAsAgedLostService(Clients clients) {
+  public MarkOverdueLoansAsAgedLostService(Clients clients,
+    ItemRepository itemRepository, LoanRepository loanRepository) {
+
+    this.itemRepository = itemRepository;
     this.lostItemPolicyRepository = new LostItemPolicyRepository(clients);
-      this.itemRepository = new ItemRepository(clients, false, false, false);
-    this.storeLoanAndItem = new StoreLoanAndItem(clients);
+    this.storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
     this.eventPublisher = new EventPublisher(clients.pubSubPublishingService());
-    this.loanPageableFetcher = new PageableFetcher<>(new LoanRepository(clients));
+    this.loanPageableFetcher = new PageableFetcher<>(loanRepository);
     this.loanScheduledNoticeService = LoanScheduledNoticeService.using(clients);
     this.userRepository = new UserRepository(clients);
   }

--- a/src/test/java/org/folio/circulation/domain/ItemTests.java
+++ b/src/test/java/org/folio/circulation/domain/ItemTests.java
@@ -35,4 +35,11 @@ class ItemTests {
 
     assertThrows(NullPointerException.class, () -> item.withLoanType(null));
   }
+
+  @Test
+  void cannotHaveANullLastCheckIn() {
+    val item = Item.from(new ItemBuilder().create());
+
+    assertThrows(NullPointerException.class, () -> item.withLastCheckIn(null));
+  }
 }

--- a/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
@@ -121,8 +121,8 @@ class OverdueFineServiceTest {
       servicePointRepository, feeFineService);
 
     overdueFineService = new OverdueFineService(
-      new OverdueFineService.Repos(overdueFinePolicyRepository, itemRepository,
-        feeFineOwnerRepository, feeFineRepository, scheduledNoticesRepository),
+      overdueFinePolicyRepository, itemRepository,
+        feeFineOwnerRepository, feeFineRepository, scheduledNoticesRepository,
       overduePeriodCalculatorService, feeFineFacade);
 
     when(userRepository.getUser(any(String.class))).thenReturn(

--- a/src/test/java/org/folio/circulation/infrastructure/storage/CirculationPolicyRepositoryTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/CirculationPolicyRepositoryTest.java
@@ -8,13 +8,12 @@ import java.util.concurrent.ExecutionException;
 
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.User;
-import org.folio.circulation.rules.CirculationRuleMatch;
-import org.folio.circulation.support.results.Result;
+import org.folio.circulation.domain.policy.LoanPolicy;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 class CirculationPolicyRepositoryTest {
-  private final CirculationPolicyRepository repository = mock(CirculationPolicyRepository.class, Mockito.CALLS_REAL_METHODS);
+  private final CirculationPolicyRepository<LoanPolicy> repository = mock(CirculationPolicyRepository.class, Mockito.CALLS_REAL_METHODS);
   private final Item item = mock(Item.class);
   private final User user = mock(User.class);
 
@@ -22,7 +21,7 @@ class CirculationPolicyRepositoryTest {
   void lookupPolicyIdShouldFailWhenPatronGroupIdIsNullForTheUser() throws ExecutionException, InterruptedException {
     when(item.isNotFound()).thenReturn(false);
     when(user.getPatronGroupId()).thenReturn(null);
-    Result<CirculationRuleMatch> result = (Result<CirculationRuleMatch>) repository.lookupPolicyId(item, user).get();
+    var result = repository.lookupPolicyId(item, user).get();
 
     assertEquals("Server error failure, reason: Unable to apply circulation rules to a user with null value as patronGroupId", result.cause().toString());
   }
@@ -32,7 +31,7 @@ class CirculationPolicyRepositoryTest {
     when(item.isNotFound()).thenReturn(false);
     when(user.getPatronGroupId()).thenReturn("1111");
     when(item.getLocationId()).thenReturn(null);
-    Result<CirculationRuleMatch> result = (Result<CirculationRuleMatch>) repository.lookupPolicyId(item, user).get();
+    var result = repository.lookupPolicyId(item, user).get();
 
     assertEquals("Server error failure, reason: Unable to apply circulation rules to an item with null value as locationId", result.cause().toString());
   }
@@ -42,9 +41,9 @@ class CirculationPolicyRepositoryTest {
     when(item.isNotFound()).thenReturn(false);
     when(user.getPatronGroupId()).thenReturn("1111");
     when(item.getLocationId()).thenReturn("2222");
-    when(item.determineLoanTypeForItem()).thenReturn(null);
+    when(item.getLoanTypeId()).thenReturn(null);
 
-    Result<CirculationRuleMatch> result = (Result<CirculationRuleMatch>) repository.lookupPolicyId(item, user).get();
+    var result = repository.lookupPolicyId(item, user).get();
 
     assertEquals("Server error failure, reason: Unable to apply circulation rules to an item which loan type can not be determined", result.cause().toString());
   }
@@ -54,10 +53,10 @@ class CirculationPolicyRepositoryTest {
     when(item.isNotFound()).thenReturn(false);
     when(user.getPatronGroupId()).thenReturn("1111");
     when(item.getLocationId()).thenReturn("2222");
-    when(item.determineLoanTypeForItem()).thenReturn("3333");
+    when(item.getLoanTypeId()).thenReturn("3333");
     when(item.getMaterialTypeId()).thenReturn(null);
 
-    Result<CirculationRuleMatch> result = (Result<CirculationRuleMatch>) repository.lookupPolicyId(item, user).get();
+    var result = repository.lookupPolicyId(item, user).get();
 
     assertEquals("Server error failure, reason: Unable to apply circulation rules to an item with null value as materialTypeId", result.cause().toString());
   }


### PR DESCRIPTION
## Purpose

In order to make it easier to change the way circulation interacts with inventory records, the representation in the domain could be separated more from the underlying representation of the records in inventory storage.

Using PUT requests to make changes to an item record means that the full storage representation needs to be available when changes are made.

Currently, the module keeps that representation within the domain.

Using a single instance of the inventory repository for each request to an endpoint (or behind the scenes process e.g. message handler or scheduled task) means that the storage representation can be cached within the repository.

This also helps to make repository dependencies more explicit, as they have to be passed down into each step that needs them (rather than creation within them using clients, which is a style that has outgrown the initial value).

More information can be found in [CIRC-1418|https://issues.folio.org/browse/CIRC-1418]

## Approach
* Work through each usage of the item repository extracting the dependency.
* Consolidate the creation of the repository as this is pulled up.

#### TODOS and Open Questions
* Remove the item storage representation from the domain

## Learning
* When modules are mostly a pass-through, keeping the domain and storage representations similar provides significant benefits in reducing the amount of mapping needed. As more behaviour is added, this design becomes an impediment to making independent changes.
