### PR TITLE
[CIRC-1683] Add unable for recall item statuses

### DIFF
--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -91,7 +91,6 @@ class RequestFromRepresentationService {
   private static final PageLimit LOANS_PAGE_LIMIT = limit(10000);
   private static final Set<ItemStatus> RECALLABLE_ITEM_STATUSES =
     Set.of(PAGED, AWAITING_PICKUP, AWAITING_DELIVERY);
-
   private static final Set<ItemStatus> ITEM_STATUSES_UNABLE_FOR_RECALL =
     Set.of(AGED_TO_LOST, DECLARED_LOST, CLAIMED_RETURNED);
   private final Request.Operation operation;

--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -322,7 +322,7 @@ class RequestFromRepresentationService {
   }
 
   private Result<Request> findItemForRecall(Request request, Item item) {
-    if (!ITEM_STATUSES_UNABLE_FOR_RECALL.contains(item.getStatus())) {
+    if (canCreateRequestForItem(item.getStatus(), RECALL)) {
       return succeeded(request.withItem(item));
     }
 

--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -287,6 +287,7 @@ class RequestFromRepresentationService {
 
     List<String> recallableItemIds = request.getInstanceItems()
       .stream()
+      .filter(item -> canCreateRequestForItem(item.getStatus(), RECALL))
       .map(Item::getItemId)
       .filter(itemId -> request.getInstanceItemsRequestPolicies().get(itemId)
         .allowsType(RECALL))
@@ -315,18 +316,10 @@ class RequestFromRepresentationService {
     Loan loan = request.getLoan();
     if (loan != null) {
       return itemRepository.fetchFor(loan)
-        .thenApply(r -> r.next(item -> findItemForRecall(request, item)));
+        .thenApply(r -> r.map(request::withItem));
     }
 
     return completedFuture(findRecallableItemOrFail(request));
-  }
-
-  private Result<Request> findItemForRecall(Request request, Item item) {
-    if (canCreateRequestForItem(item.getStatus(), RECALL)) {
-      return succeeded(request.withItem(item));
-    }
-
-    return findRecallableItemOrFail(request);
   }
 
   private Result<Request> findRecallableItemOrFail(Request request) {

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -18,6 +18,7 @@ import static api.support.http.CqlQuery.notEqual;
 import static api.support.http.Limit.limit;
 import static api.support.http.Offset.noOffset;
 import static api.support.matchers.EventMatchers.isValidLoanDueDateChangedEvent;
+import static api.support.matchers.ItemMatchers.isDeclaredLost;
 import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
 import static api.support.matchers.JsonObjectMatcher.hasNoJsonPath;
 import static api.support.matchers.PatronNoticeMatcher.hasEmailNoticeProperties;
@@ -3797,6 +3798,43 @@ public class RequestsAPICreationTests extends APITests {
   }
 
   @Test
+  void recallTlrShouldNotBeCreatedForInstanceWithOnlyAgedToLostItem() {
+    configurationsFixture.enableTlrFeature();
+    UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+    UUID instanceId = UUID.randomUUID();
+
+    ageToLostFixture.createAgedToLostLoan(buildItem(instanceId, "111"), usersFixture.charlotte());
+    Response response = requestsClient.attemptCreate(buildRecallTitleLevelRequest(
+      usersFixture.steve().getId(), pickupServicePointId, instanceId));
+
+    assertThat(response, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
+    assertThat(response.getJson(), hasErrors(1));
+    assertThat(response.getJson(), hasErrorWith(hasMessage(
+      "Request has no loan or recallable item")));
+  }
+
+  @Test
+  void recallTlrShouldNotBeCreatedForInstanceWithOnlyDeclaredLostItem() {
+    configurationsFixture.enableTlrFeature();
+    useLostItemPolicy(lostItemFeePoliciesFixture.chargeFee().getId());
+    UUID instanceId = UUID.randomUUID();
+
+    var item = buildItem(instanceId, "111");
+    var loan = checkOutFixture.checkOutByBarcode(item, usersFixture.charlotte());
+    declareLostFixtures.declareItemLost(loan.getJson());
+    var itemById = itemsFixture.getById(item.getId());
+    assertThat(itemById.getJson(), isDeclaredLost());
+
+    Response response = requestsClient.attemptCreate(buildRecallTitleLevelRequest(
+      usersFixture.steve().getId(), servicePointsFixture.cd1().getId(), instanceId));
+
+    assertThat(response, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
+    assertThat(response.getJson(), hasErrors(1));
+    assertThat(response.getJson(), hasErrorWith(hasMessage(
+      "Request has no loan or recallable item")));
+  }
+
+  @Test
   void recallTlrShouldFailWhenNotAllowedByPolicy() {
     configurationsFixture.enableTlrFeature();
     circulationRulesFixture.updateCirculationRules(differentRequestPoliciesBasedOnMaterialType());
@@ -4367,14 +4405,26 @@ public class RequestsAPICreationTests extends APITests {
       .withRequesterId(patronId);
   }
 
+  private RequestBuilder buildRecallTitleLevelRequest(UUID patronId, UUID pickupServicePointId,
+    UUID instanceId) {
+    return new RequestBuilder()
+      .recall()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withNoItemId()
+      .withNoHoldingsRecordId()
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patronId);
+  }
+
   private RequestBuilder buildItemLevelRequest(UUID patronId, UUID pickupServicePointId,
-    UUID instanceId, ItemResource secondItem) {
+    UUID instanceId, ItemResource item) {
 
     return new RequestBuilder()
       .page()
       .itemRequestLevel()
       .withInstanceId(instanceId)
-      .withItemId(secondItem.getId())
+      .withItemId(item.getId())
       .withPickupServicePointId(pickupServicePointId)
       .withRequesterId(patronId);
   }

--- a/src/test/java/api/support/fixtures/AgeToLostFixture.java
+++ b/src/test/java/api/support/fixtures/AgeToLostFixture.java
@@ -24,6 +24,7 @@ import api.support.builders.NoticePolicyBuilder;
 import api.support.fixtures.policies.PoliciesActivationFixture;
 import api.support.fixtures.policies.PoliciesToActivate;
 import api.support.http.IndividualResource;
+import api.support.http.ItemResource;
 import api.support.http.ResourceClient;
 import api.support.http.TimedTaskClient;
 import lombok.Getter;
@@ -87,6 +88,16 @@ public final class AgeToLostFixture {
     assertThat(ageToLostResult.getItem().getJson(), isAgedToLost());
 
     return ageToLostResult;
+  }
+
+  public void createAgedToLostLoan(ItemResource item, IndividualResource user) {
+    policiesActivation.use(PoliciesToActivate.builder().lostItemPolicy(
+      lostItemFeePoliciesFixture.ageToLostAfterOneMinute()));
+    checkOutFixture.checkOutByBarcode(item, user);
+    ageToLost();
+    var itemById = itemsFixture.getById(item.getId());
+
+    assertThat(itemById.getJson(), isAgedToLost());
   }
 
   public AgeToLostResult createLoanAgeToLostAndChargeFeesWithOverdues(IndividualResource lostPolicy, IndividualResource overduePolicy) {


### PR DESCRIPTION
## Purpose
Unable to recall items with status In process, In transit, On order when TLR is enabled

Resolves: [CIRC-1683](https://issues.folio.org/browse/CIRC-1683)

## Approach
- add logic for ignoring items with the statuses above;
- add tests;

