### PR TITLE
CIRC-1461 Remove redundant permission

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1148,11 +1148,6 @@
       "description": "Apply circulation rules to get matching lost item policy"
     },
     {
-      "permissionName": "note.types.collection.get",
-      "displayName": "Note types - get note types collection",
-      "description": "Get note types collection"
-    },
-    {
       "permissionName": "circulation.requests.collection.get",
       "displayName": "circulation - get request collection",
       "description": "get request collection"


### PR DESCRIPTION
## Purpose
Remove redundant permission since it's already defined in mod-notes

Resolves: [CIRC-1461](https://issues.folio.org/browse/CIRC-1461)