### PR TITLE
CIRC-1759 TLR Recall returns 500 error in some scenarios

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -398,6 +398,10 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
     return item != null && item.isFound();
   }
 
+  public boolean hasLoan() {
+    return loan != null;
+  }
+
   public enum Operation {
     CREATE, REPLACE, MOVE;
   }

--- a/src/main/java/org/folio/circulation/domain/RequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/RequestQueue.java
@@ -76,6 +76,7 @@ public class RequestQueue {
   public Loan getTheLeastRecalledLoan() {
     return requests.stream()
       .filter(Request::isRecall)
+      .filter(Request::hasLoan)
       //Counting the amount of recalls for each loan
       .collect(collectingAndThen(groupingBy(Request::getLoan, counting()), m -> m.entrySet()
         .stream()

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -4236,6 +4236,223 @@ public class RequestsAPICreationTests extends APITests {
     assertThat(createdRequest.getString("instanceId"), is(instanceId));
   }
 
+  @Test
+  void recallTlrShouldSucceedWhenItNeedsToPickLeastRecalledLoanAndRequestsWithNoLoansAreInTheQueueScenario1() {
+    configurationsFixture.enableTlrFeature();
+
+    final var patron1 = usersFixture.charlotte();
+    final var patron2 = usersFixture.jessica();
+    final var patron3 = usersFixture.steve();
+    final var patron4 = usersFixture.james();
+    final var patron5 = usersFixture.rebecca();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+
+    // Step 1
+    final var items = itemsFixture.createMultipleItemsForTheSameInstance(2);
+    final var itemA = items.get(0);
+    final var itemB = items.get(1);
+    final UUID instanceId = items.get(0).getInstanceId();
+
+    // Step 2
+    IndividualResource pageTlr = requestsClient.create(new RequestBuilder()
+      .page()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron1.getId()));
+
+    var itemAUpdated = itemsFixture.getById(itemA.getId());
+    var itemBUpdated = itemsFixture.getById(itemB.getId());
+    var pagedItem = "Paged".equals(itemAUpdated.getStatusName())
+      ? itemA : itemB;
+    var notPagedItem = itemA == pagedItem ? itemB : itemA;
+
+    // Step 3
+    checkInFixture.checkInByBarcode(pagedItem, pickupServicePointId);
+
+    var pageTlrAfterCheckIn =  requestsClient.get(pageTlr.getId());
+    assertThat(pageTlrAfterCheckIn.getJson().getString("status"), is("Open - Awaiting pickup"));
+    var pagedItemAfterCheckIn = itemsFixture.getById(pagedItem.getId());
+    assertThat(pagedItemAfterCheckIn.getStatusName(), is("Awaiting pickup"));
+
+    // Step 4
+    checkOutFixture.checkOutByBarcode(notPagedItem, patron2);
+
+    // Step 5
+    IndividualResource recallTlr1 = requestsClient.create(new RequestBuilder()
+      .recall()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron3.getId()));
+
+    assertThat(recallTlr1.getJson().getString("status"), is("Open - Not yet filled"));
+    assertThat(recallTlr1.getJson().getString("itemId"), is(notPagedItem.getId().toString()));
+
+    // Step 6
+    checkOutFixture.checkOutByBarcode(pagedItemAfterCheckIn, patron1);
+    var pageTlrAfterCheckOut =  requestsClient.get(pageTlr.getId());
+    assertThat(pageTlrAfterCheckOut.getJson().getString("status"), is("Closed - Filled"));
+
+    // Step 7
+    checkInFixture.checkInByBarcode(notPagedItem, pickupServicePointId);
+    var notPagedItemAfterCheckIn = itemsFixture.getById(notPagedItem.getId());
+    assertThat(notPagedItemAfterCheckIn.getStatusName(), is("Awaiting pickup"));
+    var recallTlr1AfterCheckOut =  requestsClient.get(recallTlr1.getId());
+    assertThat(recallTlr1AfterCheckOut.getJson().getString("status"), is("Open - Awaiting pickup"));
+
+    // Step 8
+    IndividualResource recallTlr2 = requestsClient.create(new RequestBuilder()
+      .recall()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron4.getId()));
+
+    assertThat(recallTlr2.getJson().getString("status"), is("Open - Not yet filled"));
+    assertThat(recallTlr2.getJson().getString("itemId"), is(pagedItem.getId().toString()));
+
+    // Step 9
+    IndividualResource recallTlr3 = requestsClient.create(new RequestBuilder()
+      .recall()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron5.getId()));
+
+    // Expected results
+    assertThat(recallTlr3.getJson().getString("status"), is("Open - Not yet filled"));
+    assertThat(recallTlr3.getJson().getString("itemId"), is(pagedItem.getId().toString()));
+  }
+
+  @Test
+  void recallTlrShouldSucceedWhenItNeedsToPickLeastRecalledLoanAndRequestsWithNoLoansAreInTheQueueScenario2() {
+    configurationsFixture.enableTlrFeature();
+
+    final var patron1 = usersFixture.charlotte();
+    final var patron2 = usersFixture.jessica();
+    final var patron3 = usersFixture.steve();
+    final var patron4 = usersFixture.james();
+    final var patron5 = usersFixture.rebecca();
+    final var patron6 = usersFixture.bobby();
+    final var patron7 = usersFixture.henry();
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+
+    // Step 1 - An instance with 2 items. Both Paged. Patron 1, Patron 2
+    final var items = itemsFixture.createMultipleItemsForTheSameInstance(2);
+    final var itemA = items.get(0);
+    final var itemB = items.get(1);
+    final UUID instanceId = items.get(0).getInstanceId();
+
+    IndividualResource pageTlr1 = requestsClient.create(new RequestBuilder()
+      .page()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron1.getId()));
+
+    IndividualResource pageTlr2 = requestsClient.create(new RequestBuilder()
+      .page()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron2.getId()));
+
+    var itemAAfterCheckIn = itemsFixture.getById(itemA.getId());
+    assertThat(itemAAfterCheckIn.getStatusName(), is("Paged"));
+    var itemBAfterCheckIn = itemsFixture.getById(itemB.getId());
+    assertThat(itemBAfterCheckIn.getStatusName(), is("Paged"));
+
+    // Step 2 - 2 recalls placed Patron 3, Patron 4. Both recalling item A (the same item)
+    IndividualResource recallTlr1 = requestsClient.create(new RequestBuilder()
+      .recall()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron3.getId()));
+
+    var recalledItem = recallTlr1.getJson().getString("itemId").equals(itemA.getId().toString())
+      ? itemA : itemB;
+    var notRecalledItem = recalledItem == itemA ? itemB : itemA;
+    assertThat(recallTlr1.getJson().getString("itemId"), is(recalledItem.getId().toString()));
+
+    IndividualResource recallTlr2 = requestsClient.create(new RequestBuilder()
+      .recall()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron4.getId()));
+    assertThat(recallTlr2.getJson().getString("itemId"), is(recalledItem.getId().toString()));
+
+    var recalledItemAfterFirstRecalls = itemsFixture.getById(recalledItem.getId());
+    assertThat(recalledItemAfterFirstRecalls.getStatusName(), is("Paged"));
+    var notRecalledItemAfterFirstRecalls = itemsFixture.getById(notRecalledItem.getId());
+    assertThat(notRecalledItemAfterFirstRecalls.getStatusName(), is("Paged"));
+
+    // Step 3 - Item B (not recalled) is checked in at chosen SP – Awaiting pickup.
+    checkInFixture.checkInByBarcode(notRecalledItem, pickupServicePointId);
+
+    var notRecalledItemAfterCheckIn = itemsFixture.getById(notRecalledItem.getId());
+    assertThat(notRecalledItemAfterCheckIn.getStatusName(), is("Awaiting pickup"));
+
+    // Step 4 - Item B is checked out
+    checkOutFixture.checkOutByBarcode(notRecalledItem, patron2);
+    var notRecalledItemAfterCheckOut = itemsFixture.getById(notRecalledItem.getId());
+    assertThat(notRecalledItemAfterCheckOut.getStatusName(), is("Checked out"));
+
+    // Step 5 - A recall is placed. Patron 5. Recalling the checked out Item B
+    IndividualResource recallTlr3 = requestsClient.create(new RequestBuilder()
+      .recall()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron5.getId()));
+
+    assertThat(recallTlr3.getJson().getString("itemId"), is(notRecalledItem.getId().toString()));
+
+    // Step 6 - A recall is placed. Patron 6. Recalling the checked out Item B
+    IndividualResource recallTlr4 = requestsClient.create(new RequestBuilder()
+      .recall()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron6.getId()));
+
+    assertThat(recallTlr4.getJson().getString("itemId"), is(notRecalledItem.getId().toString()));
+
+    // Step 7 -A recall is placed. Patron 7
+    IndividualResource recallTlr5 = requestsClient.create(new RequestBuilder()
+      .recall()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron7.getId()));
+
+    assertThat(recallTlr5.getJson().getString("itemId"), is(notRecalledItem.getId().toString()));
+  }
+
   private void setUpNoticesForTitleLevelRequests(boolean isNoticeEnabledInTlrSettings,
     boolean isNoticeEnabledInNoticePolicy) {
 

--- a/src/test/java/api/support/fixtures/UsersFixture.java
+++ b/src/test/java/api/support/fixtures/UsersFixture.java
@@ -67,6 +67,16 @@ public class UsersFixture {
       .inGroupFor(patronGroupsFixture.regular())));
   }
 
+  public UserResource bobby() {
+    return createIfAbsent(basedUponBobbyBibbin()
+      .inGroupFor(patronGroupsFixture.regular()));
+  }
+
+  public UserResource henry() {
+    return createIfAbsent(basedUponHenryHanks()
+      .inGroupFor(patronGroupsFixture.regular()));
+  }
+
   public UserResource undergradHenry() {
     return undergradHenry(identity());
   }


### PR DESCRIPTION
Resolves [CIRC-1759](https://issues.folio.org/browse/CIRC-1759) 

## Purpose
Recall TLRs fail when we're looking for the loan with the least number of recalls (which we only do when we couldn't find the closest-due-date not-yet recalled loan) but there is also a request in the queue that is not associated with a loan.

## Approach
Filter requests in the queue before grouping them by loan.
