### PR TITLE
CIRC-1696 Fix issue with searching the least recalled loans

### DIFF
--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -6,6 +6,8 @@ import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.folio.circulation.domain.ItemStatus.AVAILABLE;
+import static org.folio.circulation.domain.RequestType.RECALL;
+import static org.folio.circulation.domain.RequestTypeItemStatusWhiteList.canCreateRequestForItem;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -123,6 +125,7 @@ public class RequestQueue {
       //Counting the amount of recalls for each loan
       .collect(collectingAndThen(groupingBy(Request::getLoan, counting()), m -> m.entrySet()
         .stream()
+        .filter(entry -> canCreateRequestForItem(entry.getKey().getItemStatus(), RECALL))
         .min(Comparator.comparingLong(Map.Entry<Loan, Long>::getValue)
           .thenComparing(o -> o.getKey().getDueDate()))
         .map(Map.Entry::getKey)

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -86,6 +86,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -3823,6 +3824,43 @@ public class RequestsAPICreationTests extends APITests {
   }
 
   @Test
+  void recallTlrShouldBeCreatedForOnOrderItemIfInstanceHasOnOrderAndDeclaredLostItems() {
+    configurationsFixture.enableTlrFeature();
+    UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+    UUID instanceId = UUID.randomUUID();
+
+    var item = buildItem(instanceId, "111");
+    var loan = checkOutFixture.checkOutByBarcode(item, usersFixture.charlotte());
+    IndividualResource firstRequest = requestsClient.create(buildRecallTitleLevelRequest(
+      usersFixture.steve().getId(), pickupServicePointId, instanceId));
+
+    assertThat(firstRequest.getResponse(), hasStatus(HTTP_CREATED));
+    JsonObject firstRequestJson = firstRequest.getJson();
+    assertThat(firstRequestJson.getString("requestLevel"), is(RequestLevel.TITLE.getValue()));
+    assertThat(firstRequestJson.getString("requestType"), is(RECALL.getValue()));
+    assertThat(firstRequestJson.getString("instanceId"), is(instanceId.toString()));
+    assertThat(firstRequestJson.getString("itemId"), is(item.getId()));
+    assertThat(firstRequestJson.getJsonObject("item").getString("status"), is("Checked out"));
+    declareLostFixtures.declareItemLost(loan.getJson());
+
+    ItemResource onOrderItem = buildItem(instanceId, itemBuilder -> itemBuilder
+      .withBarcode("222")
+      .withMaterialType(materialTypesFixture.book().getId())
+      .onOrder());
+
+    IndividualResource secondRequest = requestsClient.create(buildRecallTitleLevelRequest(
+      usersFixture.jessica().getId(), pickupServicePointId, instanceId));
+
+    assertThat(secondRequest.getResponse(), hasStatus(HTTP_CREATED));
+    JsonObject secondRequestJson = secondRequest.getJson();
+    assertThat(secondRequestJson.getString("requestLevel"), is(RequestLevel.TITLE.getValue()));
+    assertThat(secondRequestJson.getString("requestType"), is(RECALL.getValue()));
+    assertThat(secondRequestJson.getString("instanceId"), is(instanceId.toString()));
+    assertThat(secondRequestJson.getString("itemId"), is(onOrderItem.getId()));
+    assertThat(secondRequestJson.getJsonObject("item").getString("status"), is("On order"));
+  }
+
+  @Test
   void recallTlrShouldNotBeCreatedForInstanceWithOnlyDeclaredLostItem() {
     configurationsFixture.enableTlrFeature();
     useLostItemPolicy(lostItemFeePoliciesFixture.chargeFee().getId());
@@ -4238,6 +4276,19 @@ public class RequestsAPICreationTests extends APITests {
         .addIdentifier(isbnIdentifierId, "9780866989732")
         .withId(instanceId),
       itemBuilder -> itemBuilder.withBarcode(barcode).withMaterialType(materialType.getId()));
+  }
+
+  private ItemResource buildItem(UUID instanceId,
+    Function<ItemBuilder, ItemBuilder> additionalItemProperties) {
+
+    UUID isbnIdentifierId = identifierTypesFixture.isbn().getId();
+
+    return itemsFixture.basedUponSmallAngryPlanet(
+      holdingBuilder -> holdingBuilder.forInstance(instanceId),
+      instanceBuilder -> instanceBuilder
+        .addIdentifier(isbnIdentifierId, "9780866989732")
+        .withId(instanceId),
+      additionalItemProperties);
   }
 
   private void createInstanceAndHoldingRecord(UUID instanceId) {

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -3826,6 +3826,7 @@ public class RequestsAPICreationTests extends APITests {
   @Test
   void recallTlrShouldBeCreatedForOnOrderItemIfInstanceHasOnOrderAndDeclaredLostItems() {
     configurationsFixture.enableTlrFeature();
+    useLostItemPolicy(lostItemFeePoliciesFixture.chargeFee().getId());
     UUID pickupServicePointId = servicePointsFixture.cd1().getId();
     UUID instanceId = UUID.randomUUID();
 
@@ -3841,11 +3842,12 @@ public class RequestsAPICreationTests extends APITests {
     assertThat(firstRequestJson.getString("instanceId"), is(instanceId.toString()));
     assertThat(firstRequestJson.getString("itemId"), is(item.getId()));
     assertThat(firstRequestJson.getJsonObject("item").getString("status"), is("Checked out"));
+
     declareLostFixtures.declareItemLost(loan.getJson());
+    assertThat(itemsFixture.getById(item.getId()).getJson(), isDeclaredLost());
 
     ItemResource onOrderItem = buildItem(instanceId, itemBuilder -> itemBuilder
       .withBarcode("222")
-      .withMaterialType(materialTypesFixture.book().getId())
       .onOrder());
 
     IndividualResource secondRequest = requestsClient.create(buildRecallTitleLevelRequest(
@@ -4286,7 +4288,6 @@ public class RequestsAPICreationTests extends APITests {
     return itemsFixture.basedUponSmallAngryPlanet(
       holdingBuilder -> holdingBuilder.forInstance(instanceId),
       instanceBuilder -> instanceBuilder
-        .addIdentifier(isbnIdentifierId, "9780866989732")
         .withId(instanceId),
       additionalItemProperties);
   }


### PR DESCRIPTION
## Purpose
- Fix issue with searching the least recalled loans;

Resolves: [CIRC-1696](https://issues.folio.org/browse/CIRC-1696)

## Approach
- Ignore loans with not recallable items;
- Add test;