### PR TITLE
Release 23.0.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 23.0.9 2022-05-30
+
+* Upgrade vulnerable dependencies (Vert.x, Spring, xstream) (CIRC-1539)
+* Rebuild docker container fixing ZipException on 64-bit systems (FOLIO-3484)
+
 ## 23.0.8 2022-04-15
 
 * Change due date when item is renewed (CIRC-1463)

--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,12 @@
     <antlr4.version>4.7.2</antlr4.version>
     <drools.version>7.53.0.Final</drools.version>
     <rmb.version>33.1.1</rmb.version>
-    <vertx.version>4.2.1</vertx.version>
+    <vertx.version>4.2.7</vertx.version>
     <log4j2.version>2.17.1</log4j2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <lombok.version>1.18.16</lombok.version>
-    <spring.version>5.2.7.RELEASE</spring.version>
+    <spring.version>5.2.22.RELEASE</spring.version>
     <maven.site.plugin.version>3.9.1</maven.site.plugin.version>
   </properties>
 
@@ -116,6 +116,11 @@
       <artifactId>drools-mvel</artifactId>
       <version>${drools.version}</version>
     </dependency>
+    <dependency> <!-- patch drools' xstream: https://x-stream.github.io/security.html#CVEs -->
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <version>1.4.19</version>
+    </dependency>
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
@@ -135,7 +140,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.4.0</version>
+      <version>2.4.3</version>
       <exclusions>
         <exclusion>
           <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
* Upgrade vulnerable dependencies (Vert.x, Spring, xstream) [(CIRC-1539)](https://issues.folio.org/browse/CIRC-1539)
* Rebuild docker container fixing ZipException on 64-bit systems ([FOLIO-3484](https://issues.folio.org/browse/FOLIO-3484))