### PR TITLE
CIRC-1497 Get fixed period for loan due date during recall

### DIFF
--- a/src/main/java/org/folio/circulation/domain/UpdateLoan.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateLoan.java
@@ -77,7 +77,8 @@ public class UpdateLoan {
           .after(loanPolicyRepository::lookupLoanPolicy)
           .thenApply(r -> r.next(this::recall))
           .thenApply(r -> r.next(recallResult -> updateLoanAction(recallResult, request)))
-          .thenComposeAsync(r -> r.after(closedLibraryStrategyService::applyClosedLibraryDueDateManagement))
+          .thenComposeAsync(r -> r.after(records ->
+            closedLibraryStrategyService.applyClosedLibraryDueDateManagement(records, true)))
           .thenComposeAsync(r -> r.after(loanRepository::updateLoan))
           .thenApply(r -> r.next(scheduledNoticeService::rescheduleDueDateNotices))
           .thenApply(r -> r.map(v -> requestAndRelatedRecords.withRequest(request.withLoan(v.getLoan()))));

--- a/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyService.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyService.java
@@ -84,7 +84,6 @@ public class ClosedLibraryStrategyService {
         loanPolicy, timeZone)));
   }
 
-
   private Result<ZonedDateTime> applyStrategy(
     Loan loan, LoanPolicy loanPolicy, AdjacentOpeningDays openingDays, ZoneId timeZone,
     boolean isRecall) {
@@ -137,6 +136,6 @@ public class ClosedLibraryStrategyService {
     ClosedLibraryStrategy strategy =
       ClosedLibraryStrategyUtils.determineStrategyForMovingBackward(
         loanPolicy, currentDateTime, timeZone);
-    return strategy.calculateDueDate(currentDateTime, openingDays);
+    return strategy.calculateDueDate(dueDateLimit, openingDays);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyService.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyService.java
@@ -121,7 +121,8 @@ public class ClosedLibraryStrategyService {
     ZoneId timeZone, boolean isRecall){
 
     Optional<ZonedDateTime> optionalDueDateLimit =
-      loanPolicy.getScheduleLimit(isRecall ? loan.getDueDate() : loan.getLoanDate(), isRenewal, currentDateTime);
+      loanPolicy.getScheduleLimit(isRecall ? loan.getDueDate() : loan.getLoanDate(), isRenewal,
+        currentDateTime);
     if (!optionalDueDateLimit.isPresent()) {
       return succeeded(dueDate);
     }

--- a/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyService.java
+++ b/src/main/java/org/folio/circulation/domain/policy/library/ClosedLibraryStrategyService.java
@@ -44,11 +44,16 @@ public class ClosedLibraryStrategyService {
 
   public CompletableFuture<Result<LoanAndRelatedRecords>> applyClosedLibraryDueDateManagement(
     LoanAndRelatedRecords relatedRecords) {
+    return applyClosedLibraryDueDateManagement(relatedRecords, false);
+  }
+
+  public CompletableFuture<Result<LoanAndRelatedRecords>> applyClosedLibraryDueDateManagement(
+    LoanAndRelatedRecords relatedRecords, boolean isRecall) {
 
     final Loan loan = relatedRecords.getLoan();
 
     return applyClosedLibraryDueDateManagement(loan, loan.getLoanPolicy(),
-      relatedRecords.getTimeZone())
+      relatedRecords.getTimeZone(), isRecall)
       .thenApply(mapResult(loan::changeDueDate))
       .thenApply(mapResult(relatedRecords::withLoan));
   }
@@ -65,21 +70,28 @@ public class ClosedLibraryStrategyService {
 
   private CompletableFuture<Result<ZonedDateTime>> applyClosedLibraryDueDateManagement(
     Loan loan, LoanPolicy loanPolicy, ZoneId timeZone) {
+    return applyClosedLibraryDueDateManagement(loan, loanPolicy, timeZone, false);
+  }
+
+  private CompletableFuture<Result<ZonedDateTime>> applyClosedLibraryDueDateManagement(
+    Loan loan, LoanPolicy loanPolicy, ZoneId timeZone, boolean isRecall) {
 
     LocalDate requestedDate = loan.getDueDate().withZoneSameInstant(timeZone).toLocalDate();
 
     return calendarRepository.lookupOpeningDays(requestedDate, loan.getCheckoutServicePointId())
-      .thenApply(r -> r.next(openingDays -> applyStrategy(loan, loanPolicy, openingDays, timeZone)))
+      .thenApply(r -> r.next(openingDays -> applyStrategy(loan, loanPolicy, openingDays, timeZone, isRecall)))
       .thenCompose(r -> r.after(dueDate -> truncateDueDateIfPatronExpiresEarlier(dueDate, loan,
         loanPolicy, timeZone)));
   }
 
+
   private Result<ZonedDateTime> applyStrategy(
-    Loan loan, LoanPolicy loanPolicy, AdjacentOpeningDays openingDays, ZoneId timeZone) {
+    Loan loan, LoanPolicy loanPolicy, AdjacentOpeningDays openingDays, ZoneId timeZone,
+    boolean isRecall) {
 
     return determineClosedLibraryStrategy(loanPolicy, currentDateTime, timeZone)
       .calculateDueDate(loan.getDueDate(), openingDays)
-      .next(dateTime -> applyFixedDueDateLimit(dateTime, loan, loanPolicy, openingDays, timeZone));
+      .next(dateTime -> applyFixedDueDateLimit(dateTime, loan, loanPolicy, openingDays, timeZone, isRecall));
   }
 
   private CompletableFuture<Result<ZonedDateTime>> truncateDueDateIfPatronExpiresEarlier(
@@ -107,10 +119,10 @@ public class ClosedLibraryStrategyService {
 
   private Result<ZonedDateTime> applyFixedDueDateLimit(
     ZonedDateTime dueDate, Loan loan, LoanPolicy loanPolicy, AdjacentOpeningDays openingDays,
-    ZoneId timeZone) {
+    ZoneId timeZone, boolean isRecall){
 
     Optional<ZonedDateTime> optionalDueDateLimit =
-      loanPolicy.getScheduleLimit(loan.getLoanDate(), isRenewal, currentDateTime);
+      loanPolicy.getScheduleLimit(isRecall ? loan.getDueDate() : loan.getLoanDate(), isRenewal, currentDateTime);
     if (!optionalDueDateLimit.isPresent()) {
       return succeeded(dueDate);
     }
@@ -125,6 +137,6 @@ public class ClosedLibraryStrategyService {
     ClosedLibraryStrategy strategy =
       ClosedLibraryStrategyUtils.determineStrategyForMovingBackward(
         loanPolicy, currentDateTime, timeZone);
-    return strategy.calculateDueDate(dueDateLimit, openingDays);
+    return strategy.calculateDueDate(currentDateTime, openingDays);
   }
 }

--- a/src/test/java/api/requests/scenarios/RecallItemsTests.java
+++ b/src/test/java/api/requests/scenarios/RecallItemsTests.java
@@ -8,14 +8,25 @@ import static api.support.utl.BlockOverridesUtils.buildOkapiHeadersWithPermissio
 import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTime;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.is;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
 
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.Test;
 
 import api.support.APITests;
+import api.support.builders.FixedDueDateSchedule;
+import api.support.builders.FixedDueDateSchedulesBuilder;
 import api.support.builders.LoanPolicyBuilder;
+import api.support.http.IndividualResource;
 import api.support.http.OkapiHeaders;
+import api.support.http.UserResource;
 import lombok.val;
 
 class RecallItemsTests extends APITests {
@@ -46,5 +57,51 @@ class RecallItemsTests extends APITests {
       hasJsonPath("loan.action", "recallrequested"),
       hasNoJsonPath("loan.actionComment")
     )));
+  }
+
+  @Test
+  void whenPolicyHasTwoDifferentFixedSchedulesRecallShouldApplyToTheScheduleForTheDueDateAfterRenew() {
+    ZonedDateTime fromFirst = ZonedDateTime.of(2022, 1, 2, 10, 2, 3, 0,
+      ZoneId.of("Europe/London"));
+
+    ZonedDateTime toFirst = fromFirst.plusDays(2);
+
+    ZonedDateTime dueFirst = toFirst.plusDays(5);
+
+    ZonedDateTime fromSecond = ZonedDateTime.of(2022, 1, 17, 10, 2, 3, 0,
+      ZoneId.of("Europe/London"));
+
+    ZonedDateTime toSecond = fromSecond.plusDays(3);
+
+    ZonedDateTime dueSecond = toSecond.plusDays(7);
+
+    FixedDueDateSchedulesBuilder builder = new FixedDueDateSchedulesBuilder()
+      .addSchedule(new FixedDueDateSchedule(fromFirst, toFirst, dueFirst))
+      .addSchedule(new FixedDueDateSchedule(fromSecond, toSecond, dueSecond));
+    IndividualResource fixedDueDateSchedules = fixedDueDateScheduleClient.create(builder);
+    Period recallInterval = Period.days(2);
+    use(new LoanPolicyBuilder().fixed(fixedDueDateSchedules.getId())
+      .limitedRenewals(2)
+      .withRecallsMinimumGuaranteedLoanPeriod(Period.weeks(2))
+      .withRecallsRecallReturnInterval(recallInterval)
+      .withRenewable(true));
+
+    val item = itemsFixture.basedUponNod();
+    val james = usersFixture.james();
+    val jessica = usersFixture.jessica();
+    ZonedDateTime loanDate = fromFirst.plusDays(2);
+    val loan = checkOutFixture.checkOutByBarcode(item, james, loanDate);
+    assertThat(loan.getJson().getInstant("dueDate").atZone(ZoneId.of("Europe/London")),
+      is(dueFirst));
+
+    ClockUtil.setClock(Clock.fixed(toSecond.minusHours(3).toInstant(), ZoneId.of("Europe/London")));
+
+    assertThat(loansFixture.renewLoan(item, james).getJson()
+      .getInstant("dueDate").atZone(ZoneId.of("Europe/London")), is(dueSecond));
+
+    requestsFixture.recallItem(item, jessica);
+
+    assertThat(loansFixture.getLoanById(loan.getId()).getJson().getInstant("dueDate")
+      .atZone(ZoneId.of("Europe/London")), is(recallInterval.plusDate(ClockUtil.getZonedDateTime())));
   }
 }

--- a/src/test/java/api/requests/scenarios/RecallItemsTests.java
+++ b/src/test/java/api/requests/scenarios/RecallItemsTests.java
@@ -11,10 +11,8 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
 
 import java.time.Clock;
-import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.temporal.TemporalAccessor;
 
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.utils.ClockUtil;
@@ -26,7 +24,6 @@ import api.support.builders.FixedDueDateSchedulesBuilder;
 import api.support.builders.LoanPolicyBuilder;
 import api.support.http.IndividualResource;
 import api.support.http.OkapiHeaders;
-import api.support.http.UserResource;
 import lombok.val;
 
 class RecallItemsTests extends APITests {
@@ -61,15 +58,16 @@ class RecallItemsTests extends APITests {
 
   @Test
   void whenPolicyHasTwoDifferentFixedSchedulesRecallShouldApplyToTheScheduleForTheDueDateAfterRenew() {
+    ZoneId londonZoneId = ZoneId.of("Europe/London");
     ZonedDateTime fromFirst = ZonedDateTime.of(2022, 1, 2, 10, 2, 3, 0,
-      ZoneId.of("Europe/London"));
+      londonZoneId);
 
     ZonedDateTime toFirst = fromFirst.plusDays(2);
 
     ZonedDateTime dueFirst = toFirst.plusDays(5);
 
     ZonedDateTime fromSecond = ZonedDateTime.of(2022, 1, 17, 10, 2, 3, 0,
-      ZoneId.of("Europe/London"));
+      londonZoneId);
 
     ZonedDateTime toSecond = fromSecond.plusDays(3);
 
@@ -91,17 +89,17 @@ class RecallItemsTests extends APITests {
     val jessica = usersFixture.jessica();
     ZonedDateTime loanDate = fromFirst.plusDays(2);
     val loan = checkOutFixture.checkOutByBarcode(item, james, loanDate);
-    assertThat(loan.getJson().getInstant("dueDate").atZone(ZoneId.of("Europe/London")),
+    assertThat(loan.getJson().getInstant("dueDate").atZone(londonZoneId),
       is(dueFirst));
 
-    ClockUtil.setClock(Clock.fixed(toSecond.minusHours(3).toInstant(), ZoneId.of("Europe/London")));
+    ClockUtil.setClock(Clock.fixed(toSecond.minusHours(3).toInstant(), londonZoneId));
 
     assertThat(loansFixture.renewLoan(item, james).getJson()
-      .getInstant("dueDate").atZone(ZoneId.of("Europe/London")), is(dueSecond));
+      .getInstant("dueDate").atZone(londonZoneId), is(dueSecond));
 
     requestsFixture.recallItem(item, jessica);
 
     assertThat(loansFixture.getLoanById(loan.getId()).getJson().getInstant("dueDate")
-      .atZone(ZoneId.of("Europe/London")), is(recallInterval.plusDate(ClockUtil.getZonedDateTime())));
+      .atZone(londonZoneId), is(recallInterval.plusDate(ClockUtil.getZonedDateTime())));
   }
 }

--- a/src/test/java/api/requests/scenarios/RecallItemsTests.java
+++ b/src/test/java/api/requests/scenarios/RecallItemsTests.java
@@ -59,18 +59,14 @@ class RecallItemsTests extends APITests {
   @Test
   void whenPolicyHasTwoDifferentFixedSchedulesRecallShouldApplyToTheScheduleForTheDueDateAfterRenew() {
     ZoneId londonZoneId = ZoneId.of("Europe/London");
+
     ZonedDateTime fromFirst = ZonedDateTime.of(2022, 1, 2, 10, 2, 3, 0,
       londonZoneId);
-
     ZonedDateTime toFirst = fromFirst.plusDays(2);
-
     ZonedDateTime dueFirst = toFirst.plusDays(5);
-
     ZonedDateTime fromSecond = ZonedDateTime.of(2022, 1, 17, 10, 2, 3, 0,
       londonZoneId);
-
     ZonedDateTime toSecond = fromSecond.plusDays(3);
-
     ZonedDateTime dueSecond = toSecond.plusDays(7);
 
     FixedDueDateSchedulesBuilder builder = new FixedDueDateSchedulesBuilder()
@@ -79,7 +75,7 @@ class RecallItemsTests extends APITests {
     IndividualResource fixedDueDateSchedules = fixedDueDateScheduleClient.create(builder);
     Period recallInterval = Period.days(2);
     use(new LoanPolicyBuilder().fixed(fixedDueDateSchedules.getId())
-      .limitedRenewals(2)
+      .limitedRenewals(1)
       .withRecallsMinimumGuaranteedLoanPeriod(Period.weeks(2))
       .withRecallsRecallReturnInterval(recallInterval)
       .withRenewable(true));


### PR DESCRIPTION
Resolves: https://issues.folio.org/browse/CIRC-1497

## Purpose
When recalling loans with fixed due date loan policies that have been renewed in a new loan period or had their due dates changed to a date after the original due date, the loan's due date is being set to the due date specified for the original fixed due date period for the loan's loanDate.
## Approach
When fetching fixed period for deciding on the due date, get a schedule in which a loan due date falls into.