### PR TITLE
CIRC-1752 Remove search index from request extended representation

### DIFF
--- a/ramls/request.json
+++ b/ramls/request.json
@@ -378,6 +378,11 @@
           "$ref": "override-blocks.json"
         }
       }
+    },
+    "searchIndex": {
+      "description": "Request fields used for search",
+      "type": "object",
+      "$ref": "requestSearchIndex.schema"
     }
   },
   "additionalProperties": false,

--- a/ramls/requestSearchIndex.json
+++ b/ramls/requestSearchIndex.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Fields used for search",
+  "type": "object",
+  "properties": {
+    "effectiveCallNumberComponents": {
+      "properties": {
+        "callNumber": {
+          "type": "string",
+          "description": "Effective Call Number is an identifier assigned to an item or its holding and associated with the item.",
+          "readonly": true
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Effective Call Number Prefix is the prefix of the identifier assigned to an item or its holding and associated with the item.",
+          "readonly": true
+        },
+        "suffix": {
+          "type": "string",
+          "description": "Effective Call Number Suffix is the suffix of the identifier assigned to an item or its holding and associated with the item.",
+          "readonly": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "pickupServicePointName": {
+      "description": "The name of the request pickup service point",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
@@ -34,6 +34,8 @@ public class RequestRepresentation {
     addAdditionalServicePointProperties(requestRepresentation, request.getPickupServicePoint());
     addDeliveryAddress(requestRepresentation, request, request.getRequester());
 
+    removeSearchIndexFields(requestRepresentation);
+
     return requestRepresentation;
   }
 
@@ -249,6 +251,10 @@ public class RequestRepresentation {
     }
 
     return userSummary;
+  }
+
+  private static void removeSearchIndexFields(JsonObject request) {
+    request.remove("searchIndex");
   }
 }
 

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -264,6 +264,9 @@ public class RequestsAPICreationTests extends APITests {
     assertThat("does not have information taken from proxying user",
       representation.containsKey("proxy"), is(false));
 
+    assertThat("does not have search index fields",
+      representation.containsKey("searchIndex"), is(true));
+
     assertThat("should have change metadata",
       representation.containsKey("metadata"), is(true));
 


### PR DESCRIPTION
Resolves [CIRC-1752](https://issues.folio.org/browse/CIRC-1752)

## Purpose
After [CIRCSTORE-398](https://issues.folio.org/browse/CIRCSTORE-398) is implemented, request representation will contain searchIndex field with the new fields used for request search. UI doesn't need these fields and they should be excluded from request's extended representation. Also, they should be added to the JSON schema to keep it up-to-date.

## Approach
Change JSON schema, RequestRepresentation, request creation test
