### PR TITLE
CIRC-1432 Actual cost - close aged to lost loan as paid when no processing fee should be charged

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <log4j2.version>2.17.1</log4j2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <lombok.version>1.18.16</lombok.version>
+    <lombok.version>1.18.22</lombok.version>
     <spring.version>5.2.22.RELEASE</spring.version>
     <maven.site.plugin.version>3.9.1</maven.site.plugin.version>
   </properties>

--- a/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
@@ -39,6 +39,8 @@ public class LostItemPolicy extends Policy {
   // that turns on/off the fee, but we're modelling it as a separate fee
   // to simplify logic.
   private final AutomaticallyChargeableFee ageToLostProcessingFee;
+  private static final String CHARGE_AMOUNT_ITEM = "chargeAmountItem";
+  private static final String CHARGE_TYPE = "chargeType";
 
   private LostItemPolicy(String id, String name, AutomaticallyChargeableFee declareLostProcessingFee,
     AutomaticallyChargeableFee setCostFee, ChargeableFee actualCostFee,
@@ -107,8 +109,8 @@ public class LostItemPolicy extends Policy {
     String enabledFlag) {
 
     final boolean chargeProcessingFee = getBooleanProperty(policy, enabledFlag);
-    String chargeType = Optional.ofNullable(policy.getJsonObject("chargeAmountItem"))
-      .map(object -> object.getString("chargeType"))
+    String chargeType = Optional.ofNullable(policy.getJsonObject(CHARGE_AMOUNT_ITEM))
+      .map(object -> object.getString(CHARGE_TYPE))
       .orElse("non-existent cost type");
     boolean actualCost = "actualCost".equals(chargeType);
     final BigDecimal amount = getBigDecimalProperty(policy, "lostItemProcessingFee");
@@ -119,8 +121,8 @@ public class LostItemPolicy extends Policy {
   }
 
   private static AutomaticallyChargeableFee getSetCostFee(JsonObject policy) {
-    final JsonObject chargeAmountItem = getObjectProperty(policy, "chargeAmountItem");
-    final ChargeAmountType chargeType = forValue(getProperty(chargeAmountItem, "chargeType"));
+    final JsonObject chargeAmountItem = getObjectProperty(policy, CHARGE_AMOUNT_ITEM);
+    final ChargeAmountType chargeType = forValue(getProperty(chargeAmountItem, CHARGE_TYPE));
     final BigDecimal amount = getBigDecimalProperty(chargeAmountItem, "amount");
 
     return chargeAmountItem != null && chargeType == SET_COST && amount != null
@@ -130,7 +132,7 @@ public class LostItemPolicy extends Policy {
 
   private static ChargeableFee getActualCostFee(JsonObject policy) {
     final ChargeAmountType chargeType = forValue(getNestedStringProperty(policy,
-      "chargeAmountItem", "chargeType"));
+      CHARGE_AMOUNT_ITEM, CHARGE_TYPE));
 
     return chargeType == ACTUAL_COST
       ? new ActualCostFee()

--- a/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
@@ -103,7 +103,9 @@ public class LostItemPolicy extends Policy {
       : noAutomaticallyChargeableFee();
   }
 
-  private static AutomaticallyChargeableFee getAgeToLostProcessingFee(JsonObject policy, String enabledFlag) {
+  private static AutomaticallyChargeableFee getAgeToLostProcessingFee(JsonObject policy,
+    String enabledFlag) {
+
     final boolean chargeProcessingFee = getBooleanProperty(policy, enabledFlag);
     String chargeType = Optional.ofNullable(policy.getJsonObject("chargeAmountItem"))
       .map(object -> object.getString("chargeType"))

--- a/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
@@ -190,9 +190,8 @@ public class LostItemPolicy extends Policy {
   private static class UnknownLostItemPolicy extends LostItemPolicy {
     UnknownLostItemPolicy(String id) {
       super(id, null, noAutomaticallyChargeableFee(), noAutomaticallyChargeableFee(),
-        noActualCostFee(), zeroDurationPeriod(), false, false,
-        zeroDurationPeriod(), zeroDurationPeriod(), zeroDurationPeriod(),
-        zeroDurationPeriod(), noAutomaticallyChargeableFee());
+        noAutomaticallyChargeableFee(), noActualCostFee(), zeroDurationPeriod(), false, false,
+        zeroDurationPeriod(), zeroDurationPeriod(), zeroDurationPeriod(), zeroDurationPeriod());
     }
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
@@ -14,7 +14,6 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
-import java.util.Optional;
 
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.domain.policy.Policy;
@@ -53,6 +52,7 @@ public class LostItemPolicy extends Policy {
 
     super(id, name);
     this.declareLostProcessingFee = declareLostProcessingFee;
+    this.ageToLostProcessingFee = ageToLostProcessingFee;
     this.setCostFee = setCostFee;
     this.actualCostFee = actualCostFee;
     this.feeRefundInterval = feeRefundInterval;
@@ -63,7 +63,6 @@ public class LostItemPolicy extends Policy {
     this.recalledItemAgedToLostAfterOverdueInterval = recalledItemAgedToLostAfterOverdueInterval;
     this.patronBilledAfterRecalledItemAgedToLostInterval =
       patronBilledAfterRecalledItemAgedToLostInterval;
-    this.ageToLostProcessingFee = ageToLostProcessingFee;
   }
 
   public static LostItemPolicy from(JsonObject lostItemPolicy) {

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -131,7 +131,7 @@ public class ChargeLostFeesWhenAgedToLostService {
 
   private CompletableFuture<Result<Void>> processLoan(LoanToChargeFees loan) {
     return loan.shouldCloseLoanWhenActualCostUsed()
-      ? removePreviousActionAndCloseLoanAsLostAndPaid(loan)
+      ? closeLoanAsLostAndPaid(loan).thenApply(Result::mapEmpty)
       : chargeLostFees(loan);
   }
 
@@ -328,14 +328,5 @@ public class ChargeLostFeesWhenAgedToLostService {
     loan.closeLoanAsLostAndPaid();
 
     return storeLoanAndItem.updateLoanAndItemInStorage(loan);
-  }
-
-  private CompletableFuture<Result<Void>> removePreviousActionAndCloseLoanAsLostAndPaid(
-    LoanToChargeFees loan) {
-
-    loan.getLoan().removePreviousAction();
-
-    return closeLoanAsLostAndPaid(loan)
-      .thenApply(Result::mapEmpty);
   }
 }

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -125,8 +125,24 @@ public class ChargeLostFeesWhenAgedToLostService {
     Result<List<LoanToChargeFees>> loansToChargeFeesResult) {
 
     return loansToChargeFeesResult
+      .next(this::excludeActualCostItemsWithNoLostItemProcessingFee)
       .after(loansToChargeFees -> allOf(loansToChargeFees, this::chargeLostFees))
       .thenApply(r -> r.map(ignored -> null));
+  }
+
+  private Result<List<LoanToChargeFees>> excludeActualCostItemsWithNoLostItemProcessingFee(
+    List<LoanToChargeFees> loansToChargeFees) {
+
+    List<LoanToChargeFees> loansToStopProcessingOf = loansToChargeFees.stream()
+      .filter(loan -> loan.getLostItemPolicy().hasActualCostFee())
+      .filter(loan -> !loan.getLostItemPolicy().getAgeToLostProcessingFee().isChargeable())
+      .collect(Collectors.toList());
+
+    loansToChargeFees.removeAll(loansToStopProcessingOf);
+
+    return succeeded(loansToStopProcessingOf)
+      .map(loans -> allOf(loans, this::updateLoanBillingInfo))
+      .map(r -> loansToChargeFees);
   }
 
   private CompletableFuture<Result<Void>> chargeLostFees(

--- a/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/ChargeLostFeesWhenAgedToLostService.java
@@ -131,7 +131,7 @@ public class ChargeLostFeesWhenAgedToLostService {
 
   private CompletableFuture<Result<Void>> processLoan(LoanToChargeFees loan) {
     return loan.shouldCloseLoanWhenActualCostUsed()
-      ? updateBillingInfoAndCloseLoanAsLostAndPaid(loan)
+      ? removePreviousActionAndCloseLoanAsLostAndPaid(loan)
       : chargeLostFees(loan);
   }
 
@@ -330,7 +330,7 @@ public class ChargeLostFeesWhenAgedToLostService {
     return storeLoanAndItem.updateLoanAndItemInStorage(loan);
   }
 
-  private CompletableFuture<Result<Void>> updateBillingInfoAndCloseLoanAsLostAndPaid(
+  private CompletableFuture<Result<Void>> removePreviousActionAndCloseLoanAsLostAndPaid(
     LoanToChargeFees loan) {
 
     loan.getLoan().removePreviousAction();

--- a/src/main/java/org/folio/circulation/services/agedtolost/LoanToChargeFees.java
+++ b/src/main/java/org/folio/circulation/services/agedtolost/LoanToChargeFees.java
@@ -99,6 +99,11 @@ public final class LoanToChargeFees {
       && !getLostItemPolicy().getAgeToLostProcessingFee().isChargeable();
   }
 
+  boolean shouldCloseLoanWhenActualCostUsed() {
+    return getLostItemPolicy().hasActualCostFee() &&
+      !getLostItemPolicy().getAgeToLostProcessingFee().isChargeable();
+  }
+
   public static LoanToChargeFees usingLoan(Loan loan) {
     return new LoanToChargeFees(loan, null, Collections.emptyMap(), null);
   }

--- a/src/main/java/org/folio/circulation/support/results/Result.java
+++ b/src/main/java/org/folio/circulation/support/results/Result.java
@@ -327,6 +327,10 @@ public interface Result<T> {
     }
   }
 
+  default Result<Void> mapEmpty() {
+    return map(value -> null);
+  }
+
   /**
    * Returns a BiFunction that combines two results and executes another BiFunction
    * on un-flatted values.

--- a/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
+++ b/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
@@ -15,8 +15,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.UUID;
@@ -83,7 +81,7 @@ class CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests extends APITests {
 
     val delayedBilling = result.getLoan().getJson().getJsonObject("agedToLostDelayedBilling");
     List<JsonObject> accounts = accountsClient.getAll();
-    assertTrue(delayedBilling.getBoolean("lostItemHasBeenBilled"));
+    assertThat(delayedBilling.getBoolean("lostItemHasBeenBilled"), is(true));
     assertThat(accounts.size(), is(1));
     assertThat(accounts.get(0).getDouble("amount"), is(amount));
   }

--- a/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
+++ b/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
@@ -70,7 +70,7 @@ class CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests extends APITests {
   }
 
   @Test
-  void shouldProcessingFeeBeingBilledWhenSetActualCost() {
+  void processingFeeShouldBeChargedWhenSetActualCost() {
     accountsClient.deleteAll();
     val amount = 3.0;
 

--- a/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
+++ b/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
@@ -84,8 +84,8 @@ class CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests extends APITests {
     val delayedBilling = result.getLoan().getJson().getJsonObject("agedToLostDelayedBilling");
     List<JsonObject> accounts = accountsClient.getAll();
     assertTrue(delayedBilling.getBoolean("lostItemHasBeenBilled"));
-    assertEquals(accounts.size(), 1);
-    assertEquals(accounts.get(0).getDouble("amount"), amount);
+    assertThat(accounts.size(), is(1));
+    assertThat(accounts.get(0).getDouble("amount"), is(amount));
   }
 
   @Test

--- a/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
+++ b/src/test/java/api/handlers/CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests.java
@@ -74,7 +74,7 @@ class CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests extends APITests {
     "0.0, 3.0, false",
     "0.0, 0.0, false",
     "4.0, 0.0, false",
-    "4.0, 0.0, false",
+    "4.0, 3.0, false",
   })
   void agedToLostActualCostItemShouldBeSkippedWhenNoProcessingFeeInThePolicy(
     double lostItemFee, double itemProcessingFeeAmount,
@@ -97,6 +97,10 @@ class CloseAgedToLostLoanWhenLostItemFeesAreClosedApiTests extends APITests {
 
     List<JsonObject> actualCostRecords = actualCostRecordsClient.getAll();
     assertThat(actualCostRecords.size(), is(0));
+
+    var updatedLoan = loansClient.get(result.getLoan().getId());
+    assertThat(updatedLoan.getJson().getJsonObject("status").getString("name"),
+      is("Closed"));
   }
 
   @Test

--- a/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
+++ b/src/test/java/api/loans/agetolost/ScheduledAgeToLostFeeChargingApiTest.java
@@ -425,7 +425,7 @@ class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
         .withNoFeeRefundInterval()
         .withActualCost(10.00)
         .billPatronImmediatelyWhenAgedToLost()
-        .doNotChargeProcessingFeeWhenAgedToLost());
+        .chargeProcessingFeeWhenAgedToLost(1.00));
 
     useLostItemPolicy(lostItemPolicy.getId());
 
@@ -447,7 +447,6 @@ class ScheduledAgeToLostFeeChargingApiTest extends SpringApiTest {
       feeFineOwnerFixture.cd1Owner(), feeFineTypeFixture.lostItemActualCostFee()));
     assertThat(loanFromStorage.getJson(), isLostItemHasBeenBilled());
     assertThat(itemsFixture.getById(item.getId()).getJson(), isAgedToLost());
-    assertThat(loanFromStorage, hasNoLostItemProcessingFee());
   }
 
   @Test

--- a/src/test/java/api/loans/scenarios/OverrideRenewAgedToLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/OverrideRenewAgedToLostItemTest.java
@@ -81,12 +81,13 @@ class OverrideRenewAgedToLostItemTest extends RefundAgedToLostFeesTestBase {
       .withItemAgedToLostAfterOverdue(minutes(1))
       .withPatronBilledAfterItemAgedToLost(minutes(5))
       .chargeOverdueFineWhenReturned()
-      .withNoFeeRefundInterval();
+      .withNoFeeRefundInterval()
+      .withLostItemProcessingFee(1.0);
 
     val result = ageToLostFixture.createLoanAgeToLostAndChargeFees(policy);
     createLostItemFeeActualCostAccount(result.getLoan(), itemFeeActualCost);
 
-    assertThat(feeFineActionsClient.getAll(), hasSize(1));
+    assertThat(feeFineActionsClient.getAll(), hasSize(2));
     assertThat(result.getLoan(), hasLostItemFeeActualCost(isOpen(itemFeeActualCost)));
 
     feeFineAccountFixture.payLostItemActualCostFee(result.getLoanId(), 3.0);


### PR DESCRIPTION
Resolves : [https://issues.folio.org/browse/CIRC-1432](https://issues.folio.org/browse/CIRC-1432)

## Purpose
The processing of aged to lost actual cost items should be skipped when 'Charge lost item processing fee if item aged to lost by system?' is set to `No` in the Lost item policy (except `lostItemHasBeenBilled` should be changed to `True`).

## Approach
Additional step is added to `ChargeLostFeesWhenAgedToLostService` service that excludes such loans from the list of loans that fees/fines or actual cost records will be created for.
