### PR TITLE
CIRC-1637: commons-text 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.9</version>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Upgrade org.apache.commons:commons-text from 1.9 to 1.10.0.

mod-circulation uses only StringEscapeUtils.escapeJava: https://github.com/folio-org/mod-circulation/blob/v23.1.5/src/main/java/org/folio/circulation/rules/Text2Drools.java#L4

This is not affected by this Remote Execution vulnerability in commons-text before 1.10.0: https://nvd.nist.gov/vuln/detail/CVE-2022-42889

However, to avoid false positive reports by security scanners like Snyk we bump the version.