### PR TITLE
CIRC-1471 Two recall-related automated patron blocks are not being enforced

### DIFF
--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
@@ -407,6 +407,7 @@ public class LoanRepository implements GetManyRecordsRepository<Loan> {
 
   public CompletableFuture<Result<Loan>> findLoanWithClosestDueDate(List<String> itemIds) {
     final Result<CqlQuery> cqlQuery = exactMatchAny(ITEM_ID, itemIds)
+      .combine(getStatusCQLQuery("Open"), CqlQuery::and)
       .map(cql -> cql.sortBy(ascending(DUE_DATE)));
 
     return queryLoanStorage(cqlQuery, one())

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -3,6 +3,7 @@ package api.requests;
 import static api.support.builders.RequestBuilder.OPEN_AWAITING_PICKUP;
 import static api.support.builders.RequestBuilder.OPEN_NOT_YET_FILLED;
 import static api.support.fakes.FakePubSub.getPublishedEventsAsList;
+import static api.support.fakes.PublishedEvents.byEventType;
 import static api.support.fakes.PublishedEvents.byLogEventType;
 import static api.support.fixtures.AutomatedPatronBlocksFixture.MAX_NUMBER_OF_ITEMS_CHARGED_OUT_MESSAGE;
 import static api.support.fixtures.AutomatedPatronBlocksFixture.MAX_OUTSTANDING_FEE_FINE_BALANCE_MESSAGE;
@@ -10,6 +11,7 @@ import static api.support.http.CqlQuery.exactMatch;
 import static api.support.http.CqlQuery.notEqual;
 import static api.support.http.Limit.limit;
 import static api.support.http.Offset.noOffset;
+import static api.support.matchers.EventMatchers.isValidLoanDueDateChangedEvent;
 import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
 import static api.support.matchers.JsonObjectMatcher.hasNoJsonPath;
 import static api.support.matchers.PatronNoticeMatcher.hasEmailNoticeProperties;
@@ -52,7 +54,9 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -66,6 +70,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -108,6 +113,8 @@ import api.support.builders.RequestBuilder;
 import api.support.builders.UserBuilder;
 import api.support.builders.UserManualBlockBuilder;
 import api.support.fakes.FakeModNotify;
+import api.support.fakes.FakePubSub;
+import api.support.fakes.PublishedEvents;
 import api.support.fixtures.CheckInFixture;
 import api.support.fixtures.ItemExamples;
 import api.support.fixtures.ItemsFixture;
@@ -1437,6 +1444,39 @@ public class RequestsAPICreationTests extends APITests {
     assertThat(recallRequest.getJson().getString("requestType"), is(RequestType.RECALL.getValue()));
     assertThat(requestedItem.getString("status"), is(ItemStatus.CHECKED_OUT.getValue()));
     assertThat(recallRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
+  }
+
+  @Test
+  void canCreateTitleLevelRecallRequestWhenOneLoanIsClosed() {
+    reconfigureTlrFeature(TlrFeatureStatus.ENABLED);
+    final ItemResource item = itemsFixture.basedUponSmallAngryPlanet();
+    final IndividualResource requestPickupServicePoint = servicePointsFixture.cd1();
+
+    checkOutFixture.checkOutByBarcode(item, usersFixture.jessica());
+    checkInFixture.checkInByBarcode(item);
+
+    IndividualResource loan = checkOutFixture.checkOutByBarcode(item, usersFixture.jessica());
+
+    requestsClient.create(new RequestBuilder()
+      .recall()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(item.getInstanceId())
+      .withPickupServicePointId(requestPickupServicePoint.getId())
+      .withRequesterId(usersFixture.james().getId()));
+
+    PublishedEvents publishedEvents = Awaitility.await()
+      .atMost(1, TimeUnit.SECONDS)
+      .until(FakePubSub::getPublishedEvents, hasSize(9));
+
+    JsonObject updatedLoan = loansClient.get(loan.getId()).getJson();
+    assertThat(updatedLoan.getString("dueDateChangedByRecall"), true);
+
+    JsonObject event = publishedEvents.findFirst(byEventType("LOAN_DUE_DATE_CHANGED"));
+    assertThat(event, isValidLoanDueDateChangedEvent(updatedLoan));
+    assertThat(new JsonObject(event.getString("eventPayload"))
+      .getBoolean("dueDateChangedByRecall"), equalTo(true));
   }
 
   @Test

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -1448,7 +1448,7 @@ public class RequestsAPICreationTests extends APITests {
   }
 
   @Test
-  void canCreateTitleLevelRecallRequestWhenOneLoanIsClosed() {
+  void canCreateTlrRecallForInstanceWithSingleItemAndTwoLoans() {
     reconfigureTlrFeature(TlrFeatureStatus.ENABLED);
     final ItemResource item = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource requestPickupServicePoint = servicePointsFixture.cd1();


### PR DESCRIPTION
### Purpose
Fix automated patron blocks feature based on placed recall requests with enabled tlr feature
### Approach

- Adjusted LoanRepository, RequestFromRepresentationService
- Test added

### Learning
https://issues.folio.org/browse/CIRC-1471