### PR TITLE
CIRC-1604 - Circ log: user barcodes missing in request actions

### DIFF
--- a/src/main/java/org/folio/circulation/domain/representations/logs/CirculationCheckInCheckOutLogEventMapper.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/CirculationCheckInCheckOutLogEventMapper.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain.representations.logs;
 
+import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static org.folio.circulation.domain.representations.logs.LogEventPayloadField.*;
 import static org.folio.circulation.domain.representations.logs.LogEventType.CHECK_IN;
@@ -30,13 +31,13 @@ public class CirculationCheckInCheckOutLogEventMapper {
    * @param checkInContext check-in flow context {@link CheckInContext}
    * @return check-in log event payload
    */
-  public static String mapToCheckInLogEventContent(CheckInContext checkInContext, User loggedInUser) {
+  public static String mapToCheckInLogEventContent(CheckInContext checkInContext, User loggedInUser, Loan lastLoan) {
     JsonObject logEventPayload = new JsonObject();
 
     write(logEventPayload, LOG_EVENT_TYPE.value(), CHECK_IN.value());
     write(logEventPayload, SERVICE_POINT_ID.value(), checkInContext.getCheckInServicePointId());
 
-    populateLoanData(checkInContext, logEventPayload);
+    populateLoanData(checkInContext, logEventPayload, lastLoan);
     populateItemData(checkInContext, logEventPayload, loggedInUser);
 
     ofNullable(checkInContext.getCheckInRequest())
@@ -95,8 +96,12 @@ public class CirculationCheckInCheckOutLogEventMapper {
     write(logEventPayload, SOURCE.value(), loggedInUser.getPersonalName());
   }
 
-  private static void populateLoanData(CheckInContext checkInContext, JsonObject logEventPayload) {
-    populateLoanData(checkInContext.getLoan(), logEventPayload);
+  private static void populateLoanData(CheckInContext checkInContext, JsonObject logEventPayload, Loan lastLoan) {
+    if (nonNull(checkInContext.getLoan())) {
+      populateLoanData(checkInContext.getLoan(), logEventPayload);
+    } else {
+      enrichWithUserBarcode(logEventPayload, lastLoan);
+    }
   }
 
   private static void populateLoanData(LoanAndRelatedRecords loanAndRelatedRecords, JsonObject logEventPayload) {
@@ -104,21 +109,22 @@ public class CirculationCheckInCheckOutLogEventMapper {
   }
 
   private static void populateLoanData(Loan checkInCheckOutLoan, JsonObject logEventPayload) {
-    ofNullable(checkInCheckOutLoan)
-      .ifPresent(loan -> {
-        write(logEventPayload, LOAN_ID.value(), loan.getId());
-        write(logEventPayload, IS_LOAN_CLOSED.value(), loan.isClosed());
-        write(logEventPayload, SYSTEM_RETURN_DATE.value(), loan.getSystemReturnDate());
-        write(logEventPayload, RETURN_DATE.value(), loan.getReturnDate());
-        write(logEventPayload, DUE_DATE.value(), loan.getDueDate());
-        ofNullable(loan.getUser())
-          .ifPresent(user -> {
-            write(logEventPayload, USER_ID.value(), user.getId());
-            write(logEventPayload, USER_BARCODE.value(), user.getBarcode());
-          });
-        ofNullable(loan.getProxy())
-          .ifPresent(proxy -> write(logEventPayload, PROXY_BARCODE.value(), proxy.getBarcode()));
+    write(logEventPayload, LOAN_ID.value(), checkInCheckOutLoan.getId());
+    write(logEventPayload, IS_LOAN_CLOSED.value(), checkInCheckOutLoan.isClosed());
+    write(logEventPayload, SYSTEM_RETURN_DATE.value(), checkInCheckOutLoan.getSystemReturnDate());
+    write(logEventPayload, RETURN_DATE.value(), checkInCheckOutLoan.getReturnDate());
+    write(logEventPayload, DUE_DATE.value(), checkInCheckOutLoan.getDueDate());
+    ofNullable(checkInCheckOutLoan.getUser())
+      .ifPresent(user -> {
+        write(logEventPayload, USER_ID.value(), user.getId());
+        write(logEventPayload, USER_BARCODE.value(), user.getBarcode());
       });
+    ofNullable(checkInCheckOutLoan.getProxy())
+      .ifPresent(proxy -> write(logEventPayload, PROXY_BARCODE.value(), proxy.getBarcode()));
+  }
+
+  private static void enrichWithUserBarcode(JsonObject logEventPayload, Loan lastLoan) {
+    write(logEventPayload, USER_BARCODE.value(), lastLoan.getUser().getBarcode());
   }
 
   private static JsonArray getUpdatedRequests(CheckInContext checkInContext) {

--- a/src/main/java/org/folio/circulation/domain/representations/logs/CirculationCheckInCheckOutLogEventMapper.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/CirculationCheckInCheckOutLogEventMapper.java
@@ -124,7 +124,7 @@ public class CirculationCheckInCheckOutLogEventMapper {
   }
 
   private static void enrichWithUserBarcode(JsonObject logEventPayload, Loan lastLoan) {
-    write(logEventPayload, USER_BARCODE.value(), lastLoan.getUser().getBarcode());
+    ofNullable(lastLoan.getUser()).ifPresent(user -> write(logEventPayload, USER_BARCODE.value(), user.getBarcode()));
   }
 
   private static JsonArray getUpdatedRequests(CheckInContext checkInContext) {

--- a/src/main/java/org/folio/circulation/domain/representations/logs/CirculationCheckInCheckOutLogEventMapper.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/CirculationCheckInCheckOutLogEventMapper.java
@@ -31,13 +31,13 @@ public class CirculationCheckInCheckOutLogEventMapper {
    * @param checkInContext check-in flow context {@link CheckInContext}
    * @return check-in log event payload
    */
-  public static String mapToCheckInLogEventContent(CheckInContext checkInContext, User loggedInUser, Loan lastLoan) {
+  public static String mapToCheckInLogEventContent(CheckInContext checkInContext, User loggedInUser, User userFromLastLoan) {
     JsonObject logEventPayload = new JsonObject();
 
     write(logEventPayload, LOG_EVENT_TYPE.value(), CHECK_IN.value());
     write(logEventPayload, SERVICE_POINT_ID.value(), checkInContext.getCheckInServicePointId());
 
-    populateLoanData(checkInContext, logEventPayload, lastLoan);
+    populateLoanData(checkInContext, logEventPayload, userFromLastLoan);
     populateItemData(checkInContext, logEventPayload, loggedInUser);
 
     ofNullable(checkInContext.getCheckInRequest())
@@ -96,11 +96,11 @@ public class CirculationCheckInCheckOutLogEventMapper {
     write(logEventPayload, SOURCE.value(), loggedInUser.getPersonalName());
   }
 
-  private static void populateLoanData(CheckInContext checkInContext, JsonObject logEventPayload, Loan lastLoan) {
+  private static void populateLoanData(CheckInContext checkInContext, JsonObject logEventPayload, User userFromLastLoan) {
     if (nonNull(checkInContext.getLoan())) {
       populateLoanData(checkInContext.getLoan(), logEventPayload);
     } else {
-      enrichWithUserBarcode(logEventPayload, lastLoan);
+      enrichWithUserBarcode(logEventPayload, userFromLastLoan);
     }
   }
 
@@ -123,8 +123,8 @@ public class CirculationCheckInCheckOutLogEventMapper {
       .ifPresent(proxy -> write(logEventPayload, PROXY_BARCODE.value(), proxy.getBarcode()));
   }
 
-  private static void enrichWithUserBarcode(JsonObject logEventPayload, Loan lastLoan) {
-    ofNullable(lastLoan.getUser()).ifPresent(user -> write(logEventPayload, USER_BARCODE.value(), user.getBarcode()));
+  private static void enrichWithUserBarcode(JsonObject logEventPayload, User userFromLastLoan) {
+    ofNullable(userFromLastLoan).ifPresent(user -> write(logEventPayload, USER_BARCODE.value(), userFromLastLoan.getBarcode()));
   }
 
   private static JsonArray getUpdatedRequests(CheckInContext checkInContext) {

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -117,7 +117,7 @@ public class CheckInByBarcodeResource extends Resource {
       .thenComposeAsync(r -> r.after(processAdapter::refundLostItemFees))
       .thenComposeAsync(r -> r.after(
         records -> processAdapter.createOverdueFineIfNecessary(records, context)))
-      .thenComposeAsync(r -> r.after(v -> eventPublisher.publishItemCheckedInEvents(v, userRepository)))
+      .thenComposeAsync(r -> r.after(v -> eventPublisher.publishItemCheckedInEvents(v, userRepository, loanRepository)))
       .thenApply(r -> r.next(requestScheduledNoticeService::rescheduleRequestNotices))
       .thenApply(r -> r.map(CheckInByBarcodeResponse::fromRecords))
       .thenApply(r -> r.map(CheckInByBarcodeResponse::toHttpResponse))


### PR DESCRIPTION
[CIRC-1604](https://issues.folio.org/browse/CIRC-1604) - Circ log: user barcodes missing in request actions

## Purpose
When filtering on an item barcode in the circulation log, actions associated with a request do not show the user barcode

## Approach
Retrieve user barcode from the last loan for item.

