### PR TITLE
CIRC-1676 Downgrade Drools to v7.73

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <antlr4.version>4.11.1</antlr4.version>
-    <drools.version>8.31.0.Final</drools.version>
+    <drools.version>7.73.0.Final</drools.version>
     <rmb.version>35.0.4</rmb.version>
     <vertx.version>4.3.5</vertx.version>
     <log4j2.version>2.19.0</log4j2.version>
@@ -108,17 +108,7 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-core</artifactId>
-      <version>${drools.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-compiler</artifactId>
-      <version>${drools.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-mvel</artifactId>
+      <artifactId>drools-engine-classic</artifactId>
       <version>${drools.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
[CIRC-1676](https://issues.folio.org/browse/CIRC-1676)

## Purpose
Circulation rules execution stopped working.

## Approach
Downgrading to v7.73

#### TODOS and Open Questions
Try to upgrade to v8 in the future

