### PR TITLE
CIRC-1655 Send TLR awaiting pickup notice on check in

### DIFF
--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -7,6 +7,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.folio.circulation.domain.ItemStatus.AVAILABLE;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -18,8 +19,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class RequestQueue {
+  private final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+
   private List<Request> requests;
   private final List<UpdatedRequestPair> updatedRequests;
 
@@ -210,5 +215,19 @@ public class RequestQueue {
     }
   }
 
+  public void replaceRequest(Request newRequest) {
+    if (newRequest.getId() == null) {
+      log.warn("Failed attempt to replace request in the queue");
+      return;
+    }
 
+    requests = requests.stream()
+      .map(request -> {
+        if (request.getId() != null && request.getId().equals(newRequest.getId())) {
+          return newRequest;
+        }
+        return request;
+      })
+      .collect(toList());
+  }
 }

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -84,6 +84,9 @@ public class UpdateRequestQueue {
     Request requestBeingFulfilled = requestQueue.getHighestPriorityRequestFulfillableByItem(item);
     if (requestBeingFulfilled.getItemId() == null || !requestBeingFulfilled.isFor(item)) {
       requestBeingFulfilled = requestBeingFulfilled.withItem(item);
+
+      // Replacing request in the queue because another instance of it has been created
+      requestQueue.replaceRequest(requestBeingFulfilled);
     }
 
     requestQueue.updateRequestPositionOnCheckIn(requestBeingFulfilled.getId());

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -3303,13 +3303,12 @@ public class RequestsAPICreationTests extends APITests {
   void awaitingPickupNoticeShouldBeSentDuringCheckInWhenItemCreatedAfterHoldTlr() {
     configurationsFixture.enableTlrFeature();
 
-    JsonObject availableNoticeConfig = new NoticeConfigurationBuilder()
-      .withTemplateId(UUID.randomUUID())
-      .withAvailableEvent()
-      .create();
     NoticePolicyBuilder noticePolicy = new NoticePolicyBuilder()
       .withName("Policy with available notice")
-      .withLoanNotices(Collections.singletonList(availableNoticeConfig));
+      .withLoanNotices(Collections.singletonList(new NoticeConfigurationBuilder()
+        .withTemplateId(UUID.randomUUID())
+        .withAvailableEvent()
+        .create()));
     use(noticePolicy);
 
     UUID instanceId = UUID.randomUUID();
@@ -3336,13 +3335,12 @@ public class RequestsAPICreationTests extends APITests {
   void awaitingPickupNoticeShouldBeSentDuringCheckInWhenItemIsReturnedAndTlrHoldExists() {
     configurationsFixture.enableTlrFeature();
 
-    JsonObject availableNoticeConfig = new NoticeConfigurationBuilder()
-      .withTemplateId(UUID.randomUUID())
-      .withAvailableEvent()
-      .create();
     NoticePolicyBuilder noticePolicy = new NoticePolicyBuilder()
       .withName("Policy with available notice")
-      .withLoanNotices(Collections.singletonList(availableNoticeConfig));
+      .withLoanNotices(Collections.singletonList(new NoticeConfigurationBuilder()
+        .withTemplateId(UUID.randomUUID())
+        .withAvailableEvent()
+        .create()));
     use(noticePolicy);
 
     UUID instanceId = UUID.randomUUID();

--- a/src/test/java/api/support/fixtures/ItemsFixture.java
+++ b/src/test/java/api/support/fixtures/ItemsFixture.java
@@ -176,6 +176,18 @@ public class ItemsFixture {
         loanTypesFixture.canCirculate().getId()));
   }
 
+  public void basedUponSmallAngryPlanetWithNoItem(
+    Function<HoldingBuilder, HoldingBuilder> additionalHoldingsRecordProperties,
+    Function<InstanceBuilder, InstanceBuilder> additionalInstanceProperties) {
+
+    applyAdditionalProperties(
+      additionalHoldingsRecordProperties,
+      additionalInstanceProperties,
+      InstanceExamples.basedUponSmallAngryPlanet(booksInstanceTypeId(),
+        getPersonalContributorNameTypeId()),
+      thirdFloorHoldings());
+  }
+
   public ItemResource basedUponSmallAngryPlanet(
     Function<HoldingBuilder, HoldingBuilder> additionalHoldingsRecordProperties,
     Function<InstanceBuilder, InstanceBuilder> additionalInstanceProperties,
@@ -288,6 +300,16 @@ public class ItemsFixture {
       additionalItemProperties.apply(itemBuilder));
   }
 
+  private void applyAdditionalProperties(
+    Function<HoldingBuilder, HoldingBuilder> additionalHoldingsRecordProperties,
+    Function<InstanceBuilder, InstanceBuilder> additionalInstanceProperties,
+    InstanceBuilder instanceBuilder, HoldingBuilder holdingsRecordBuilder) {
+
+    createHoldingAndInstanceWithNoItem(
+      additionalInstanceProperties.apply(instanceBuilder),
+      additionalHoldingsRecordProperties.apply(holdingsRecordBuilder));
+  }
+
   private ItemResource create(
     InstanceBuilder instanceBuilder,
     HoldingBuilder holdingsRecordBuilder,
@@ -304,6 +326,16 @@ public class ItemsFixture {
         .create());
 
     return new ItemResource(item, holding, instance);
+  }
+
+  private void createHoldingAndInstanceWithNoItem(
+    InstanceBuilder instanceBuilder,
+    HoldingBuilder holdingsRecordBuilder) {
+
+    IndividualResource instance = instancesClient.create(
+      instanceBuilder.withInstanceTypeId(booksInstanceTypeId()));
+
+    holdingsClient.create(holdingsRecordBuilder.forInstance(instance.getId()));
   }
 
   public HoldingBuilder thirdFloorHoldings() {

--- a/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestQueueTests.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -38,6 +39,23 @@ class RequestQueueTests {
       assertEquals(requestAfterUpdate.getPosition(), expectedPosition);
       assertEquals(requestBeforeUpdate.getId(), requestAfterUpdate.getId());
     }
+  }
+
+  @Test
+  void replaceRequestShouldHandleRequestsWithNullId() {
+    String requestId = randomId();
+    List<Request> requests = List.of(
+      buildRequest(1, OPEN_NOT_YET_FILLED, requestId));
+    RequestQueue requestQueue = new RequestQueue(requests);
+
+    requestQueue.replaceRequest(buildRequest(1, OPEN_NOT_YET_FILLED, null));
+
+    String firstInQueueRequestId = requestQueue.getRequests().stream()
+      .findFirst()
+      .orElse(null)
+      .getId();
+
+    assertEquals(requestId, firstInQueueRequestId);
   }
 
   private static Stream<Arguments> argumentsForUpdateRequestPositionOnCheckIn() {


### PR DESCRIPTION
Resolves [CIRC-1655](https://issues.folio.org/browse/CIRC-1655)

## Purpose
mod-circulation fails to send an "Awaiting pickup" patron notice in this scenario:
- Create an instance and a holdings record with no items
- Create a hold TLR for this instance
- Create an item
- Check-in the item

## Approach
When new instance of a request is created with one of the "with" methods, the request queue still holds the old instance of the request which is not updated. Now we replace the old instance with the new.
