### PR TITLE
CIRC-1569 Change item status on request deletion

### DIFF
--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -121,8 +121,8 @@ public class UpdateItem {
   public CompletableFuture<Result<Request>> onRequestDeletion(Request request) {
     // Only page request changes item status to 'Paged'
     // Other request types (Hold and Recall) don't change item status, it stays 'Checked out'
-    if (request.getRequestType().isPage() && request.getItem() != null
-      && PAGED.equals(request.getItem().getStatus())) {
+    if (request.getRequestType() != null && request.getRequestType().isPage()
+      && request.getItem() != null && PAGED.equals(request.getItem().getStatus())) {
 
       return itemRepository.updateItem(request.getItem().changeStatus(AVAILABLE))
         .thenApply(r -> r.map(item -> request));

--- a/src/main/java/org/folio/circulation/domain/UpdateItem.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateItem.java
@@ -7,6 +7,7 @@ import static org.folio.circulation.domain.ItemStatus.PAGED;
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.results.MappingFunctions.when;
 import static org.folio.circulation.support.results.Result.of;
+import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.Result.succeeded;
 
 import java.time.ZonedDateTime;
@@ -115,6 +116,19 @@ public class UpdateItem {
     return onLoanUpdate(loanAndRelatedRecords.getLoan(),
       loanAndRelatedRecords.getRequestQueue())
       .thenApply(itemResult -> itemResult.map(loanAndRelatedRecords::withItem));
+  }
+
+  public CompletableFuture<Result<Request>> onRequestDeletion(Request request) {
+    // Only page request changes item status to 'Paged'
+    // Other request types (Hold and Recall) don't change item status, it stays 'Checked out'
+    if (request.getRequestType().isPage() && request.getItem() != null
+      && PAGED.equals(request.getItem().getStatus())) {
+
+      return itemRepository.updateItem(request.getItem().changeStatus(AVAILABLE))
+        .thenApply(r -> r.map(item -> request));
+    }
+
+    return ofAsync(request);
   }
 
   private CompletableFuture<Result<Item>> onLoanUpdate(

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -207,9 +207,12 @@ public class RequestCollectionResource extends CollectionResource {
       requestRepository), requestRepository, new ServicePointRepository(clients),
       new ConfigurationRepository(clients));
 
+    UpdateItem updateItem = new UpdateItem(itemRepository);
+
     fromFutureResult(requestRepository.getById(id))
       .flatMapFuture(requestRepository::delete)
       .flatMapFuture(updateRequestQueue::onDeletion)
+      .flatMapFuture(updateItem::onRequestDeletion)
       .map(toFixedValue(NoContentResponse::noContent))
       .onComplete(context::write, context::write);
   }

--- a/src/test/java/api/requests/RequestsAPIDeletionTests.java
+++ b/src/test/java/api/requests/RequestsAPIDeletionTests.java
@@ -9,6 +9,8 @@ import static org.hamcrest.core.Is.is;
 
 import org.folio.circulation.domain.MultipleRecords;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import api.support.APITests;
 import api.support.builders.ItemBuilder;
@@ -87,13 +89,18 @@ class RequestsAPIDeletionTests extends APITests {
       itemAfterRequestDeletion.getStatusName(), is(ItemBuilder.AVAILABLE));
   }
 
-  @Test
-  void holdRequestDeletionDoesNotChangeItemStatus() {
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "Hold",
+    "Recall"
+  })
+  void holdAndRecallRequestsDeletionDoesNotChangeItemStatus(String requestType) {
     final var nod = itemsFixture.basedUponNod();
 
     checkOutFixture.checkOutByBarcode(nod);
 
-    final var request = requestsFixture.place(requestFor(nod, usersFixture.charlotte()));
+    final var request = requestsFixture.place(requestFor(nod, usersFixture.charlotte())
+        .withRequestType(requestType));
 
     var itemAfterRequestCreation = itemsFixture.getById(nod.getId());
     assertThat("item status is still Checked out",


### PR DESCRIPTION
Resolves CIRC-1569

## Purpose
When page request is created, item status changes to `Paged`. After that, when such request is deleted, item status stays `Paged` which is incorrect because there are no page request associated with this item.

## Approach
Change item status back to `Available` when page request is deleted
