### PR TITLE
Release 22.1.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 22.1.6 2022-05-30
+
+* Upgrade vulnerable dependencies (Vert.x, Spring, xstream) (CIRC-1539)
+* Rebuild docker container fixing ZipException on 64-bit systems (FOLIO-3484)
+
 ## 22.1.5 2022-04-25
 
 * Suspend sending notices after a loan is marked as claimed returned (CIRC-1427)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>22.1.6-SNAPSHOT</version>
+  <version>22.1.6</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -281,7 +281,7 @@
     <url>https://github.com/folio-org/mod-inventory</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory.git</developerConnection>
-    <tag>v22.1.0</tag>
+    <tag>v22.1.6</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>22.1.6</version>
+  <version>22.1.7-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -281,7 +281,7 @@
     <url>https://github.com/folio-org/mod-inventory</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory.git</developerConnection>
-    <tag>v22.1.6</tag>
+    <tag>v22.1.0</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,13 +25,13 @@
   <properties>
     <antlr4.version>4.7.2</antlr4.version>
     <drools.version>7.53.0.Final</drools.version>
-    <rmb.version>31.1.0</rmb.version>
-    <vertx.version>4.1.1</vertx.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <rmb.version>33.1.1</rmb.version>
+    <vertx.version>4.2.7</vertx.version>
+    <log4j2.version>2.17.1</log4j2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <lombok.version>1.18.16</lombok.version>
-    <spring.version>5.2.7.RELEASE</spring.version>
+    <spring.version>5.2.22.RELEASE</spring.version>
     <maven.site.plugin.version>3.9.1</maven.site.plugin.version>
   </properties>
 
@@ -126,6 +126,11 @@
       <artifactId>drools-mvel</artifactId>
       <version>${drools.version}</version>
     </dependency>
+    <dependency> <!-- patch drools' xstream: https://x-stream.github.io/security.html#CVEs -->
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <version>1.4.19</version>
+    </dependency>
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
@@ -144,7 +149,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.0.7</version>
+      <version>2.4.3</version>
       <exclusions>
         <exclusion>
           <groupId>org.hamcrest</groupId>

--- a/src/main/java/org/folio/circulation/services/PubSubPublishingService.java
+++ b/src/main/java/org/folio/circulation/services/PubSubPublishingService.java
@@ -41,7 +41,7 @@ public class PubSubPublishingService {
       .withEventType(eventType)
       .withEventPayload(payload)
       .withEventMetadata(new EventMetadata()
-        .withPublishedBy(PubSubClientUtils.constructModuleName())
+        .withPublishedBy(PubSubClientUtils.getModuleId())
         .withTenantId(okapiHeaders.get(OKAPI_TENANT_HEADER))
         .withEventTTL(1));
 

--- a/src/test/java/api/support/fixtures/TenantActivationFixture.java
+++ b/src/test/java/api/support/fixtures/TenantActivationFixture.java
@@ -3,8 +3,7 @@ package api.support.fixtures;
 import static api.support.APITestContext.circulationModuleUrl;
 
 import org.folio.circulation.support.http.client.Response;
-import org.folio.rest.tools.PomReader;
-
+import org.folio.util.pubsub.PubSubClientUtils;
 import api.support.RestAssuredClient;
 import io.vertx.core.json.JsonObject;
 
@@ -16,11 +15,8 @@ public class TenantActivationFixture {
   }
 
   public Response postTenant() {
-    String moduleName = PomReader.INSTANCE.getModuleName();
-    String currentVersion = PomReader.INSTANCE.getVersion();
-
     return restAssuredClient.post(
-      new JsonObject().put("id", String.format("%s-%s", moduleName, currentVersion)),
+      new JsonObject().put("id", PubSubClientUtils.getModuleId()),
       circulationModuleUrl("/_/tenant"), "tenant-api-post-test-request");
   }
 

--- a/src/test/java/api/support/matchers/PubSubRegistrationMatchers.java
+++ b/src/test/java/api/support/matchers/PubSubRegistrationMatchers.java
@@ -1,7 +1,7 @@
 package api.support.matchers;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
-import static org.folio.util.pubsub.PubSubClientUtils.constructModuleName;
+import static org.folio.util.pubsub.PubSubClientUtils.getModuleId;
 import static org.hamcrest.core.Is.is;
 
 import org.hamcrest.Matcher;
@@ -11,7 +11,7 @@ import io.vertx.core.json.JsonObject;
 public class PubSubRegistrationMatchers {
   public static Matcher<JsonObject> isValidPublishersRegistration() {
     return JsonObjectMatcher.allOfPaths(
-      hasJsonPath("moduleId", is(constructModuleName())),
+      hasJsonPath("moduleId", is(getModuleId())),
       hasJsonPath("eventDescriptors[0].eventType", is("ITEM_CHECKED_OUT")),
       hasJsonPath("eventDescriptors[1].eventType", is("ITEM_CHECKED_IN")),
       hasJsonPath("eventDescriptors[2].eventType", is("ITEM_DECLARED_LOST")),
@@ -25,7 +25,7 @@ public class PubSubRegistrationMatchers {
 
   public static Matcher<JsonObject> isValidSubscribersRegistration() {
     return JsonObjectMatcher.allOfPaths(
-      hasJsonPath("moduleId", is(constructModuleName())),
+      hasJsonPath("moduleId", is(getModuleId())),
       hasJsonPath("subscriptionDefinitions[0].eventType",
         is("LOAN_RELATED_FEE_FINE_CLOSED"))
     );


### PR DESCRIPTION
* Upgrade vulnerable dependencies (Vert.x, Spring, xstream) ([CIRC-1539](https://issues.folio.org/browse/CIRC-1539))
* Rebuild docker container fixing ZipException on 64-bit systems ([FOLIO-3484](https://issues.folio.org/browse/FOLIO-3484))