### PR TITLE
CIRC-584 Remove unnecessary reference records fetches when moving requests

### DIFF
--- a/src/main/java/org/folio/circulation/domain/MoveRequestProcessAdapter.java
+++ b/src/main/java/org/folio/circulation/domain/MoveRequestProcessAdapter.java
@@ -21,7 +21,8 @@ public class MoveRequestProcessAdapter {
 
   CompletableFuture<Result<RequestAndRelatedRecords>> findDestinationItem(
      RequestAndRelatedRecords requestAndRelatedRecords) {
-    return itemRepository.fetchById(requestAndRelatedRecords.getDestinationItemId())
+
+    return itemRepository.fetchItemWithHoldingsAndInstance(requestAndRelatedRecords.getDestinationItemId())
       .thenApply(r -> r.map(requestAndRelatedRecords::withItem))
       .thenComposeAsync(r -> r.after(this::findLoanForItem));
   }
@@ -34,7 +35,7 @@ public class MoveRequestProcessAdapter {
 
   CompletableFuture<Result<RequestAndRelatedRecords>> findSourceItem(
       RequestAndRelatedRecords requestAndRelatedRecords) {
-    return itemRepository.fetchById(requestAndRelatedRecords.getSourceItemId())
+    return itemRepository.fetchItemWithHoldingsAndInstance(requestAndRelatedRecords.getSourceItemId())
       .thenApply(result -> result.map(requestAndRelatedRecords::withItem))
       .thenComposeAsync(r -> r.after(this::findLoanForItem));
   }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -13,6 +13,8 @@ import static org.folio.circulation.support.http.client.PageLimit.one;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.json.JsonPropertyWriter.remove;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
+import static org.folio.circulation.support.results.AsynchronousResult.*;
+import static org.folio.circulation.support.results.AsynchronousResultBindings.*;
 import static org.folio.circulation.support.results.AsynchronousResultBindings.combineAfter;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
@@ -45,6 +47,8 @@ import org.folio.circulation.support.SingleRecordFetcher;
 import org.folio.circulation.support.fetching.CqlIndexValuesFinder;
 import org.folio.circulation.support.fetching.CqlQueryFinder;
 import org.folio.circulation.support.http.client.CqlQuery;
+import org.folio.circulation.support.results.AsynchronousResult;
+import org.folio.circulation.support.results.AsynchronousResultBindings;
 import org.folio.circulation.support.results.Result;
 
 import io.vertx.core.json.JsonObject;
@@ -257,6 +261,8 @@ public class ItemRepository {
     return fetchItemsFor(result, includeItemMap, this::fetchItemsWithHoldingsRecords);
   }
 
+
+
   public <T extends ItemRelatedRecord> CompletableFuture<Result<MultipleRecords<T>>>
   fetchItemsFor(Result<MultipleRecords<T>> result, BiFunction<T, Item, T> includeItemMap,
     Function<Collection<String>, CompletableFuture<Result<MultipleRecords<Item>>>> fetcher) {
@@ -310,6 +316,12 @@ public class ItemRepository {
 
     return fetchItems(itemIds)
       .thenComposeAsync(this::fetchHoldingsRecords);
+  }
+
+  public CompletableFuture<Result<Item>> fetchItemWithHoldingsAndInstance(String itemId) {
+    return fetchItem(itemId)
+      .thenComposeAsync(combineAfter(this::fetchHoldingsRecord, Item::withHoldings))
+      .thenComposeAsync(combineAfter(this::fetchInstance, Item::withInstance));
   }
 
   public CompletableFuture<Result<Item>> fetchItemRelatedRecords(Result<Item> itemResult) {

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -13,8 +13,6 @@ import static org.folio.circulation.support.http.client.PageLimit.one;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.json.JsonPropertyWriter.remove;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
-import static org.folio.circulation.support.results.AsynchronousResult.*;
-import static org.folio.circulation.support.results.AsynchronousResultBindings.*;
 import static org.folio.circulation.support.results.AsynchronousResultBindings.combineAfter;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
@@ -47,8 +45,6 @@ import org.folio.circulation.support.SingleRecordFetcher;
 import org.folio.circulation.support.fetching.CqlIndexValuesFinder;
 import org.folio.circulation.support.fetching.CqlQueryFinder;
 import org.folio.circulation.support.http.client.CqlQuery;
-import org.folio.circulation.support.results.AsynchronousResult;
-import org.folio.circulation.support.results.AsynchronousResultBindings;
 import org.folio.circulation.support.results.Result;
 
 import io.vertx.core.json.JsonObject;
@@ -260,8 +256,6 @@ public class ItemRepository {
 
     return fetchItemsFor(result, includeItemMap, this::fetchItemsWithHoldingsRecords);
   }
-
-
 
   public <T extends ItemRelatedRecord> CompletableFuture<Result<MultipleRecords<T>>>
   fetchItemsFor(Result<MultipleRecords<T>> result, BiFunction<T, Item, T> includeItemMap,


### PR DESCRIPTION
Resolves: https://issues.folio.org/browse/CIRC-584
## Purpose
This story about revising findSourceItem/findDestinationItem methods and remove fetching of unnecessary reference records (the first candidate might be location).
## Approach
Fetch only holdings record and instance for item