### PR TITLE
CIRC-1565 - request record is not correctly stored in the log.

### DIFF
--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -357,7 +357,7 @@ public class EventPublisher {
   }
 
   public RequestAndRelatedRecords publishLogRecordAsync(RequestAndRelatedRecords requestAndRelatedRecords, Request originalRequest, LogEventType logEventType) {
-    runAsync(() -> publishLogRecord(mapToRequestLogEventJson(originalRequest, prepareUpdatedRequest(requestAndRelatedRecords)), logEventType));
+    runAsync(() -> publishLogRecord(mapToRequestLogEventJson(originalRequest, fetchRequestAndUpdateMetadata(requestAndRelatedRecords)), logEventType));
     return requestAndRelatedRecords;
   }
 
@@ -368,7 +368,7 @@ public class EventPublisher {
     return succeeded(value);
   }
 
-  private Request prepareUpdatedRequest(RequestAndRelatedRecords requestAndRelatedRecords) {
+  private Request fetchRequestAndUpdateMetadata(RequestAndRelatedRecords requestAndRelatedRecords) {
     var request = requestAndRelatedRecords.getRequest();
     if (nonNull(request)) {
       var requestJson = request.asJson();

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.services;
 
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -372,7 +373,10 @@ public class EventPublisher {
     if (nonNull(request)) {
       var requestJson = request.asJson();
       var metadataJson = requestJson.getJsonObject(METADATA);
-      if (nonNull(metadataJson) && nonNull(webContext)) {
+      if (nonNull(webContext)) {
+        if (isNull(metadataJson)) {
+          metadataJson = new JsonObject();
+        }
         write(metadataJson, UPDATED_BY_USER_ID, webContext.getUserId());
         write(requestJson, METADATA, metadataJson);
         return Request.from(requestJson);


### PR DESCRIPTION
[CIRC-1565](CIRC-1565 - request record is not correctly stored in the log.) - request record is not correctly stored in the log.

## Purpose
The source of an edit to a request record is not correctly stored in the log.
This is a problem when attempting to determine why a request was edited.

## Approach
* Fixed event publisher logic
