### PR TITLE
CIRC-1526 Add policy IDs to the Account record

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -968,7 +968,7 @@
     },
     {
       "id": "feesfines",
-      "version": "16.3 17.2"
+      "version": "16.3 17.3"
     },
     {
       "id": "location-units",

--- a/src/main/java/org/folio/circulation/domain/OverdueFineService.java
+++ b/src/main/java/org/folio/circulation/domain/OverdueFineService.java
@@ -227,6 +227,9 @@ public class OverdueFineService {
       .withAmount(new FeeAmount(params.fineAmount))
       .withStaffUserId(params.loggedInUserId)
       .withCurrentServicePointId(params.loan.getCheckInServicePointId())
+      .withLoanPolicyId(params.loan.getLoanPolicyId())
+      .withOverdueFinePolicyId(params.loan.getOverdueFinePolicyId())
+      .withLostItemFeePolicyId(params.loan.getLostItemPolicyId())
       .build();
 
     return feeFineFacade.createAccount(createAccountCommand);

--- a/src/main/java/org/folio/circulation/domain/representations/StoredAccount.java
+++ b/src/main/java/org/folio/circulation/domain/representations/StoredAccount.java
@@ -53,6 +53,9 @@ public class StoredAccount extends JsonObject {
     this.put("status", createNamedObject("Open"));
 
     this.put("contributors", mapContributorNamesToJson(item));
+    this.put("loanPolicyId", loan.getLoanPolicyId());
+    this.put("overdueFinePolicyId", loan.getOverdueFinePolicyId());
+    this.put("lostItemFeePolicyId", loan.getLostItemPolicyId());
   }
 
   private StoredAccount(JsonObject json) {

--- a/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
+++ b/src/main/java/org/folio/circulation/services/LostItemFeeChargingService.java
@@ -221,6 +221,9 @@ public class LostItemFeeChargingService {
       .withFeeFineOwner(context.feeFineOwner)
       .withLoan(context.loan)
       .withItem(context.loan.getItem())
+      .withLoanPolicyId(context.loan.getLoanPolicyId())
+      .withOverdueFinePolicyId(context.loan.getOverdueFinePolicyId())
+      .withLostItemFeePolicyId(context.loan.getLostItemPolicyId())
       .build();
   }
 

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -196,6 +196,9 @@ public class ChargeLostFeesWhenAgedToLostService {
       .withFeeFineOwner(loanToCharge.getOwner())
       .withLoan(loanToCharge.getLoan())
       .withItem(loanToCharge.getLoan().getItem())
+      .withLoanPolicyId(loanToCharge.getLoan().getLoanPolicyId())
+      .withOverdueFinePolicyId(loanToCharge.getLoan().getOverdueFinePolicyId())
+      .withLostItemFeePolicyId(loanToCharge.getLoan().getLostItemPolicyId())
       .build();
   }
 

--- a/src/main/java/org/folio/circulation/services/support/CreateAccountCommand.java
+++ b/src/main/java/org/folio/circulation/services/support/CreateAccountCommand.java
@@ -20,4 +20,7 @@ public final class CreateAccountCommand {
   private final String staffUserId;
   private final boolean createdByAutomatedProcess;
   private final String currentServicePointId;
+  private final String loanPolicyId;
+  private final String overdueFinePolicyId;
+  private final String lostItemFeePolicyId;
 }

--- a/src/test/java/api/loans/DeclareLostAPITests.java
+++ b/src/test/java/api/loans/DeclareLostAPITests.java
@@ -863,10 +863,10 @@ class DeclareLostAPITests extends APITests {
       return;
     }
     assertThat(account.getString("loanPolicyId"), is(loan.getJson().getString("loanPolicyId")));
-    assertThat(account.getString("overdueFinePolicyId"), is(
-      loan.getJson().getString("overdueFinePolicyId")));
-    assertThat(account.getString("lostItemFeePolicyId"), is(
-      loan.getJson().getString("lostItemPolicyId")));
+    assertThat(account.getString("overdueFinePolicyId"), is(loan.getJson().getString(
+      "overdueFinePolicyId")));
+    assertThat(account.getString("lostItemFeePolicyId"), is(loan.getJson().getString(
+      "lostItemPolicyId")));
 
     final JsonObject action = feeFineActionsClient
       .getMany(queryFromTemplate("accountId==%s", account.getString("id")))

--- a/src/test/java/api/loans/DeclareLostAPITests.java
+++ b/src/test/java/api/loans/DeclareLostAPITests.java
@@ -220,13 +220,13 @@ class DeclareLostAPITests extends APITests {
       .getJsonObject(0)
       .getString("name");
 
-    verifyFeeHasBeenCharged(loan.getId(), "Lost item fee", allOf(
+    verifyFeeHasBeenCharged(loan, "Lost item fee", allOf(
       hasJsonPath("ownerId", expectedOwnerId),
       hasJsonPath("feeFineType", "Lost item fee"),
       hasJsonPath("amount", expectedItemFee),
       hasJsonPath("contributors[0].name", contributorName)));
 
-    verifyFeeHasBeenCharged(loan.getId(), "Lost item processing fee", allOf(
+    verifyFeeHasBeenCharged(loan, "Lost item processing fee", allOf(
       hasJsonPath("ownerId", expectedOwnerId),
       hasJsonPath("feeFineType", "Lost item processing fee"),
       hasJsonPath("amount", expectedProcessingFee),
@@ -250,7 +250,7 @@ class DeclareLostAPITests extends APITests {
 
     assertThat(loan.getJson(), isOpen());
 
-    verifyFeeHasBeenCharged(loan.getId(), "Lost item fee", allOf(
+    verifyFeeHasBeenCharged(loan, "Lost item fee", allOf(
       hasJsonPath("ownerId", expectedOwnerId),
       hasJsonPath("feeFineType", "Lost item fee"),
       hasJsonPath("amount", expectedItemFee)
@@ -274,7 +274,7 @@ class DeclareLostAPITests extends APITests {
 
     assertThat(loan.getJson(), isOpen());
 
-    verifyFeeHasBeenCharged(loan.getId(), "Lost item processing fee", allOf(
+    verifyFeeHasBeenCharged(loan, "Lost item processing fee", allOf(
       hasJsonPath("ownerId", expectedOwnerId),
       hasJsonPath("feeFineType", "Lost item processing fee"),
       hasJsonPath("amount", expectedProcessingFee)
@@ -852,16 +852,21 @@ class DeclareLostAPITests extends APITests {
     }
   }
 
-  private void verifyFeeHasBeenCharged(UUID loanId, String feeType,
+  private void verifyFeeHasBeenCharged(IndividualResource loan, String feeType,
     Matcher<JsonObject> accountMatcher) {
 
-    final JsonObject account = getAccountForLoan(loanId, feeType);
+    final JsonObject account = getAccountForLoan(loan.getId(), feeType);
 
     assertThat(account, accountMatcher);
 
     if (account == null) {
       return;
     }
+    assertThat(account.getString("loanPolicyId"), is(loan.getJson().getString("loanPolicyId")));
+    assertThat(account.getString("overdueFinePolicyId"), is(
+      loan.getJson().getString("overdueFinePolicyId")));
+    assertThat(account.getString("lostItemFeePolicyId"), is(
+      loan.getJson().getString("lostItemPolicyId")));
 
     final JsonObject action = feeFineActionsClient
       .getMany(queryFromTemplate("accountId==%s", account.getString("id")))

--- a/src/test/java/api/support/matchers/OverdueFineMatcher.java
+++ b/src/test/java/api/support/matchers/OverdueFineMatcher.java
@@ -39,7 +39,10 @@ public class OverdueFineMatcher {
       hasJsonPath("loanId", UUIDMatcher.is(getUUIDProperty(loan, "id"))),
       hasJsonPath("userId", is(loan.getString("userId"))),
       hasJsonPath("itemId", UUIDMatcher.is(item.getId())),
-      hasJsonPath("dueDate", is(loan.getString(LoanProperties.DUE_DATE)))
+      hasJsonPath("dueDate", is(loan.getString(LoanProperties.DUE_DATE))),
+      hasJsonPath("loanPolicyId", is(loan.getString("loanPolicyId"))),
+      hasJsonPath("overdueFinePolicyId", is(loan.getString("overdueFinePolicyId"))),
+      hasJsonPath("lostItemFeePolicyId", is(loan.getString("lostItemPolicyId")))
     ));
 
     if (loan.getString(LoanProperties.RETURN_DATE) != null) {


### PR DESCRIPTION
## Purpose
- save policy ids in an account, to avoid cleaning up after anonymization;
- create tests;

Resolves: [CIRC-1526](https://issues.folio.org/browse/CIRC-1526)