### PR TITLE
CIRC-1639: Upgrade vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>2.13.4.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -121,6 +122,11 @@
       <artifactId>xstream</artifactId>
       <version>1.4.19</version>
     </dependency>
+    <dependency> <!-- patch drools' commons-codec: https://app.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518 -->
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
+    </dependency>
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
@@ -140,21 +146,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.4.3</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-all</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>joda-time</groupId>
-          <artifactId>joda-time</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>


### PR DESCRIPTION
Upgrade jackson-databind from 2.13.2.1 to 2.13.4.2 fixing Denial of Service (DoS https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004

Upgrade commons-codec from 1.11 to 1.15 fixing Information Exposure: https://app.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518

Upgrade mod-pubsub-client from 2.4.3 to 2.7.0.

Upgrading mod-pubsub-client indirectly upgrades plexus-utils from 3.0.22 to 3.3.1 fixing Directory Traversal https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31521

Upgrading mod-pubsub-client indirectly upgrades spring-beans from 5.2.8.RELEASE to 5.2.22.RELEASE fixing Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2022-22970

Upgrading mod-pubsub-client removes the unused spring-beans dependency that was version 5.2.8.RELEASE and vulnerable: https://nvd.nist.gov/vuln/detail/CVE-2022-22965

Upgrading mod-pubsub-client removes the unused scala-library dependency that was version 2.13.1 and vulnerable: https://nvd.nist.gov/vuln/detail/CVE-2022-36944

Upgrading mod-pubsub-client removes the unused javax.el dependency that was at version 3.0.1-b11 and vulnerable: https://nvd.nist.gov/vuln/detail/CVE-2021-28170

Upgrading mod-pubsub-client removes the unused kafka-clients dependency that was at version 2.5.0 and vulnerable: https://nvd.nist.gov/vuln/detail/CVE-2021-38153

The breaking change in the OkapiConnectionParams constructor requires a trivial code change in PubSubPublishingService.