### PR TITLE
CIRC-1507 When TLR feature is disabled, assign ILR during instance level requests creation

### DIFF
--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -269,12 +269,11 @@ public class RequestByInstanceIdResource extends Resource {
     JsonObject requestBody, ItemByInstanceIdFinder itemFinder,
     LoanRepository loanRepository, RequestQueueRepository requestQueueRepository) {
 
-    return succeeded(requestBody.put(REQUEST_LEVEL, "Item"))
-      .after(body -> RequestByInstanceIdRequest.from(body)
+    return RequestByInstanceIdRequest.from(requestBody.put(REQUEST_LEVEL, RequestLevel.ITEM.getValue()))
       .map(InstanceRequestRelatedRecords::new)
       .after(instanceRequest -> getPotentialItems(itemFinder, instanceRequest,
         loanRepository, requestQueueRepository))
-      .thenApply( r -> r.next(RequestByInstanceIdResource::instanceToItemRequests)));
+      .thenApply( r -> r.next(RequestByInstanceIdResource::instanceToItemRequests));
   }
 
   private CompletableFuture<Result<RequestAndRelatedRecords>> placeRequests(

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -269,11 +269,12 @@ public class RequestByInstanceIdResource extends Resource {
     JsonObject requestBody, ItemByInstanceIdFinder itemFinder,
     LoanRepository loanRepository, RequestQueueRepository requestQueueRepository) {
 
-    return RequestByInstanceIdRequest.from(requestBody)
+    return succeeded(requestBody.put(REQUEST_LEVEL, "Item"))
+      .after(body -> RequestByInstanceIdRequest.from(body)
       .map(InstanceRequestRelatedRecords::new)
       .after(instanceRequest -> getPotentialItems(itemFinder, instanceRequest,
         loanRepository, requestQueueRepository))
-      .thenApply( r -> r.next(RequestByInstanceIdResource::instanceToItemRequests));
+      .thenApply( r -> r.next(RequestByInstanceIdResource::instanceToItemRequests)));
   }
 
   private CompletableFuture<Result<RequestAndRelatedRecords>> placeRequests(

--- a/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
+++ b/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 
 import org.folio.circulation.domain.ItemStatus;
+import org.folio.circulation.domain.RequestLevel;
 import org.folio.circulation.domain.RequestType;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.utils.ClockUtil;
@@ -76,6 +77,7 @@ class InstanceRequestsAPICreationTests extends APITests {
       instanceMultipleCopies.getId(), item2.getId(), RequestType.PAGE);
 
     assertThat(representation, hasJsonPath("patronComments", "I need the book"));
+    assertThat(representation, hasJsonPath("requestLevel", RequestLevel.ITEM.getValue()));
   }
 
   @Test

--- a/src/test/java/api/support/builders/RequestByInstanceIdRequestBuilder.java
+++ b/src/test/java/api/support/builders/RequestByInstanceIdRequestBuilder.java
@@ -30,7 +30,6 @@ public class RequestByInstanceIdRequestBuilder implements Builder {
     JsonObject requestBody = new JsonObject();
 
     write(requestBody, "instanceId", instanceId);
-    write(requestBody, "requestLevel", "Item");
     write(requestBody, "requestDate", formatDateTimeOptional(requestDate));
     write(requestBody, "requesterId", requesterId);
     write(requestBody, "pickupServicePointId", pickupServicePointId);


### PR DESCRIPTION
Resolves: https://issues.folio.org/browse/CIRC-1507
## Purpose
When creating the instance level request via mod-patron, the user receives the error. This happens because on mod-circulation side we are still looking for the request level field in the json from the mod-patron, which does not pass tit any more.

## Approach
Pass requestLevel -> Item when creating item level requests