### PR TITLE
CIRC-1564 Add notes v3.0 interface support

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1006,7 +1006,7 @@
     },
     {
       "id": "notes",
-      "version": "1.0 2.0"
+      "version": "1.0 2.0 3.0"
     }
   ],
   "permissionSets": [

--- a/src/main/java/org/folio/circulation/domain/notes/NoteType.java
+++ b/src/main/java/org/folio/circulation/domain/notes/NoteType.java
@@ -7,5 +7,4 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class NoteType {
   private final String id;
-  private final String type;
 }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/notes/NoteTypeToJsonMapper.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/notes/NoteTypeToJsonMapper.java
@@ -8,6 +8,6 @@ import io.vertx.core.json.JsonObject;
 
 public class NoteTypeToJsonMapper {
   public NoteType fromJson(JsonObject json) {
-    return new NoteType(getProperty(json, "id"), getProperty(json, "type"));
+    return new NoteType(getProperty(json, "id"));
   }
 }

--- a/src/test/java/org/folio/circulation/domain/notes/GeneralNoteTypeValidatorTests.java
+++ b/src/test/java/org/folio/circulation/domain/notes/GeneralNoteTypeValidatorTests.java
@@ -37,6 +37,6 @@ class GeneralNoteTypeValidatorTests {
   }
 
   private NoteType generateNoteType() {
-    return new NoteType(UUID.randomUUID().toString(), "General");
+    return new NoteType(UUID.randomUUID().toString());
   }
 }


### PR DESCRIPTION
Resolves [CIRC-1564](https://issues.folio.org/browse/CIRC-1564)

## Purpose
Support `notes` `v3.0` interface after a breaking change on the `mod-notes` side

## Approach
`mod-circulation` is not using fields that were changed in `mod-notes` which allows to just add `v3.0` support. Also, the field `type` was removed from `NoteType` because it doesn't exist. Despite that, `mod-circulations` attempts to parse it
