### PR TITLE
CIRC-1731: haveAssociatedFeesAndFines serialized JSON array

### DIFF
--- a/ramls/loan-anonymization.raml
+++ b/ramls/loan-anonymization.raml
@@ -20,6 +20,7 @@ traits:
     /by-user/{userId}:
       post:
         is: [validate]
+        description: "Note that a 422 error with haveAssociatedFeesAndFines message and key loanIds has a value that is not a JSON array but a JSON string that contains a serialized JSON array of the loan ids."
         responses:
           200:
             description: "Chosen loans have been successfully anonymized"

--- a/src/main/java/org/folio/circulation/domain/representations/anonymization/AnonymizeLoansRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/anonymization/AnonymizeLoansRepresentation.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 
 import org.folio.circulation.domain.anonymization.LoanAnonymizationRecords;
 import org.folio.circulation.support.results.Result;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class AnonymizeLoansRepresentation {
@@ -33,13 +34,13 @@ public class AnonymizeLoansRepresentation {
 
   }
 
-  private static List<Error> mapToErrors(Map<String, Collection<String>> multiMap) {
+  static List<Error> mapToErrors(Map<String, Collection<String>> multiMap) {
     return multiMap.keySet()
       .stream()
       .map(k -> new Error().withMessage(k)
         .withParameters(Collections.singletonList(new Parameter().withKey("loanIds")
-          .withValue(multiMap.get(k).toString()))))
+          // errors.schema defines value as String so we need to serialize the JsonArray
+          .withValue(new JsonArray(List.copyOf(multiMap.get(k))).toString()))))
       .collect(Collectors.toList());
-
   }
 }

--- a/src/test/java/org/folio/circulation/domain/representations/anonymization/AnonymizeLoansRepresentationTest.java
+++ b/src/test/java/org/folio/circulation/domain/representations/anonymization/AnonymizeLoansRepresentationTest.java
@@ -1,0 +1,38 @@
+package org.folio.circulation.domain.representations.anonymization;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AnonymizeLoansRepresentationTest {
+
+  @Test
+  void mapToErrors() {
+    Map<String, Collection<String>> multiMap = Map.of(
+        "foo", List.of("foo1", "foo2"),
+        "bar", List.of("bar1"));
+    List<Error> errors = AnonymizeLoansRepresentation.mapToErrors(multiMap);
+    assertThat(errors.size(), is(2));
+    Error foo = errors.get(0);
+    Error bar = errors.get(1);
+    // accept in any order
+    if ("foo".equals(bar.getMessage())) {
+      foo = errors.get(1);
+      bar = errors.get(0);
+    }
+    assertThat(foo.getMessage(), is("foo"));
+    var parameters = foo.getParameters();
+    assertThat(parameters.get(0).getKey(), is("loanIds"));
+    assertThat(parameters.get(0).getValue(), is("[\"foo1\",\"foo2\"]"));
+
+    assertThat(bar.getMessage(), is("bar"));
+    parameters = bar.getParameters();
+    assertThat(parameters.get(0).getKey(), is("loanIds"));
+    assertThat(parameters.get(0).getValue(), is("[\"bar1\"]"));
+  }
+
+}


### PR DESCRIPTION
## Purpose
Front-end parses loanIds as serialized JSON array:
```
[
  { "key": "loadnIds", "value": "[\"f14e4831-ca99-4f8e-bc2e-6c5e72e071d8\",\"a8e964ff-81b3-489e-aa81-6d97aa1bc601\"] }
]
```

## Approach
Wrap loan ids into a JSON array and then serialized it to conform to the error.schema/parameters.schema RAML spec.
Document this hack in RAML and source code and add unit test.

## Learning
The parameters.schema RAML spec is already an array that allows any number of parameters:
```
[
  { "key": "loadnId", "value": "f14e4831-ca99-4f8e-bc2e-6c5e72e071d8" },
  { "key": "loadnId", "value": "a8e964ff-81b3-489e-aa81-6d97aa1bc601" }
]
```
There has never been a need for a hack like this where a JSON array is forced into a single JSON String by serializing the array.