### PR TITLE
[CIRC-1550] Fix NPE when user without barcode try to checkout already requested item

### DIFF
--- a/src/main/java/org/folio/circulation/domain/validation/CheckOutValidators.java
+++ b/src/main/java/org/folio/circulation/domain/validation/CheckOutValidators.java
@@ -237,6 +237,10 @@ public class CheckOutValidators {
   public CompletableFuture<Result<LoanAndRelatedRecords>> refuseWhenRequestedByAnotherPatron(
     Result<LoanAndRelatedRecords> result) {
 
+    if (errorHandler.hasAny(FAILED_TO_FETCH_USER)) {
+      return completedFuture(result);
+    }
+
     return requestedByAnotherPatronValidator.refuseWhenRequestedByAnotherPatron(result)
       .thenApply(r -> r.mapFailure(failure -> errorHandler.handleValidationError(failure,
         ITEM_REQUESTED_BY_ANOTHER_PATRON, result)));

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -42,6 +42,7 @@ import static api.support.matchers.TextDateTimeMatcher.withinSecondsAfter;
 import static api.support.matchers.UUIDMatcher.is;
 import static api.support.matchers.ValidationErrorMatchers.hasCode;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
+import static api.support.matchers.ValidationErrorMatchers.hasErrors;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
 import static api.support.matchers.ValidationErrorMatchers.hasUUIDParameter;
@@ -2558,12 +2559,12 @@ class CheckOutByBarcodeTests extends APITests {
     requestsFixture.placeItemLevelPageRequest(item, item.getInstanceId(), usersFixture.jessica());
     var steveWithNoBarcode = usersFixture.steve(UserBuilder::withNoBarcode);
 
-    var response = checkOutFixture.attemptCheckOutByBarcode(item, steveWithNoBarcode);
-    assertThat(response.getJson(), hasErrorWith(allOf(
+    var response = checkOutFixture.attemptCheckOutByBarcode(item, steveWithNoBarcode).getJson();
+    assertThat(response, hasErrors(1));
+    assertThat(response, hasErrorWith(allOf(
       hasMessage("Could not find user with matching barcode"),
       hasCode(USER_BARCODE_NOT_FOUND),
       hasUserBarcodeParameter(steveWithNoBarcode))));
-    assertThat(response.getJson().getJsonArray("errors").size(), is(1));
   }
 
   private IndividualResource placeRequest(String requestLevel, ItemResource item,

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -2554,7 +2554,7 @@ class CheckOutByBarcodeTests extends APITests {
 
   @Test
   void shouldNotFailIfPatronDoesNotHaveBarcodeAndItemWasAlreadyRequested() {
-    var item = itemsFixture.createMultipleItemsForTheSameInstance(1).get(0);
+    var item = itemsFixture.basedUponDunkirk();
     requestsFixture.placeItemLevelPageRequest(item, item.getInstanceId(), usersFixture.jessica());
     var steveWithNoBarcode = usersFixture.steve(UserBuilder::withNoBarcode);
 

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -2563,6 +2563,7 @@ class CheckOutByBarcodeTests extends APITests {
       hasMessage("Could not find user with matching barcode"),
       hasCode(USER_BARCODE_NOT_FOUND),
       hasUserBarcodeParameter(steveWithNoBarcode))));
+    assertThat(response.getJson().getJsonArray("errors").size(), is(1));
   }
 
   private IndividualResource placeRequest(String requestLevel, ItemResource item,


### PR DESCRIPTION
## Purpose
Modal window with the error message: "Item not checked out User does not have a barcode. A user barcode is required to check out an item." should be displayed if a requested item is checked out for a user without a barcode;

Resolves: [CIRC-1550](https://issues.folio.org/browse/CIRC-1550)

## Approach
- Fix NPE;
- Create a test to cover the scenario;

