### PR TITLE
CIRC-1454 Use Identity Map to Cache Item Representation

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -114,10 +114,6 @@ public class Item {
     return changed;
   }
 
-  public JsonObject getItem() {
-    return itemRepresentation;
-  }
-
   public String getTitle() {
     return instance.getTitle();
   }

--- a/src/main/java/org/folio/circulation/domain/MultipleRecords.java
+++ b/src/main/java/org/folio/circulation/domain/MultipleRecords.java
@@ -58,6 +58,10 @@ public class MultipleRecords<T> {
       wrappedRecords, totalRecords));
   }
 
+  public T firstOrNull() {
+    return getRecords().stream().findFirst().orElse(null);
+  }
+
   public <R> Set<R> toKeys(Function<T, R> keyMapper) {
     return getRecords().stream()
       .map(keyMapper)

--- a/src/main/java/org/folio/circulation/infrastructure/storage/IdentityMap.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/IdentityMap.java
@@ -1,13 +1,56 @@
 package org.folio.circulation.infrastructure.storage;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
-public class IdentityMap<T> {
-  private final Map<String, T> identityMapHash = new HashMap<>();
+import org.folio.circulation.domain.MultipleRecords;
 
-  public Map<String, T> getIdentityMap() {
-    return identityMapHash;
+import io.vertx.core.json.JsonObject;
+import lombok.NonNull;
+
+/*
+  Is specific to JsonObject because a copy is required due to JsonObject being
+  mutable (and hence other reference could change the entry)
+
+  Could be made generic by introducing an optional mapper for values (which would
+  do the copy for JsonObject, could define to Function.identity())
+ */
+public class IdentityMap {
+  private final Map<String, JsonObject> map = new HashMap<>();
+  private final Function<JsonObject, String> keyMapper;
+
+  public IdentityMap(Function<JsonObject, String> keyMapper) {
+    this.keyMapper = keyMapper;
   }
 
+  public boolean entryNotPresent(String key) {
+    return !map.containsKey(key);
+  }
+
+  public JsonObject get(String key) {
+    return map.get(key);
+  }
+
+  public JsonObject add(JsonObject value) {
+    if (value != null) {
+      // Needs to be a copy because JsonObject is mutable
+      map.put(keyMapper.apply(value), value.copy());
+    }
+
+    return value;
+  }
+
+  public MultipleRecords<JsonObject> add(@NonNull MultipleRecords<JsonObject> values) {
+    add(values.getRecords());
+
+    return values;
+  }
+
+  public Collection<JsonObject> add(@NonNull Collection<JsonObject> values) {
+    values.forEach(this::add);
+
+    return values;
+  }
 }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/IdentityMap.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/IdentityMap.java
@@ -1,0 +1,13 @@
+package org.folio.circulation.infrastructure.storage;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class IdentityMap<T> {
+  private final Map<String, T> identityMapHash = new HashMap<>();
+
+  public Map<String, T> getIdentityMap() {
+    return identityMapHash;
+  }
+
+}

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -165,7 +165,7 @@ public class ItemRepository {
 
       return findByIndexNameAndQuery(holdingsRecords.toKeys(byId()), HOLDINGS_RECORD_ID,
         exactMatch("status.name", ItemStatus.AVAILABLE.getValue()))
-        .thenApply(r -> r.map(items -> items.stream().findFirst().orElse(null)));
+        .thenApply(mapResult(items -> items.stream().findFirst().orElse(null)));
     });
   }
 
@@ -185,7 +185,7 @@ public class ItemRepository {
     return SingleRecordFetcher.json(loanTypesClient, "loan types",
       response -> succeeded(null))
       .fetch(item.getLoanTypeId())
-      .thenApply(r -> r.map(new LoanTypeMapper()::toDomain));
+      .thenApply(mapResult(new LoanTypeMapper()::toDomain));
   }
 
   public CompletableFuture<Result<Item>> fetchByBarcode(String barcode) {
@@ -202,7 +202,7 @@ public class ItemRepository {
     Result<Collection<Item>> result) {
 
     return result.after(items -> locationRepository.getAllItemLocations(items)
-      .thenApply(r -> r.map(locations -> map(items, populateItemLocations(locations)))));
+      .thenApply(mapResult(locations -> map(items, populateItemLocations(locations)))));
   }
 
   private Function<Item, Item> populateItemLocations(Map<String, Location> locations) {
@@ -221,7 +221,7 @@ public class ItemRepository {
 
     return result.after(items ->
       materialTypeRepository.getMaterialTypes(items)
-        .thenApply(r -> r.map(materialTypes -> items.stream()
+        .thenApply(mapResult(materialTypes -> items.stream()
             .map(item -> item.withMaterialType(mapper.toDomain(materialTypes
               .getOrDefault(item.getMaterialTypeId(), null))))
             .collect(Collectors.toList()))));
@@ -276,7 +276,7 @@ public class ItemRepository {
       final var mapper = new InstanceMapper();
 
       return fetchInstancesByIds(instanceIds)
-        .thenApply(r -> r.map(instances -> items.stream()
+        .thenApply(mapResult(instances -> items.stream()
           .map(item -> item.withInstance(mapper.toDomain(
               findById(item.getInstanceId(), instances.getRecords()).orElse(null))))
           .collect(Collectors.toList())));
@@ -303,7 +303,7 @@ public class ItemRepository {
       final var mapper = new HoldingsMapper();
 
       return fetchHoldingsByIds(holdingsIds)
-        .thenApply(r -> r.map(holdings -> items.stream()
+        .thenApply(mapResult(holdings -> items.stream()
           .map(item -> item.withHoldings(mapper.toDomain(
               findById(item.getHoldingsRecordId(), holdings.getRecords()).orElse(null))))
           .collect(Collectors.toList())));
@@ -364,8 +364,8 @@ public class ItemRepository {
         return SingleRecordFetcher.json(holdingsClient, "holding",
             r -> failedValidation("Holding does not exist", ITEM_ID, item.getItemId()))
           .fetch(item.getHoldingsRecordId())
-          .thenApply(r -> r.map(mapper::toDomain))
-          .thenApply(r -> r.map(item::withHoldings));
+          .thenApply(mapResult(mapper::toDomain))
+          .thenApply(mapResult(item::withHoldings));
       }
     });
   }
@@ -381,8 +381,8 @@ public class ItemRepository {
 
         return SingleRecordFetcher.jsonOrNull(instancesClient, "instance")
           .fetch(item.getInstanceId())
-          .thenApply(r -> r.map(mapper::toDomain))
-          .thenApply(r -> r.map(item::withInstance));
+          .thenApply(mapResult(mapper::toDomain))
+          .thenApply(mapResult(item::withInstance));
       }
     });
   }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -113,7 +113,7 @@ public class ItemRepository {
 
   public CompletableFuture<Result<Item>> updateItem(Item item) {
     if (item == null) {
-      return completedFuture(null);
+      return ofAsync(() -> null);
     }
 
     if (!identityMap.containsKey(item.getItemId())) {

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -47,6 +47,7 @@ import org.folio.circulation.domain.LoanType;
 import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.ServicePoint;
+import org.folio.circulation.infrastructure.storage.IdentityMap;
 import org.folio.circulation.infrastructure.storage.ServicePointRepository;
 import org.folio.circulation.storage.mappers.HoldingsMapper;
 import org.folio.circulation.storage.mappers.InstanceMapper;
@@ -76,7 +77,7 @@ public class ItemRepository {
   private final LocationRepository locationRepository;
   private final MaterialTypeRepository materialTypeRepository;
   private final ServicePointRepository servicePointRepository;
-  private final Map<String, JsonObject> identityMap = new HashMap<>();
+  private final IdentityMap<JsonObject> identityMap = new IdentityMap<>();
 
   public ItemRepository(Clients clients) {
     this(clients.itemsStorage(), clients.holdingsStorage(),
@@ -116,12 +117,12 @@ public class ItemRepository {
       return ofAsync(() -> null);
     }
 
-    if (!identityMap.containsKey(item.getItemId())) {
+    if (!identityMap.getIdentityMap().containsKey(item.getItemId())) {
       return completedFuture(Result.failed(new ServerErrorFailure(
         "Cannot update item when original representation is not available in identity map")));
     }
 
-    final var updatedItemRepresentation = identityMap.get(item.getItemId());
+    final var updatedItemRepresentation = identityMap.getIdentityMap().get(item.getItemId());
 
     write(updatedItemRepresentation, STATUS_PROPERTY,
       new JsonObject().put("name", item.getStatus().getValue()));
@@ -502,7 +503,7 @@ public class ItemRepository {
       if (item != null) {
         // Needs to be a copy because JsonObject is mutable
         // and passed between instances of an item
-        identityMap.put(getProperty(item, "id"), item.copy());
+        identityMap.getIdentityMap().put(getProperty(item, "id"), item.copy());
       }
 
       return item;

--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
@@ -15,20 +15,20 @@ import static org.folio.circulation.domain.representations.LoanProperties.PATRON
 import static org.folio.circulation.domain.representations.LoanProperties.PATRON_GROUP_ID_AT_CHECKOUT;
 import static org.folio.circulation.support.CqlSortBy.ascending;
 import static org.folio.circulation.support.CqlSortBy.descending;
-import static org.folio.circulation.support.http.client.CqlQuery.exactMatchAny;
-import static org.folio.circulation.support.json.JsonPropertyWriter.write;
-import static org.folio.circulation.support.results.Result.failed;
-import static org.folio.circulation.support.results.Result.of;
-import static org.folio.circulation.support.results.Result.succeeded;
-import static org.folio.circulation.support.results.ResultBinding.flatMapResult;
-import static org.folio.circulation.support.results.ResultBinding.mapResult;
 import static org.folio.circulation.support.fetching.RecordFetching.findWithMultipleCqlIndexValues;
 import static org.folio.circulation.support.http.CommonResponseInterpreters.noContentRecordInterpreter;
 import static org.folio.circulation.support.http.ResponseMapping.forwardOnFailure;
 import static org.folio.circulation.support.http.ResponseMapping.mapUsingJson;
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
+import static org.folio.circulation.support.http.client.CqlQuery.exactMatchAny;
 import static org.folio.circulation.support.http.client.PageLimit.one;
+import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.folio.circulation.support.results.CommonFailures.failedDueToServerError;
+import static org.folio.circulation.support.results.Result.failed;
+import static org.folio.circulation.support.results.Result.of;
+import static org.folio.circulation.support.results.Result.succeeded;
+import static org.folio.circulation.support.results.ResultBinding.flatMapResult;
+import static org.folio.circulation.support.results.ResultBinding.mapResult;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Collection;
@@ -39,6 +39,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Account;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Loan;
@@ -53,18 +55,15 @@ import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FetchSingleRecord;
 import org.folio.circulation.support.FindWithMultipleCqlIndexValues;
 import org.folio.circulation.support.RecordNotFoundFailure;
-import org.folio.circulation.support.fetching.GetManyRecordsRepository;
-import org.folio.circulation.support.http.client.Offset;
-import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.SingleRecordFetcher;
+import org.folio.circulation.support.fetching.GetManyRecordsRepository;
 import org.folio.circulation.support.http.client.CqlQuery;
+import org.folio.circulation.support.http.client.Offset;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.client.ResponseInterpreter;
 import org.folio.circulation.support.results.CommonFailures;
-import org.folio.circulation.support.utils.CollectionUtil;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.folio.circulation.support.results.Result;
 
 import io.vertx.core.json.JsonObject;
 
@@ -403,7 +402,7 @@ public class LoanRepository implements GetManyRecordsRepository<Loan> {
       .map(cql -> cql.sortBy(descending(LOAN_DATE)));
 
     return queryLoanStorage(cqlQuery, one())
-      .thenApply(r -> r.map(CollectionUtil::firstOrNull));
+      .thenApply(mapResult(MultipleRecords::firstOrNull));
   }
 
   public CompletableFuture<Result<Loan>> findLoanWithClosestDueDate(List<String> itemIds) {
@@ -411,7 +410,7 @@ public class LoanRepository implements GetManyRecordsRepository<Loan> {
       .map(cql -> cql.sortBy(ascending(DUE_DATE)));
 
     return queryLoanStorage(cqlQuery, one())
-      .thenApply(r -> r.map(CollectionUtil::firstOrNull));
+      .thenApply(mapResult(MultipleRecords::firstOrNull));
   }
 
   public CompletableFuture<Result<Loan>> findLoanForAccount(Account account) {

--- a/src/main/java/org/folio/circulation/storage/mappers/ItemMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/ItemMapper.java
@@ -1,0 +1,11 @@
+package org.folio.circulation.storage.mappers;
+
+import org.folio.circulation.domain.Item;
+
+import io.vertx.core.json.JsonObject;
+
+public class ItemMapper {
+  public Item toDomain(JsonObject representation) {
+    return Item.from(representation);
+  }
+}

--- a/src/main/java/org/folio/circulation/support/utils/CollectionUtil.java
+++ b/src/main/java/org/folio/circulation/support/utils/CollectionUtil.java
@@ -9,26 +9,11 @@ import java.util.stream.Collectors;
 public final class CollectionUtil {
   private CollectionUtil() {}
 
-  public static <T> T firstOrNull(Collection<T> collection) {
-    if (collection == null) {
-      return null;
-    }
-
-    return collection.stream()
-      .findFirst()
-      .orElse(null);
-  }
-
   public static <T, R> Set<R> nonNullUniqueSetOf(Collection<T> collection, Function<T, R> mapper) {
     return collection.stream()
+      .filter(Objects::nonNull)
       .map(mapper)
       .filter(Objects::nonNull)
       .collect(Collectors.toSet());
-  }
-
-  public static <T, R> Collection<R> map(Collection<T> collection, Function<T, R> mapper) {
-    return collection.stream()
-      .map(mapper)
-      .collect(Collectors.toList());
   }
 }

--- a/src/main/java/org/folio/circulation/support/utils/CollectionUtil.java
+++ b/src/main/java/org/folio/circulation/support/utils/CollectionUtil.java
@@ -6,8 +6,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.folio.circulation.domain.MultipleRecords;
-
 public final class CollectionUtil {
   private CollectionUtil() {}
 
@@ -19,20 +17,6 @@ public final class CollectionUtil {
     return collection.stream()
       .findFirst()
       .orElse(null);
-  }
-
-  public static <T> T firstOrNull(MultipleRecords<T> records) {
-    if (records == null) {
-      return null;
-    }
-
-    return firstOrNull(records.getRecords());
-  }
-
-  public static <T, R> Set<R> uniqueSetOf(Collection<T> collection, Function<T, R> mapper) {
-    return collection.stream()
-      .map(mapper)
-      .collect(Collectors.toSet());
   }
 
   public static <T, R> Set<R> nonNullUniqueSetOf(Collection<T> collection, Function<T, R> mapper) {

--- a/src/test/java/org/folio/circulation/infrastructure/storage/IdentityMapTests.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/IdentityMapTests.java
@@ -1,0 +1,116 @@
+package org.folio.circulation.infrastructure.storage;
+
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.folio.circulation.domain.MultipleRecords;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonObject;
+
+class IdentityMapTests {
+  private final IdentityMap identityMap = new IdentityMap(json -> getProperty(json, "id"));
+
+  @Nested
+  @DisplayName("when created")
+  class whenNew {
+    @Nested
+    @DisplayName("after adding an entry")
+    class AfterAddingAnEntry {
+      private final String id = UUID.randomUUID().toString();
+      private final JsonObject entry = createEntry(id, "foo");
+
+      @BeforeEach
+      void addEntry() {
+        identityMap.add(entry);
+      }
+
+      @Test
+      void includesTheEntry() {
+        /*
+          This is somewhat counter-intuitive.
+          At the moment, the only client cares about an entry not being present
+          so that it can fail fast with an error, and hence no `entryPresent`
+          method is needed at the moment
+        */
+        assertThat(identityMap.entryNotPresent(id), is(false));
+      }
+
+      @Test
+      void theEntryCanBeRetrieved() {
+        final var fetchedEntry = identityMap.get(id);
+
+        assertThat(fetchedEntry, is(notNullValue()));
+        assertThat(getProperty(fetchedEntry, "id"), is(id));
+        assertThat(getProperty(fetchedEntry, "name"), is("foo"));
+      }
+
+      @Test
+      void theRetrievedEntryIsACopy() {
+        final var fetchedEntry = identityMap.get(id);
+
+        /*
+          As JsonObject is mutable, the entry in the identity map must be a copy
+          to stop it from being changed by a different reference
+         */
+        assertThat(fetchedEntry, is(not(sameInstance(entry))));
+      }
+    }
+
+    @Nested
+    @DisplayName("after adding multiple entries")
+    class AfterAddingMultipleEntry {
+      private final String firstId = UUID.randomUUID().toString();
+      private final String secondId = UUID.randomUUID().toString();
+      private final String thirdId = UUID.randomUUID().toString();
+
+      @BeforeEach
+      void addEntries() {
+        final var multipleEntries = new MultipleRecords<>(
+          List.of(createEntry(firstId, "foo"),
+            createEntry(secondId, "bar"), createEntry(thirdId, "squiggle")), 3);
+
+        identityMap.add(multipleEntries);
+      }
+
+      @Test
+      void includesTheEntries() {
+        assertThat(identityMap.entryNotPresent(firstId), is(false));
+        assertThat(identityMap.entryNotPresent(secondId), is(false));
+        assertThat(identityMap.entryNotPresent(thirdId), is(false));
+      }
+
+      @Test
+      void doesNotIncludeOtherEntries() {
+        assertThat(identityMap.entryNotPresent(UUID.randomUUID().toString()), is(true));
+      }
+
+      @Test
+      void theEntriesCanBeRetrieved() {
+        assertThat(getName(firstId), is("foo"));
+        assertThat(getName(secondId), is("bar"));
+        assertThat(getName(thirdId), is("squiggle"));
+      }
+
+      private String getName(String firstId) {
+        return getProperty(identityMap.get(firstId), "name");
+      }
+    }
+  }
+
+  private JsonObject createEntry(String id, String name) {
+    return new JsonObject()
+      .put("id", id)
+      .put("name", name);
+  }
+}

--- a/src/test/java/org/folio/circulation/infrastructure/storage/IdentityMapTests.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/IdentityMapTests.java
@@ -4,6 +4,7 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -36,6 +37,19 @@ class IdentityMapTests {
     @DisplayName("cannot add null multiple records")
     void cannotAddNullMultipleRecords() {
       assertThrows(NullPointerException.class, () -> identityMap.add((MultipleRecords<JsonObject>)null));
+    }
+
+    @Test
+    @DisplayName("nothing happens when attempting to add a null entry")
+    void nothingHappensWhenAddingANewEntry() {
+      /*
+        This is designed to make it easier to apply the identity map as a side effect
+        whilst chaining it with other steps in a process
+
+        Requiring the client to check for null would mean each use having to
+        include additional code
+       */
+      assertThat(identityMap.add((JsonObject) null), is(nullValue()));
     }
 
     @Nested

--- a/src/test/java/org/folio/circulation/infrastructure/storage/IdentityMapTests.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/IdentityMapTests.java
@@ -6,7 +6,9 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -24,6 +26,18 @@ class IdentityMapTests {
   @Nested
   @DisplayName("when created")
   class whenNew {
+    @Test
+    @DisplayName("cannot add null collection of entries")
+    void cannotAddNullCollectionOfEntries() {
+      assertThrows(NullPointerException.class, () -> identityMap.add((Collection<JsonObject>)null));
+    }
+
+    @Test
+    @DisplayName("cannot add null multiple records")
+    void cannotAddNullMultipleRecords() {
+      assertThrows(NullPointerException.class, () -> identityMap.add((MultipleRecords<JsonObject>)null));
+    }
+
     @Nested
     @DisplayName("after adding an entry")
     class AfterAddingAnEntry {
@@ -36,6 +50,7 @@ class IdentityMapTests {
       }
 
       @Test
+      @DisplayName("identity map includes entry")
       void includesTheEntry() {
         /*
           This is somewhat counter-intuitive.
@@ -47,6 +62,7 @@ class IdentityMapTests {
       }
 
       @Test
+      @DisplayName("entry can be retrieved")
       void theEntryCanBeRetrieved() {
         final var fetchedEntry = identityMap.get(id);
 
@@ -56,6 +72,7 @@ class IdentityMapTests {
       }
 
       @Test
+      @DisplayName("the retrieved entry is a copy of the original")
       void theRetrievedEntryIsACopy() {
         final var fetchedEntry = identityMap.get(id);
 
@@ -84,6 +101,7 @@ class IdentityMapTests {
       }
 
       @Test
+      @DisplayName("identity map includes all of the entries")
       void includesTheEntries() {
         assertThat(identityMap.entryNotPresent(firstId), is(false));
         assertThat(identityMap.entryNotPresent(secondId), is(false));
@@ -91,11 +109,13 @@ class IdentityMapTests {
       }
 
       @Test
+      @DisplayName("identity map does not include other entries")
       void doesNotIncludeOtherEntries() {
         assertThat(identityMap.entryNotPresent(UUID.randomUUID().toString()), is(true));
       }
 
       @Test
+      @DisplayName("each entry can be retrieved")
       void theEntriesCanBeRetrieved() {
         assertThat(getName(firstId), is("foo"));
         assertThat(getName(secondId), is("bar"));

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
@@ -3,6 +3,8 @@ package org.folio.circulation.infrastructure.storage.inventory;
 import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
 import static api.support.matchers.ResultMatchers.succeeded;
 import static org.folio.circulation.support.results.Result.ofAsync;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -29,18 +31,6 @@ import lombok.SneakyThrows;
 
 class ItemRepositoryTests {
   @Test
-  void cannotUpdateAnItemThatHasNotBeenFetched() {
-    final var repository = createRepository(null);
-
-    final var notFetchedItem = dummyItem();
-
-    final var updateResult = get(repository.updateItem(notFetchedItem));
-
-    assertThat(updateResult, isErrorFailureContaining(
-      "Cannot update item when original representation is not available in identity map"));
-  }
-
-  @Test
   void canUpdateAnItemThatHasBeenFetched() {
     final var itemsClient = mock(CollectionResourceClient.class);
     final var repository = createRepository(itemsClient);
@@ -60,6 +50,28 @@ class ItemRepositoryTests {
     final var updateResult = get(repository.updateItem(fetchedItem));
 
     assertThat(updateResult, succeeded());
+  }
+
+  @Test
+  void cannotUpdateAnItemThatHasNotBeenFetched() {
+    final var repository = createRepository(null);
+
+    final var notFetchedItem = dummyItem();
+
+    final var updateResult = get(repository.updateItem(notFetchedItem));
+
+    assertThat(updateResult, isErrorFailureContaining(
+      "Cannot update item when original representation is not available in identity map"));
+  }
+
+  @Test
+  void nullItemIsNotUpdated() {
+    final var repository = createRepository(null);
+
+    final var updateResult = get(repository.updateItem(null));
+
+    assertThat(updateResult, succeeded());
+    assertThat(updateResult.value(), is(nullValue()));
   }
 
   private void mockedClientGet(CollectionResourceClient client, String body) {

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
@@ -1,8 +1,15 @@
 package org.folio.circulation.infrastructure.storage.inventory;
 
 import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
+import static api.support.matchers.ResultMatchers.succeeded;
+import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -10,25 +17,85 @@ import org.folio.circulation.domain.Holdings;
 import org.folio.circulation.domain.Instance;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.LoanType;
+import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.MaterialType;
+import org.folio.circulation.support.CollectionResourceClient;
+import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.results.Result;
 import org.junit.jupiter.api.Test;
 
+import io.vertx.core.json.JsonObject;
 import lombok.SneakyThrows;
 
 class ItemRepositoryTests {
   @Test
   void cannotUpdateAnItemThatHasNotBeenFetched() {
-    final var repository = new ItemRepository(null, null, null, null, null,
-      null, null);
+    final var repository = createRepository(null);
 
-    final var notFetchedItem = new Item(null, null, null, null, null, null, null, false,
-      Holdings.unknown(), Instance.unknown(), MaterialType.unknown(), LoanType.unknown());
+    final var notFetchedItem = dummyItem();
 
     final var updateResult = get(repository.updateItem(notFetchedItem));
 
     assertThat(updateResult, isErrorFailureContaining(
       "Cannot update item when original representation is not available in identity map"));
+  }
+
+  @Test
+  void canUpdateAnItemThatHasBeenFetched() {
+    final var itemsClient = mock(CollectionResourceClient.class);
+    final var repository = createRepository(itemsClient);
+
+    final var itemJson = new JsonObject()
+      .put("holdingsRecordId", UUID.randomUUID())
+      .put("effectiveLocationId", UUID.randomUUID());
+
+    mockedClientGet(itemsClient, itemJson.encodePrettily());
+
+    when(itemsClient.put(any(), any())).thenReturn(ofAsync(
+      () -> new Response(204, null, "application/json")));
+
+    final var fetchedItem = get(repository.fetchById(UUID.randomUUID().toString()))
+      .value();
+
+    final var updateResult = get(repository.updateItem(fetchedItem));
+
+    assertThat(updateResult, succeeded());
+  }
+
+  private void mockedClientGet(CollectionResourceClient client, String body) {
+    when(client.get(anyString())).thenReturn(Result.ofAsync(
+      () -> new Response(200, body, "application/json")));
+  }
+
+  private ItemRepository createRepository(CollectionResourceClient itemsClient) {
+    final var holdingsClient = mock(CollectionResourceClient.class);
+    final var instancesClient = mock(CollectionResourceClient.class);
+    final var locationRepository = mock(LocationRepository.class);
+    final var materialTypeRepository = mock(MaterialTypeRepository.class);
+
+    final var holdings = new JsonObject()
+      .put("instanceId", UUID.randomUUID());
+
+    mockedClientGet(holdingsClient, holdings.encodePrettily());
+
+    final var instance = new JsonObject();
+
+    mockedClientGet(instancesClient, instance.encodePrettily());
+
+    when(locationRepository.getLocation(any()))
+      .thenReturn(ofAsync(() -> Location.from(new JsonObject())));
+
+    when(materialTypeRepository.getFor(any()))
+      .thenReturn(ofAsync(MaterialType::unknown));
+
+    return new ItemRepository(itemsClient, holdingsClient, instancesClient,
+      null, locationRepository, materialTypeRepository, null);
+  }
+
+  private Item dummyItem() {
+    return new Item(null, null, null, null, null, null, null, false,
+      Holdings.unknown(), Instance.unknown(), MaterialType.unknown(),
+      LoanType.unknown());
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
@@ -1,0 +1,38 @@
+package org.folio.circulation.infrastructure.storage.inventory;
+
+import static api.support.matchers.FailureMatcher.isErrorFailureContaining;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.folio.circulation.domain.Holdings;
+import org.folio.circulation.domain.Instance;
+import org.folio.circulation.domain.Item;
+import org.folio.circulation.domain.LoanType;
+import org.folio.circulation.domain.MaterialType;
+import org.folio.circulation.support.results.Result;
+import org.junit.jupiter.api.Test;
+
+import lombok.SneakyThrows;
+
+class ItemRepositoryTests {
+  @Test
+  void cannotUpdateAnItemThatHasNotBeenFetched() {
+    final var repository = new ItemRepository(null, null, null, null, null,
+      null, null);
+
+    final var notFetchedItem = new Item(null, null, null, null, null, null, null, false,
+      Holdings.unknown(), Instance.unknown(), MaterialType.unknown(), LoanType.unknown());
+
+    final var updateResult = get(repository.updateItem(notFetchedItem));
+
+    assertThat(updateResult, isErrorFailureContaining(
+      "Cannot update item when original representation is not available in identity map"));
+  }
+
+  @SneakyThrows
+  private <T> Result<T> get(CompletableFuture<Result<T>> future) {
+    return future.get(1, TimeUnit.SECONDS);
+  }
+}

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
@@ -8,7 +8,9 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
@@ -35,19 +37,24 @@ class ItemRepositoryTests {
     final var itemsClient = mock(CollectionResourceClient.class);
     final var repository = createRepository(itemsClient);
 
+    final var itemId = UUID.randomUUID().toString();
+
     final var itemJson = new JsonObject()
+      .put("id", itemId)
       .put("holdingsRecordId", UUID.randomUUID())
       .put("effectiveLocationId", UUID.randomUUID());
 
     mockedClientGet(itemsClient, itemJson.encodePrettily());
 
     when(itemsClient.put(any(), any())).thenReturn(ofAsync(
-      () -> new Response(204, null, "application/json")));
+      () -> new Response(204, itemJson.toString(), "application/json")));
 
-    final var fetchedItem = get(repository.fetchById(UUID.randomUUID().toString()))
+    final var fetchedItem = get(repository.fetchById(itemId))
       .value();
 
     final var updateResult = get(repository.updateItem(fetchedItem));
+
+    verify(itemsClient).put(eq(itemId), any());
 
     assertThat(updateResult, succeeded());
   }


### PR DESCRIPTION
## Purpose
In order to make it easier to change the way circulation interacts with inventory records, the representation in the domain could be separated more from the underlying representation of the records in inventory storage.

Using PUT requests to make changes to an item record means that the full storage representation needs to be available when changes are made.

Currently, the module keeps that representation within the domain.

A step in removing that representation from the domain is to move the copy of the representation in the item repository instead of the domain class.

For more information, refer to [CIRC-1454](https://issues.folio.org/browse/CIRC-1454)

## Approach
* Introduce the identity map into the repository
* Remove public access to the item representation in the item domain class

## TODO
* Improve item repository tests by extracting higher level collaborators rather than collection resource clients
* Remove the representation within the item domain class