### PR TITLE
Split item status enum CIRC-1416

### DIFF
--- a/src/main/java/org/folio/circulation/domain/CallNumberComponents.java
+++ b/src/main/java/org/folio/circulation/domain/CallNumberComponents.java
@@ -5,11 +5,17 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty
 import java.util.Optional;
 
 import io.vertx.core.json.JsonObject;
+import lombok.Value;
 
+@Value
 public class CallNumberComponents {
-  private final String callNumber;
-  private final String prefix;
-  private final String suffix;
+  String callNumber;
+  String prefix;
+  String suffix;
+
+  public static CallNumberComponents unknown() {
+    return new CallNumberComponents(null, null, null);
+  }
 
   private CallNumberComponents(String callNumber, String prefix, String suffix) {
     this.callNumber = callNumber;
@@ -17,24 +23,11 @@ public class CallNumberComponents {
     this.suffix = suffix;
   }
 
-  public String getCallNumber() {
-    return callNumber;
-  }
-
-  public String getPrefix() {
-    return prefix;
-  }
-
-  public String getSuffix() {
-    return suffix;
-  }
-
   private static CallNumberComponents fromJson(JsonObject callNumberComponents) {
     return new CallNumberComponents(
       getProperty(callNumberComponents, "callNumber"),
       getProperty(callNumberComponents, "prefix"),
-      getProperty(callNumberComponents, "suffix")
-    );
+      getProperty(callNumberComponents, "suffix"));
   }
 
   /**
@@ -45,11 +38,11 @@ public class CallNumberComponents {
    */
   public static CallNumberComponents fromItemJson(JsonObject itemJson) {
     if (itemJson == null) {
-      return null;
+      return unknown();
     }
 
     return Optional.ofNullable(itemJson.getJsonObject("effectiveCallNumberComponents"))
       .map(CallNumberComponents::fromJson)
-      .orElse(null);
+      .orElse(unknown());
   }
 }

--- a/src/main/java/org/folio/circulation/domain/CheckInContext.java
+++ b/src/main/java/org/folio/circulation/domain/CheckInContext.java
@@ -9,6 +9,7 @@ import org.folio.circulation.domain.representations.CheckInByBarcodeRequest;
 import org.folio.circulation.support.utils.ClockUtil;
 
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 
 /**
  * The loan captures a snapshot of the item status
@@ -54,7 +55,7 @@ public class CheckInContext {
       this.itemStatusBeforeCheckIn);
   }
 
-  public CheckInContext withItem(Item item) {
+  public CheckInContext withItem(@NonNull Item item) {
 
     //When the item is updated, also update the item for the loan,
     //as they should be the same

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -178,7 +178,7 @@ public class Item {
   }
 
   public ItemStatus getStatus() {
-    return ItemStatus.from(getStatusName(), getStatusDate());
+    return new ItemStatus(ItemStatusName.from(getStatusName()), getStatusDate());
   }
 
   public String getStatusName() {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -39,6 +39,11 @@ public class Item {
   @NonNull private final MaterialType materialType;
   @NonNull private final LoanType loanType;
   @NonNull private final ItemDescription description;
+  private final String barcode;
+  private final String copyNumber;
+  private final String enumeration;
+  private final String temporaryLoanTypeId;
+  private final String permanentLoanTypeId;
 
   public static Item from(JsonObject representation) {
     return new ItemMapper().toDomain(representation);
@@ -48,7 +53,9 @@ public class Item {
     Location permanentLocation, ServicePoint inTransitDestinationServicePoint,
     boolean changed, Holdings holdings, Instance instance,
     MaterialType materialType, LoanType loanType,
-    ItemDescription description) {
+    ItemDescription description, String barcode,
+    String copyNumber, String enumeration, String temporaryLoanTypeId,
+    String permanentLoanTypeId) {
 
     this.id = id;
     this.itemRepresentation = itemRepresentation;
@@ -63,6 +70,11 @@ public class Item {
     this.materialType = materialType;
     this.loanType = loanType;
     this.description = description;
+    this.barcode = barcode;
+    this.copyNumber = copyNumber;
+    this.enumeration = enumeration;
+    this.temporaryLoanTypeId = temporaryLoanTypeId;
+    this.permanentLoanTypeId = permanentLoanTypeId;
   }
 
   public boolean isCheckedOut() {
@@ -331,59 +343,75 @@ public class Item {
     return firstNonBlank(permanentLocation.getId(), holdings.getPermanentLocationId());
   }
 
-  public Item withLocation(Location newLocation) {
+  public Item withLocation(@NonNull Location newLocation) {
     return new Item(this.id, this.itemRepresentation, newLocation,
       this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, this.holdings,
-      this.instance, this.materialType, this.loanType, description);
+      this.instance, this.materialType, this.loanType, description, this.barcode,
+      this.copyNumber, this.enumeration, this.temporaryLoanTypeId,
+      this.permanentLoanTypeId);
   }
 
   public Item withMaterialType(@NonNull MaterialType materialType) {
     return new Item(this.id, this.itemRepresentation, this.location,
       this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, this.holdings,
-      this.instance, materialType, this.loanType, this.description);
+      this.instance, materialType, this.loanType, this.description, this.barcode,
+      this.copyNumber, this.enumeration, this.temporaryLoanTypeId,
+      this.permanentLoanTypeId);
   }
 
   public Item withHoldings(@NonNull Holdings holdings) {
     return new Item(this.id, this.itemRepresentation, this.location,
       this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, holdings,
-      this.instance, this.materialType, this.loanType, this.description);
+      this.instance, this.materialType, this.loanType, this.description,
+      this.barcode, this.copyNumber, this.enumeration, this.temporaryLoanTypeId,
+      this.permanentLoanTypeId);
   }
 
   public Item withInstance(@NonNull Instance instance) {
     return new Item(this.id, this.itemRepresentation, this.location,
       this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, this.holdings,
-      instance, this.materialType, this.loanType, this.description);
+      instance, this.materialType, this.loanType, this.description,
+      this.barcode, this.copyNumber, this.enumeration, this.temporaryLoanTypeId,
+      this.permanentLoanTypeId);
   }
 
   public Item withLoanType(@NonNull LoanType loanType) {
     return new Item(this.id, this.itemRepresentation, this.location,
       this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, this.holdings,
-      this.instance, this.materialType, loanType, this.description);
+      this.instance, this.materialType, loanType, this.description,
+      this.barcode, this.copyNumber, this.enumeration, this.temporaryLoanTypeId,
+      this.permanentLoanTypeId);
   }
 
   public Item withLastCheckIn(@NonNull LastCheckIn lastCheckIn) {
     return new Item(this.id, this.itemRepresentation, this.location,
       lastCheckIn, this.callNumberComponents, this.permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, this.holdings,
-      this.instance, this.materialType, this.loanType, this.description);
+      this.instance, this.materialType, this.loanType, this.description,
+      this.barcode, this.copyNumber, this.enumeration, this.temporaryLoanTypeId,
+      this.permanentLoanTypeId);
   }
 
-  public Item withPermanentLocation(Location permanentLocation) {
+  public Item withPermanentLocation(@NonNull Location permanentLocation) {
     return new Item(this.id, this.itemRepresentation, this.location,
       this.lastCheckIn, this.callNumberComponents, permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, this.holdings,
-      this.instance, this.materialType, this.loanType, this.description);
+      this.instance, this.materialType, this.loanType, this.description,
+      this.barcode, this.copyNumber, this.enumeration, this.temporaryLoanTypeId,
+      this.permanentLoanTypeId);
   }
 
   public Item withInTransitDestinationServicePoint(ServicePoint servicePoint) {
     return new Item(this.id, this.itemRepresentation, this.location,
       this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
       servicePoint, this.changed, this.holdings, this.instance,
-      this.materialType, this.loanType, this.description);
+      this.materialType, this.loanType, this.description, this.barcode,
+      this.copyNumber, this.enumeration, this.temporaryLoanTypeId,
+      this.permanentLoanTypeId);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -18,8 +18,10 @@ import java.util.stream.Stream;
 import org.folio.circulation.storage.mappers.ItemMapper;
 
 import io.vertx.core.json.JsonObject;
+import lombok.AllArgsConstructor;
 import lombok.NonNull;
 
+@AllArgsConstructor
 public class Item {
   private final String id;
   @NonNull private final Location location;
@@ -50,28 +52,7 @@ public class Item {
   public static Item from(JsonObject representation) {
     return new ItemMapper().toDomain(representation);
   }
-  public Item(String id, Location effectiveLocation,
-    LastCheckIn lastCheckIn, CallNumberComponents callNumberComponents,
-    Location permanentLocation, ServicePoint inTransitDestinationServicePoint,
-    boolean changed, Holdings holdings, Instance instance,
-    MaterialType materialType, LoanType loanType,
-    ItemDescription description, ItemStatus status) {
-
-    this.id = id;
-    this.location = effectiveLocation;
-    this.lastCheckIn = lastCheckIn;
-    this.callNumberComponents = callNumberComponents;
-    this.permanentLocation = permanentLocation;
-    this.inTransitDestinationServicePoint = inTransitDestinationServicePoint;
-    this.changed = changed;
-    this.holdings = holdings;
-    this.instance = instance;
-    this.materialType = materialType;
-    this.loanType = loanType;
-    this.description = description;
-    this.status = status;
-  }
-
+  
   public boolean isCheckedOut() {
     return isInStatus(CHECKED_OUT);
   }

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -109,7 +109,7 @@ public class Item {
     return isInStatus(DECLARED_LOST);
   }
 
-  public boolean isInStatus(ItemStatus status) {
+  private boolean isInStatus(ItemStatus status) {
     return getStatus().equals(status);
   }
 
@@ -119,6 +119,10 @@ public class Item {
 
   public boolean isNotInStatus(ItemStatus status) {
     return !isInStatus(status);
+  }
+
+  public boolean isNotInStatus(ItemStatusName status) {
+    return !getStatus().is(status);
   }
 
   public boolean hasChanged() {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -113,10 +113,6 @@ public class Item {
     return getStatus().is(status);
   }
 
-  public boolean isNotInStatus(ItemStatus status) {
-    return !getStatus().equals(status);
-  }
-
   public boolean isNotInStatus(ItemStatusName status) {
     return !getStatus().is(status);
   }

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -2,13 +2,13 @@ package org.folio.circulation.domain;
 
 import static org.apache.commons.lang3.StringUtils.firstNonBlank;
 import static org.folio.circulation.domain.ItemStatus.AVAILABLE;
-import static org.folio.circulation.domain.ItemStatus.AWAITING_PICKUP;
-import static org.folio.circulation.domain.ItemStatus.CHECKED_OUT;
-import static org.folio.circulation.domain.ItemStatus.CLAIMED_RETURNED;
-import static org.folio.circulation.domain.ItemStatus.DECLARED_LOST;
 import static org.folio.circulation.domain.ItemStatus.IN_TRANSIT;
-import static org.folio.circulation.domain.ItemStatus.MISSING;
-import static org.folio.circulation.domain.ItemStatus.PAGED;
+import static org.folio.circulation.domain.ItemStatusName.AWAITING_PICKUP;
+import static org.folio.circulation.domain.ItemStatusName.CHECKED_OUT;
+import static org.folio.circulation.domain.ItemStatusName.CLAIMED_RETURNED;
+import static org.folio.circulation.domain.ItemStatusName.DECLARED_LOST;
+import static org.folio.circulation.domain.ItemStatusName.MISSING;
+import static org.folio.circulation.domain.ItemStatusName.PAGED;
 import static org.folio.circulation.domain.representations.ItemProperties.STATUS_PROPERTY;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
@@ -98,23 +98,23 @@ public class Item {
   }
 
   public boolean isAvailable() {
-    return isInStatus(AVAILABLE);
+    return isInStatus(ItemStatusName.AVAILABLE);
   }
 
   private boolean isInTransit() {
-    return isInStatus(IN_TRANSIT);
+    return isInStatus(ItemStatusName.IN_TRANSIT);
   }
 
   public boolean isDeclaredLost() {
     return isInStatus(DECLARED_LOST);
   }
 
-  boolean isNotSameStatus(ItemStatus prospectiveStatus) {
-    return !isInStatus(prospectiveStatus);
-  }
-
   public boolean isInStatus(ItemStatus status) {
     return getStatus().equals(status);
+  }
+
+  public boolean isInStatus(ItemStatusName status) {
+    return getStatus().is(status);
   }
 
   public boolean isNotInStatus(ItemStatus status) {
@@ -274,7 +274,7 @@ public class Item {
   }
 
   public Item changeStatus(ItemStatus newStatus) {
-    if (isNotSameStatus(newStatus)) {
+    if (isNotInStatus(newStatus)) {
       changed = true;
     }
 

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -120,7 +120,7 @@ public class Item {
   public boolean isNotInStatus(ItemStatusName status) {
     return !getStatus().is(status);
   }
-  
+
   public boolean hasChanged() {
     return changed;
   }
@@ -271,24 +271,6 @@ public class Item {
       return getPermanentLocation().getName();
     }
     return "";
-  }
-
-  public Item changeStatus(ItemStatus newStatus) {
-    if (isNotInStatus(newStatus)) {
-      changed = true;
-    }
-
-    write(itemRepresentation, STATUS_PROPERTY,
-      new JsonObject().put("name", newStatus.getValue()));
-
-    //TODO: Remove this hack to remove destination service point
-    // needs refactoring of how in transit for pickup is done
-    if(!isInTransit()) {
-      return removeDestination();
-    }
-    else {
-      return this;
-    }
   }
 
   public Item changeStatus(ItemStatusName newStatus) {

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -22,7 +22,6 @@ import lombok.NonNull;
 
 public class Item {
   private final String id;
-  private final JsonObject itemRepresentation;
   @NonNull private final Location location;
   private final LastCheckIn lastCheckIn;
   private final CallNumberComponents callNumberComponents;
@@ -41,9 +40,9 @@ public class Item {
   }
 
   public static Item unknown(String id) {
-    return new Item(id, new JsonObject(), Location.unknown(),
-      LastCheckIn.unknown(), CallNumberComponents.unknown(), Location.unknown(),
-      ServicePoint.unknown(), false, Holdings.unknown(), Instance.unknown(),
+    return new Item(id, Location.unknown(), LastCheckIn.unknown(),
+      CallNumberComponents.unknown(), Location.unknown(), ServicePoint.unknown(),
+      false, Holdings.unknown(), Instance.unknown(),
       MaterialType.unknown(), LoanType.unknown(), ItemDescription.unknown(),
       ItemStatus.unknown());
   }
@@ -51,7 +50,7 @@ public class Item {
   public static Item from(JsonObject representation) {
     return new ItemMapper().toDomain(representation);
   }
-  public Item(String id, JsonObject itemRepresentation, Location effectiveLocation,
+  public Item(String id, Location effectiveLocation,
     LastCheckIn lastCheckIn, CallNumberComponents callNumberComponents,
     Location permanentLocation, ServicePoint inTransitDestinationServicePoint,
     boolean changed, Holdings holdings, Instance instance,
@@ -59,7 +58,6 @@ public class Item {
     ItemDescription description, ItemStatus status) {
 
     this.id = id;
-    this.itemRepresentation = itemRepresentation;
     this.location = effectiveLocation;
     this.lastCheckIn = lastCheckIn;
     this.callNumberComponents = callNumberComponents;
@@ -267,8 +265,8 @@ public class Item {
 
     // The previous code did not change the item status date
     // that behaviour has been preserved even though it is confusing
-    return new Item(this.id, this.itemRepresentation, this.location,
-      this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
+    return new Item(this.id, this.location, this.lastCheckIn,
+      this.callNumberComponents, this.permanentLocation,
       destinationServicePoint, newChanged, this.holdings,
       this.instance, this.materialType, this.loanType, this.description,
       new ItemStatus(newStatus, status.getDate()));
@@ -314,7 +312,10 @@ public class Item {
   }
 
   public boolean isFound() {
-    return itemRepresentation != null;
+    // this relies on items that are completely unknown are defined without an ID
+    // this might not represent the case where an item's ID is known yet that
+    // record could not be found / fetched
+    return id != null;
   }
 
   public LastCheckIn getLastCheckIn() {
@@ -326,64 +327,64 @@ public class Item {
   }
 
   public Item withLocation(@NonNull Location newLocation) {
-    return new Item(this.id, this.itemRepresentation, newLocation,
-      this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
+    return new Item(this.id, newLocation, this.lastCheckIn,
+      this.callNumberComponents, this.permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, this.holdings,
       this.instance, this.materialType, this.loanType, this.description,
       this.status);
   }
 
   public Item withMaterialType(@NonNull MaterialType materialType) {
-    return new Item(this.id, this.itemRepresentation, this.location,
-      this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
+    return new Item(this.id, this.location, this.lastCheckIn,
+      this.callNumberComponents, this.permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, this.holdings,
       this.instance, materialType, this.loanType, this.description,
       this.status);
   }
 
   public Item withHoldings(@NonNull Holdings holdings) {
-    return new Item(this.id, this.itemRepresentation, this.location,
-      this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
+    return new Item(this.id, this.location, this.lastCheckIn,
+      this.callNumberComponents, this.permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, holdings,
       this.instance, this.materialType, this.loanType, this.description,
       this.status);
   }
 
   public Item withInstance(@NonNull Instance instance) {
-    return new Item(this.id, this.itemRepresentation, this.location,
-      this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
+    return new Item(this.id, this.location, this.lastCheckIn,
+      this.callNumberComponents, this.permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, this.holdings,
       instance, this.materialType, this.loanType, this.description,
       this.status);
   }
 
   public Item withLoanType(@NonNull LoanType loanType) {
-    return new Item(this.id, this.itemRepresentation, this.location,
-      this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
+    return new Item(this.id, this.location, this.lastCheckIn,
+      this.callNumberComponents, this.permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, this.holdings,
       this.instance, this.materialType, loanType, this.description,
       this.status);
   }
 
   public Item withLastCheckIn(@NonNull LastCheckIn lastCheckIn) {
-    return new Item(this.id, this.itemRepresentation, this.location,
-      lastCheckIn, this.callNumberComponents, this.permanentLocation,
+    return new Item(this.id, this.location, lastCheckIn,
+      this.callNumberComponents, this.permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, this.holdings,
       this.instance, this.materialType, this.loanType, this.description,
       this.status);
   }
 
   public Item withPermanentLocation(@NonNull Location permanentLocation) {
-    return new Item(this.id, this.itemRepresentation, this.location,
-      this.lastCheckIn, this.callNumberComponents, permanentLocation,
+    return new Item(this.id, this.location, this.lastCheckIn,
+      this.callNumberComponents, permanentLocation,
       this.inTransitDestinationServicePoint, this.changed, this.holdings,
       this.instance, this.materialType, this.loanType, this.description,
       this.status);
   }
 
   public Item withInTransitDestinationServicePoint(ServicePoint servicePoint) {
-    return new Item(this.id, this.itemRepresentation, this.location,
-      this.lastCheckIn, this.callNumberComponents, this.permanentLocation,
+    return new Item(this.id, this.location, this.lastCheckIn,
+      this.callNumberComponents, this.permanentLocation,
       servicePoint, this.changed, this.holdings, this.instance,
       this.materialType, this.loanType, this.description, this.status);
   }

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -45,6 +45,18 @@ public class Item {
   private final String temporaryLoanTypeId;
   private final String permanentLoanTypeId;
 
+  public static Item unknown() {
+    return unknown(null);
+  }
+
+  public static Item unknown(String id) {
+    return new Item(id, new JsonObject(), Location.unknown(),
+      LastCheckIn.unknown(), CallNumberComponents.unknown(), Location.unknown(),
+      ServicePoint.unknown(), false, Holdings.unknown(), Instance.unknown(),
+      MaterialType.unknown(), LoanType.unknown(), null, null, null,
+      null, null, null);
+  }
+
   public static Item from(JsonObject representation) {
     return new ItemMapper().toDomain(representation);
   }

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -291,7 +291,7 @@ public class Item {
 
     //TODO: Remove this hack to remove destination service point
     // needs refactoring of how in transit for pickup is done
-    if(!isInTransit()) {
+    if (newStatus == IN_TRANSIT) {
       return removeDestination();
     }
     else {

--- a/src/main/java/org/folio/circulation/domain/ItemStatus.java
+++ b/src/main/java/org/folio/circulation/domain/ItemStatus.java
@@ -77,6 +77,6 @@ public enum ItemStatus {
   }
 
   public boolean isLostNotResolved() {
-    return this == DECLARED_LOST || this == AGED_TO_LOST;
+    return getName().isLostNotResolved();
   }
 }

--- a/src/main/java/org/folio/circulation/domain/ItemStatus.java
+++ b/src/main/java/org/folio/circulation/domain/ItemStatus.java
@@ -1,7 +1,5 @@
 package org.folio.circulation.domain;
 
-import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
-
 import java.util.Arrays;
 
 public enum ItemStatus {
@@ -27,6 +25,8 @@ public enum ItemStatus {
   RESTRICTED("Restricted"),
   AGED_TO_LOST("Aged to lost");
 
+  private final ItemStatusName name;
+
   public static ItemStatus from(String value) {
     return Arrays.stream(values())
       .filter(status -> status.valueMatches(value))
@@ -44,20 +44,19 @@ public enum ItemStatus {
       .orElse(NONE);
   }
 
-  private final String value;
   // FIXME: Enum constants are singletons, date must not be associated with it
   private String date;
 
   ItemStatus(String value) {
-    this.value = value;
+    name = ItemStatusName.from(value);
   }
 
   public String getValue() {
-    return value;
+    return name.getName();
   }
 
   public ItemStatusName getName() {
-    return ItemStatusName.from(value);
+    return name;
   }
 
   public String getDate() {
@@ -69,11 +68,11 @@ public enum ItemStatus {
   }
 
   private boolean valueMatches(String value) {
-    return equalsIgnoreCase(getValue(), value);
+    return name.equals(ItemStatusName.from(value));
   }
 
   public boolean is(ItemStatusName name) {
-    return equalsIgnoreCase(value, name.getName());
+    return this.name.equals(name);
   }
 
   public boolean isLostNotResolved() {

--- a/src/main/java/org/folio/circulation/domain/ItemStatus.java
+++ b/src/main/java/org/folio/circulation/domain/ItemStatus.java
@@ -56,6 +56,10 @@ public enum ItemStatus {
     return value;
   }
 
+  public ItemStatusName getName() {
+    return ItemStatusName.from(value);
+  }
+
   public String getDate() {
     return date;
   }

--- a/src/main/java/org/folio/circulation/domain/ItemStatus.java
+++ b/src/main/java/org/folio/circulation/domain/ItemStatus.java
@@ -4,6 +4,10 @@ import lombok.Value;
 
 @Value
 public class ItemStatus {
+  public static ItemStatus unknown() {
+    return new ItemStatus(ItemStatusName.NONE, null);
+  }
+
   ItemStatusName name;
   String date;
 

--- a/src/main/java/org/folio/circulation/domain/ItemStatus.java
+++ b/src/main/java/org/folio/circulation/domain/ItemStatus.java
@@ -1,74 +1,14 @@
 package org.folio.circulation.domain;
 
-import java.util.Arrays;
+import lombok.Value;
 
-public enum ItemStatus {
-  NONE(""),
-  AVAILABLE("Available"),
-  AWAITING_PICKUP("Awaiting pickup"),
-  AWAITING_DELIVERY("Awaiting delivery"),
-  CHECKED_OUT("Checked out"),
-  IN_TRANSIT("In transit"),
-  MISSING("Missing"),
-  PAGED("Paged"),
-  ON_ORDER("On order"),
-  IN_PROCESS("In process"),
-  DECLARED_LOST("Declared lost"),
-  CLAIMED_RETURNED("Claimed returned"),
-  WITHDRAWN("Withdrawn"),
-  LOST_AND_PAID("Lost and paid"),
-  INTELLECTUAL_ITEM("Intellectual item"),
-  IN_PROCESS_NON_REQUESTABLE("In process (non-requestable)"),
-  LONG_MISSING("Long missing"),
-  UNAVAILABLE("Unavailable"),
-  UNKNOWN("Unknown"),
-  RESTRICTED("Restricted"),
-  AGED_TO_LOST("Aged to lost");
-
-  private final ItemStatusName name;
-
-  public static ItemStatus from(String value) {
-    return Arrays.stream(values())
-      .filter(status -> status.valueMatches(value))
-      .findFirst()
-      .orElse(NONE);
-  }
-
-  public static ItemStatus from(String value, String date) {
-    return Arrays.stream(values())
-      .filter(status -> status.valueMatches(value))
-      .findFirst().map(status -> {
-        status.setDate(date);
-        return status;
-      })
-      .orElse(NONE);
-  }
-
-  // FIXME: Enum constants are singletons, date must not be associated with it
-  private String date;
-
-  ItemStatus(String value) {
-    name = ItemStatusName.from(value);
-  }
+@Value
+public class ItemStatus {
+  ItemStatusName name;
+  String date;
 
   public String getValue() {
     return name.getName();
-  }
-
-  public ItemStatusName getName() {
-    return name;
-  }
-
-  public String getDate() {
-    return date;
-  }
-
-  void setDate(String date) {
-    this.date = date;
-  }
-
-  private boolean valueMatches(String value) {
-    return name.equals(ItemStatusName.from(value));
   }
 
   public boolean is(ItemStatusName name) {

--- a/src/main/java/org/folio/circulation/domain/ItemStatusName.java
+++ b/src/main/java/org/folio/circulation/domain/ItemStatusName.java
@@ -29,7 +29,7 @@ public enum ItemStatusName {
 
   public static ItemStatusName from(String value) {
     return Arrays.stream(values())
-      .filter(status -> status.valueMatches(value))
+      .filter(status -> equalsIgnoreCase(status.name, value))
       .findFirst()
       .orElse(NONE);
   }
@@ -42,10 +42,6 @@ public enum ItemStatusName {
 
   public String getName() {
     return name;
-  }
-
-  private boolean valueMatches(String value) {
-    return equalsIgnoreCase(getName(), value);
   }
 
   public boolean isLostNotResolved() {

--- a/src/main/java/org/folio/circulation/domain/ItemStatusName.java
+++ b/src/main/java/org/folio/circulation/domain/ItemStatusName.java
@@ -4,7 +4,7 @@ import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
 import java.util.Arrays;
 
-public enum ItemStatus {
+public enum ItemStatusName {
   NONE(""),
   AVAILABLE("Available"),
   AWAITING_PICKUP("Awaiting pickup"),
@@ -27,49 +27,25 @@ public enum ItemStatus {
   RESTRICTED("Restricted"),
   AGED_TO_LOST("Aged to lost");
 
-  public static ItemStatus from(String value) {
+  public static ItemStatusName from(String value) {
     return Arrays.stream(values())
       .filter(status -> status.valueMatches(value))
       .findFirst()
       .orElse(NONE);
   }
 
-  public static ItemStatus from(String value, String date) {
-    return Arrays.stream(values())
-      .filter(status -> status.valueMatches(value))
-      .findFirst().map(status -> {
-        status.setDate(date);
-        return status;
-      })
-      .orElse(NONE);
+  private final String name;
+
+  ItemStatusName(String name) {
+    this.name = name;
   }
 
-  private final String value;
-  // FIXME: Enum constants are singletons, date must not be associated with it
-  private String date;
-
-  ItemStatus(String value) {
-    this.value = value;
-  }
-
-  public String getValue() {
-    return value;
-  }
-
-  public String getDate() {
-    return date;
-  }
-
-  void setDate(String date) {
-    this.date = date;
+  public String getName() {
+    return name;
   }
 
   private boolean valueMatches(String value) {
-    return equalsIgnoreCase(getValue(), value);
-  }
-
-  public boolean is(ItemStatusName name) {
-    return equalsIgnoreCase(value, name.getName());
+    return equalsIgnoreCase(getName(), value);
   }
 
   public boolean isLostNotResolved() {

--- a/src/main/java/org/folio/circulation/domain/LastCheckIn.java
+++ b/src/main/java/org/folio/circulation/domain/LastCheckIn.java
@@ -19,6 +19,10 @@ public class LastCheckIn {
   private final String staffMemberId;
   private ServicePoint servicePoint;
 
+  public static LastCheckIn unknown() {
+    return new LastCheckIn(null, null, null);
+  }
+
   public LastCheckIn(ZonedDateTime dateTime, UUID servicePointId, String staffMemberId) {
     this.dateTime = dateTime;
     this.servicePointId = servicePointId;

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.domain;
 
-import static java.lang.Boolean.TRUE;
 import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.nonNull;
@@ -10,7 +10,6 @@ import static lombok.AccessLevel.PRIVATE;
 import static org.folio.circulation.domain.FeeAmount.noFeeAmount;
 import static org.folio.circulation.domain.LoanAction.CHECKED_IN;
 import static org.folio.circulation.domain.LoanAction.CHECKED_OUT;
-import static org.folio.circulation.domain.LoanAction.CLAIMED_RETURNED;
 import static org.folio.circulation.domain.LoanAction.CLOSED_LOAN;
 import static org.folio.circulation.domain.LoanAction.DECLARED_LOST;
 import static org.folio.circulation.domain.LoanAction.ITEM_AGED_TO_LOST;
@@ -566,7 +565,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   public Loan claimItemReturned(String comment, ZonedDateTime claimedReturnedDate) {
-    changeAction(CLAIMED_RETURNED);
+    changeAction(LoanAction.CLAIMED_RETURNED);
     if (StringUtils.isNotBlank(comment)) {
       changeActionComment(comment);
     }

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -463,11 +463,11 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   public boolean isDeclaredLost() {
-    return hasItemWithStatus(ItemStatus.DECLARED_LOST);
+    return hasItemWithStatus(ItemStatusName.DECLARED_LOST);
   }
 
   public boolean isAgedToLost() {
-    return hasItemWithStatus(ItemStatus.AGED_TO_LOST);
+    return hasItemWithStatus(ItemStatusName.AGED_TO_LOST);
   }
 
   public boolean isItemLost() {
@@ -475,7 +475,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   public boolean isClaimedReturned() {
-    return hasItemWithStatus(ItemStatus.CLAIMED_RETURNED);
+    return hasItemWithStatus(ItemStatusName.CLAIMED_RETURNED);
   }
 
   public boolean isRenewed() {
@@ -487,11 +487,11 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     return false;
   }
 
-  public boolean hasItemWithStatus(ItemStatus itemStatus) {
+  public boolean hasItemWithStatus(ItemStatusName itemStatus) {
     return hasItemWithAnyStatus(itemStatus);
   }
 
-  public boolean hasItemWithAnyStatus(ItemStatus... itemStatuses) {
+  public boolean hasItemWithAnyStatus(ItemStatusName... itemStatuses) {
     return item != null && Stream.of(itemStatuses).anyMatch(item::isInStatus);
   }
 

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -157,12 +157,12 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     write(representation, "checkinServicePointId", servicePointId);
   }
 
-  public Loan changeItemStatusForItemAndLoan(ItemStatus itemStatus) {
+  public Loan changeItemStatusForItemAndLoan(ItemStatusName itemStatus) {
     Item itemToChange = getItem();
 
     executeIfNotNull(itemToChange, f -> f.changeStatus(itemStatus));
 
-    changeItemStatus(itemStatus.getValue());
+    changeItemStatus(itemStatus.getName());
 
     return this;
   }
@@ -457,7 +457,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   public Loan declareItemLost(String comment, ZonedDateTime dateTime) {
     changeAction(DECLARED_LOST);
     changeActionComment(comment);
-    changeItemStatusForItemAndLoan(ItemStatus.DECLARED_LOST);
+    changeItemStatusForItemAndLoan(ItemStatusName.DECLARED_LOST);
     changeDeclaredLostDateTime(dateTime);
     return this;
   }
@@ -571,7 +571,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
       changeActionComment(comment);
     }
 
-    changeItemStatusForItemAndLoan(ItemStatus.CLAIMED_RETURNED);
+    changeItemStatusForItemAndLoan(ItemStatusName.CLAIMED_RETURNED);
     changeClaimedReturnedDate(claimedReturnedDate);
 
     return this;
@@ -600,7 +600,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   public Loan markItemMissing(String comment) {
-    changeItemStatusForItemAndLoan(ItemStatus.MISSING);
+    changeItemStatusForItemAndLoan(ItemStatusName.MISSING);
 
     return closeLoan(MISSING, comment);
   }
@@ -619,7 +619,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   public void closeLoanAsLostAndPaid() {
     closeLoan(CLOSED_LOAN);
-    changeItemStatusForItemAndLoan(ItemStatus.LOST_AND_PAID);
+    changeItemStatusForItemAndLoan(ItemStatusName.LOST_AND_PAID);
   }
 
   public Loan copy() {
@@ -631,7 +631,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
   public Loan ageOverdueItemToLost(ZonedDateTime ageToLostDate) {
     changeAction(ITEM_AGED_TO_LOST);
     removeActionComment();
-    changeItemStatusForItemAndLoan(ItemStatus.AGED_TO_LOST);
+    changeItemStatusForItemAndLoan(ItemStatusName.AGED_TO_LOST);
     setAgedToLostDate(ageToLostDate);
 
     return this;

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -689,12 +689,12 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     return previousDueDate;
   }
 
-  public ItemStatus getItemStatus() {
+  public ItemStatusName getItemStatus() {
     if (item != null) {
-      return item.getStatus();
+      return item.getStatus().getName();
     }
 
-   return ItemStatus.from(getItemStatusName());
+   return ItemStatusName.from(getItemStatusName());
   }
 
   public String getItemStatusName() {

--- a/src/main/java/org/folio/circulation/domain/LoanAndRelatedRecords.java
+++ b/src/main/java/org/folio/circulation/domain/LoanAndRelatedRecords.java
@@ -9,6 +9,7 @@ import org.folio.circulation.domain.configuration.TlrSettingsConfiguration;
 import io.vertx.core.json.JsonObject;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.With;
 
 @AllArgsConstructor
@@ -54,7 +55,7 @@ public class LoanAndRelatedRecords implements UserRelatedRecord {
     return withLoan(loan.withProxy(newProxy));
   }
 
-  public LoanAndRelatedRecords withItem(Item newItem) {
+  public LoanAndRelatedRecords withItem(@NonNull Item newItem) {
     return withLoan(loan.withItem(newItem));
   }
 

--- a/src/main/java/org/folio/circulation/domain/LoanAndRelatedRecords.java
+++ b/src/main/java/org/folio/circulation/domain/LoanAndRelatedRecords.java
@@ -42,7 +42,7 @@ public class LoanAndRelatedRecords implements UserRelatedRecord {
     this(loan, null, null, timeZone, new JsonObject(), null, null, null);
   }
 
-  public LoanAndRelatedRecords changeItemStatus(ItemStatus status) {
+  public LoanAndRelatedRecords changeItemStatus(ItemStatusName status) {
     return withItem(getItem().changeStatus(status));
   }
 

--- a/src/main/java/org/folio/circulation/domain/LoanCheckInService.java
+++ b/src/main/java/org/folio/circulation/domain/LoanCheckInService.java
@@ -27,11 +27,11 @@ public class LoanCheckInService {
           systemDateTime, request.getServicePointId()));
     }
 
-    if (loan.isAgedToLost()) {
-      loan.removeAgedToLostBillingInfo();
-    }
+    final Loan changedLoan = loan.isAgedToLost()
+      ? loan.removeAgedToLostBillingInfo()
+      : loan;
 
-    return succeeded(loan.checkIn(request.getCheckInDate(), systemDateTime,
+    return succeeded(changedLoan.checkIn(request.getCheckInDate(), systemDateTime,
       request.getServicePointId()));
   }
 

--- a/src/main/java/org/folio/circulation/domain/MoveRequestService.java
+++ b/src/main/java/org/folio/circulation/domain/MoveRequestService.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain;
 
+import static org.folio.circulation.domain.ItemStatusName.AVAILABLE;
 import static org.folio.circulation.domain.representations.logs.LogEventType.REQUEST_MOVED;
 import static org.folio.circulation.support.results.Result.of;
 
@@ -75,7 +76,7 @@ public class MoveRequestService {
 
     Item item = requestAndRelatedRecords.getRequest().getItem();
 
-    if (item.getStatus().equals(ItemStatus.AVAILABLE)) {
+    if (item.getStatus().is(AVAILABLE)) {
       return requestAndRelatedRecords.withRequestType(RequestType.PAGE);
     }
 

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -109,7 +109,7 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   boolean isFulfillable() {
     return getFulfilmentPreference() == HOLD_SHELF || getFulfilmentPreference() == DELIVERY;
   }
-  
+
   public boolean isPage() {
     return getRequestType() == RequestType.PAGE;
   }
@@ -289,7 +289,7 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
     return changedPosition;
   }
 
-  ItemStatus checkedInItemStatus() {
+  ItemStatusName checkedInItemStatus() {
     return getFulfilmentPreference().toCheckedInItemStatus();
   }
 

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -227,7 +227,8 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   }
 
   boolean allowedForItem() {
-    return RequestTypeItemStatusWhiteList.canCreateRequestForItem(getItem().getStatus(), getRequestType());
+    return RequestTypeItemStatusWhiteList.canCreateRequestForItem(
+      getItem().getStatus().getName(), getRequestType());
   }
 
   LoanAction actionOnCreateOrUpdate() {

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -43,6 +43,7 @@ import org.folio.circulation.domain.configuration.TlrSettingsConfiguration;
 import io.vertx.core.json.JsonObject;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.With;
 
 @AllArgsConstructor
@@ -66,6 +67,7 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   @With
   private final Collection<Item> instanceItems;
 
+  @NonNull
   private final Item item;
 
   @With
@@ -91,15 +93,17 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
   public static Request from(JsonObject representation) {
     // TODO: make sure that operation and TLR settings don't matter for all processes calling
     //  this constructor
-    return new Request(null, null, representation, null, null, new ArrayList<>(), null, null, null,
-      null, null, null, false, null, false);
+    return new Request(null, null, representation, null, null,
+      new ArrayList<>(), Item.unknown(), null, null, null, null, null, false,
+      null, false);
   }
 
   public static Request from(TlrSettingsConfiguration tlrSettingsConfiguration, Operation operation,
     JsonObject representation) {
 
     return new Request(tlrSettingsConfiguration, operation, representation, null, null,
-      new ArrayList<>(), null, null, null, null, null, null, false, null, false);
+      new ArrayList<>(), Item.unknown(), null, null, null, null, null, false,
+      null, false);
   }
 
   public JsonObject asJson() {
@@ -183,9 +187,8 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
     return requestRepresentation.getString(HOLDINGS_RECORD_ID);
   }
 
-  public Request withItem(Item newItem) {
-    // NOTE: this is null in RequestsAPIUpdatingTests.replacingAnExistingRequestRemovesItemInformationWhenItemDoesNotExist test
-    if (newItem != null && newItem.getItemId() != null && newItem.getHoldingsRecordId() != null) {
+  public Request withItem(@NonNull Item newItem) {
+    if (newItem.getItemId() != null && newItem.getHoldingsRecordId() != null) {
       requestRepresentation.put(ITEM_ID, newItem.getItemId());
       requestRepresentation.put(HOLDINGS_RECORD_ID, newItem.getHoldingsRecordId());
     }

--- a/src/main/java/org/folio/circulation/domain/RequestAndRelatedRecords.java
+++ b/src/main/java/org/folio/circulation/domain/RequestAndRelatedRecords.java
@@ -44,9 +44,8 @@ public class RequestAndRelatedRecords implements UserRelatedRecord, ItemRelatedR
   }
 
   public RequestAndRelatedRecords withRequest(Request newRequest) {
-    Item item = this.request.getItem();
     return new RequestAndRelatedRecords(
-      newRequest.withItem(item == null ? newRequest.getItem() : item),
+      newRequest,
       this.requestQueue,
       null,
       this.moveRequestRecord,

--- a/src/main/java/org/folio/circulation/domain/RequestFulfilmentPreference.java
+++ b/src/main/java/org/folio/circulation/domain/RequestFulfilmentPreference.java
@@ -1,8 +1,8 @@
 package org.folio.circulation.domain;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
-import static org.folio.circulation.domain.ItemStatus.AWAITING_DELIVERY;
-import static org.folio.circulation.domain.ItemStatus.AWAITING_PICKUP;
+import static org.folio.circulation.domain.ItemStatusName.AWAITING_DELIVERY;
+import static org.folio.circulation.domain.ItemStatusName.AWAITING_PICKUP;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,7 +35,7 @@ public enum RequestFulfilmentPreference {
       .orElse(NONE);
   }
 
-  ItemStatus toCheckedInItemStatus() {
+  ItemStatusName toCheckedInItemStatus() {
     switch(this) {
       case HOLD_SHELF:
         return AWAITING_PICKUP;
@@ -44,7 +44,7 @@ public enum RequestFulfilmentPreference {
         return AWAITING_DELIVERY;
 
       default:
-        return ItemStatus.NONE;
+        return ItemStatusName.NONE;
     }
   }
 

--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
-import static org.folio.circulation.domain.ItemStatus.AVAILABLE;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,14 +44,10 @@ public class RequestQueue {
       .collect(toList()));
   }
 
-  ItemStatus checkedInItemStatus(Item item) {
+  ItemStatusName checkedInItemStatus(Item item) {
     return hasOutstandingRequestsFulfillableByItem(item)
       ? getHighestPriorityRequestFulfillableByItem(item).checkedInItemStatus()
-      : AVAILABLE;
-  }
-
-  boolean hasOutstandingFulfillableRequests() {
-    return !fulfillableRequests().isEmpty();
+      : ItemStatusName.AVAILABLE;
   }
 
   boolean hasOutstandingRequestsFulfillableByItem(Item item) {

--- a/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
@@ -81,8 +81,7 @@ public class RequestRepresentation {
 
     ItemStatus status = item.getStatus();
     if (status != null) {
-      String statusValue = status.getValue();
-      itemSummary.put("status", statusValue);
+      write(itemSummary, "status", status.getValue());
     }
 
     write(itemSummary, "callNumber", item.getCallNumber());

--- a/src/main/java/org/folio/circulation/domain/RequestTypeItemStatusWhiteList.java
+++ b/src/main/java/org/folio/circulation/domain/RequestTypeItemStatusWhiteList.java
@@ -1,35 +1,35 @@
 package org.folio.circulation.domain;
 
-import static org.folio.circulation.domain.ItemStatus.AGED_TO_LOST;
-import static org.folio.circulation.domain.ItemStatus.AVAILABLE;
-import static org.folio.circulation.domain.ItemStatus.AWAITING_DELIVERY;
-import static org.folio.circulation.domain.ItemStatus.AWAITING_PICKUP;
-import static org.folio.circulation.domain.ItemStatus.CHECKED_OUT;
-import static org.folio.circulation.domain.ItemStatus.CLAIMED_RETURNED;
-import static org.folio.circulation.domain.ItemStatus.DECLARED_LOST;
-import static org.folio.circulation.domain.ItemStatus.INTELLECTUAL_ITEM;
-import static org.folio.circulation.domain.ItemStatus.IN_PROCESS;
-import static org.folio.circulation.domain.ItemStatus.IN_PROCESS_NON_REQUESTABLE;
-import static org.folio.circulation.domain.ItemStatus.IN_TRANSIT;
-import static org.folio.circulation.domain.ItemStatus.LONG_MISSING;
-import static org.folio.circulation.domain.ItemStatus.LOST_AND_PAID;
-import static org.folio.circulation.domain.ItemStatus.MISSING;
-import static org.folio.circulation.domain.ItemStatus.NONE;
-import static org.folio.circulation.domain.ItemStatus.ON_ORDER;
-import static org.folio.circulation.domain.ItemStatus.PAGED;
-import static org.folio.circulation.domain.ItemStatus.RESTRICTED;
-import static org.folio.circulation.domain.ItemStatus.UNAVAILABLE;
-import static org.folio.circulation.domain.ItemStatus.UNKNOWN;
-import static org.folio.circulation.domain.ItemStatus.WITHDRAWN;
+import static org.folio.circulation.domain.ItemStatusName.AGED_TO_LOST;
+import static org.folio.circulation.domain.ItemStatusName.AVAILABLE;
+import static org.folio.circulation.domain.ItemStatusName.AWAITING_DELIVERY;
+import static org.folio.circulation.domain.ItemStatusName.AWAITING_PICKUP;
+import static org.folio.circulation.domain.ItemStatusName.CHECKED_OUT;
+import static org.folio.circulation.domain.ItemStatusName.CLAIMED_RETURNED;
+import static org.folio.circulation.domain.ItemStatusName.DECLARED_LOST;
+import static org.folio.circulation.domain.ItemStatusName.INTELLECTUAL_ITEM;
+import static org.folio.circulation.domain.ItemStatusName.IN_PROCESS;
+import static org.folio.circulation.domain.ItemStatusName.IN_PROCESS_NON_REQUESTABLE;
+import static org.folio.circulation.domain.ItemStatusName.IN_TRANSIT;
+import static org.folio.circulation.domain.ItemStatusName.LONG_MISSING;
+import static org.folio.circulation.domain.ItemStatusName.LOST_AND_PAID;
+import static org.folio.circulation.domain.ItemStatusName.MISSING;
+import static org.folio.circulation.domain.ItemStatusName.NONE;
+import static org.folio.circulation.domain.ItemStatusName.ON_ORDER;
+import static org.folio.circulation.domain.ItemStatusName.PAGED;
+import static org.folio.circulation.domain.ItemStatusName.RESTRICTED;
+import static org.folio.circulation.domain.ItemStatusName.UNAVAILABLE;
+import static org.folio.circulation.domain.ItemStatusName.UNKNOWN;
+import static org.folio.circulation.domain.ItemStatusName.WITHDRAWN;
 
 import java.util.EnumMap;
 
 public class RequestTypeItemStatusWhiteList {
-  private static EnumMap<ItemStatus, Boolean> recallRules;
-  private static EnumMap<ItemStatus, Boolean> holdRules;
-  private static EnumMap<ItemStatus, Boolean> pageRules;
-  private static EnumMap<ItemStatus, Boolean> noneRules;
-  private static EnumMap<RequestType, EnumMap<ItemStatus, Boolean>> requestsRulesMap;
+  private static EnumMap<ItemStatusName, Boolean> recallRules;
+  private static EnumMap<ItemStatusName, Boolean> holdRules;
+  private static EnumMap<ItemStatusName, Boolean> pageRules;
+  private static EnumMap<ItemStatusName, Boolean> noneRules;
+  private static EnumMap<RequestType, EnumMap<ItemStatusName, Boolean>> requestsRulesMap;
 
   static {
     initRecallRules();
@@ -44,7 +44,7 @@ public class RequestTypeItemStatusWhiteList {
   }
 
   private static void initRecallRules() {
-    recallRules = new EnumMap<>(ItemStatus.class);
+    recallRules = new EnumMap<>(ItemStatusName.class);
     recallRules.put(CHECKED_OUT, true);
     recallRules.put(AVAILABLE, false);
     recallRules.put(AWAITING_PICKUP, true);
@@ -69,7 +69,7 @@ public class RequestTypeItemStatusWhiteList {
   }
 
   private static void initHoldRules() {
-    holdRules = new EnumMap<>(ItemStatus.class);
+    holdRules = new EnumMap<>(ItemStatusName.class);
     holdRules.put(CHECKED_OUT, true);
     holdRules.put(AVAILABLE, false);
     holdRules.put(AWAITING_PICKUP, true);
@@ -94,7 +94,7 @@ public class RequestTypeItemStatusWhiteList {
   }
 
   private static void initPageRules() {
-    pageRules = new EnumMap<>(ItemStatus.class);
+    pageRules = new EnumMap<>(ItemStatusName.class);
     pageRules.put(CHECKED_OUT, false);
     pageRules.put(AVAILABLE, true);
     pageRules.put(RESTRICTED, true);
@@ -119,7 +119,7 @@ public class RequestTypeItemStatusWhiteList {
   }
 
   private static void initNoneRules() {
-    noneRules = new EnumMap<>(ItemStatus.class);
+    noneRules = new EnumMap<>(ItemStatusName.class);
     noneRules.put(CHECKED_OUT, false);
     noneRules.put(AVAILABLE, false);
     noneRules.put(AWAITING_PICKUP, false);
@@ -150,7 +150,7 @@ public class RequestTypeItemStatusWhiteList {
     requestsRulesMap.put(RequestType.NONE, noneRules);
   }
 
-  public static boolean canCreateRequestForItem(ItemStatus itemStatus, RequestType requestType) {
+  public static boolean canCreateRequestForItem(ItemStatusName itemStatus, RequestType requestType) {
     return requestsRulesMap.get(requestType).get(itemStatus);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -147,7 +147,7 @@ public class UpdateItem {
     ItemStatus prospectiveStatus,
     Item item) {
 
-    if(item.isNotSameStatus(prospectiveStatus)) {
+    if(item.isNotInStatus(prospectiveStatus)) {
       item.changeStatus(prospectiveStatus);
 
       return storeItem(item);

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -3,6 +3,7 @@ package org.folio.circulation.domain;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.domain.ItemStatusName.AVAILABLE;
 import static org.folio.circulation.domain.ItemStatusName.CHECKED_OUT;
+import static org.folio.circulation.domain.ItemStatusName.DECLARED_LOST;
 import static org.folio.circulation.domain.ItemStatusName.PAGED;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.results.MappingFunctions.when;
@@ -200,7 +201,7 @@ public class UpdateItem {
       return itemStatusOnCheckIn(requestQueue, loan.getItem());
     }
     else if (loan.getItem().isDeclaredLost()) {
-      return ItemStatusName.from(loan.getItem().getStatus().getValue());
+      return DECLARED_LOST;
     }
     return CHECKED_OUT;
   }

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -146,9 +146,7 @@ public class UpdateItem {
     ItemStatusName prospectiveStatus, Item item) {
 
     if (item.isNotInStatus(prospectiveStatus)) {
-      item.changeStatus(prospectiveStatus);
-
-      return storeItem(item);
+      return storeItem(item.changeStatus(prospectiveStatus));
     }
     else {
       return completedFuture(succeeded(item));

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
@@ -158,7 +158,7 @@ public class LoanScheduledNoticeHandler extends ScheduledNoticeHandler {
         ItemStatusName.AGED_TO_LOST, CLAIMED_RETURNED)) {
 
       logMessages.add(String.format("Recurring overdue notice for item in status \"%s\"",
-        loan.getItemStatus()));
+        loan.getItemStatusName()));
     }
 
     if (logMessages.isEmpty()) {
@@ -180,7 +180,7 @@ public class LoanScheduledNoticeHandler extends ScheduledNoticeHandler {
 
     if (loan.hasItemWithAnyStatus(DECLARED_LOST, CLAIMED_RETURNED)) {
       logMessages.add(
-        String.format("Recurring notice for item in status \"%s\"", loan.getItemStatus()));
+        String.format("Recurring notice for item in status \"%s\"", loan.getItemStatusName()));
     }
     if (loan.isRenewed()) {
       logMessages.add("Loan was renewed");

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
@@ -3,8 +3,8 @@ package org.folio.circulation.domain.notice.schedule;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.circulation.domain.FeeFine.lostItemFeeTypes;
-import static org.folio.circulation.domain.ItemStatus.CLAIMED_RETURNED;
-import static org.folio.circulation.domain.ItemStatus.DECLARED_LOST;
+import static org.folio.circulation.domain.ItemStatusName.CLAIMED_RETURNED;
+import static org.folio.circulation.domain.ItemStatusName.DECLARED_LOST;
 import static org.folio.circulation.domain.notice.NoticeTiming.BEFORE;
 import static org.folio.circulation.domain.notice.TemplateContextUtil.createLoanNoticeContext;
 import static org.folio.circulation.domain.notice.schedule.TriggeringEvent.AGED_TO_LOST;
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.folio.circulation.domain.ItemStatus;
+import org.folio.circulation.domain.ItemStatusName;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
@@ -154,7 +154,9 @@ public class LoanScheduledNoticeHandler extends ScheduledNoticeHandler {
     if (noticeConfig.hasBeforeTiming() && isBeforeMillis(dueDate, systemTime)) {
       logMessages.add("Loan is overdue");
     }
-    if (loan.hasItemWithAnyStatus(DECLARED_LOST, ItemStatus.AGED_TO_LOST, CLAIMED_RETURNED)) {
+    if (loan.hasItemWithAnyStatus(DECLARED_LOST,
+        ItemStatusName.AGED_TO_LOST, CLAIMED_RETURNED)) {
+
       logMessages.add(String.format("Recurring overdue notice for item in status \"%s\"",
         loan.getItemStatus()));
     }

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -481,8 +481,8 @@ public class LoanPolicy extends Policy {
 
   private Loan changeDueDate(ZonedDateTime dueDate, Loan loan) {
     if (!loan.wasDueDateChangedByRecall()) {
-      loan.changeDueDate(dueDate);
-      loan.setDueDateChangedByRecall();
+      return loan.changeDueDate(dueDate)
+        .setDueDateChangedByRecall();
     }
 
     return loan;

--- a/src/main/java/org/folio/circulation/domain/representations/ItemProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemProperties.java
@@ -2,6 +2,6 @@ package org.folio.circulation.domain.representations;
 
 public class ItemProperties {
   private ItemProperties() { }
-  public static final String LAST_CHECK_IN = "lastCheckIn";
+
   public static final String CALL_NUMBER_COMPONENTS = "callNumberComponents";
 }

--- a/src/main/java/org/folio/circulation/domain/representations/ItemProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemProperties.java
@@ -2,8 +2,6 @@ package org.folio.circulation.domain.representations;
 
 public class ItemProperties {
   private ItemProperties() { }
-
-  public static final String STATUS_PROPERTY = "status";
   public static final String LAST_CHECK_IN = "lastCheckIn";
   public static final String CALL_NUMBER_COMPONENTS = "callNumberComponents";
 }

--- a/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
@@ -43,7 +43,7 @@ public class ItemSummaryRepresentation {
       status.put("date", item.getStatus().getDate());
     }
 
-    write(itemSummary, ItemProperties.STATUS_PROPERTY, status);
+    write(itemSummary, "status", status);
 
     write(itemSummary, "inTransitDestinationServicePointId",
       item.getInTransitDestinationServicePointId());

--- a/src/main/java/org/folio/circulation/domain/validation/CheckInValidators.java
+++ b/src/main/java/org/folio/circulation/domain/validation/CheckInValidators.java
@@ -1,6 +1,6 @@
 package org.folio.circulation.domain.validation;
 
-import static org.folio.circulation.domain.ItemStatus.INTELLECTUAL_ITEM;
+import static org.folio.circulation.domain.ItemStatusName.INTELLECTUAL_ITEM;
 import static org.folio.circulation.domain.representations.CheckInByBarcodeRequest.CLAIMED_RETURNED_RESOLUTION;
 import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
 import static org.folio.circulation.support.results.Result.succeeded;

--- a/src/main/java/org/folio/circulation/domain/validation/ItemStatusValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ItemStatusValidator.java
@@ -1,19 +1,19 @@
 package org.folio.circulation.domain.validation;
 
-import static org.folio.circulation.domain.ItemStatus.AGED_TO_LOST;
-import static org.folio.circulation.domain.ItemStatus.CLAIMED_RETURNED;
-import static org.folio.circulation.domain.ItemStatus.DECLARED_LOST;
-import static org.folio.circulation.domain.ItemStatus.INTELLECTUAL_ITEM;
-import static org.folio.circulation.domain.ItemStatus.MISSING;
+import static org.folio.circulation.domain.ItemStatusName.AGED_TO_LOST;
+import static org.folio.circulation.domain.ItemStatusName.CLAIMED_RETURNED;
+import static org.folio.circulation.domain.ItemStatusName.DECLARED_LOST;
+import static org.folio.circulation.domain.ItemStatusName.INTELLECTUAL_ITEM;
+import static org.folio.circulation.domain.ItemStatusName.MISSING;
 import static org.folio.circulation.support.results.Result.succeeded;
 
 import java.util.function.Function;
 
 import org.folio.circulation.domain.Item;
-import org.folio.circulation.domain.ItemStatus;
+import org.folio.circulation.domain.ItemStatusName;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
-import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.ValidationErrorFailure;
+import org.folio.circulation.support.results.Result;
 
 public class ItemStatusValidator {
   private final Function<Item, ValidationErrorFailure> itemStatusErrorFunction;
@@ -23,7 +23,7 @@ public class ItemStatusValidator {
   }
 
   private Result<LoanAndRelatedRecords> refuseWhenItemIs(
-    Result<LoanAndRelatedRecords> loanAndRelatedRecords, ItemStatus status) {
+    Result<LoanAndRelatedRecords> loanAndRelatedRecords, ItemStatusName status) {
 
     return loanAndRelatedRecords.failWhen(
       records -> succeeded(records.getLoan().getItem().isInStatus(status)),

--- a/src/main/java/org/folio/circulation/domain/validation/NotInItemStatusValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/NotInItemStatusValidator.java
@@ -1,10 +1,10 @@
 package org.folio.circulation.domain.validation;
 
-import static org.folio.circulation.domain.ItemStatus.CLAIMED_RETURNED;
-import static org.folio.circulation.support.results.Result.succeeded;
+import static org.folio.circulation.domain.ItemStatusName.CLAIMED_RETURNED;
 import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
+import static org.folio.circulation.support.results.Result.succeeded;
 
-import org.folio.circulation.domain.ItemStatus;
+import org.folio.circulation.domain.ItemStatusName;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.support.results.Result;
 
@@ -20,11 +20,11 @@ public final class NotInItemStatusValidator {
   }
 
   private static Result<Loan> refuseWhenItemIsNotInStatus(
-    Result<Loan> loanResult, ItemStatus status) {
+    Result<Loan> loanResult, ItemStatusName status) {
 
     return loanResult.failWhen(
       records -> succeeded(loanResult.value().getItem().isNotInStatus(status)),
       loan -> singleValidationError(String.format("Item is not %s",
-        status.getValue()), "itemId", loanResult.value().getItem().getItemId()));
+        status.getName()), "itemId", loanResult.value().getItem().getItemId()));
   }
 }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -2,7 +2,7 @@ package org.folio.circulation.infrastructure.storage.inventory;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Function.identity;
-import static org.folio.circulation.domain.ItemStatus.AVAILABLE;
+import static org.folio.circulation.domain.ItemStatusName.AVAILABLE;
 import static org.folio.circulation.domain.MultipleRecords.CombinationMatchers.matchRecordsById;
 import static org.folio.circulation.domain.representations.ItemProperties.LAST_CHECK_IN;
 import static org.folio.circulation.domain.representations.ItemProperties.STATUS_PROPERTY;
@@ -127,7 +127,7 @@ public class ItemRepository {
     }
 
     return findByIndexNameAndQuery(holdingsRecords.toKeys(Holdings::getId),
-      "holdingsRecordId", exactMatch("status.name", AVAILABLE.getValue()))
+      "holdingsRecordId", exactMatch("status.name", AVAILABLE.getName()))
       .thenApply(mapResult(MultipleRecords::firstOrNull));
   }
 

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -5,7 +5,6 @@ import static java.util.function.Function.identity;
 import static org.folio.circulation.domain.ItemStatusName.AVAILABLE;
 import static org.folio.circulation.domain.MultipleRecords.CombinationMatchers.matchRecordsById;
 import static org.folio.circulation.domain.representations.ItemProperties.LAST_CHECK_IN;
-import static org.folio.circulation.domain.representations.ItemProperties.STATUS_PROPERTY;
 import static org.folio.circulation.support.fetching.MultipleCqlIndexValuesCriteria.byIndex;
 import static org.folio.circulation.support.http.CommonResponseInterpreters.noContentRecordInterpreter;
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
@@ -93,7 +92,7 @@ public class ItemRepository {
 
     final var updatedItemRepresentation = identityMap.get(item.getItemId());
 
-    write(updatedItemRepresentation, STATUS_PROPERTY,
+    write(updatedItemRepresentation, "status",
       new JsonObject().put("name", item.getStatus().getValue()));
 
     remove(updatedItemRepresentation, IN_TRANSIT_DESTINATION_SERVICE_POINT_ID);

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -147,9 +147,9 @@ public class ItemRepository {
     return result.combineAfter(this::fetchLocations,
       (items, locations) -> items
         .combineRecords(locations, matchRecordsById(Item::getPermanentLocationId, Location::getId),
-          Item::withPermanentLocation, null)
+          Item::withPermanentLocation, Location.unknown())
         .combineRecords(locations, matchRecordsById(Item::getEffectiveLocationId, Location::getId),
-          Item::withLocation, null));
+          Item::withLocation, Location.unknown()));
   }
 
   private CompletableFuture<Result<MultipleRecords<Location>>> fetchLocations(

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -2,7 +2,6 @@ package org.folio.circulation.infrastructure.storage.inventory;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Function.identity;
-import static org.folio.circulation.domain.ItemStatusName.AVAILABLE;
 import static org.folio.circulation.domain.MultipleRecords.CombinationMatchers.matchRecordsById;
 import static org.folio.circulation.support.fetching.MultipleCqlIndexValuesCriteria.byIndex;
 import static org.folio.circulation.support.http.CommonResponseInterpreters.noContentRecordInterpreter;
@@ -117,23 +116,6 @@ public class ItemRepository {
     else {
       write(representation, LAST_CHECK_IN_PROPERTY, lastCheckIn.toJson());
     }
-  }
-
-  public CompletableFuture<Result<Item>> getFirstAvailableItemByInstanceId(String instanceId) {
-    return holdingsRepository.fetchByInstanceId(instanceId)
-      .thenCompose(r -> r.after(this::getAvailableItem));
-  }
-
-  private CompletableFuture<Result<Item>> getAvailableItem(
-    MultipleRecords<Holdings> holdingsRecords) {
-
-    if (holdingsRecords == null || holdingsRecords.isEmpty()) {
-      return ofAsync(() -> Item.from(null));
-    }
-
-    return findByIndexNameAndQuery(holdingsRecords.toKeys(Holdings::getId),
-      "holdingsRecordId", exactMatch("status.name", AVAILABLE.getName()))
-      .thenApply(mapResult(MultipleRecords::firstOrNull));
   }
 
   public CompletableFuture<Result<Item>> fetchByBarcode(String barcode) {

--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
@@ -3,7 +3,7 @@ package org.folio.circulation.infrastructure.storage.loans;
 import static java.lang.String.format;
 import static java.util.Objects.nonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.folio.circulation.domain.ItemStatus.IN_TRANSIT;
+import static org.folio.circulation.domain.ItemStatusName.IN_TRANSIT;
 import static org.folio.circulation.domain.representations.LoanProperties.BORROWER;
 import static org.folio.circulation.domain.representations.LoanProperties.DUE_DATE;
 import static org.folio.circulation.domain.representations.LoanProperties.FEESANDFINES;
@@ -44,6 +44,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Account;
 import org.folio.circulation.domain.Item;
+import org.folio.circulation.domain.ItemStatusName;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.domain.MultipleRecords;
@@ -235,7 +236,7 @@ public class LoanRepository implements GetManyRecordsRepository<Loan> {
   public CompletableFuture<Result<Collection<Loan>>> findByItemIds(
     Collection<String> itemIds) {
 
-    Result<CqlQuery> statusQuery = exactMatch(ITEM_STATUS, IN_TRANSIT.getValue());
+    Result<CqlQuery> statusQuery = exactMatch(ITEM_STATUS, IN_TRANSIT.getName());
     FindWithMultipleCqlIndexValues<Loan> fetcher = findWithMultipleCqlIndexValues(
       loansStorageClient, RECORDS_PROPERTY_NAME, Loan::from);
 

--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
@@ -44,7 +44,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Account;
 import org.folio.circulation.domain.Item;
-import org.folio.circulation.domain.ItemStatusName;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.domain.MultipleRecords;
@@ -68,6 +67,7 @@ import org.folio.circulation.support.results.CommonFailures;
 import org.folio.circulation.support.results.Result;
 
 import io.vertx.core.json.JsonObject;
+import lombok.NonNull;
 
 public class LoanRepository implements GetManyRecordsRepository<Loan> {
   private static final String RECORDS_PROPERTY_NAME = "loans";
@@ -144,13 +144,13 @@ public class LoanRepository implements GetManyRecordsRepository<Loan> {
    * success with null if the no open loan is found,
    * failure if more than one open loan for the item found
    */
-  public CompletableFuture<Result<Loan>> findOpenLoanForItem(Item item) {
+  public CompletableFuture<Result<Loan>> findOpenLoanForItem(@NonNull Item item) {
     return findOpenLoans(item.getItemId())
       .thenApply(loansResult -> loansResult.next(loans -> {
         if (loans.getTotalRecords() == 0) {
           return succeeded(null);
         }
-        else if(loans.getTotalRecords() == 1) {
+        else if (loans.getTotalRecords() == 1) {
           final Optional<Loan> firstLoan = loans.getRecords().stream().findFirst();
 
           return firstLoan

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -1,7 +1,6 @@
 package org.folio.circulation.resources;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.folio.circulation.domain.ItemStatus.CHECKED_OUT;
 import static org.folio.circulation.domain.LoanAction.CHECKED_OUT_THROUGH_OVERRIDE;
 import static org.folio.circulation.resources.handlers.error.CirculationErrorType.FAILED_TO_FETCH_ITEM;
 import static org.folio.circulation.resources.handlers.error.CirculationErrorType.FAILED_TO_FETCH_PROXY_USER;
@@ -16,6 +15,7 @@ import static org.folio.circulation.support.results.Result.succeeded;
 import java.time.ZonedDateTime;
 import java.util.concurrent.CompletableFuture;
 
+import org.folio.circulation.domain.ItemStatusName;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.domain.LoanRepresentation;
@@ -206,7 +206,7 @@ public class CheckOutByBarcodeResource extends Resource {
   }
 
   private LoanAndRelatedRecords checkOutItem(LoanAndRelatedRecords loanAndRelatedRecords) {
-    return loanAndRelatedRecords.changeItemStatus(CHECKED_OUT);
+    return loanAndRelatedRecords.changeItemStatus(ItemStatusName.CHECKED_OUT);
   }
 
   private Result<HttpResponse> createdLoanFrom(Result<JsonObject> result,

--- a/src/main/java/org/folio/circulation/resources/PickSlipsResource.java
+++ b/src/main/java/org/folio/circulation/resources/PickSlipsResource.java
@@ -5,6 +5,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
+import static org.folio.circulation.domain.ItemStatusName.PAGED;
 import static org.folio.circulation.support.fetching.MultipleCqlIndexValuesCriteria.byIndex;
 import static org.folio.circulation.support.fetching.RecordFetching.findWithCqlQuery;
 import static org.folio.circulation.support.fetching.RecordFetching.findWithMultipleCqlIndexValues;
@@ -22,7 +23,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.Item;
-import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.Request;
@@ -122,7 +122,7 @@ public class PickSlipsResource extends Resource {
       return completedFuture(succeeded(emptyList()));
     }
 
-    Result<CqlQuery> statusQuery = exactMatch(STATUS_NAME_KEY, ItemStatus.PAGED.getValue());
+    Result<CqlQuery> statusQuery = exactMatch(STATUS_NAME_KEY, PAGED.getName());
 
     return itemRepository.findByIndexNameAndQuery(locationIds, EFFECTIVE_LOCATION_ID_KEY, statusQuery)
       .thenComposeAsync(r -> r.after(items -> fetchLocationDetailsForItems(items, locations,

--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -5,9 +5,10 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.folio.circulation.domain.ItemStatus.AWAITING_DELIVERY;
-import static org.folio.circulation.domain.ItemStatus.AWAITING_PICKUP;
-import static org.folio.circulation.domain.ItemStatus.PAGED;
+import static org.folio.circulation.domain.ItemStatusName.AVAILABLE;
+import static org.folio.circulation.domain.ItemStatusName.AWAITING_DELIVERY;
+import static org.folio.circulation.domain.ItemStatusName.AWAITING_PICKUP;
+import static org.folio.circulation.domain.ItemStatusName.PAGED;
 import static org.folio.circulation.domain.RequestLevel.ITEM;
 import static org.folio.circulation.domain.RequestLevel.TITLE;
 import static org.folio.circulation.domain.representations.RequestProperties.HOLDINGS_RECORD_ID;
@@ -51,7 +52,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Item;
-import org.folio.circulation.domain.ItemStatus;
+import org.folio.circulation.domain.ItemStatusName;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.Request;
@@ -85,7 +86,7 @@ import io.vertx.core.json.JsonObject;
 class RequestFromRepresentationService {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private static final PageLimit LOANS_PAGE_LIMIT = limit(10000);
-  private static final Set<ItemStatus> RECALLABLE_ITEM_STATUSES =
+  private static final Set<ItemStatusName> RECALLABLE_ITEM_STATUSES =
     Set.of(PAGED, AWAITING_PICKUP, AWAITING_DELIVERY);
   private final Request.Operation operation;
   private final InstanceRepository instanceRepository;
@@ -317,7 +318,7 @@ class RequestFromRepresentationService {
   private Result<Request> findRecallableItemOrFail(Request request) {
     return request.getInstanceItems()
       .stream()
-      .filter(item -> RECALLABLE_ITEM_STATUSES.contains(item.getStatus()))
+      .filter(item -> RECALLABLE_ITEM_STATUSES.contains(item.getStatus().getName()))
       .findFirst()
       .map(request::withItem)
       .map(Result::succeeded)

--- a/src/main/java/org/folio/circulation/resources/RequestHoldShelfClearanceResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestHoldShelfClearanceResource.java
@@ -1,6 +1,6 @@
 package org.folio.circulation.resources;
 
-import static org.folio.circulation.domain.ItemStatus.AWAITING_PICKUP;
+import static org.folio.circulation.domain.ItemStatusName.AWAITING_PICKUP;
 import static org.folio.circulation.domain.RequestStatus.CLOSED_CANCELLED;
 import static org.folio.circulation.domain.RequestStatus.CLOSED_PICKUP_EXPIRED;
 import static org.folio.circulation.domain.RequestStatus.OPEN_AWAITING_PICKUP;
@@ -92,7 +92,7 @@ public class RequestHoldShelfClearanceResource extends Resource {
 
     final String servicePointId = routingContext.request().getParam(SERVICE_POINT_ID_PARAM);
 
-    itemReportRepository.getAllItemsByField(STATUS_NAME_KEY, AWAITING_PICKUP.getValue())
+    itemReportRepository.getAllItemsByField(STATUS_NAME_KEY, AWAITING_PICKUP.getName())
       .thenComposeAsync(r -> r.after(this::mapContextToItemIdList))
       .thenComposeAsync(r -> r.after(this::mapItemIdsInBatchItemIds))
       .thenComposeAsync(r -> findAwaitingPickupRequestsByItemsIds(requestsStorage, r.value()))

--- a/src/main/java/org/folio/circulation/resources/handlers/LoanRelatedFeeFineClosedHandlerResource.java
+++ b/src/main/java/org/folio/circulation/resources/handlers/LoanRelatedFeeFineClosedHandlerResource.java
@@ -112,9 +112,12 @@ public class LoanRelatedFeeFineClosedHandlerResource extends Resource {
     }
 
     boolean wasLoanOpen = loan.isOpen();
-    loan.closeLoanAsLostAndPaid();
 
-    return new StoreLoanAndItem(loanRepository, itemRepository).updateLoanAndItemInStorage(loan)
+    final var changedLoan = loan.closeLoanAsLostAndPaid();
+
+    final var storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
+
+    return storeLoanAndItem.updateLoanAndItemInStorage(changedLoan)
       .thenCompose(r -> r.after(l -> publishLoanClosedEvent(l, wasLoanOpen, eventPublisher)));
   }
 

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewByIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewByIdResource.java
@@ -61,7 +61,7 @@ public class RenewByIdResource extends RenewalResource {
     String itemId, CirculationErrorHandler errorHandler) {
 
     return itemFinder.findItemById(itemId)
-      .thenApply(r -> errorHandler.handleValidationResult(r, ITEM_DOES_NOT_EXIST, (Item) null));
+      .thenApply(r -> errorHandler.handleValidationResult(r, ITEM_DOES_NOT_EXIST, Item.unknown()));
   }
 
   private CompletableFuture<Result<Loan>> lookupLoan(

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -462,11 +462,11 @@ public abstract class RenewalResource extends Resource {
   }
 
   private Loan overrideRenewLoan(ZonedDateTime dueDate, Loan loan, String comment) {
-    if (loan.isAgedToLost()) {
-      loan.removeAgedToLostBillingInfo();
-    }
+    final Loan changedLoan = loan.isAgedToLost()
+      ? loan.removeAgedToLostBillingInfo()
+      : loan;
 
-    return loan.overrideRenewal(dueDate, loan.getLoanPolicyId(), comment)
+    return changedLoan.overrideRenewal(dueDate, loan.getLoanPolicyId(), comment)
       .changeItemStatusForItemAndLoan(CHECKED_OUT);
   }
 

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -1,10 +1,10 @@
 package org.folio.circulation.resources.renewal;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.folio.circulation.domain.ItemStatus.AGED_TO_LOST;
-import static org.folio.circulation.domain.ItemStatus.CLAIMED_RETURNED;
-import static org.folio.circulation.domain.ItemStatus.DECLARED_LOST;
+import static org.folio.circulation.domain.ItemStatusName.AGED_TO_LOST;
 import static org.folio.circulation.domain.ItemStatusName.CHECKED_OUT;
+import static org.folio.circulation.domain.ItemStatusName.CLAIMED_RETURNED;
+import static org.folio.circulation.domain.ItemStatusName.DECLARED_LOST;
 import static org.folio.circulation.domain.RequestType.HOLD;
 import static org.folio.circulation.domain.RequestType.RECALL;
 import static org.folio.circulation.domain.override.OverridableBlockType.PATRON_BLOCK;
@@ -48,7 +48,7 @@ import java.util.function.Function;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.StoreLoanAndItem;
-import org.folio.circulation.domain.ItemStatus;
+import org.folio.circulation.domain.ItemStatusName;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanRepresentation;
 import org.folio.circulation.domain.OverdueFineService;
@@ -111,9 +111,9 @@ public abstract class RenewalResource extends Resource {
   private static final String DUE_DATE = "dueDate";
   private static final String OVERRIDE_BLOCKS = "overrideBlocks";
   private static final String RENEWAL_DUE_DATE_REQUIRED_OVERRIDE_BLOCK = "renewalDueDateRequiredBlock";
-  private static final EnumSet<ItemStatus> ITEM_STATUSES_DISALLOWED_FOR_RENEW = EnumSet.of(
+  private static final EnumSet<ItemStatusName> ITEM_STATUSES_DISALLOWED_FOR_RENEW = EnumSet.of(
     AGED_TO_LOST, DECLARED_LOST);
-  private static final EnumSet<ItemStatus> ITEM_STATUSES_NOT_POSSIBLE_TO_RENEW = EnumSet.of(
+  private static final EnumSet<ItemStatusName> ITEM_STATUSES_NOT_POSSIBLE_TO_RENEW = EnumSet.of(
     CLAIMED_RETURNED);
   private boolean isRenewalBlockOverrideRequested;
 

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -2,9 +2,9 @@ package org.folio.circulation.resources.renewal;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.domain.ItemStatus.AGED_TO_LOST;
-import static org.folio.circulation.domain.ItemStatus.CHECKED_OUT;
 import static org.folio.circulation.domain.ItemStatus.CLAIMED_RETURNED;
 import static org.folio.circulation.domain.ItemStatus.DECLARED_LOST;
+import static org.folio.circulation.domain.ItemStatusName.CHECKED_OUT;
 import static org.folio.circulation.domain.RequestType.HOLD;
 import static org.folio.circulation.domain.RequestType.RECALL;
 import static org.folio.circulation.domain.override.OverridableBlockType.PATRON_BLOCK;

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -259,12 +259,13 @@ public class EventPublisher {
       .thenCompose(r -> r.after(v -> publishStatusChangeEvent(ITEM_AGED_TO_LOST, loan)));
   }
 
-  public CompletableFuture<Result<Void>> publishClosedLoanEvent(Loan loan) {
+  public CompletableFuture<Result<Loan>> publishClosedLoanEvent(Loan loan) {
     if (!CHECKED_IN.getValue().equalsIgnoreCase(loan.getAction())) {
       return publishLogRecord(LoanLogContext.from(loan)
-        .withServicePointId(loan.getCheckoutServicePointId()).asJson(), LOAN);
+        .withServicePointId(loan.getCheckoutServicePointId()).asJson(), LOAN)
+        .thenApply(r -> r.map(x -> loan));
     }
-    return CompletableFuture.completedFuture(succeeded(null));
+    return CompletableFuture.completedFuture(succeeded(loan));
   }
 
   public CompletableFuture<Result<Loan>> publishMarkedAsMissingLoanEvent(Loan loan) {

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -190,10 +190,11 @@ public class EventPublisher {
   }
 
   private CompletableFuture<Result<Loan>> publishDueDateChangedEvent(Loan loan, RequestAndRelatedRecords records) {
-    if (records.getRecalledLoanPreviousDueDate() != null) {
-      loan.setPreviousDueDate(records.getRecalledLoanPreviousDueDate());
-    }
-    return publishDueDateChangedEvent(loan, records.getRequest().getRequester(), false);
+    final var loanWithPreviousDueDate = records.getRecalledLoanPreviousDueDate() != null
+      ? loan.setPreviousDueDate(records.getRecalledLoanPreviousDueDate())
+      : loan;
+
+    return publishDueDateChangedEvent(loanWithPreviousDueDate, records.getRequest().getRequester(), false);
   }
 
   private CompletableFuture<Result<Loan>> publishDueDateChangedEvent(Loan loan, User user, boolean renewalContext) {

--- a/src/main/java/org/folio/circulation/services/ItemForPageTlrService.java
+++ b/src/main/java/org/folio/circulation/services/ItemForPageTlrService.java
@@ -4,6 +4,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static org.folio.circulation.domain.ItemStatusName.AVAILABLE;
 import static org.folio.circulation.domain.representations.RequestProperties.INSTANCE_ID;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 
@@ -17,7 +18,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import org.folio.circulation.domain.Item;
-import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.infrastructure.storage.inventory.LocationRepository;
@@ -38,7 +38,7 @@ public class ItemForPageTlrService {
   public CompletableFuture<Result<Request>> findItem(Request request) {
     List<Item> availableItems = request.getInstanceItems()
       .stream()
-      .filter(item -> ItemStatus.AVAILABLE == item.getStatus())
+      .filter(item -> item.getStatus().is(AVAILABLE))
       .collect(toList());
 
     if (availableItems.isEmpty()) {

--- a/src/main/java/org/folio/circulation/services/ItemsInTransitReportService.java
+++ b/src/main/java/org/folio/circulation/services/ItemsInTransitReportService.java
@@ -3,7 +3,7 @@ package org.folio.circulation.services;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toSet;
-import static org.folio.circulation.domain.ItemStatus.IN_TRANSIT;
+import static org.folio.circulation.domain.ItemStatusName.IN_TRANSIT;
 import static org.folio.circulation.support.results.Result.combineAll;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
@@ -87,7 +87,7 @@ public class ItemsInTransitReportService {
   private CompletableFuture<Result<ItemsInTransitReportContext>> fetchItems(
     ItemsInTransitReportContext context) {
 
-    return itemReportRepository.getAllItemsByField("status.name", IN_TRANSIT.getValue())
+    return itemReportRepository.getAllItemsByField("status.name", IN_TRANSIT.getName())
       .thenApply(r -> r.next(itemsReportFetcher ->
         combineAll(itemsReportFetcher.getResultListOfItems())
           .map(listOfPages -> listOfPages.stream()

--- a/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
@@ -150,8 +150,7 @@ public class LostItemFeeChargingService {
 
   private CompletableFuture<Result<Loan>> closeLoanAsLostAndPaidAndPublishEvent(Loan loan) {
     return closeLoanAsLostAndPaidAndUpdateInStorage(loan)
-    .thenCompose(r -> r.after(eventPublisher::publishClosedLoanEvent))
-    .thenApply(r -> r.map(v -> loan));
+    .thenCompose(r -> r.after(eventPublisher::publishClosedLoanEvent));
   }
 
   private Boolean isOpenLostItemFee(Account account) {
@@ -160,7 +159,7 @@ public class LostItemFeeChargingService {
   }
 
   private Boolean hasLostItemFees(Loan loan) {
-    return loan.getAccounts().stream().anyMatch(account -> isOpenLostItemFee(account));
+    return loan.getAccounts().stream().anyMatch(this::isOpenLostItemFee);
   }
 
   private CompletableFuture<Result<Loan>> closeLoanAsLostAndPaidAndUpdateInStorage(Loan loan) {

--- a/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
@@ -164,8 +164,7 @@ public class LostItemFeeChargingService {
   }
 
   private CompletableFuture<Result<Loan>> closeLoanAsLostAndPaidAndUpdateInStorage(Loan loan) {
-    loan.closeLoanAsLostAndPaid();
-    return storeLoanAndItem.updateLoanAndItemInStorage(loan);
+    return storeLoanAndItem.updateLoanAndItemInStorage(loan.closeLoanAsLostAndPaid());
   }
 
   private boolean shouldCloseLoan(LostItemPolicy policy) {

--- a/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeRefundContext.java
@@ -3,7 +3,7 @@ package org.folio.circulation.services;
 import static org.folio.circulation.domain.AccountCancelReason.CANCELLED_ITEM_RENEWED;
 import static org.folio.circulation.domain.AccountCancelReason.CANCELLED_ITEM_RETURNED;
 import static org.folio.circulation.domain.AccountRefundReason.LOST_ITEM_FOUND;
-import static org.folio.circulation.domain.ItemStatus.LOST_AND_PAID;
+import static org.folio.circulation.domain.ItemStatusName.LOST_AND_PAID;
 
 import java.time.ZonedDateTime;
 import java.util.Collection;
@@ -59,7 +59,8 @@ public final class LostItemFeeRefundContext {
   }
 
   boolean shouldRefundFeesForItem() {
-    return initialItemStatus.isLostNotResolved() || initialItemStatus == LOST_AND_PAID;
+    return initialItemStatus.isLostNotResolved()
+      || initialItemStatus.getName() == LOST_AND_PAID;
   }
 
   boolean hasLoan() {

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -4,7 +4,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.folio.circulation.domain.FeeFine.LOST_ITEM_FEE_TYPE;
 import static org.folio.circulation.domain.FeeFine.LOST_ITEM_PROCESSING_FEE_TYPE;
 import static org.folio.circulation.domain.FeeFine.lostItemFeeTypes;
-import static org.folio.circulation.domain.ItemStatus.AGED_TO_LOST;
+import static org.folio.circulation.domain.ItemStatusName.AGED_TO_LOST;
 import static org.folio.circulation.domain.representations.LoanProperties.AGED_TO_LOST_DELAYED_BILLING;
 import static org.folio.circulation.domain.representations.LoanProperties.DATE_LOST_ITEM_SHOULD_BE_BILLED;
 import static org.folio.circulation.domain.representations.LoanProperties.ITEM_STATUS;
@@ -272,7 +272,7 @@ public class ChargeLostFeesWhenAgedToLostService {
     final ZonedDateTime currentDate = getZonedDateTime();
 
     final Result<CqlQuery> billingDateQuery = lessThanOrEqualTo(billingDateProperty, currentDate);
-    final Result<CqlQuery> agedToLostQuery = exactMatch(ITEM_STATUS, AGED_TO_LOST.getValue());
+    final Result<CqlQuery> agedToLostQuery = exactMatch(ITEM_STATUS, AGED_TO_LOST.getName());
     final Result<CqlQuery> hasNotBeenBilledQuery = exactMatch(
       lostItemHasBeenBilled, "false");
 

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -129,13 +129,13 @@ public class ChargeLostFeesWhenAgedToLostService {
       .thenApply(Result::mapEmpty);
   }
 
-  private CompletableFuture<Result<Void>> processLoan(LoanToChargeFees loan) {
+  private CompletableFuture<Result<Loan>> processLoan(LoanToChargeFees loan) {
     return loan.shouldCloseLoanWhenActualCostUsed()
-      ? closeLoanAsLostAndPaid(loan).thenApply(Result::mapEmpty)
+      ? closeLoanAsLostAndPaid(loan)
       : chargeLostFees(loan);
   }
 
-  private CompletableFuture<Result<Void>> chargeLostFees(
+  private CompletableFuture<Result<Loan>> chargeLostFees(
     LoanToChargeFees loanToChargeFees) {
 
     return ofAsync(() -> loanToChargeFees)
@@ -146,7 +146,7 @@ public class ChargeLostFeesWhenAgedToLostService {
       .exceptionally(t -> handleFailure(loanToChargeFees, t.getMessage()));
   }
 
-  private static Result<Void> handleFailure(LoanToChargeFees loan, String errorMessage) {
+  private static Result<Loan> handleFailure(LoanToChargeFees loan, String errorMessage) {
     log.error("Failed to charge lost item fee(s) for loan {}: {}", loan.getLoanId(), errorMessage);
     return succeeded(null);
   }

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -324,9 +324,9 @@ public class ChargeLostFeesWhenAgedToLostService {
   private CompletableFuture<Result<Loan>> closeLoanAsLostAndPaid(LoanToChargeFees loanToChargeFees) {
     final Loan loan = loanToChargeFees.getLoan();
 
-    loan.setLostItemHasBeenBilled();
-    loan.closeLoanAsLostAndPaid();
+    final var changedLoan = loan.setLostItemHasBeenBilled()
+      .closeLoanAsLostAndPaid();
 
-    return storeLoanAndItem.updateLoanAndItemInStorage(loan);
+    return storeLoanAndItem.updateLoanAndItemInStorage(changedLoan);
   }
 }

--- a/src/main/java/org/folio/circulation/services/agedtolost/MarkOverdueLoansAsAgedLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/MarkOverdueLoansAsAgedLostService.java
@@ -1,8 +1,8 @@
 package org.folio.circulation.services.agedtolost;
 
-import static org.folio.circulation.domain.ItemStatus.AGED_TO_LOST;
-import static org.folio.circulation.domain.ItemStatus.CLAIMED_RETURNED;
-import static org.folio.circulation.domain.ItemStatus.DECLARED_LOST;
+import static org.folio.circulation.domain.ItemStatusName.AGED_TO_LOST;
+import static org.folio.circulation.domain.ItemStatusName.CLAIMED_RETURNED;
+import static org.folio.circulation.domain.ItemStatusName.DECLARED_LOST;
 import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.support.CqlSortBy.ascending;
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
@@ -141,9 +141,9 @@ public class MarkOverdueLoansAsAgedLostService {
   private Result<CqlQuery> loanFetchQuery() {
     final Result<CqlQuery> statusQuery = exactMatch("status.name", "Open");
     final Result<CqlQuery> dueDateQuery = lessThan("dueDate", formatDateTime(ClockUtil.getZonedDateTime()));
-    final Result<CqlQuery> claimedReturnedQuery = notEqual("itemStatus", CLAIMED_RETURNED.getValue());
-    final Result<CqlQuery> agedToLostQuery = notEqual("itemStatus", AGED_TO_LOST.getValue());
-    final Result<CqlQuery> declaredLostQuery = notEqual("itemStatus", DECLARED_LOST.getValue());
+    final Result<CqlQuery> claimedReturnedQuery = notEqual("itemStatus", CLAIMED_RETURNED.getName());
+    final Result<CqlQuery> agedToLostQuery = notEqual("itemStatus", AGED_TO_LOST.getName());
+    final Result<CqlQuery> declaredLostQuery = notEqual("itemStatus", DECLARED_LOST.getName());
 
     return statusQuery.combine(dueDateQuery, CqlQuery::and)
       .combine(claimedReturnedQuery, CqlQuery::and)

--- a/src/main/java/org/folio/circulation/storage/mappers/ItemMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/ItemMapper.java
@@ -24,7 +24,7 @@ import io.vertx.core.json.JsonObject;
 
 public class ItemMapper {
   public Item toDomain(JsonObject representation) {
-    return new Item(getProperty(representation, "id"), representation,
+    return new Item(getProperty(representation, "id"),
       Location.unknown(getProperty(representation, "effectiveLocationId")),
       LastCheckIn.fromItemJson(representation),
       CallNumberComponents.fromItemJson(representation),

--- a/src/main/java/org/folio/circulation/storage/mappers/ItemMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/ItemMapper.java
@@ -1,6 +1,7 @@
 package org.folio.circulation.storage.mappers;
 
 import static org.apache.commons.lang3.StringUtils.firstNonBlank;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.json.JsonStringArrayPropertyFetcher.toStream;
 
@@ -11,6 +12,8 @@ import org.folio.circulation.domain.Holdings;
 import org.folio.circulation.domain.Instance;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.ItemDescription;
+import org.folio.circulation.domain.ItemStatus;
+import org.folio.circulation.domain.ItemStatusName;
 import org.folio.circulation.domain.LastCheckIn;
 import org.folio.circulation.domain.LoanType;
 import org.folio.circulation.domain.Location;
@@ -31,10 +34,7 @@ public class ItemMapper {
       Instance.unknown(),
       MaterialType.unknown(getProperty(representation, "materialTypeId")),
       LoanType.unknown(getLoanTypeId(representation)), getDescription(representation),
-      getProperty(representation, "barcode"), getProperty(representation,
-      "copyNumber"), getProperty(representation, "enumeration"),
-      getProperty(representation, "temporaryLoanTypeId"),
-      getProperty(representation, "permanentLoanTypeId"));
+      getItemStatus(representation));
   }
 
   private ItemDescription getDescription(JsonObject representation) {
@@ -48,6 +48,14 @@ public class ItemMapper {
       getProperty(representation, "descriptionOfPieces"),
       toStream(representation, "yearCaption")
         .collect(Collectors.toList()));
+  }
+
+  private ItemStatus getItemStatus(JsonObject representation) {
+    final String STATUS_PROPERTY = "status";
+
+    return new ItemStatus(ItemStatusName
+      .from(getNestedStringProperty(representation, STATUS_PROPERTY, "name")),
+        getNestedStringProperty(representation, STATUS_PROPERTY, "date"));
   }
 
   private ServicePoint getInTransitServicePoint(JsonObject representation) {

--- a/src/main/java/org/folio/circulation/storage/mappers/ItemMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/ItemMapper.java
@@ -30,7 +30,11 @@ public class ItemMapper {
       Holdings.unknown(getProperty(representation, "holdingsRecordId")),
       Instance.unknown(),
       MaterialType.unknown(getProperty(representation, "materialTypeId")),
-      LoanType.unknown(getLoanTypeId(representation)), getDescription(representation));
+      LoanType.unknown(getLoanTypeId(representation)), getDescription(representation),
+      getProperty(representation, "barcode"), getProperty(representation,
+      "copyNumber"), getProperty(representation, "enumeration"),
+      getProperty(representation, "temporaryLoanTypeId"),
+      getProperty(representation, "permanentLoanTypeId"));
   }
 
   private ItemDescription getDescription(JsonObject representation) {

--- a/src/main/java/org/folio/circulation/support/json/JsonPropertyWriter.java
+++ b/src/main/java/org/folio/circulation/support/json/JsonPropertyWriter.java
@@ -49,12 +49,8 @@ public class JsonPropertyWriter {
     }
   }
 
-  public static void write(
-    JsonObject to,
-    String propertyName,
-    JsonObject value) {
-
-    if(value != null) {
+  public static void write(JsonObject to, String propertyName, JsonObject value) {
+    if (to != null && value != null) {
       to.put(propertyName, value);
     }
   }

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -36,6 +36,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.waitAtMost;
 import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
 import static org.folio.circulation.domain.EventType.ITEM_CHECKED_IN;
+import static org.folio.circulation.domain.ItemStatusName.AWAITING_PICKUP;
 import static org.folio.circulation.domain.RequestStatus.CLOSED_CANCELLED;
 import static org.folio.circulation.domain.RequestStatus.CLOSED_PICKUP_EXPIRED;
 import static org.folio.circulation.domain.RequestStatus.CLOSED_UNFILLED;
@@ -66,7 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.folio.circulation.domain.ItemStatus;
+import org.folio.circulation.domain.ItemStatusName;
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.domain.User;
@@ -870,7 +871,7 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
 
     // check that both item and first request are awaiting pickup
 
-    assertThatItemStatusIs(item.getId(), ItemStatus.AWAITING_PICKUP);
+    assertThatItemStatusIs(item.getId(), AWAITING_PICKUP);
     assertThatRequestStatusIs(firstRequest.getId(), RequestStatus.OPEN_AWAITING_PICKUP);
 
     // verify that Request Awaiting Pickup notice was sent for first request
@@ -913,7 +914,7 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
 
     // verify that first request was closed, and that item is still awaiting pickup
 
-    assertThatItemStatusIs(item.getId(), ItemStatus.AWAITING_PICKUP);
+    assertThatItemStatusIs(item.getId(), AWAITING_PICKUP);
     assertThatRequestStatusIs(firstRequest.getId(), firstRequestUpdateStatus);
 
     // check the item in again
@@ -922,7 +923,7 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
 
     // verify that item is still awaiting pickup, and that second request is now awaiting pickup
 
-    assertThatItemStatusIs(item.getId(), ItemStatus.AWAITING_PICKUP);
+    assertThatItemStatusIs(item.getId(), AWAITING_PICKUP);
     assertThatRequestStatusIs(secondRequest.getId(), RequestStatus.OPEN_AWAITING_PICKUP);
 
     // verify that Request Awaiting Pickup notice was sent to second requester
@@ -1757,10 +1758,10 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
     return LocalDate.of(dateTime.getYear(), dateTime.getMonthValue(), dateTime.getDayOfMonth());
   }
 
-  private void assertThatItemStatusIs(UUID itemId, ItemStatus status) {
+  private void assertThatItemStatusIs(UUID itemId, ItemStatusName status) {
     final var item = itemsFixture.getById(itemId);
 
-    assertThat(item.getStatusName(), is(status.getValue()));
+    assertThat(item.getStatusName(), is(status.getName()));
   }
 
   private void assertThatRequestStatusIs(UUID requestId, RequestStatus status) {

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -22,7 +22,7 @@ import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfPublishedEven
 import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfSentNotices;
 import static java.time.ZoneOffset.UTC;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.folio.circulation.domain.ItemStatus.CHECKED_OUT;
+import static org.folio.circulation.domain.ItemStatusName.CHECKED_OUT;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE_ERROR;
 import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTime;
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import org.folio.circulation.domain.ItemStatusName;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.server.ValidationError;
@@ -462,7 +463,7 @@ class OverrideRenewByBarcodeTests extends APITests {
 
     assertThat("item status should be changed",
       renewedLoan.getJsonObject("item").getJsonObject("status").getString("name"),
-      is(CHECKED_OUT.getValue()));
+      is(CHECKED_OUT.getName()));
 
     ZonedDateTime expectedDueDate = loanDate.plusWeeks(2);
     assertThat("due date should be 2 weeks later",

--- a/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
+++ b/src/test/java/api/requests/InstanceRequestsAPICreationTests.java
@@ -13,6 +13,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfSentNotices;
 import static java.time.ZoneOffset.UTC;
 import static org.folio.HttpStatus.HTTP_CREATED;
+import static org.folio.circulation.domain.ItemStatusName.CHECKED_OUT;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -29,7 +30,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.RequestLevel;
 import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.domain.RequestType;
@@ -1045,7 +1045,7 @@ class InstanceRequestsAPICreationTests extends APITests {
       ? holdRequest.getJson().getJsonObject("item") : new JsonObject();
 
     assertThat(requestedItem.getString("status"),
-      is(ItemStatus.CHECKED_OUT.getValue()));
+      is(CHECKED_OUT.getName()));
   }
 
 }

--- a/src/test/java/api/requests/ItemsInTransitReportTests.java
+++ b/src/test/java/api/requests/ItemsInTransitReportTests.java
@@ -1,6 +1,7 @@
 package api.requests;
 
 import static api.support.JsonCollectionAssistant.getRecordById;
+import static api.support.builders.ItemBuilder.IN_TRANSIT;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static java.time.ZoneOffset.UTC;
 import static org.folio.circulation.support.StreamToListMapper.toList;
@@ -19,7 +20,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.support.json.JsonPropertyFetcher;
 import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -490,8 +490,7 @@ class ItemsInTransitReportTests extends APITests {
     UUID secondServicePointId) {
 
     assertThat(itemJson.getString(BARCODE_KEY), is(item.getBarcode()));
-    assertThat(itemJson.getJsonObject(STATUS_KEY).getMap().get(NAME),
-      is(ItemStatus.IN_TRANSIT.getValue()));
+    assertThat(itemJson.getJsonObject(STATUS_KEY).getMap().get(NAME), is(IN_TRANSIT));
 
     assertThat(itemJson.getString(DESTINATION_SERVICE_POINT), is(secondServicePointId.toString()));
 

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -1,5 +1,6 @@
 package api.requests;
 
+import static api.support.builders.ItemBuilder.PAGED;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.time.ZoneOffset.UTC;
@@ -22,7 +23,6 @@ import java.util.stream.Stream;
 
 import org.folio.circulation.domain.CallNumberComponents;
 import org.folio.circulation.domain.Item;
-import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.domain.User;
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import api.support.APITests;
 import api.support.builders.Address;
+import api.support.builders.ItemBuilder;
 import api.support.builders.RequestBuilder;
 import api.support.fixtures.AddressExamples;
 import api.support.http.IndividualResource;
@@ -184,7 +185,7 @@ class PickSlipsTests extends APITests {
 
     assertEquals(item.getTitle(), itemContext.getString("title"));
     assertEquals(item.getBarcode(), itemContext.getString("barcode"));
-    assertEquals(ItemStatus.PAGED.getValue(), itemContext.getString("status"));
+    assertEquals(PAGED, itemContext.getString("status"));
     assertEquals(item.getPrimaryContributorName(), itemContext.getString("primaryContributor"));
     assertEquals(contributorNames, itemContext.getString("allContributors"));
     assertEquals(item.getEnumeration(), itemContext.getString("enumeration"));

--- a/src/test/java/api/requests/scenarios/RequestPolicyTests.java
+++ b/src/test/java/api/requests/scenarios/RequestPolicyTests.java
@@ -1,5 +1,6 @@
 package api.requests.scenarios;
 
+import static api.support.builders.ItemBuilder.PAGED;
 import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
@@ -12,13 +13,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 
-import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.domain.RequestType;
 import org.folio.circulation.support.http.client.Response;
 import org.junit.jupiter.api.Test;
 
 import api.support.APITests;
+import api.support.builders.ItemBuilder;
 import api.support.builders.RequestBuilder;
 import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonObject;
@@ -67,7 +68,7 @@ class RequestPolicyTests extends APITests {
 
     JsonObject requestedItem = recallRequest.getJson().getJsonObject("item");
     assertThat(recallRequest.getJson().getString("requestType"), is(RequestType.RECALL.getValue()));
-    assertThat(requestedItem.getString("status"), is(ItemStatus.CHECKED_OUT.getValue()));
+    assertThat(requestedItem.getString("status"), is(ItemBuilder.CHECKED_OUT));
     assertThat(recallRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
   }
 
@@ -149,7 +150,7 @@ class RequestPolicyTests extends APITests {
 
     JsonObject requestedItem = recallRequest.getJson().getJsonObject("item");
     assertThat(recallRequest.getJson().getString("requestType"), is(RequestType.HOLD.getValue()));
-    assertThat(requestedItem.getString("status"), is(ItemStatus.CHECKED_OUT.getValue()));
+    assertThat(requestedItem.getString("status"), is(ItemBuilder.CHECKED_OUT));
     assertThat(recallRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
   }
 
@@ -223,7 +224,7 @@ class RequestPolicyTests extends APITests {
 
     JsonObject requestedItem = recallRequest.getJson().getJsonObject("item");
     assertThat(recallRequest.getJson().getString("requestType"), is(RequestType.PAGE.getValue()));
-    assertThat(requestedItem.getString("status"), is(ItemStatus.PAGED.getValue()));
+    assertThat(requestedItem.getString("status"), is(PAGED));
     assertThat(recallRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
   }
 
@@ -295,7 +296,7 @@ class RequestPolicyTests extends APITests {
 
     JsonObject requestedItem = recallRequest.getJson().getJsonObject("item");
     assertThat(recallRequest.getJson().getString("requestType"), is(RequestType.RECALL.getValue()));
-    assertThat(requestedItem.getString("status"), is(ItemStatus.CHECKED_OUT.getValue()));
+    assertThat(requestedItem.getString("status"), is(ItemBuilder.CHECKED_OUT));
     assertThat(recallRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
   }
 

--- a/src/test/java/api/requests/scenarios/RequestsServicePointsTests.java
+++ b/src/test/java/api/requests/scenarios/RequestsServicePointsTests.java
@@ -1,5 +1,8 @@
 package api.requests.scenarios;
 
+import static api.support.builders.ItemBuilder.AWAITING_PICKUP;
+import static api.support.builders.ItemBuilder.IN_TRANSIT;
+import static api.support.builders.ItemBuilder.PAGED;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -7,7 +10,6 @@ import java.lang.invoke.MethodHandles;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.support.utils.ClockUtil;
@@ -36,7 +38,7 @@ class RequestsServicePointsTests extends APITests {
       .by(usersFixture.james()));
 
     JsonObject requestItem = firstRequest.getJson().getJsonObject("item");
-    assertThat(requestItem.getString("status"), is(ItemStatus.PAGED.getValue()));
+    assertThat(requestItem.getString("status"), is(PAGED));
     assertThat(firstRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
 
     checkInFixture.checkInByBarcode(smallAngryPlanet, ClockUtil.getZonedDateTime(), servicePoint.getId());
@@ -44,7 +46,8 @@ class RequestsServicePointsTests extends APITests {
     MultipleRecords<JsonObject> requests = requestsFixture.getQueueFor(smallAngryPlanet);
     JsonObject pagedRequestRecord = requests.getRecords().iterator().next();
 
-    assertThat(pagedRequestRecord.getJsonObject("item").getString("status"), is(ItemStatus.AWAITING_PICKUP.getValue()));
+    assertThat(pagedRequestRecord.getJsonObject("item").getString("status"),
+      is(AWAITING_PICKUP));
     assertThat(pagedRequestRecord.getString("status"), is(RequestStatus.OPEN_AWAITING_PICKUP.getValue()));
   }
 
@@ -63,7 +66,8 @@ class RequestsServicePointsTests extends APITests {
     MultipleRecords<JsonObject> requests = requestsFixture.getQueueFor(inTransitItem);
     JsonObject pagedRequestRecord = requests.getRecords().iterator().next();
 
-    assertThat(pagedRequestRecord.getJsonObject("item").getString("status"), is(ItemStatus.AWAITING_PICKUP.getValue()));
+    assertThat(pagedRequestRecord.getJsonObject("item").getString("status"),
+      is(AWAITING_PICKUP));
     assertThat(pagedRequestRecord.getString("status"), is(RequestStatus.OPEN_AWAITING_PICKUP.getValue()));
   }
 
@@ -81,7 +85,7 @@ class RequestsServicePointsTests extends APITests {
       .by(usersFixture.james()));
 
     JsonObject requestItem = firstRequest.getJson().getJsonObject("item");
-    assertThat(requestItem.getString("status"), is(ItemStatus.PAGED.getValue()));
+    assertThat(requestItem.getString("status"), is(PAGED));
     assertThat(firstRequest.getJson().getString("status"), is(RequestStatus.OPEN_NOT_YET_FILLED.getValue()));
 
     log.info("requestServicePoint" + requestPickupServicePoint.getId());
@@ -92,7 +96,8 @@ class RequestsServicePointsTests extends APITests {
     MultipleRecords<JsonObject> requests = requestsFixture.getQueueFor(smallAngryPlanet);
     JsonObject pagedRequestRecord = requests.getRecords().iterator().next();
 
-    assertThat(pagedRequestRecord.getJsonObject("item").getString("status"), is(ItemStatus.IN_TRANSIT.getValue()));
+    assertThat(pagedRequestRecord.getJsonObject("item").getString("status"),
+      is(IN_TRANSIT));
     assertThat(pagedRequestRecord.getString("status"), is(RequestStatus.OPEN_IN_TRANSIT.getValue()));
   }
 }

--- a/src/test/java/api/support/fixtures/ItemsFixture.java
+++ b/src/test/java/api/support/fixtures/ItemsFixture.java
@@ -1,9 +1,10 @@
 package api.support.fixtures;
 
+import static api.support.builders.ItemBuilder.DECLARED_LOST;
+import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
 import static java.util.function.Function.identity;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
-import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
@@ -14,12 +15,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.folio.circulation.domain.ItemStatus;
-import api.support.http.IndividualResource;
-
 import api.support.builders.HoldingBuilder;
 import api.support.builders.InstanceBuilder;
 import api.support.builders.ItemBuilder;
+import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
 import api.support.http.ResourceClient;
 import io.vertx.core.json.JsonObject;
@@ -318,7 +317,7 @@ public class ItemsFixture {
 
   public IndividualResource setupDeclaredLostItem() {
     IndividualResource declaredLostItem = basedUponSmallAngryPlanet(ItemBuilder::declaredLost);
-    assertThat(declaredLostItem.getResponse().getJson().getJsonObject("status").getString("name"), is(ItemStatus.DECLARED_LOST.getValue()));
+    assertThat(declaredLostItem, hasItemStatus(DECLARED_LOST));
 
     return declaredLostItem;
   }

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -83,7 +83,8 @@ class RequestQueueTests {
       .put("status", status.getValue())
       .put("position", position);
 
-    return new Request(null, null, json, null, null, null, null, null, null, null, null, null, false, null, false);
+    return new Request(null, null, json, null, null, null, Item.unknown(),
+      null, null, null, null, null, false, null, false);
   }
 
   private static String randomId() {

--- a/src/test/java/org/folio/circulation/domain/RequestTypeItemStatusWhiteListTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestTypeItemStatusWhiteListTests.java
@@ -2,23 +2,24 @@ package org.folio.circulation.domain;
 
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
-import static org.folio.circulation.domain.ItemStatus.AGED_TO_LOST;
-import static org.folio.circulation.domain.ItemStatus.AVAILABLE;
-import static org.folio.circulation.domain.ItemStatus.AWAITING_DELIVERY;
-import static org.folio.circulation.domain.ItemStatus.CHECKED_OUT;
-import static org.folio.circulation.domain.ItemStatus.CLAIMED_RETURNED;
-import static org.folio.circulation.domain.ItemStatus.DECLARED_LOST;
-import static org.folio.circulation.domain.ItemStatus.INTELLECTUAL_ITEM;
-import static org.folio.circulation.domain.ItemStatus.IN_PROCESS;
-import static org.folio.circulation.domain.ItemStatus.IN_PROCESS_NON_REQUESTABLE;
-import static org.folio.circulation.domain.ItemStatus.LONG_MISSING;
-import static org.folio.circulation.domain.ItemStatus.LOST_AND_PAID;
-import static org.folio.circulation.domain.ItemStatus.ON_ORDER;
-import static org.folio.circulation.domain.ItemStatus.PAGED;
-import static org.folio.circulation.domain.ItemStatus.RESTRICTED;
-import static org.folio.circulation.domain.ItemStatus.UNAVAILABLE;
-import static org.folio.circulation.domain.ItemStatus.UNKNOWN;
-import static org.folio.circulation.domain.ItemStatus.WITHDRAWN;
+import static org.folio.circulation.domain.ItemStatusName.AGED_TO_LOST;
+import static org.folio.circulation.domain.ItemStatusName.AVAILABLE;
+import static org.folio.circulation.domain.ItemStatusName.AWAITING_DELIVERY;
+import static org.folio.circulation.domain.ItemStatusName.CHECKED_OUT;
+import static org.folio.circulation.domain.ItemStatusName.CLAIMED_RETURNED;
+import static org.folio.circulation.domain.ItemStatusName.DECLARED_LOST;
+import static org.folio.circulation.domain.ItemStatusName.INTELLECTUAL_ITEM;
+import static org.folio.circulation.domain.ItemStatusName.IN_PROCESS;
+import static org.folio.circulation.domain.ItemStatusName.IN_PROCESS_NON_REQUESTABLE;
+import static org.folio.circulation.domain.ItemStatusName.LONG_MISSING;
+import static org.folio.circulation.domain.ItemStatusName.LOST_AND_PAID;
+import static org.folio.circulation.domain.ItemStatusName.NONE;
+import static org.folio.circulation.domain.ItemStatusName.ON_ORDER;
+import static org.folio.circulation.domain.ItemStatusName.PAGED;
+import static org.folio.circulation.domain.ItemStatusName.RESTRICTED;
+import static org.folio.circulation.domain.ItemStatusName.UNAVAILABLE;
+import static org.folio.circulation.domain.ItemStatusName.UNKNOWN;
+import static org.folio.circulation.domain.ItemStatusName.WITHDRAWN;
 import static org.folio.circulation.domain.RequestType.HOLD;
 import static org.folio.circulation.domain.RequestType.PAGE;
 import static org.folio.circulation.domain.RequestType.RECALL;
@@ -89,7 +90,7 @@ class  RequestTypeItemStatusWhiteListTests {
 
   @Test
   void cannotCreatePagedRequestWhenItemStatusIsNone() {
-    assertFalse(canCreateRequestForItem(ItemStatus.NONE, PAGE));
+    assertFalse(canCreateRequestForItem(NONE, PAGE));
   }
 
   @Test

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
@@ -21,6 +21,7 @@ import org.folio.circulation.domain.Holdings;
 import org.folio.circulation.domain.Instance;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.ItemDescription;
+import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.LoanType;
 import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.MaterialType;
@@ -115,8 +116,7 @@ class ItemRepositoryTests {
     return new Item(null, null, Location.unknown(), null, null, Location.unknown(),
       null, false,
       Holdings.unknown(), Instance.unknown(), MaterialType.unknown(),
-      LoanType.unknown(), ItemDescription.unknown(), null,
-      null, null, null, null);
+      LoanType.unknown(), ItemDescription.unknown(), ItemStatus.unknown());
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
@@ -113,10 +113,10 @@ class ItemRepositoryTests {
   }
 
   private Item dummyItem() {
-    return new Item(null, null, Location.unknown(), null, null, Location.unknown(),
-      null, false,
-      Holdings.unknown(), Instance.unknown(), MaterialType.unknown(),
-      LoanType.unknown(), ItemDescription.unknown(), ItemStatus.unknown());
+    return new Item(null, Location.unknown(), null, null,
+      Location.unknown(), null, false, Holdings.unknown(),
+      Instance.unknown(), MaterialType.unknown(), LoanType.unknown(),
+      ItemDescription.unknown(), ItemStatus.unknown());
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
@@ -112,9 +112,11 @@ class ItemRepositoryTests {
   }
 
   private Item dummyItem() {
-    return new Item(null, null, null, null, null, null, null, false,
+    return new Item(null, null, Location.unknown(), null, null, Location.unknown(),
+      null, false,
       Holdings.unknown(), Instance.unknown(), MaterialType.unknown(),
-      LoanType.unknown(), ItemDescription.unknown());
+      LoanType.unknown(), ItemDescription.unknown(), null,
+      null, null, null, null);
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/circulation/resources/renewal/OverrideRenewalTest.java
+++ b/src/test/java/org/folio/circulation/resources/renewal/OverrideRenewalTest.java
@@ -8,7 +8,7 @@ import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasMessageContaining;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
-import static org.folio.circulation.domain.ItemStatus.CHECKED_OUT;
+import static org.folio.circulation.domain.ItemStatusName.CHECKED_OUT;
 import static org.folio.circulation.domain.policy.Period.weeks;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.folio.circulation.support.json.JsonPropertyWriter.writeByPath;
@@ -48,7 +48,7 @@ class OverrideRenewalTest {
     final Result<Loan> renewedLoan = renew(LoanPolicy.from(loanPolicyJson), overrideDate);
 
     assertDueDate(overrideDate, renewedLoan);
-    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus());
+    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus().getName());
   }
 
   @Test
@@ -61,7 +61,7 @@ class OverrideRenewalTest {
     final Result<Loan> renewedLoan = renew(LoanPolicy.from(loanPolicyJson), overrideDate);
 
     assertDueDate(overrideDate, renewedLoan);
-    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus());
+    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus().getName());
   }
 
   @Test
@@ -97,7 +97,7 @@ class OverrideRenewalTest {
     final Result<Loan> renewedLoan = renew(LoanPolicy.from(loanPolicyJson), overrideDate);
 
     assertDueDate(overrideDate, renewedLoan);
-    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus());
+    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus().getName());
   }
 
   @Test
@@ -126,7 +126,7 @@ class OverrideRenewalTest {
     final Result<Loan> renewedLoan = renew(loan, overrideDueDate);
 
     assertDueDate(overrideDueDate, renewedLoan);
-    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus());
+    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus().getName());
   }
 
   @Test
@@ -143,7 +143,7 @@ class OverrideRenewalTest {
     final Result<Loan> renewedLoan = renew(loan, null);
 
     assertDueDateWithinOneSecondAfter(estimatedDueDate, renewedLoan);
-    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus());
+    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus().getName());
   }
 
   @Test
@@ -168,7 +168,7 @@ class OverrideRenewalTest {
     final Result<Loan> renewedLoan = renewWithRecall(loan, overrideDueDate);
 
     assertDueDate(overrideDueDate, renewedLoan);
-    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus());
+    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus().getName());
   }
 
   @Test
@@ -188,7 +188,7 @@ class OverrideRenewalTest {
     final Result<Loan> renewedLoan = renewWithRecall(loan, null);
 
     assertDueDateWithinOneSecondAfter(estimatedDueDate, renewedLoan);
-    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus());
+    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus().getName());
   }
 
   @Test
@@ -201,7 +201,7 @@ class OverrideRenewalTest {
     final Result<Loan> renewedLoan = renew(loan, overrideDueDate);
 
     assertDueDate(overrideDueDate, renewedLoan);
-    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus());
+    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus().getName());
   }
 
   @Test
@@ -223,7 +223,7 @@ class OverrideRenewalTest {
     final Result<Loan> renewedLoan = renew(loan, null);
 
     assertDueDateWithinOneSecondAfter(estimatedDueDate, renewedLoan);
-    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus());
+    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus().getName());
   }
 
   @Test
@@ -234,7 +234,7 @@ class OverrideRenewalTest {
     final Result<Loan> renewedLoan = renew(loan, overrideDate);
 
     assertDueDate(overrideDate, renewedLoan);
-    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus());
+    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus().getName());
   }
 
   @Test
@@ -285,7 +285,7 @@ class OverrideRenewalTest {
     final Result<Loan> renewedLoan = renew(loan, newDueDate);
 
     assertDueDate(newDueDate, renewedLoan);
-    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus());
+    assertEquals(CHECKED_OUT, renewedLoan.value().getItem().getStatus().getName());
 
     assertThat(renewedLoan.value().asJson(), allOf(
       hasNoJsonPath("agedToLostDelayedBilling.lostItemHasBeenBilled"),

--- a/src/test/java/org/folio/circulation/resources/renewal/RegularRenewalTest.java
+++ b/src/test/java/org/folio/circulation/resources/renewal/RegularRenewalTest.java
@@ -2,7 +2,7 @@ package org.folio.circulation.resources.renewal;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.folio.circulation.domain.ItemStatus.AGED_TO_LOST;
+import static org.folio.circulation.domain.ItemStatusName.AGED_TO_LOST;
 import static org.folio.circulation.domain.policy.Period.days;
 import static org.folio.circulation.support.utils.ClockUtil.getZonedDateTime;
 import static org.hamcrest.CoreMatchers.is;
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.spy;
 
 import java.util.UUID;
 
-import org.folio.circulation.domain.ItemStatus;
+import org.folio.circulation.domain.ItemStatusName;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestQueue;
@@ -179,7 +179,7 @@ class RegularRenewalTest {
     final var loanPolicy = new LoanPolicyBuilder().asDomainObject();
     final var loan = new LoanBuilder().asDomainObject()
       .withLoanPolicy(loanPolicy)
-      .changeItemStatusForItemAndLoan(ItemStatus.from(itemStatus));
+      .changeItemStatusForItemAndLoan(ItemStatusName.from(itemStatus));
 
     CirculationErrorHandler errorHandler = new OverridingErrorHandler(null);
     renew(loan, errorHandler);


### PR DESCRIPTION
## Purpose

In order to make it easier to change the way circulation interacts with inventory records, the representation in the domain could be separated more from the underlying representation of the records in inventory storage.

One of the last remaining usages of the JSON representation is the item status. This requires more dedicated changes due to how the current enumeration has state that it should not have (as enumeration instances as shared).

## Approach

* Duplicate the current item status enumeration
* Use the duplicate to represent the name only
* Change the existing enumeration to a class (to stop the issues with item status date)
* Change the loan to respect the new item instance when the state changes (due to the item being intended to have immutable state)

#### TODOS and Open Questions
* The call number components constant is the only field left in the item properties class, this needs to be removed however it is used in quite a lot of the API tests. These will need to be changed before this can be removed.

## Learning
* Enumeration values are shared, they should not be allowed mutable state
