### PR TITLE
Use fixed date time during refund processing tests CIRC-1494

### DIFF
--- a/src/test/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicyTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
@@ -143,7 +144,8 @@ class LostItemPolicyTest {
 
     final LostItemPolicy lostItemPolicy = LostItemPolicy.from(builder.create());
 
-    final ZonedDateTime now = getZonedDateTime();
+    final ZonedDateTime now
+      = ZonedDateTime.of(2022, 3, 27, 11, 25, 35, 0, ZoneId.of("UTC"));
     setClock(fixed(now.toInstant(), ZoneOffset.UTC));
 
     final ZonedDateTime lostDateTime = period.minusDate(now);


### PR DESCRIPTION
## Purpose

The mainline [build](https://jenkins-aws.indexdata.com/job/folio-org/job/mod-circulation/job/master/971) of mod-circulation currently fails.

This test failure is caused by using the current date / time as the basis for other relative date / times.

One of those scenarios is for moving the current date / time back by 6 months. Unfortunately, that leads to the date being the 30th instead of the 31st because September has 30 days rather than 31.

This can be resolved by using a fixed started point rather than relying on the current system date / time