### PR TITLE
CIRC-1532 Don't pass dash comment with lost item fees

### DIFF
--- a/src/main/java/org/folio/circulation/services/feefine/CancelAccountRequest.java
+++ b/src/main/java/org/folio/circulation/services/feefine/CancelAccountRequest.java
@@ -19,7 +19,6 @@ final class CancelAccountRequest {
     write(json, "servicePointId", servicePointId);
     write(json, "userName", userName);
     write(json, "cancellationReason", cancellationReason);
-    write(json, "comments", "-");
 
     return json;
   }

--- a/src/test/resources/fee-fine-cancel-operation-16-1.json
+++ b/src/test/resources/fee-fine-cancel-operation-16-1.json
@@ -28,7 +28,6 @@
   },
   "additionalProperties": false,
   "required": [
-    "comments",
     "notifyPatron",
     "servicePointId",
     "userName"


### PR DESCRIPTION
Resolves: https://issues.folio.org/browse/CIRC-1532

## Purpose
When creating Cancel Action Request, mod-circulation should not fill the comments field with a dash. 
