### PR TITLE
CIRC-1574 Add itemLimit parameter to the item limit error

### DIFF
--- a/src/main/java/org/folio/circulation/domain/validation/CheckOutValidators.java
+++ b/src/main/java/org/folio/circulation/domain/validation/CheckOutValidators.java
@@ -278,7 +278,7 @@ public class CheckOutValidators {
     return request.getBlockOverrides().getItemLimitBlockOverride().isRequested()
       ? new OverridingLoanValidator(ITEM_LIMIT_BLOCK, request.getBlockOverrides(), permissions)
       : new BlockValidator<>(ITEM_LIMIT_IS_REACHED,
-      new ItemLimitValidator(request, loanRepository)::refuseWhenItemLimitIsReached);
+      new ItemLimitValidator(loanRepository)::refuseWhenItemLimitIsReached);
   }
 
   private BlockValidator<LoanAndRelatedRecords> createLoanPolicyValidator(CheckOutByBarcodeRequest request,

--- a/src/main/java/org/folio/circulation/domain/validation/CheckOutValidators.java
+++ b/src/main/java/org/folio/circulation/domain/validation/CheckOutValidators.java
@@ -278,7 +278,7 @@ public class CheckOutValidators {
     return request.getBlockOverrides().getItemLimitBlockOverride().isRequested()
       ? new OverridingLoanValidator(ITEM_LIMIT_BLOCK, request.getBlockOverrides(), permissions)
       : new BlockValidator<>(ITEM_LIMIT_IS_REACHED,
-      new ItemLimitValidator(loanRepository)::refuseWhenItemLimitIsReached);
+      new ItemLimitValidator(request, loanRepository)::refuseWhenItemLimitIsReached);
   }
 
   private BlockValidator<LoanAndRelatedRecords> createLoanPolicyValidator(CheckOutByBarcodeRequest request,

--- a/src/main/java/org/folio/circulation/domain/validation/ItemLimitValidationErrorCause.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ItemLimitValidationErrorCause.java
@@ -9,6 +9,9 @@ import static org.folio.circulation.support.ErrorCode.ITEM_LIMIT_PATRON_GROUP_MA
 
 import org.folio.circulation.support.ErrorCode;
 
+import lombok.Getter;
+import lombok.Setter;
+
 public enum ItemLimitValidationErrorCause {
   CAN_NOT_DETERMINE("can not determine item limit validation error cause", null),
   PATRON_GROUP_MATERIAL_TYPE_LOAN_TYPE("for combination of patron group, material type and loan type",
@@ -22,8 +25,11 @@ public enum ItemLimitValidationErrorCause {
   MATERIAL_TYPE("for material type", ITEM_LIMIT_MATERIAL_TYPE),
   LOAN_TYPE("for loan type", ITEM_LIMIT_LOAN_TYPE);
 
+  @Setter
+  @Getter
   private Integer itemLimit;
   private String description;
+  @Getter
   private ErrorCode errorCode;
 
   ItemLimitValidationErrorCause(String description, ErrorCode errorCode) {
@@ -33,13 +39,5 @@ public enum ItemLimitValidationErrorCause {
 
   public String formatMessage() {
     return String.format("Patron has reached maximum limit of %d items %s", itemLimit, description);
-  }
-
-  public ErrorCode getErrorCode() {
-    return errorCode;
-  }
-
-  public void setItemLimit(Integer itemLimit) {
-    this.itemLimit = itemLimit;
   }
 }

--- a/src/main/java/org/folio/circulation/domain/validation/ItemLimitValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ItemLimitValidator.java
@@ -65,8 +65,9 @@ public class ItemLimitValidator {
           ItemLimitValidationErrorCause cause = getValidationErrorCause(ruleConditions);
 
           if (cause == null) {
-            log.warn("Can not determine item limit validation error cause " +
-              "for item {}, patron {}", loan.getItemId(), loan.getUserId());
+            String message = String.format("Can not determine item limit validation error cause " +
+              "for item %s, patron %s", loan.getItemId(), loan.getUserId());
+            log.warn(message);
             return itemLimitErrorFunction.apply(CAN_NOT_DETERMINE);
           }
 

--- a/src/main/java/org/folio/circulation/domain/validation/ItemLimitValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ItemLimitValidator.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
-import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.representations.CheckOutByBarcodeRequest;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.rules.AppliedRuleConditions;
@@ -33,8 +32,6 @@ import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.results.Result;
-
-import io.netty.util.internal.StringUtil;
 
 public class ItemLimitValidator {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());

--- a/src/main/java/org/folio/circulation/domain/validation/ItemLimitValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ItemLimitValidator.java
@@ -22,7 +22,6 @@ import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
-import org.folio.circulation.domain.representations.CheckOutByBarcodeRequest;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.rules.AppliedRuleConditions;
 import org.folio.circulation.support.ValidationErrorFailure;

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -100,13 +100,11 @@ import org.awaitility.Awaitility;
 import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.domain.representations.logs.LogEventType;
-import org.folio.circulation.domain.validation.ItemLimitValidator;
 import org.folio.circulation.support.http.client.Response;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.Spy;
 
 import api.support.APITests;
 import api.support.TlrFeatureStatus;
@@ -123,7 +121,6 @@ import api.support.builders.RequestBuilder;
 import api.support.builders.UserBuilder;
 import api.support.fakes.FakePubSub;
 import api.support.fakes.FakeStorageModule;
-import api.support.http.CheckOutResource;
 import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
 import api.support.http.OkapiHeaders;
@@ -151,9 +148,6 @@ class CheckOutByBarcodeTests extends APITests {
   private static final String PATRON_ACTION_SESSION_STORAGE_PATH =
     "/patron-action-session-storage/patron-action-sessions";
   private static final String ITEM_LIMIT = "itemLimit";
-
-  @Spy
-  private ItemLimitValidator itemLimitValidator;
 
   @Test
   void canCheckOutUsingItemAndUserBarcode() {

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -63,11 +63,11 @@ import static org.folio.circulation.domain.representations.ItemProperties.CALL_N
 import static org.folio.circulation.domain.representations.logs.LogEventType.CHECK_OUT;
 import static org.folio.circulation.domain.representations.logs.LogEventType.CHECK_OUT_THROUGH_OVERRIDE;
 import static org.folio.circulation.support.ErrorCode.ITEM_HAS_OPEN_LOAN;
-import static org.folio.circulation.support.ErrorCode.ITEM_NOT_LOANABLE;
 import static org.folio.circulation.support.ErrorCode.ITEM_LIMIT_LOAN_TYPE;
 import static org.folio.circulation.support.ErrorCode.ITEM_LIMIT_MATERIAL_TYPE;
 import static org.folio.circulation.support.ErrorCode.ITEM_LIMIT_MATERIAL_TYPE_LOAN_TYPE;
 import static org.folio.circulation.support.ErrorCode.ITEM_LIMIT_PATRON_GROUP_MATERIAL_TYPE_LOAN_TYPE;
+import static org.folio.circulation.support.ErrorCode.ITEM_NOT_LOANABLE;
 import static org.folio.circulation.support.ErrorCode.USER_BARCODE_NOT_FOUND;
 import static org.folio.circulation.support.utils.ClockUtil.getZonedDateTime;
 import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTime;
@@ -145,6 +145,7 @@ class CheckOutByBarcodeTests extends APITests {
   private static final String PATRON_WAS_BLOCKED_MESSAGE = "Patron blocked from borrowing";
   private static final String PATRON_ACTION_SESSION_STORAGE_PATH =
     "/patron-action-session-storage/patron-action-sessions";
+  private static final String ITEM_LIMIT = "itemLimit";
 
   @Test
   void canCheckOutUsingItemAndUserBarcode() {
@@ -1113,7 +1114,8 @@ class CheckOutByBarcodeTests extends APITests {
     Response response = checkOutFixture.attemptCheckOutByBarcode(secondBookTypeItem, steve);
     assertThat(response.getJson(), hasErrorWith(allOf(
       hasMessage("Patron has reached maximum limit of 1 items for material type"),
-      hasCode(ITEM_LIMIT_MATERIAL_TYPE))));
+      hasCode(ITEM_LIMIT_MATERIAL_TYPE),
+      hasParameter(ITEM_LIMIT, "1"))));
     secondBookTypeItem = itemsClient.get(secondBookTypeItem);
     assertThat(secondBookTypeItem, hasItemStatus(AVAILABLE));
 
@@ -1141,7 +1143,8 @@ class CheckOutByBarcodeTests extends APITests {
     Response response = checkOutFixture.attemptCheckOutByBarcode(secondBookTypeItem, steve);
     assertThat(response.getJson(), hasErrorWith(allOf(
       hasMessage("Patron has reached maximum limit of 1 items for loan type"),
-      hasCode(ITEM_LIMIT_LOAN_TYPE))));
+      hasCode(ITEM_LIMIT_LOAN_TYPE),
+      hasParameter(ITEM_LIMIT, "1"))));
     secondBookTypeItem = itemsClient.get(secondBookTypeItem);
     assertThat(secondBookTypeItem, hasItemStatus(AVAILABLE));
 
@@ -1171,7 +1174,8 @@ class CheckOutByBarcodeTests extends APITests {
     assertThat(response.getJson(), hasErrorWith(allOf(
       hasMessage("Patron has reached maximum limit of 1 items for combination of " +
         "material type and loan type"),
-      hasCode(ITEM_LIMIT_MATERIAL_TYPE_LOAN_TYPE))));
+      hasCode(ITEM_LIMIT_MATERIAL_TYPE_LOAN_TYPE),
+      hasParameter(ITEM_LIMIT, "1"))));
     secondBookTypeItem = itemsClient.get(secondBookTypeItem);
     assertThat(secondBookTypeItem, hasItemStatus(AVAILABLE));
 
@@ -1204,7 +1208,8 @@ class CheckOutByBarcodeTests extends APITests {
     assertThat(response.getJson(), hasErrorWith(allOf(
       hasMessage("Patron has reached maximum limit of 1 items for combination of patron group," +
         " material type and loan type"),
-      hasCode(ITEM_LIMIT_PATRON_GROUP_MATERIAL_TYPE_LOAN_TYPE))));
+      hasCode(ITEM_LIMIT_PATRON_GROUP_MATERIAL_TYPE_LOAN_TYPE),
+      hasParameter(ITEM_LIMIT, "1"))));
     secondBookTypeItem = itemsClient.get(secondBookTypeItem);
     assertThat(secondBookTypeItem, hasItemStatus(AVAILABLE));
 
@@ -1246,7 +1251,8 @@ class CheckOutByBarcodeTests extends APITests {
     assertThat(response.getJson(), hasErrorWith(allOf(
       hasMessage("Patron has reached maximum limit of 1 items for combination of patron group, " +
         "material type and loan type"),
-      hasCode(ITEM_LIMIT_PATRON_GROUP_MATERIAL_TYPE_LOAN_TYPE))));
+      hasCode(ITEM_LIMIT_PATRON_GROUP_MATERIAL_TYPE_LOAN_TYPE),
+      hasParameter(ITEM_LIMIT, "1"))));
     secondBookTypeItem = itemsClient.get(secondBookTypeItem);
     assertThat(secondBookTypeItem, hasItemStatus(AVAILABLE));
 
@@ -1275,7 +1281,8 @@ class CheckOutByBarcodeTests extends APITests {
     Response response = checkOutFixture.attemptCheckOutByBarcode(secondBookTypeItem, steve);
     assertThat(response.getJson(), hasErrorWith(allOf(
       hasMessage("Patron has reached maximum limit of 1 items for material type"),
-      hasCode(ITEM_LIMIT_MATERIAL_TYPE))));
+      hasCode(ITEM_LIMIT_MATERIAL_TYPE),
+      hasParameter(ITEM_LIMIT, "1"))));
     secondBookTypeItem = itemsClient.get(secondBookTypeItem);
     assertThat(secondBookTypeItem, hasItemStatus(AVAILABLE));
   }
@@ -1300,7 +1307,8 @@ class CheckOutByBarcodeTests extends APITests {
     Response response = checkOutFixture.attemptCheckOutByBarcode(secondBookTypeItem, steve);
     assertThat(response.getJson(), hasErrorWith(allOf(
       hasMessage("Patron has reached maximum limit of 1 items for material type"),
-      hasCode(ITEM_LIMIT_MATERIAL_TYPE))));
+      hasCode(ITEM_LIMIT_MATERIAL_TYPE),
+      hasParameter(ITEM_LIMIT, "1"))));
 
     secondBookTypeItem = itemsClient.get(secondBookTypeItem);
     assertThat(secondBookTypeItem, hasItemStatus(AVAILABLE));
@@ -1328,7 +1336,8 @@ class CheckOutByBarcodeTests extends APITests {
     Response response = checkOutFixture.attemptCheckOutByBarcode(secondBookTypeItem, steve);
     assertThat(response.getJson(), hasErrorWith(allOf(
       hasMessage("Patron has reached maximum limit of 1 items for material type"),
-      hasCode(ITEM_LIMIT_MATERIAL_TYPE))));
+      hasCode(ITEM_LIMIT_MATERIAL_TYPE),
+      hasParameter(ITEM_LIMIT, "1"))));
 
     secondBookTypeItem = itemsClient.get(secondBookTypeItem);
     assertThat(secondBookTypeItem, hasItemStatus(AVAILABLE));
@@ -1801,7 +1810,8 @@ class CheckOutByBarcodeTests extends APITests {
     Response response = checkOutFixture.attemptCheckOutByBarcode(secondBookTypeItem, steve);
     assertThat(response.getJson(), hasErrorWith(allOf(
       hasMessage("Patron has reached maximum limit of 1 items for material type"),
-      hasCode(ITEM_LIMIT_MATERIAL_TYPE))));
+      hasCode(ITEM_LIMIT_MATERIAL_TYPE),
+      hasParameter(ITEM_LIMIT, "1"))));
 
     final OkapiHeaders okapiHeaders = buildOkapiHeadersWithPermissions(
       OVERRIDE_ITEM_LIMIT_BLOCK_PERMISSION);


### PR DESCRIPTION
## Purpose 
- UI needs to receive itemLimit as a parameter to be able to translate error message properly. itemLimit parameter object should be added to the parameters array of the error when patron reaches item limit during check-out

Resolves: [CIRC-1574](https://issues.folio.org/browse/CIRC-1574)
