### PR TITLE
CIRC-1571 Add missed permissions for fee-fine-scheduled-notices

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -752,6 +752,8 @@
             "scheduled-notice-storage.scheduled-notices.collection.get",
             "scheduled-notice-storage.scheduled-notices.item.delete",
             "scheduled-notice-storage.scheduled-notices.item.put",
+            "circulation-storage.loan-policies.item.get",
+            "circulation-storage.loan-policies.collection.get",
             "configuration.entries.item.get",
             "configuration.entries.collection.get",
             "patron-notice.post",


### PR DESCRIPTION
## Purpose
Add missed permissions for fee-fine-scheduled-notices-processing

Resolves: [CIRC-1571](https://issues.folio.org/browse/CIRC-1571)

