### PR TITLE
CIRC-1738: Add required 'feefineactions.collection.get' permission to 'circulation.renew-loan' permission set

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1511,6 +1511,7 @@
         "patron-notice.post",
         "feefines.collection.get",
         "feefines.item.post",
+        "feefineactions.collection.get",
         "feefineactions.item.post",
         "owners.collection.get",
         "accounts.item.post",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1513,6 +1513,7 @@
         "feefines.item.post",
         "feefineactions.collection.get",
         "feefineactions.item.post",
+        "feefineactions.item.get",
         "owners.collection.get",
         "accounts.item.post",
         "accounts.cancel.post",


### PR DESCRIPTION
Resolves: [CIRC-1738](https://issues.folio.org/browse/CIRC-1738) Permission should allow for renewal of Aged to Lost items, but generates error message

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
