### PR TITLE
CIRC-1684 Allow TLR recalls for In transit, In process, On order items

### DIFF
--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -5,14 +5,10 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.folio.circulation.domain.ItemStatus.AWAITING_DELIVERY;
-import static org.folio.circulation.domain.ItemStatus.AWAITING_PICKUP;
-import static org.folio.circulation.domain.ItemStatus.IN_PROCESS;
-import static org.folio.circulation.domain.ItemStatus.IN_TRANSIT;
-import static org.folio.circulation.domain.ItemStatus.ON_ORDER;
-import static org.folio.circulation.domain.ItemStatus.PAGED;
 import static org.folio.circulation.domain.RequestLevel.ITEM;
 import static org.folio.circulation.domain.RequestLevel.TITLE;
+import static org.folio.circulation.domain.RequestType.RECALL;
+import static org.folio.circulation.domain.RequestTypeItemStatusWhiteList.canCreateRequestForItem;
 import static org.folio.circulation.domain.representations.RequestProperties.HOLDINGS_RECORD_ID;
 import static org.folio.circulation.domain.representations.RequestProperties.INSTANCE_ID;
 import static org.folio.circulation.domain.representations.RequestProperties.ITEM_ID;
@@ -44,7 +40,6 @@ import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -53,7 +48,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Item;
-import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.Request;
@@ -62,7 +56,6 @@ import org.folio.circulation.domain.RequestFulfilmentPreference;
 import org.folio.circulation.domain.RequestLevel;
 import org.folio.circulation.domain.RequestQueue;
 import org.folio.circulation.domain.RequestStatus;
-import org.folio.circulation.domain.RequestType;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.configuration.TlrSettingsConfiguration;
 import org.folio.circulation.domain.validation.ProxyRelationshipValidator;
@@ -89,8 +82,6 @@ import io.vertx.core.json.JsonObject;
 class RequestFromRepresentationService {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private static final PageLimit LOANS_PAGE_LIMIT = limit(10000);
-  private static final Set<ItemStatus> RECALLABLE_ITEM_STATUSES =
-    Set.of(PAGED, AWAITING_PICKUP, AWAITING_DELIVERY, IN_TRANSIT, IN_PROCESS, ON_ORDER);
   private final Request.Operation operation;
   private final InstanceRepository instanceRepository;
   private final ItemRepository itemRepository;
@@ -298,7 +289,7 @@ class RequestFromRepresentationService {
       .stream()
       .map(Item::getItemId)
       .filter(itemId -> request.getInstanceItemsRequestPolicies().get(itemId)
-        .allowsType(RequestType.RECALL))
+        .allowsType(RECALL))
       .collect(toList());
 
     return loanRepository.findLoanWithClosestDueDate(recallableItemIds, recalledLoansIds)
@@ -329,7 +320,7 @@ class RequestFromRepresentationService {
   private Result<Request> findRecallableItemOrFail(Request request) {
     return request.getInstanceItems()
       .stream()
-      .filter(item -> RECALLABLE_ITEM_STATUSES.contains(item.getStatus()))
+      .filter(item -> canCreateRequestForItem(item.getStatus(), RECALL))
       .findFirst()
       .map(request::withItem)
       .map(Result::succeeded)

--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -7,6 +7,9 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.folio.circulation.domain.ItemStatus.AWAITING_DELIVERY;
 import static org.folio.circulation.domain.ItemStatus.AWAITING_PICKUP;
+import static org.folio.circulation.domain.ItemStatus.IN_PROCESS;
+import static org.folio.circulation.domain.ItemStatus.IN_TRANSIT;
+import static org.folio.circulation.domain.ItemStatus.ON_ORDER;
 import static org.folio.circulation.domain.ItemStatus.PAGED;
 import static org.folio.circulation.domain.RequestLevel.ITEM;
 import static org.folio.circulation.domain.RequestLevel.TITLE;
@@ -87,7 +90,7 @@ class RequestFromRepresentationService {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private static final PageLimit LOANS_PAGE_LIMIT = limit(10000);
   private static final Set<ItemStatus> RECALLABLE_ITEM_STATUSES =
-    Set.of(PAGED, AWAITING_PICKUP, AWAITING_DELIVERY);
+    Set.of(PAGED, AWAITING_PICKUP, AWAITING_DELIVERY, IN_TRANSIT, IN_PROCESS, ON_ORDER);
   private final Request.Operation operation;
   private final InstanceRepository instanceRepository;
   private final ItemRepository itemRepository;

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -1703,7 +1703,7 @@ public class RequestsAPICreationTests extends APITests {
 
   @ParameterizedTest
   @CsvSource({"Awaiting pickup", "Paged", "Awaiting delivery", "In transit", "In process",
-    "On order"})
+    "On order", "Checked out", "Restricted"})
   void tlrRecallWithoutLoanShouldPickRecallableItemFromRequestedInstance(String itemStatus) {
     IndividualResource requestPickupServicePoint = servicePointsFixture.cd1();
     IndividualResource inTransitPickupServicePoint = servicePointsFixture.cd2();
@@ -1746,10 +1746,9 @@ public class RequestsAPICreationTests extends APITests {
   }
 
   @ParameterizedTest
-  @CsvSource({"Available", "Checked out", "Missing", "Long missing", "Withdrawn",
-    "Claimed returned", "Declared lost", "Aged to lost", "Lost and paid",
-    "In process (non-requestable)", "Intellectual item", "Unavailable", "Restricted", "Unknown",
-    "Order closed"})
+  @CsvSource({"Available", "Missing", "Long missing", "Withdrawn", "Claimed returned",
+    "Declared lost", "Aged to lost", "Lost and paid", "In process (non-requestable)",
+    "Intellectual item", "Unavailable", "Unknown", "Order closed"})
   void tlrRecallShouldFailWhenRequestHasNoLoanOrRecallableItem(String itemStatus) {
     IndividualResource requestPickupServicePoint = servicePointsFixture.cd1();
     UUID instanceId = instancesFixture.basedUponDunkirk().getId();
@@ -3842,7 +3841,7 @@ public class RequestsAPICreationTests extends APITests {
 
     assertThat(response.getJson(), allOf(
       hasErrorWith(allOf(
-        hasMessage("Request has no loan or recallable item")
+        hasMessage("Recall requests are not allowed for this patron and item combination")
       ))));
   }
 


### PR DESCRIPTION
Resolves [CIRC-1684](https://issues.folio.org/browse/CIRC-1684)

## Purpose
TLR recalls were only allowed for "Awaiting pickup", "Paged", "Awaiting delivery" items only. They should be also allowed for "In transit", "In process", "On order" item statuses.

## Approach
Use the same white list of item statuses that ILR recalls use
