### PR TITLE
CIRC1587 ( Add the field "requester.preferredFirstName" )

### DIFF
--- a/src/main/java/org/folio/circulation/domain/User.java
+++ b/src/main/java/org/folio/circulation/domain/User.java
@@ -89,6 +89,10 @@ public class User {
     return getNestedStringProperty(representation, PERSONAL_PROPERTY_NAME, "firstName");
   }
 
+  public String getPreferredFirstName() {
+    return getNestedStringProperty(representation, PERSONAL_PROPERTY_NAME, "preferredFirstName");
+  }
+
   public String getMiddleName() {
     return getNestedStringProperty(representation, PERSONAL_PROPERTY_NAME, "middleName");
   }

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -148,6 +148,7 @@ public class TemplateContextUtil {
   public static JsonObject createUserContext(User user) {
     return new JsonObject()
     .put("firstName", user.getFirstName())
+    .put("preferredFirstName",user.getPreferredFirstName())
     .put("lastName", user.getLastName())
     .put("middleName", user.getMiddleName())
     .put("barcode", user.getBarcode());

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -286,6 +286,7 @@ public void verifyItemEffectiveLocationIdAtCheckOut() {
 
     assertThat(userContext.getString("firstName"), is(requesterUser.getFirstName()));
     assertThat(userContext.getString("lastName"), is(requesterUser.getLastName()));
+    assertThat(userContext.getString("preferredFirstName"), is(requesterUser.getPreferredFirstName()));
     assertThat(userContext.getString("middleName"), is(requesterUser.getMiddleName()));
     assertThat(userContext.getString("barcode"), is(requesterUser.getBarcode()));
     assertThat(userContext.getString("addressLine1"), is(address.getAddressLineOne()));

--- a/src/test/java/api/support/builders/UserBuilder.java
+++ b/src/test/java/api/support/builders/UserBuilder.java
@@ -15,6 +15,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
   private final String lastName;
   private final String firstName;
   private final String middleName;
+  private final String preferredFirstName;
   private final String barcode;
   private final UUID patronGroupId;
   private final Boolean active;
@@ -22,7 +23,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
   private final Collection<Address> addresses;
 
   public UserBuilder() {
-    this(UUID.randomUUID(), "sjones", "Jones", "Steven", null, "785493025613",
+    this(UUID.randomUUID(), "sjones", "Jones", "Steven", null, null,"785493025613",
       null, true, null, new ArrayList<>());
   }
 
@@ -32,6 +33,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
     String lastName,
     String firstName,
     String middleName,
+    String preferredFirstName,
     String barcode,
     UUID patronGroupId,
     Boolean active,
@@ -43,6 +45,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
 
     this.lastName = lastName;
     this.middleName = middleName;
+    this.preferredFirstName = preferredFirstName;
     this.firstName = firstName;
 
     this.barcode = barcode;
@@ -82,6 +85,10 @@ public class UserBuilder extends JsonBuilder implements Builder {
         personalInformation.put("middleName", this.middleName);
       }
 
+      if(this.preferredFirstName != null) {
+        personalInformation.put("preferredFirstName", this.preferredFirstName);
+      }
+
       if(this.addresses != null && !this.addresses.isEmpty()) {
         JsonArray mappedAddresses = new JsonArray();
 
@@ -115,6 +122,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
       lastName,
       firstName,
       this.middleName,
+      this.preferredFirstName,
       this.barcode,
       this.patronGroupId,
       this.active,
@@ -129,6 +137,37 @@ public class UserBuilder extends JsonBuilder implements Builder {
       lastName,
       firstName,
       middleName,
+      this.preferredFirstName,
+      this.barcode,
+      this.patronGroupId,
+      this.active,
+      this.expirationDate,
+      this.addresses);
+  }
+
+  public UserBuilder withPreferredFirstName(String lastName, String firstName,String preferredFirstName) {
+    return new UserBuilder(
+      this.id,
+      firstName.substring(0, 1).concat(lastName).toLowerCase(),
+      lastName,
+      firstName,
+      this.middleName,
+      preferredFirstName,
+      this.barcode,
+      this.patronGroupId,
+      this.active,
+      this.expirationDate,
+      this.addresses);
+  }
+
+  public UserBuilder withPreferredFirstName(String lastName, String firstName,String middleName,String preferredFirstName) {
+    return new UserBuilder(
+      this.id,
+      firstName.substring(0, 1).concat(lastName).toLowerCase(),
+      lastName,
+      firstName,
+      middleName,
+      preferredFirstName,
       this.barcode,
       this.patronGroupId,
       this.active,
@@ -143,6 +182,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
       null,
       null,
       null,
+      this.preferredFirstName,
       this.barcode,
       this.patronGroupId,
       this.active,
@@ -157,6 +197,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.lastName,
       this.firstName,
       this.middleName,
+      this.preferredFirstName,
       barcode,
       this.patronGroupId,
       this.active,
@@ -171,6 +212,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.lastName,
       this.firstName,
       this.middleName,
+      this.preferredFirstName,
       null,
       this.patronGroupId,
       this.active,
@@ -185,6 +227,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.lastName,
       this.firstName,
       this.middleName,
+      this.preferredFirstName,
       this.barcode,
       this.patronGroupId,
       this.active,
@@ -203,6 +246,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.lastName,
       this.firstName,
       this.middleName,
+      this.preferredFirstName,
       this.barcode,
       patronGroupId,
       this.active,
@@ -229,6 +273,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.lastName,
       this.firstName,
       this.middleName,
+      this.preferredFirstName,
       this.barcode,
       this.patronGroupId,
       active,
@@ -243,6 +288,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.lastName,
       this.firstName,
       this.middleName,
+      this.preferredFirstName,
       this.barcode,
       this.patronGroupId,
       this.active,
@@ -257,6 +303,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.lastName,
       this.firstName,
       this.middleName,
+      this.preferredFirstName,
       this.barcode,
       this.patronGroupId,
       this.active,
@@ -284,6 +331,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.lastName,
       this.firstName,
       this.middleName,
+      this.preferredFirstName,
       this.barcode,
       this.patronGroupId,
       this.active,
@@ -298,6 +346,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.lastName,
       this.firstName,
       this.middleName,
+      this.preferredFirstName,
       this.barcode,
       this.patronGroupId,
       this.active,

--- a/src/test/java/api/support/fixtures/TemplateContextMatchers.java
+++ b/src/test/java/api/support/fixtures/TemplateContextMatchers.java
@@ -63,6 +63,7 @@ public class TemplateContextMatchers {
     Map<String, Matcher<String>> tokenMatchers = new HashMap<>();
     tokenMatchers.put(prefix + ".firstName", is(personal.getString("firstName")));
     tokenMatchers.put(prefix + ".lastName", is(personal.getString("lastName")));
+    tokenMatchers.put(prefix + ".preferredFirstName", is(personal.getString("preferredFirstName")));
     tokenMatchers.put(prefix + ".barcode", is(userJson.getString("barcode")));
     return tokenMatchers;
   }

--- a/src/test/java/api/support/fixtures/UserExamples.java
+++ b/src/test/java/api/support/fixtures/UserExamples.java
@@ -5,14 +5,14 @@ import api.support.builders.UserBuilder;
 public class UserExamples {
   public static UserBuilder basedUponStevenJones() {
     return new UserBuilder()
-      .withName("Jones", "Steven", "Jacob")
+      .withPreferredFirstName("Jones", "Steven", "Jacob","Jon")
       .withBarcode("5694596854")
       .withActive(true);
   }
 
   public static UserBuilder basedUponJessicaPontefract() {
     return new UserBuilder()
-      .withName("Pontefract", "Jessica")
+      .withPreferredFirstName("Pontefract", "Jessica","Jess")
       .withBarcode("7697595697")
       .withActive(true);
   }


### PR DESCRIPTION
https://issues.folio.org/browse/CIRC-1587

## Purpose
Please add the field "requester.preferredFirstName" to the Requester Object in the Staff Slip context, for hold, request delivery and transit slips generated in the Check in app.

Scenario:

Given: I have printed out the staff slip, the template of which contains the token “requester.preferredFirstName” + the user's Prefered first name is populated,
When: I look at the text of that token on the piece of paper,
Then: I see the plain text name of the Prefered first name, as can be seen in the UI of Users.
Example: On the piece of paper, I see “Jules”, and NOT "Julie".
Scenario:

Given:  I have printed out the staff slip, the template of which contains the token “requester.preferredFirstName” + the user's Prefered first name is not populated,
When: I look at the text of that token on the piece of paper,
Then: I see the plain text name of the First name, as can be seen in the UI of Users.
Example: On the piece of paper, I see “Julie”.

## Approach:
1. Modified TemplateContextUtil 
2. Test case updated

## Response:

1. https://issues.folio.org/secure/attachment/56236/token-hold-slip-scenario1.mp4
2. 
![image](https://user-images.githubusercontent.com/103935659/212005919-d54c52e4-d1a3-4532-b84b-365fcd3f2f50.png)
 