### PR TITLE
CIRC-1539: Upgrade vulnerable dependencies (Vert.x, Spring, xstream)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,12 @@
     <antlr4.version>4.7.2</antlr4.version>
     <drools.version>7.53.0.Final</drools.version>
     <rmb.version>33.1.1</rmb.version>
-    <vertx.version>4.2.1</vertx.version>
+    <vertx.version>4.2.7</vertx.version>
     <log4j2.version>2.17.1</log4j2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <lombok.version>1.18.16</lombok.version>
-    <spring.version>5.2.7.RELEASE</spring.version>
+    <spring.version>5.2.22.RELEASE</spring.version>
     <maven.site.plugin.version>3.9.1</maven.site.plugin.version>
   </properties>
 
@@ -116,6 +116,11 @@
       <artifactId>drools-mvel</artifactId>
       <version>${drools.version}</version>
     </dependency>
+    <dependency> <!-- patch drools' xstream: https://x-stream.github.io/security.html#CVEs -->
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <version>1.4.19</version>
+    </dependency>
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
@@ -135,7 +140,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.4.0</version>
+      <version>2.4.3</version>
       <exclusions>
         <exclusion>
           <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-1539

Upgrade dependencies fixing security vulnerabilities.

Upgrade Vert.x from 4.2.1 to 4.2.7. This indirectly upgrades jackson-databind from 2.11.4 to 2.13.2.1 fixing Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2020-36518

Upgrade Spring from 5.2.7 to 5.2.22 fixing Spring4Shell vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2022-22965

Upgrade mod-pubsub-client from 2.4.0 to 2.4.3 fixing Socket Leaks.

Upgrade xstream from 1.4.16 to 1.4.19 fixing Arbitrary Code Execution: many CVEs, see complete list at https://x-stream.github.io/security.html#CVEs , for example https://nvd.nist.gov/vuln/detail/CVE-2021-39139