### PR TITLE
[CIRC-1515] Delete overnight notice when failed to build template context for it

### DIFF
--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -2,12 +2,11 @@ package org.folio.circulation.domain.notice;
 
 import static java.lang.Math.max;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTime;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -50,14 +49,12 @@ public class TemplateContextUtil {
       .put(LOAN, createLoanContext(loan));
   }
 
-  public static JsonObject createMultiLoanNoticeContext(User user, Collection<Loan> loans) {
-    List<JsonObject> loanContexts = loans.stream()
-      .map(TemplateContextUtil::createLoanNoticeContextWithoutUser)
-      .collect(toList());
+  public static JsonObject createMultiLoanNoticeContext(User user,
+    Collection<JsonObject> loanContexts) {
 
     return new JsonObject()
       .put(USER, createUserContext(user))
-      .put(LOANS, new JsonArray(loanContexts));
+      .put(LOANS, new JsonArray(new ArrayList<>(loanContexts)));
   }
 
   public static JsonObject createLoanNoticeContext(Loan loan) {

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedLoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedLoanScheduledNoticeHandler.java
@@ -3,6 +3,7 @@ package org.folio.circulation.domain.notice.schedule;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toList;
+import static org.folio.circulation.domain.notice.TemplateContextUtil.createLoanNoticeContextWithoutUser;
 import static org.folio.circulation.domain.notice.TemplateContextUtil.createMultiLoanNoticeContext;
 import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.support.AsyncCoordinationUtil.allResultsOf;
@@ -17,7 +18,6 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.notice.ScheduledPatronNoticeService;
 import org.folio.circulation.domain.notice.schedule.ScheduledNoticeHandler.ScheduledNoticeContext;
@@ -27,6 +27,8 @@ import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.results.Result;
+
+import io.vertx.core.json.JsonObject;
 
 public class GroupedLoanScheduledNoticeHandler {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
@@ -56,27 +58,38 @@ public class GroupedLoanScheduledNoticeHandler {
     List<ScheduledNotice> notices) {
 
     //TODO: user and template are the same for all notices in the group, so they can be fetched only once
-    return allResultsOf(notices, this::fetchData)
-      .thenCompose(this::discardDataFetchingFailures)
+    return allResultsOf(notices, this::buildContext)
+      .thenCompose(this::discardContextBuildingFailures)
       .thenCompose(r -> r.after(this::sendGroupedNotice))
       .thenCompose(r -> r.after(this::updateGroupedNotice))
       .thenCompose(r -> handleResult(r, notices))
       .exceptionally(t -> handleException(t, notices));
   }
 
-  private CompletableFuture<Result<ScheduledNoticeContext>> fetchData(ScheduledNotice notice) {
+  private CompletableFuture<Result<ScheduledNoticeContext>> buildContext(ScheduledNotice notice) {
     return ofAsync(() -> new ScheduledNoticeContext(notice))
       .thenCompose(r -> r.after(loanScheduledNoticeHandler::fetchData))
-      .thenCompose(r -> handleDataCollectionFailure(r, notice))
+      .thenApply(r -> r.map(GroupedLoanScheduledNoticeHandler::buildLoanNoticeContext))
+      .thenApply(r -> r.map(GroupedLoanScheduledNoticeHandler::buildNoticeLogContextItem))
+      .thenCompose(r -> handleContextBuildingFailure(r, notice))
       .thenApply(r -> r.mapFailure(f -> loanScheduledNoticeHandler.publishErrorEvent(f, notice)));
   }
 
-  protected CompletableFuture<Result<ScheduledNoticeContext>> handleDataCollectionFailure(
+  private static ScheduledNoticeContext buildLoanNoticeContext(ScheduledNoticeContext context) {
+    return context.withLoanNoticeContext(createLoanNoticeContextWithoutUser(context.getLoan()));
+  }
+
+  private static ScheduledNoticeContext buildNoticeLogContextItem(ScheduledNoticeContext context) {
+    return context.withNoticeLogContextItem(
+      LoanScheduledNoticeHandler.buildNoticeLogContextItem(context));
+  }
+
+  protected CompletableFuture<Result<ScheduledNoticeContext>> handleContextBuildingFailure(
     Result<ScheduledNoticeContext> result, ScheduledNotice notice) {
 
     if (result.failed()) {
       HttpFailure cause = result.cause();
-      log.error("Failed to collect data for scheduled notice: {}.\n{}", cause, notice);
+      log.error("Failed to build context for scheduled notice: {}.\n{}", cause, notice);
 
       return loanScheduledNoticeHandler.deleteNotice(notice, cause.toString())
         .thenApply(r -> r.next(n -> result));
@@ -85,7 +98,7 @@ public class GroupedLoanScheduledNoticeHandler {
     return completedFuture(result);
   }
 
-  private CompletableFuture<Result<List<ScheduledNoticeContext>>> discardDataFetchingFailures(
+  private CompletableFuture<Result<List<ScheduledNoticeContext>>> discardContextBuildingFailures(
     List<Result<ScheduledNoticeContext>> results) {
 
     var failedResults = results.stream()
@@ -93,7 +106,7 @@ public class GroupedLoanScheduledNoticeHandler {
       .collect(toList());
 
     if (!failedResults.isEmpty()) {
-      log.error("Failed to collect data for {} out of {} scheduled notices",
+      log.error("Failed to build context for {} out of {} scheduled notices",
         failedResults.size(), results.size());
 
       results.removeAll(failedResults);
@@ -124,17 +137,16 @@ public class GroupedLoanScheduledNoticeHandler {
     ScheduledNoticeContext contextSample = relevantContexts.get(0);
     User user = contextSample.getLoan().getUser();
 
-    List<Loan> loans = relevantContexts.stream()
-      .map(ScheduledNoticeContext::getLoan)
+    List<JsonObject> noticeLoanContexts = relevantContexts.stream()
+      .map(ScheduledNoticeContext::getLoanNoticeContext)
       .collect(toList());
 
-    log.info("Attempting to send a grouped notice for {} scheduled notices",
-      relevantContexts.size());
+    log.info("Attempting to send a grouped notice for {} scheduled notices", relevantContexts.size());
 
     return patronNoticeService.sendNotice(
       contextSample.getNotice().getConfiguration(),
       user.getId(),
-      createMultiLoanNoticeContext(user, loans),
+      createMultiLoanNoticeContext(user, noticeLoanContexts),
       buildNoticeLogContext(relevantContexts, user))
       .thenApply(mapResult(v -> contexts));
   }
@@ -143,7 +155,7 @@ public class GroupedLoanScheduledNoticeHandler {
     User user) {
 
     List<NoticeLogContextItem> items = contexts.stream()
-      .map(LoanScheduledNoticeHandler::buildNoticeLogContextItem)
+      .map(ScheduledNoticeContext::getNoticeLogContextItem)
       .collect(toList());
 
     return new NoticeLogContext()

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedLoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedLoanScheduledNoticeHandler.java
@@ -144,10 +144,10 @@ public class GroupedLoanScheduledNoticeHandler {
     log.info("Attempting to send a grouped notice for {} scheduled notices", relevantContexts.size());
 
     return patronNoticeService.sendNotice(
-      contextSample.getNotice().getConfiguration(),
-      user.getId(),
-      createMultiLoanNoticeContext(user, noticeLoanContexts),
-      buildNoticeLogContext(relevantContexts, user))
+        contextSample.getNotice().getConfiguration(),
+        user.getId(),
+        createMultiLoanNoticeContext(user, noticeLoanContexts),
+        buildNoticeLogContext(relevantContexts, user))
       .thenApply(mapResult(v -> contexts));
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
@@ -21,6 +21,7 @@ import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.notice.ScheduledPatronNoticeService;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
+import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
 import org.folio.circulation.infrastructure.storage.feesandfines.AccountRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.PatronNoticePolicyRepository;
@@ -234,6 +235,8 @@ public abstract class ScheduledNoticeHandler {
     private Request request;
     private String patronNoticePolicyId;
     private boolean lostItemFeesForAgedToLostNoticeExist;
+    private JsonObject loanNoticeContext;
+    private NoticeLogContextItem noticeLogContextItem;
   }
 
 }

--- a/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
@@ -532,19 +532,16 @@ class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests {
     );
 
     ZonedDateTime loanDate = ZonedDateTime.of(2019, 8, 23, 10, 30, 59, 123, ZoneOffset.UTC);
-
     IndividualResource firstLoan = checkOutFixture.checkOutByBarcode(
-      itemsFixture.basedUponNod(), usersFixture.james(), loanDate);
-
-    IndividualResource secondLoan = checkOutFixture.checkOutByBarcode(
       itemsFixture.basedUponTemeraire(), usersFixture.james(), loanDate);
+    checkOutFixture.checkOutByBarcode(itemsFixture.basedUponNod(), usersFixture.james(), loanDate);
 
     verifyNumberOfScheduledNotices(2);
 
     loansFixture.replaceLoan(firstLoan.getId(),
       firstLoan.getJson().put("loanDate", loanDate.toLocalDateTime().toString())); // remove time zone
 
-    ZonedDateTime dueDate = parseDateTime(firstLoan.getJson().getString("dueDate"));;
+    ZonedDateTime dueDate = parseDateTime(firstLoan.getJson().getString("dueDate"));
 
     scheduledNoticeProcessingClient.runDueDateNotRealTimeNoticesProcessing(dueDate.plusDays(1));
 

--- a/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
@@ -518,6 +518,43 @@ class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests {
   }
 
   @Test
+  void noticeIsDeletedWhenLoanDateTimeZoneIsMissing() {
+    JsonObject uponAtDueDateNoticeConfig = new NoticeConfigurationBuilder()
+      .withTemplateId(TEMPLATE_ID)
+      .withDueDateEvent()
+      .withUponAtTiming()
+      .sendInRealTime(false)
+      .create();
+
+    use(new NoticePolicyBuilder()
+      .withName("Policy with due date notices")
+      .withLoanNotices(Collections.singletonList(uponAtDueDateNoticeConfig))
+    );
+
+    ZonedDateTime loanDate = ZonedDateTime.of(2019, 8, 23, 10, 30, 59, 123, ZoneOffset.UTC);
+
+    IndividualResource firstLoan = checkOutFixture.checkOutByBarcode(
+      itemsFixture.basedUponNod(), usersFixture.james(), loanDate);
+
+    IndividualResource secondLoan = checkOutFixture.checkOutByBarcode(
+      itemsFixture.basedUponTemeraire(), usersFixture.james(), loanDate);
+
+    verifyNumberOfScheduledNotices(2);
+
+    loansFixture.replaceLoan(firstLoan.getId(),
+      firstLoan.getJson().put("loanDate", loanDate.toLocalDateTime().toString())); // remove time zone
+
+    ZonedDateTime dueDate = parseDateTime(firstLoan.getJson().getString("dueDate"));;
+
+    scheduledNoticeProcessingClient.runDueDateNotRealTimeNoticesProcessing(dueDate.plusDays(1));
+
+    verifyNumberOfSentNotices(1);
+    verifyNumberOfScheduledNotices(0);
+    verifyNumberOfPublishedEvents(NOTICE, 1);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 1);
+  }
+
+  @Test
   void noticeIsNotSentOrDeletedWhenPatronNoticeRequestFails() {
     JsonObject uponAtDueDateNoticeConfig = new NoticeConfigurationBuilder()
       .withTemplateId(TEMPLATE_ID)


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Failure to build the template context for one individual overnight notice causes the processing of the whole group of overnight notices to fail. We should build context individually for each notice and remove the broken notice from the group before we attempt to send it.

Resolves [CIRC-1515](https://issues.folio.org/browse/CIRC-1515).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
