### PR TITLE
CIRC-1596: instance-storage 9.0, holdings-storage 6.0, item-storage 10.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -894,15 +894,15 @@
     },
     {
       "id": "item-storage",
-      "version": "8.7 9.0"
+      "version": "8.7 9.0 10.0"
     },
     {
       "id": "instance-storage",
-      "version": "4.0 5.0 6.0 7.0 8.0"
+      "version": "4.0 5.0 6.0 7.0 8.0 9.0"
     },
     {
       "id": "holdings-storage",
-      "version": "1.3 2.0 3.0 4.0 5.0"
+      "version": "1.3 2.0 3.0 4.0 5.0 6.0"
     },
     {
       "id": "request-storage",


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-1596

mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

mod-circulation is not affected because the incompatible change is in the DELETE all APIs only that is not used by mod-circulation.

Only the okapiInterfaces need to be bumped in "requires" section of ModuleDescriptor-template.json