### PR TITLE
CIRC-1760 Editing a recall TLR changes recalled item

### DIFF
--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -248,10 +248,10 @@ class RequestFromRepresentationService {
       itemAndLoanFetchingFunction = this::fetchItemAndLoanForPageTlr;
     }
     else if (request.isTitleLevel() && request.isRecall()) {
-      if (request.getOperation() != Request.Operation.REPLACE) {
-        itemAndLoanFetchingFunction = this::fetchItemAndLoanForRecallTlr;
-      } else {
+      if (request.getOperation() == Request.Operation.REPLACE) {
         itemAndLoanFetchingFunction = this::fetchItemAndLoanDefault;
+      } else {
+        itemAndLoanFetchingFunction = this::fetchItemAndLoanForRecallTlrCreation;
       }
     }
     else {
@@ -300,7 +300,7 @@ class RequestFromRepresentationService {
       .toCompletableFuture();
   }
 
-  private CompletableFuture<Result<Request>> fetchItemAndLoanForRecallTlr(
+  private CompletableFuture<Result<Request>> fetchItemAndLoanForRecallTlrCreation(
     RequestAndRelatedRecords records) {
 
     Request request = records.getRequest();

--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -241,24 +242,40 @@ class RequestFromRepresentationService {
     RequestAndRelatedRecords records) {
 
     Request request = records.getRequest();
+    Function<RequestAndRelatedRecords, CompletableFuture<Result<Request>>>
+      itemAndLoanFetchingFunction;
     if (request.isTitleLevel() && request.isPage()) {
-      return fetchItemAndLoanForPageTlr(records.getRequest())
-        .thenApply(mapResult(records::withRequest));
+      itemAndLoanFetchingFunction = this::fetchItemAndLoanForPageTlr;
+    }
+    else if (request.isTitleLevel() && request.isRecall()) {
+      if (request.getOperation() != Request.Operation.REPLACE) {
+        itemAndLoanFetchingFunction = this::fetchItemAndLoanForRecallTlr;
+      } else {
+        itemAndLoanFetchingFunction = this::fetchItemAndLoanDefault;
+      }
+    }
+    else {
+      itemAndLoanFetchingFunction = this::fetchItemAndLoanDefault;
     }
 
-    if (request.isTitleLevel() && request.isRecall()) {
-      return fetchItemAndLoanForRecallTlrRequest(records)
-        .thenApply(mapResult(records::withRequest));
-    }
+    return completedFuture(records)
+      .thenCompose(itemAndLoanFetchingFunction)
+      .thenApply(mapResult(records::withRequest));
+  }
 
-    return fromFutureResult(findItemForRequest(request))
+  private CompletableFuture<Result<Request>> fetchItemAndLoanDefault(
+    RequestAndRelatedRecords records) {
+
+    return fromFutureResult(findItemForRequest(records.getRequest()))
       .flatMapFuture(this::fetchLoan)
       .flatMapFuture(this::fetchUserForLoan)
-      .map(records::withRequest)
       .toCompletableFuture();
   }
 
-  private CompletableFuture<Result<Request>> fetchItemAndLoanForPageTlr(Request request) {
+  private CompletableFuture<Result<Request>> fetchItemAndLoanForPageTlr(
+    RequestAndRelatedRecords records) {
+
+    Request request = records.getRequest();
     return request.getOperation() == Request.Operation.CREATE
       ? fetchItemAndLoanForPageTlrCreation(request)
       : fetchItemAndLoanForPageTlrReplacement(request);
@@ -283,8 +300,9 @@ class RequestFromRepresentationService {
       .toCompletableFuture();
   }
 
-  private CompletableFuture<Result<Request>> fetchItemAndLoanForRecallTlrRequest(
+  private CompletableFuture<Result<Request>> fetchItemAndLoanForRecallTlr(
     RequestAndRelatedRecords records) {
+
     Request request = records.getRequest();
     if (errorHandler.hasAny(INVALID_INSTANCE_ID)) {
       return ofAsync(() -> request);

--- a/src/test/java/api/requests/RequestsAPIUpdatingTests.java
+++ b/src/test/java/api/requests/RequestsAPIUpdatingTests.java
@@ -918,13 +918,13 @@ class RequestsAPIUpdatingTests extends APITests {
     assertThat(expectedQueue, hasJsonPath("requests[0].item.barcode", itemA.getBarcode()));
 
     // 2. The patron that has itemA on loan SHOULD NOT be able to renew their loan as it's recalled
-    Response itemARenewalResponse = loansFixture.attemptRenewal(422, itemA, patron1);
+    Response itemARenewalResponse = loansFixture.attemptRenewal(itemA, patron1);
     assertThat(itemARenewalResponse.getJson(), hasJsonPath("errors[0].message",
       "items cannot be renewed when there is an active recall request"));
     assertThat(itemARenewalResponse.getJson().getJsonArray("errors").size(), is(1));
 
     // 3. The patron that has Item B on loan SHOULD be able to renew their loan
-    Response itemBRenewalResponse = loansFixture.attemptRenewal(200, itemB, patron2);
+    var itemBRenewalResponse = loansFixture.renewLoan(itemB, patron2);
     JsonObject itemBRenewalResponseJson = itemBRenewalResponse.getJson();
     assertThat(itemBRenewalResponseJson.getString("action"), is("renewed"));
     assertThat(itemBRenewalResponseJson.getString("userId"), is(patron2.getId().toString()));

--- a/src/test/java/api/support/fixtures/UserExamples.java
+++ b/src/test/java/api/support/fixtures/UserExamples.java
@@ -52,4 +52,25 @@ public class UserExamples {
       .withBarcode("6430777932")
       .withActive(true);
   }
+
+  static UserBuilder basedUponAlanTuring() {
+    return new UserBuilder()
+      .withName("Alan", "Turing")
+      .withBarcode("7677535617")
+      .withActive(true);
+  }
+
+  static UserBuilder basedUponBenAffleck() {
+    return new UserBuilder()
+      .withName("Ben", "Affleck")
+      .withBarcode("7671175356")
+      .withActive(true);
+  }
+
+  static UserBuilder basedUponTomHanks() {
+    return new UserBuilder()
+      .withName("Tom", "Hanks")
+      .withBarcode("7671375356")
+      .withActive(true);
+  }
 }

--- a/src/test/java/api/support/fixtures/UserExamples.java
+++ b/src/test/java/api/support/fixtures/UserExamples.java
@@ -52,25 +52,4 @@ public class UserExamples {
       .withBarcode("6430777932")
       .withActive(true);
   }
-
-  static UserBuilder basedUponAlanTuring() {
-    return new UserBuilder()
-      .withName("Alan", "Turing")
-      .withBarcode("7677535617")
-      .withActive(true);
-  }
-
-  static UserBuilder basedUponBenAffleck() {
-    return new UserBuilder()
-      .withName("Ben", "Affleck")
-      .withBarcode("7671175356")
-      .withActive(true);
-  }
-
-  static UserBuilder basedUponTomHanks() {
-    return new UserBuilder()
-      .withName("Tom", "Hanks")
-      .withBarcode("7671375356")
-      .withActive(true);
-  }
 }

--- a/src/test/java/api/support/fixtures/UsersFixture.java
+++ b/src/test/java/api/support/fixtures/UsersFixture.java
@@ -80,21 +80,6 @@ public class UsersFixture {
       .inGroupFor(patronGroupsFixture.regular()));
   }
 
-  public UserResource alan() {
-    return createIfAbsent(basedUponAlanTuring()
-      .inGroupFor(patronGroupsFixture.regular()));
-  }
-
-  public UserResource ben() {
-    return createIfAbsent(basedUponBenAffleck()
-      .inGroupFor(patronGroupsFixture.regular()));
-  }
-
-  public UserResource tom() {
-    return createIfAbsent(basedUponTomHanks()
-      .inGroupFor(patronGroupsFixture.regular()));
-  }
-
   public UserResource undergradHenry() {
     return undergradHenry(identity());
   }

--- a/src/test/java/api/support/fixtures/UsersFixture.java
+++ b/src/test/java/api/support/fixtures/UsersFixture.java
@@ -1,7 +1,5 @@
 package api.support.fixtures;
 
-import static api.support.fixtures.UserExamples.basedUponAlanTuring;
-import static api.support.fixtures.UserExamples.basedUponBenAffleck;
 import static api.support.fixtures.UserExamples.basedUponBobbyBibbin;
 import static api.support.fixtures.UserExamples.basedUponCharlotteBroadwell;
 import static api.support.fixtures.UserExamples.basedUponHenryHanks;
@@ -9,16 +7,14 @@ import static api.support.fixtures.UserExamples.basedUponJamesRodwell;
 import static api.support.fixtures.UserExamples.basedUponJessicaPontefract;
 import static api.support.fixtures.UserExamples.basedUponRebeccaStuart;
 import static api.support.fixtures.UserExamples.basedUponStevenJones;
-import static api.support.fixtures.UserExamples.basedUponTomHanks;
 import static java.util.function.Function.identity;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 
 import java.util.function.Function;
 
-import api.support.http.IndividualResource;
-
 import api.support.APITestContext;
 import api.support.builders.UserBuilder;
+import api.support.http.IndividualResource;
 import api.support.http.ResourceClient;
 import api.support.http.UserResource;
 

--- a/src/test/java/api/support/fixtures/UsersFixture.java
+++ b/src/test/java/api/support/fixtures/UsersFixture.java
@@ -1,5 +1,7 @@
 package api.support.fixtures;
 
+import static api.support.fixtures.UserExamples.basedUponAlanTuring;
+import static api.support.fixtures.UserExamples.basedUponBenAffleck;
 import static api.support.fixtures.UserExamples.basedUponBobbyBibbin;
 import static api.support.fixtures.UserExamples.basedUponCharlotteBroadwell;
 import static api.support.fixtures.UserExamples.basedUponHenryHanks;
@@ -7,6 +9,7 @@ import static api.support.fixtures.UserExamples.basedUponJamesRodwell;
 import static api.support.fixtures.UserExamples.basedUponJessicaPontefract;
 import static api.support.fixtures.UserExamples.basedUponRebeccaStuart;
 import static api.support.fixtures.UserExamples.basedUponStevenJones;
+import static api.support.fixtures.UserExamples.basedUponTomHanks;
 import static java.util.function.Function.identity;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 
@@ -74,6 +77,21 @@ public class UsersFixture {
 
   public UserResource henry() {
     return createIfAbsent(basedUponHenryHanks()
+      .inGroupFor(patronGroupsFixture.regular()));
+  }
+
+  public UserResource alan() {
+    return createIfAbsent(basedUponAlanTuring()
+      .inGroupFor(patronGroupsFixture.regular()));
+  }
+
+  public UserResource ben() {
+    return createIfAbsent(basedUponBenAffleck()
+      .inGroupFor(patronGroupsFixture.regular()));
+  }
+
+  public UserResource tom() {
+    return createIfAbsent(basedUponTomHanks()
       .inGroupFor(patronGroupsFixture.regular()));
   }
 


### PR DESCRIPTION
Resolves [CIRC-1760](https://issues.folio.org/browse/CIRC-1760)

## Purpose
The strategy for fetching item and loan was the same for TLR recall creation and replacement.

## Approach
Use default strategy for TLR recall replacement (which fixes the bug) but keep the same behavior for TLR recall creation (closest-due-date, least-recalled etc.)
