### PR TITLE
CIRC-1677 Allow hold TLR for a title with no HRs

### DIFF
--- a/src/main/java/org/folio/circulation/domain/CreateRequestService.java
+++ b/src/main/java/org/folio/circulation/domain/CreateRequestService.java
@@ -195,7 +195,8 @@ public class CreateRequestService {
   private CompletableFuture<Result<RequestAndRelatedRecords>> checkPolicy(
     RequestAndRelatedRecords records) {
 
-    if (errorHandler.hasAny(INVALID_ITEM_ID, ITEM_DOES_NOT_EXIST, INVALID_USER_OR_PATRON_GROUP_ID,
+    if (errorHandler.hasAny(INVALID_INSTANCE_ID, INSTANCE_DOES_NOT_EXIST, INVALID_ITEM_ID,
+      ITEM_DOES_NOT_EXIST, INVALID_USER_OR_PATRON_GROUP_ID,
       TLR_RECALL_WITHOUT_OPEN_LOAN_OR_RECALLABLE_ITEM)) {
 
       return ofAsync(() -> records);
@@ -220,7 +221,8 @@ public class CreateRequestService {
   }
 
   private CompletableFuture<Result<Boolean>> shouldCheckItem(RequestAndRelatedRecords records) {
-    return ofAsync(() -> errorHandler.hasNone(INVALID_ITEM_ID));
+    return ofAsync(() -> errorHandler.hasNone(INVALID_INSTANCE_ID, INSTANCE_DOES_NOT_EXIST,
+      INVALID_ITEM_ID));
   }
 
   private CompletableFuture<Result<RequestAndRelatedRecords>> doNothing(

--- a/src/main/java/org/folio/circulation/domain/validation/RequestLoanValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/RequestLoanValidator.java
@@ -58,8 +58,9 @@ public class RequestLoanValidator {
     RequestAndRelatedRecords requestAndRelatedRecords) {
 
     final Request request = requestAndRelatedRecords.getRequest();
+    final UUID instanceId = UUID.fromString(request.getInstanceId());
 
-    return itemByInstanceIdFinder.getItemsByInstanceId(UUID.fromString(request.getInstanceId()))
+    return itemByInstanceIdFinder.getItemsByInstanceId(instanceId, false)
       .thenCombine(
         loanRepository.findOpenLoansByUserIdWithItem(LOANS_PAGE_LIMIT, request.getUserId()),
         (items, loans) -> verifyNoMatchOrFailAsAlreadyLoaned(items, loans, requestAndRelatedRecords)

--- a/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestByInstanceIdResource.java
@@ -137,8 +137,9 @@ public class RequestByInstanceIdResource extends Resource {
 
     final var loanRepository = repositories.getLoanRepository();
     final var requestQueueRepository = repositories.getRequestQueueRepository();
+    final var instanceId = requestRelatedRecords.getInstanceLevelRequest().getInstanceId();
 
-    return finder.getItemsByInstanceId(requestRelatedRecords.getInstanceLevelRequest().getInstanceId())
+    return finder.getItemsByInstanceId(instanceId, true)
       .thenApply(r -> r.next(this::validateItems))
       .thenCompose(r -> r.after(items -> getRequestQueues(items,
         requestRelatedRecords, requestQueueRepository)))

--- a/src/main/java/org/folio/circulation/storage/ItemByInstanceIdFinder.java
+++ b/src/main/java/org/folio/circulation/storage/ItemByInstanceIdFinder.java
@@ -2,11 +2,12 @@ package org.folio.circulation.storage;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Function.identity;
-import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
 import static org.folio.circulation.support.fetching.RecordFetching.findWithCqlQuery;
 import static org.folio.circulation.support.json.JsonKeys.byId;
+import static org.folio.circulation.support.results.Result.succeeded;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -47,8 +48,7 @@ public class ItemByInstanceIdFinder {
 
     return holdingsRecordsResult.after(holdingsRecords -> {
       if (holdingsRecords == null || holdingsRecords.isEmpty()) {
-        return completedFuture(failedValidation(
-          "There are no holdings for this instance", "holdingsRecords", "null"));
+        return completedFuture(succeeded(List.of()));
       }
 
       Set<String> holdingsIds = holdingsRecords.toKeys(byId());

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -4199,6 +4199,26 @@ public class RequestsAPICreationTests extends APITests {
     }
   }
 
+  @Test
+  void canCreateHoldTlrForInstanceWithNoHoldingsRecords() {
+    reconfigureTlrFeature(ENABLED, null, null, null);
+
+    UUID instanceId = instancesFixture.basedUponDunkirk().getId();
+
+    IndividualResource response = requestsClient.create(new RequestBuilder()
+      .hold()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withNoItemId()
+      .withNoHoldingsRecordId()
+      .withRequesterId(usersFixture.steve().getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId()));
+
+    JsonObject createdRequest = response.getJson();
+    assertThat(createdRequest.getString("requestLevel"), is("Title"));
+    assertThat(createdRequest.getString("instanceId"), is(instanceId));
+  }
+
   private void setUpNoticesForTitleLevelRequests(boolean isNoticeEnabledInTlrSettings,
     boolean isNoticeEnabledInNoticePolicy) {
 

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -454,16 +454,33 @@ public class RequestsAPICreationTests extends APITests {
     UUID patronId = usersFixture.charlotte().getId();
     final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
 
-    Response postResponse = requestsClient.attemptCreate(new RequestBuilder()
-      .withRequestType(requestType)
-      .titleRequestLevel()
-      .withNoItemId()
-      .withInstanceId(UUID.randomUUID())
-      .withPickupServicePointId(pickupServicePointId)
-      .withRequesterId(patronId));
+    Response placeRequestWithoutHoldingsRecordIdResponse = requestsClient.attemptCreate(
+      new RequestBuilder()
+        .withRequestType(requestType)
+        .titleRequestLevel()
+        .withNoItemId()
+        .withNoHoldingsRecordId()
+        .withInstanceId(UUID.randomUUID())
+        .withPickupServicePointId(pickupServicePointId)
+        .withRequesterId(patronId));
 
-    assertThat(postResponse, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
-    assertThat(postResponse.getJson(), hasErrorWith(hasMessage("There are no holdings for this instance")));
+    assertThat(placeRequestWithoutHoldingsRecordIdResponse, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
+    assertThat(placeRequestWithoutHoldingsRecordIdResponse.getJson(),
+      hasErrorWith(hasMessage("Instance does not exist")));
+
+    Response placeRequestWithRandomHoldingsRecordIdResponse = requestsClient.attemptCreate(
+      new RequestBuilder()
+        .withRequestType(requestType)
+        .titleRequestLevel()
+        .withNoItemId()
+        .withInstanceId(UUID.randomUUID())
+        .withPickupServicePointId(pickupServicePointId)
+        .withRequesterId(patronId));
+
+    assertThat(placeRequestWithRandomHoldingsRecordIdResponse,
+      hasStatus(HTTP_UNPROCESSABLE_ENTITY));
+    assertThat(placeRequestWithRandomHoldingsRecordIdResponse.getJson(),
+      hasErrorWith(hasMessage("Instance does not exist")));
   }
 
   @ParameterizedTest
@@ -2939,7 +2956,7 @@ public class RequestsAPICreationTests extends APITests {
 
     final JsonObject responseJson = postResponse.getJson();
 
-    assertThat(responseJson, hasErrors(4));
+    assertThat(responseJson, hasErrors(3));
 
     assertThat(responseJson, hasErrorWith(allOf(
       hasMessage("Instance does not exist"),


### PR DESCRIPTION
Resolves [CIRC-1677](https://issues.folio.org/browse/CIRC-1677)

## Purpose
Hold TLRs for titles with no holdings records should be allowed

## Approach
Remove validation failure when no holdings record could be found for a particular instance ID.
Error message may change when instance doesn't exist

