### PR TITLE
CIRC-1767 Add additionalInfo token to the fee/fine notice context

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Account.java
+++ b/src/main/java/org/folio/circulation/domain/Account.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain;
 
+import static java.lang.String.format;
 import static org.folio.circulation.domain.FeeAmount.noFeeAmount;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedDateTimeProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
@@ -197,4 +198,9 @@ public class Account {
     return compareToMillis(left.getDateAction(), right.getDateAction());
   }
 
+  @Override
+  public String toString() {
+    return format("Account(id=%s, feeFineType=%s, amount=%s)", id, getFeeFineType(),
+      amount.toScaledString());
+  }
 }

--- a/src/main/java/org/folio/circulation/domain/FeeFineAction.java
+++ b/src/main/java/org/folio/circulation/domain/FeeFineAction.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain;
 
+import static java.lang.String.format;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTimeProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 
@@ -69,5 +70,11 @@ public class FeeFineAction {
 
   public String getPaymentMethod() {
     return representation.getString("paymentMethod");
+  }
+
+  @Override
+  public String toString() {
+    return format("FeeFineAction(id=%s, accountId=%s, typeAction=%s, amount=%s)", getId(),
+      getAccountId(), getActionType(), getAmount().toScaledString());
   }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -303,8 +303,6 @@ public class TemplateContextUtil {
 
     if (chargeAction != null) {
       write(context, "additionalInfo", getPatronInfoFromComment(chargeAction));
-    } else {
-      write(context, "additionalInfo", "None");
     }
 
     return context;

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -4,6 +4,7 @@ import static java.lang.Math.max;
 import static java.util.stream.Collectors.joining;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTime;
+import static org.folio.circulation.support.utils.FeeFineActionHelper.getPatronInfoFromComment;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -275,19 +276,21 @@ public class TemplateContextUtil {
     return loanContext;
   }
 
-  public static JsonObject createFeeFineNoticeContext(Account account, Loan loan) {
-    return createLoanNoticeContext(loan)
-      .put(FEE_CHARGE, createFeeChargeContext(account));
-  }
-
   public static JsonObject createFeeFineNoticeContext(Account account, Loan loan,
     FeeFineAction feeFineAction) {
 
-    return createFeeFineNoticeContext(account, loan)
+    return createLoanNoticeContext(loan)
+      .put(FEE_CHARGE, createFeeChargeContext(account, feeFineAction));
+  }
+
+  public static JsonObject createFeeFineChargeAndActionNoticeContext(Account account, Loan loan,
+    FeeFineAction feeFineAction) {
+
+    return createFeeFineNoticeContext(account, loan, feeFineAction)
       .put(FEE_ACTION, createFeeActionContext(feeFineAction));
   }
 
-  private static JsonObject createFeeChargeContext(Account account) {
+  private static JsonObject createFeeChargeContext(Account account, FeeFineAction feeFineAction) {
     JsonObject context = new JsonObject();
 
     write(context, "owner", account.getFeeFineOwner());
@@ -297,6 +300,8 @@ public class TemplateContextUtil {
     write(context, "remainingAmount", account.getRemaining().toScaledString());
     write(context, "chargeDate", account.getCreationDate());
     write(context, "chargeDateTime", account.getCreationDate());
+
+    write(context, "additionalInfo", getPatronInfoFromComment(feeFineAction));
 
     return context;
   }

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -284,13 +284,13 @@ public class TemplateContextUtil {
   }
 
   public static JsonObject createFeeFineChargeAndActionNoticeContext(Account account, Loan loan,
-    FeeFineAction feeFineAction) {
+    FeeFineAction currentAction, FeeFineAction chargeAction) {
 
-    return createFeeFineChargeNoticeContext(account, loan, feeFineAction)
-      .put(FEE_ACTION, createFeeActionContext(feeFineAction));
+    return createFeeFineChargeNoticeContext(account, loan, chargeAction)
+      .put(FEE_ACTION, createFeeActionContext(currentAction));
   }
 
-  private static JsonObject createFeeChargeContext(Account account, FeeFineAction feeFineAction) {
+  private static JsonObject createFeeChargeContext(Account account, FeeFineAction chargeAction) {
     JsonObject context = new JsonObject();
 
     write(context, "owner", account.getFeeFineOwner());
@@ -301,8 +301,8 @@ public class TemplateContextUtil {
     write(context, "chargeDate", account.getCreationDate());
     write(context, "chargeDateTime", account.getCreationDate());
 
-    if (feeFineAction != null) {
-      write(context, "additionalInfo", getPatronInfoFromComment(feeFineAction));
+    if (chargeAction != null) {
+      write(context, "additionalInfo", getPatronInfoFromComment(chargeAction));
     }
 
     return context;

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -294,7 +294,7 @@ public class TemplateContextUtil {
   }
 
   private static JsonObject createFeeChargeContext(Account account, FeeFineAction chargeAction) {
-    log.debug("createFeeChargeContext:: params account{}, chargeAction={}", account, chargeAction);
+    log.debug("createFeeChargeContext:: params account={}, chargeAction={}", account, chargeAction);
 
     JsonObject context = new JsonObject();
     write(context, "owner", account.getFeeFineOwner());

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -27,7 +27,6 @@ import org.folio.circulation.domain.ServicePoint;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.policy.LoanPolicy;
 import org.folio.circulation.support.utils.ClockUtil;
-import org.folio.rest.tools.utils.LogUtil;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -277,10 +277,10 @@ public class TemplateContextUtil {
   }
 
   public static JsonObject createFeeFineChargeNoticeContext(Account account, Loan loan,
-    FeeFineAction feeFineAction) {
+    FeeFineAction chargeAction) {
 
     return createLoanNoticeContext(loan)
-      .put(FEE_CHARGE, createFeeChargeContext(account, feeFineAction));
+      .put(FEE_CHARGE, createFeeChargeContext(account, chargeAction));
   }
 
   public static JsonObject createFeeFineChargeAndActionNoticeContext(Account account, Loan loan,
@@ -303,6 +303,8 @@ public class TemplateContextUtil {
 
     if (chargeAction != null) {
       write(context, "additionalInfo", getPatronInfoFromComment(chargeAction));
+    } else {
+      write(context, "additionalInfo", "None");
     }
 
     return context;

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -276,7 +276,7 @@ public class TemplateContextUtil {
     return loanContext;
   }
 
-  public static JsonObject createFeeFineNoticeContext(Account account, Loan loan,
+  public static JsonObject createFeeFineChargeNoticeContext(Account account, Loan loan,
     FeeFineAction feeFineAction) {
 
     return createLoanNoticeContext(loan)
@@ -286,7 +286,7 @@ public class TemplateContextUtil {
   public static JsonObject createFeeFineChargeAndActionNoticeContext(Account account, Loan loan,
     FeeFineAction feeFineAction) {
 
-    return createFeeFineNoticeContext(account, loan, feeFineAction)
+    return createFeeFineChargeNoticeContext(account, loan, feeFineAction)
       .put(FEE_ACTION, createFeeActionContext(feeFineAction));
   }
 
@@ -301,7 +301,9 @@ public class TemplateContextUtil {
     write(context, "chargeDate", account.getCreationDate());
     write(context, "chargeDateTime", account.getCreationDate());
 
-    write(context, "additionalInfo", getPatronInfoFromComment(feeFineAction));
+    if (feeFineAction != null) {
+      write(context, "additionalInfo", getPatronInfoFromComment(feeFineAction));
+    }
 
     return context;
   }

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -6,11 +6,14 @@ import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTime;
 import static org.folio.circulation.support.utils.FeeFineActionHelper.getPatronInfoFromComment;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
 
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Account;
 import org.folio.circulation.domain.CallNumberComponents;
 import org.folio.circulation.domain.CheckInContext;
@@ -24,12 +27,14 @@ import org.folio.circulation.domain.ServicePoint;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.policy.LoanPolicy;
 import org.folio.circulation.support.utils.ClockUtil;
+import org.folio.rest.tools.utils.LogUtil;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class TemplateContextUtil {
 
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private static final String USER = "user";
   private static final String ITEM = "item";
   private static final String REQUEST = "request";
@@ -38,7 +43,6 @@ public class TemplateContextUtil {
   private static final String LOANS = "loans";
   private static final String FEE_CHARGE = "feeCharge";
   private static final String FEE_ACTION = "feeAction";
-
   private static final String UNLIMITED = "unlimited";
 
   private TemplateContextUtil() {
@@ -291,8 +295,9 @@ public class TemplateContextUtil {
   }
 
   private static JsonObject createFeeChargeContext(Account account, FeeFineAction chargeAction) {
-    JsonObject context = new JsonObject();
+    log.debug("createFeeChargeContext:: params account{}, chargeAction={}", account, chargeAction);
 
+    JsonObject context = new JsonObject();
     write(context, "owner", account.getFeeFineOwner());
     write(context, "type", account.getFeeFineType());
     write(context, "paymentStatus", account.getPaymentStatus());
@@ -302,6 +307,8 @@ public class TemplateContextUtil {
     write(context, "chargeDateTime", account.getCreationDate());
 
     if (chargeAction != null) {
+      log.info("createFeeChargeContext:: adding charge action info. account={}, chargeAction={}",
+        account, chargeAction);
       write(context, "additionalInfo", getPatronInfoFromComment(chargeAction));
     }
 

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
@@ -7,9 +7,12 @@ import static org.folio.circulation.support.results.ResultBinding.mapResult;
 import static org.folio.circulation.support.utils.ClockUtil.getZonedDateTime;
 import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
 
+import java.lang.invoke.MethodHandles;
 import java.time.ZonedDateTime;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.notice.TemplateContextUtil;
 import org.folio.circulation.domain.policy.Period;
@@ -24,6 +27,7 @@ import org.folio.circulation.support.results.Result;
 import io.vertx.core.json.JsonObject;
 
 public class FeeFineScheduledNoticeHandler extends ScheduledNoticeHandler {
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private final FeeFineActionRepository actionRepository;
   private final LoanPolicyRepository loanPolicyRepository;
 
@@ -61,6 +65,8 @@ public class FeeFineScheduledNoticeHandler extends ScheduledNoticeHandler {
 
   private CompletableFuture<Result<ScheduledNoticeContext>> fetchChargeAction(
     ScheduledNoticeContext context) {
+
+    log.info("fetchChargeAction:: context");
 
     return actionRepository.findChargeActionForAccount(context.getAccount())
       .thenApply(mapResult(context::withChargeAction));

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
@@ -27,7 +27,6 @@ import org.folio.circulation.support.results.Result;
 import io.vertx.core.json.JsonObject;
 
 public class FeeFineScheduledNoticeHandler extends ScheduledNoticeHandler {
-  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private final FeeFineActionRepository actionRepository;
   private final LoanPolicyRepository loanPolicyRepository;
 

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
@@ -11,6 +11,7 @@ import java.time.ZonedDateTime;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.notice.TemplateContextUtil;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
@@ -105,8 +106,9 @@ public class FeeFineScheduledNoticeHandler extends ScheduledNoticeHandler {
   @Override
   protected JsonObject buildNoticeContextJson(ScheduledNoticeContext context) {
     return context.getNotice().getTriggeringEvent().isAutomaticFeeFineAdjustment()
-      ? createFeeFineNoticeContext(context.getAccount(), context.getLoan(), context.getAction())
-      : createFeeFineNoticeContext(context.getAccount(), context.getLoan());
+      ? TemplateContextUtil.createFeeFineChargeAndActionNoticeContext(context.getAccount(),
+      context.getLoan(), context.getAction())
+      : createFeeFineNoticeContext(context.getAccount(), context.getLoan(), context.getAction());
   }
 
   private static ScheduledNotice getNextRecurringNotice(ScheduledNotice notice) {

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
@@ -1,20 +1,17 @@
 package org.folio.circulation.domain.notice.schedule;
 
 import static java.util.Collections.singletonList;
+import static org.folio.circulation.domain.notice.TemplateContextUtil.createFeeFineChargeAndActionNoticeContext;
 import static org.folio.circulation.domain.notice.TemplateContextUtil.createFeeFineChargeNoticeContext;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.ResultBinding.mapResult;
 import static org.folio.circulation.support.utils.ClockUtil.getZonedDateTime;
 import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
 
-import java.lang.invoke.MethodHandles;
 import java.time.ZonedDateTime;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Loan;
-import org.folio.circulation.domain.notice.TemplateContextUtil;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
@@ -117,7 +114,7 @@ public class FeeFineScheduledNoticeHandler extends ScheduledNoticeHandler {
   @Override
   protected JsonObject buildNoticeContextJson(ScheduledNoticeContext context) {
     return context.getNotice().getTriggeringEvent().isAutomaticFeeFineAdjustment()
-      ? TemplateContextUtil.createFeeFineChargeAndActionNoticeContext(context.getAccount(),
+      ? createFeeFineChargeAndActionNoticeContext(context.getAccount(),
       context.getLoan(), context.getCurrentAction(), context.getChargeAction())
       : createFeeFineChargeNoticeContext(context.getAccount(), context.getLoan(),
       context.getChargeAction());

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
@@ -1,7 +1,7 @@
 package org.folio.circulation.domain.notice.schedule;
 
 import static java.util.Collections.singletonList;
-import static org.folio.circulation.domain.notice.TemplateContextUtil.createFeeFineNoticeContext;
+import static org.folio.circulation.domain.notice.TemplateContextUtil.createFeeFineChargeNoticeContext;
 import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.folio.circulation.support.results.ResultBinding.mapResult;
 import static org.folio.circulation.support.utils.ClockUtil.getZonedDateTime;
@@ -108,7 +108,7 @@ public class FeeFineScheduledNoticeHandler extends ScheduledNoticeHandler {
     return context.getNotice().getTriggeringEvent().isAutomaticFeeFineAdjustment()
       ? TemplateContextUtil.createFeeFineChargeAndActionNoticeContext(context.getAccount(),
       context.getLoan(), context.getAction())
-      : createFeeFineNoticeContext(context.getAccount(), context.getLoan(), context.getAction());
+      : createFeeFineChargeNoticeContext(context.getAccount(), context.getLoan(), context.getAction());
   }
 
   private static ScheduledNotice getNextRecurringNotice(ScheduledNotice notice) {

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/FeeFineScheduledNoticeHandler.java
@@ -66,8 +66,6 @@ public class FeeFineScheduledNoticeHandler extends ScheduledNoticeHandler {
   private CompletableFuture<Result<ScheduledNoticeContext>> fetchChargeAction(
     ScheduledNoticeContext context) {
 
-    log.info("fetchChargeAction:: context");
-
     return actionRepository.findChargeActionForAccount(context.getAccount())
       .thenApply(mapResult(context::withChargeAction));
   }

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeContext.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeContext.java
@@ -19,7 +19,8 @@ import lombok.With;
 public class ScheduledNoticeContext {
   private final ScheduledNotice notice;
   private Account account;
-  private FeeFineAction action;
+  private FeeFineAction currentAction;
+  private FeeFineAction chargeAction;
   private Loan loan;
   private Request request;
   private String patronNoticePolicyId;

--- a/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
@@ -74,12 +74,7 @@ public class FeeFineActionRepository {
     return new CqlQueryFinder<>(feeFineActionsStorageClient, "feefineactions", identity())
       .findByQuery(query, PageLimit.one())
       .thenApply(mapResult(records -> records.mapRecords(FeeFineAction::from)))
-      .thenApply(mapResult(MultipleRecords::getRecords))
-      .thenApply(mapResult(records -> {
-        log.info("findChargeActionForAccount:: found {} fee/fine actions for account {}",
-          records.size(), account);
-        return records.stream().findFirst().orElse(null);
-      }));
+      .thenApply(mapResult(MultipleRecords::firstOrNull));
   }
 
   public CompletableFuture<Result<Void>> createAll(

--- a/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
@@ -71,7 +71,7 @@ public class FeeFineActionRepository {
     Result<CqlQuery> query = CqlQuery.exactMatch("accountId", account.getId())
       .combine(exactMatch("typeAction", account.getFeeFineType()), CqlQuery::and);
 
-    return new CqlQueryFinder<>(feeFineActionsStorageClient, "feeFineAction", identity())
+    return new CqlQueryFinder<>(feeFineActionsStorageClient, "feefineactions", identity())
       .findByQuery(query, PageLimit.one())
       .thenApply(mapResult(records -> records.mapRecords(FeeFineAction::from)))
       .thenApply(mapResult(MultipleRecords::getRecords))

--- a/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
@@ -65,7 +65,7 @@ public class FeeFineActionRepository {
       return ofAsync(() -> null);
     }
 
-    Result<CqlQuery> query = CqlQuery.exactMatch("expirationDate", account.getId())
+    Result<CqlQuery> query = CqlQuery.exactMatch("accountId", account.getId())
       .combine(exactMatch("typeAction", account.getFeeFineType()), CqlQuery::and);
 
     return new CqlQueryFinder<>(feeFineActionsStorageClient, "feeFineAction", identity())

--- a/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
@@ -2,23 +2,34 @@ package org.folio.circulation.infrastructure.storage.feesandfines;
 
 import static java.util.Objects.isNull;
 import static java.util.concurrent.CompletableFuture.allOf;
+import static java.util.function.Function.identity;
 import static org.folio.circulation.support.http.ResponseMapping.forwardOnFailure;
 import static org.folio.circulation.support.http.ResponseMapping.mapUsingJson;
+import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.ofAsync;
+import static org.folio.circulation.support.results.ResultBinding.mapResult;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
+import org.folio.circulation.domain.Account;
 import org.folio.circulation.domain.FeeFineAction;
+import org.folio.circulation.domain.MultipleRecords;
+import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.representations.StoredFeeFineAction;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FetchSingleRecord;
 import org.folio.circulation.support.RecordNotFoundFailure;
+import org.folio.circulation.support.fetching.CqlIndexValuesFinder;
+import org.folio.circulation.support.fetching.CqlQueryFinder;
+import org.folio.circulation.support.http.client.CqlQuery;
+import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.client.ResponseInterpreter;
 import org.folio.circulation.support.results.CommonFailures;
 import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.ClockUtil;
 
 public class FeeFineActionRepository {
   private final CollectionResourceClient feeFineActionsStorageClient;
@@ -47,6 +58,21 @@ public class FeeFineActionRepository {
       .mapTo(FeeFineAction::from)
       .whenNotFound(failed(new RecordNotFoundFailure("feeFineAction", id)))
       .fetch(id);
+  }
+
+  public CompletableFuture<Result<FeeFineAction>> findChargeActionForAccount(Account account) {
+    if (isNull(account)) {
+      return ofAsync(() -> null);
+    }
+
+    Result<CqlQuery> query = CqlQuery.lessThan("expirationDate", account.getId())
+      .combine(exactMatch("typeAction", account.getFeeFineType()), CqlQuery::and);
+
+    return new CqlQueryFinder<>(feeFineActionsStorageClient, "feeFineAction", identity())
+      .findByQuery(query, PageLimit.one())
+      .thenApply(mapResult(records -> records.mapRecords(FeeFineAction::from)))
+      .thenApply(mapResult(MultipleRecords::getRecords))
+      .thenApply(mapResult(c -> c.stream().findFirst().orElse(null)));
   }
 
   public CompletableFuture<Result<Void>> createAll(

--- a/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
@@ -65,7 +65,7 @@ public class FeeFineActionRepository {
       return ofAsync(() -> null);
     }
 
-    Result<CqlQuery> query = CqlQuery.lessThan("expirationDate", account.getId())
+    Result<CqlQuery> query = CqlQuery.exactMatch("expirationDate", account.getId())
       .combine(exactMatch("typeAction", account.getFeeFineType()), CqlQuery::and);
 
     return new CqlQueryFinder<>(feeFineActionsStorageClient, "feeFineAction", identity())

--- a/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
@@ -62,11 +62,11 @@ public class FeeFineActionRepository {
   }
 
   public CompletableFuture<Result<FeeFineAction>> findChargeActionForAccount(Account account) {
+    log.debug("findChargeActionForAccount:: params account={}", account);
+
     if (isNull(account)) {
       return ofAsync(() -> null);
     }
-
-    log.info("findChargeActionForAccount:: account={}", account.toJson().encodePrettily());
 
     Result<CqlQuery> query = CqlQuery.exactMatch("accountId", account.getId())
       .combine(exactMatch("typeAction", account.getFeeFineType()), CqlQuery::and);
@@ -76,7 +76,8 @@ public class FeeFineActionRepository {
       .thenApply(mapResult(records -> records.mapRecords(FeeFineAction::from)))
       .thenApply(mapResult(MultipleRecords::getRecords))
       .thenApply(mapResult(records -> {
-        log.info("findChargeActionForAccount:: records_number={}", records.size());
+        log.info("findChargeActionForAccount:: found {} fee/fine actions for account {}",
+          records.size(), account);
         return records.stream().findFirst().orElse(null);
       }));
   }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/feesandfines/FeeFineActionRepository.java
@@ -72,7 +72,7 @@ public class FeeFineActionRepository {
       .findByQuery(query, PageLimit.one())
       .thenApply(mapResult(records -> records.mapRecords(FeeFineAction::from)))
       .thenApply(mapResult(MultipleRecords::getRecords))
-      .thenApply(mapResult(c -> c.stream().findFirst().orElse(null)));
+      .thenApply(mapResult(records -> records.stream().findFirst().orElse(null)));
   }
 
   public CompletableFuture<Result<Void>> createAll(

--- a/src/main/java/org/folio/circulation/support/utils/FeeFineActionHelper.java
+++ b/src/main/java/org/folio/circulation/support/utils/FeeFineActionHelper.java
@@ -1,0 +1,37 @@
+package org.folio.circulation.support.utils;
+
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.circulation.domain.FeeFineAction;
+
+public class FeeFineActionHelper {
+  public static final String PATRON_COMMENTS_KEY = "PATRON";
+  public static final String STAFF_COMMENTS_KEY = "STAFF";
+  private static final String COMMENT_KEY_VALUE_SEPARATOR = " : ";
+  private static final String COMMENTS_SEPARATOR = " \n ";
+
+  private FeeFineActionHelper() {
+    throw new UnsupportedOperationException("Do not instantiate");
+  }
+
+  public static String getStaffInfoFromComment(FeeFineAction action) {
+    return defaultString(parseFeeFineComments(action.getComments()).get(STAFF_COMMENTS_KEY));
+  }
+
+  public static String getPatronInfoFromComment(FeeFineAction action) {
+    return defaultString(parseFeeFineComments(action.getComments()).get(PATRON_COMMENTS_KEY));
+  }
+
+  private static Map<String, String> parseFeeFineComments(String comments) {
+    return Arrays.stream(defaultString(comments).split(COMMENTS_SEPARATOR))
+      .map(s -> s.split(COMMENT_KEY_VALUE_SEPARATOR))
+      .filter(arr -> arr.length == 2)
+      .map(strings -> Pair.of(strings[0], strings[1]))
+      .collect(Collectors.toMap(Pair::getKey, Pair::getValue, (s, s2) -> s));
+  }
+}

--- a/src/test/java/api/handlers/CloseLostLoanWhenLostItemFeesAreClosed.java
+++ b/src/test/java/api/handlers/CloseLostLoanWhenLostItemFeesAreClosed.java
@@ -88,7 +88,7 @@ public class CloseLostLoanWhenLostItemFeesAreClosed extends APITests {
       .withPaymentStatus("Outstanding"));
 
     feeFineActionsClient.create(new FeefineActionsBuilder()
-      .forAccount(account.getId())
+      .withAccountId(account.getId())
       .withBalance(amount)
       .withActionAmount(amount)
       .withActionType("Lost item fee (actual cost)"));

--- a/src/test/java/api/loans/anonymization/LoanAnonymizationTests.java
+++ b/src/test/java/api/loans/anonymization/LoanAnonymizationTests.java
@@ -66,9 +66,9 @@ abstract public class LoanAnonymizationTests extends APITests {
       .withRemainingFeeFine(150));
 
     FeefineActionsBuilder builder = new FeefineActionsBuilder()
-      .forAccount(account.getId())
-      .withBalance(150)
-      .withDate(null);
+      .withAccountId(account.getId())
+      .withBalance(150.0)
+      .withDateAction(null);
 
     feeFineActionsClient.create(builder);
   }
@@ -82,14 +82,14 @@ abstract public class LoanAnonymizationTests extends APITests {
       .withRemainingFeeFine(0));
 
     FeefineActionsBuilder builder = new FeefineActionsBuilder()
-      .forAccount(account.getId())
-      .withBalance(0)
-      .withDate(closedDate);
+      .withAccountId(account.getId())
+      .withBalance(0.0)
+      .withDateAction(closedDate);
 
     FeefineActionsBuilder builder1 = new FeefineActionsBuilder()
-      .forAccount(account.getId())
-      .withBalance(0)
-      .withDate(closedDate.minusDays(1));
+      .withAccountId(account.getId())
+      .withBalance(0.0)
+      .withDateAction(closedDate.minusDays(1));
 
     feeFineActionsClient.create(builder);
     feeFineActionsClient.create(builder1);

--- a/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
@@ -186,14 +186,8 @@ class CheckInDeclaredLostItemTest extends RefundDeclaredLostFeesTestBase {
     assertThat(actualCostRecordsClient.getAll(), hasSize(1));
     String recordId = actualCostRecordsClient.getAll().get(0).getString("id");
     runWithTimeOffset(() -> createLostItemFeeActualCostAccount(itemFeeActualCost,
-      UUID.fromString(recordId)), ofMinutes(2));
+      UUID.fromString(recordId), "AC info for staff", "AC info for patron"), ofMinutes(2));
     assertThat(accountsClient.getAll(), hasSize(2));
-
-    var chargeAction = feeFineActionsClient.getAll().stream()
-      .filter(a -> a.getString("typeAction").equals("Lost item fee (actual cost)"))
-      .findFirst()
-      .orElseThrow();
-    var additionalInfoForPatron = chargeAction.getString("comments").split("PATRON : ")[1];
 
     checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
       .forItem(item)
@@ -206,6 +200,6 @@ class CheckInDeclaredLostItemTest extends RefundDeclaredLostFeesTestBase {
     verifyNumberOfSentNotices(2);
     assertThat(FakeModNotify.getSentPatronNotices(), hasItems(
       hasEmailNoticeProperties(user.getId(), templateId, getFeeChargeAdditionalInfoContextMatcher(
-        additionalInfoForPatron))));
+        "AC info for patron"))));
   }
 }

--- a/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
@@ -1,22 +1,28 @@
 package api.loans.scenarios;
 
 import static api.support.PubsubPublisherTestUtils.assertThatPublishedLoanLogRecordEventsAreValid;
+import static api.support.fixtures.TemplateContextMatchers.getFeeChargeAdditionalInfoContextMatcher;
 import static api.support.matchers.AccountMatchers.isOpen;
 import static api.support.matchers.ItemMatchers.isAvailable;
 import static api.support.matchers.LoanAccountMatcher.hasLostItemFee;
 import static api.support.matchers.LoanAccountMatcher.hasLostItemFeeActualCost;
 import static api.support.matchers.LoanAccountMatcher.hasLostItemProcessingFee;
+import static api.support.matchers.PatronNoticeMatcher.hasEmailNoticeProperties;
 import static api.support.matchers.ValidationErrorMatchers.hasErrorWith;
 import static api.support.matchers.ValidationErrorMatchers.hasMessage;
 import static api.support.matchers.ValidationErrorMatchers.hasParameter;
+import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfScheduledNotices;
+import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfSentNotices;
 import static java.time.Duration.ofMinutes;
 import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import org.folio.circulation.support.http.client.Response;
@@ -25,6 +31,10 @@ import org.junit.jupiter.api.Test;
 
 import api.support.builders.CheckInByBarcodeRequestBuilder;
 import api.support.builders.DeclareItemLostRequestBuilder;
+import api.support.builders.NoticeConfigurationBuilder;
+import api.support.builders.NoticePolicyBuilder;
+import api.support.fakes.FakeModNotify;
+import api.support.fixtures.policies.PoliciesToActivate;
 import api.support.http.IndividualResource;
 import api.support.http.UserResource;
 import io.vertx.core.json.JsonObject;
@@ -148,11 +158,25 @@ class CheckInDeclaredLostItemTest extends RefundDeclaredLostFeesTestBase {
     final UUID servicePointId = servicePointsFixture.cd1().getId();
     UserResource user = usersFixture.charlotte();
     feeFineOwnerFixture.ownerForServicePoint(servicePointId);
-    useLostItemPolicy(lostItemFeePoliciesFixture.create(
-      lostItemFeePoliciesFixture.facultyStandardPolicy()
-        .withName("Lost item fee actual cost policy")
-        .chargeProcessingFeeWhenDeclaredLost(itemProcessingFee)
-        .withActualCost(itemFeeActualCost)).getId());
+
+    var templateId = UUID.randomUUID();
+    templateFixture.createDummyNoticeTemplate(templateId);
+
+    use(PoliciesToActivate.builder()
+      .lostItemPolicy(lostItemFeePoliciesFixture.create(
+        lostItemFeePoliciesFixture.facultyStandardPolicy()
+          .withName("Lost item fee actual cost policy")
+          .chargeProcessingFeeWhenDeclaredLost(itemProcessingFee)
+          .withActualCost(itemFeeActualCost)))
+      .noticePolicy(noticePoliciesFixture.create(
+        new NoticePolicyBuilder()
+          .withName("Patron notice policy with fee/fine notices")
+          .withFeeFineNotices(List.of(new NoticeConfigurationBuilder()
+            .withAgedToLostReturnedEvent()
+            .withTemplateId(templateId)
+            .withUponAtTiming()
+            .sendInRealTime(true)
+            .create())))));
 
     loan = checkOutFixture.checkOutByBarcode(item, user);
     declareLostFixtures.declareItemLost(new DeclareItemLostRequestBuilder()
@@ -165,10 +189,23 @@ class CheckInDeclaredLostItemTest extends RefundDeclaredLostFeesTestBase {
       UUID.fromString(recordId)), ofMinutes(2));
     assertThat(accountsClient.getAll(), hasSize(2));
 
+    var chargeAction = feeFineActionsClient.getAll().stream()
+      .filter(a -> a.getString("typeAction").equals("Lost item fee (actual cost)"))
+      .findFirst()
+      .orElseThrow();
+    var additionalInfoForPatron = chargeAction.getString("comments").split("PATRON : ")[1];
+
     checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
       .forItem(item)
       .at(servicePointsFixture.cd1()));
     assertThat(loan, hasLostItemFeeActualCost(isClosedCancelled(itemFeeActualCost)));
     assertThat(loan, hasLostItemProcessingFee(isClosedCancelled(itemProcessingFee)));
+
+    verifyNumberOfScheduledNotices(2);
+    scheduledNoticeProcessingClient.runFeeFineNoticesProcessing(ZonedDateTime.now().plusHours(1));
+    verifyNumberOfSentNotices(2);
+    assertThat(FakeModNotify.getSentPatronNotices(), hasItems(
+      hasEmailNoticeProperties(user.getId(), templateId, getFeeChargeAdditionalInfoContextMatcher(
+        additionalInfoForPatron))));
   }
 }

--- a/src/test/java/api/loans/scenarios/OverrideRenewAgedToLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/OverrideRenewAgedToLostItemTest.java
@@ -108,7 +108,7 @@ class OverrideRenewAgedToLostItemTest extends RefundAgedToLostFeesTestBase {
       .feeFineStatusOpen());
 
     feeFineActionsClient.create(new FeefineActionsBuilder()
-      .forAccount(account.getId())
+      .withAccountId(account.getId())
       .withBalance(amount)
       .withActionAmount(amount)
       .withActionType("Lost item fee (actual cost)"));

--- a/src/test/java/api/loans/scenarios/RefundDeclaredLostFeesTestBase.java
+++ b/src/test/java/api/loans/scenarios/RefundDeclaredLostFeesTestBase.java
@@ -462,10 +462,12 @@ public abstract class RefundDeclaredLostFeesTestBase extends SpringApiTest {
       .feeFineStatusOpen());
 
     feeFineActionsClient.create(new FeefineActionsBuilder()
-      .forAccount(account.getId())
+      .withAccountId(account.getId())
       .withBalance(amount)
       .withActionAmount(amount)
-      .withActionType("Lost item fee (actual cost)"));
+      .withActionType("Lost item fee (actual cost)")
+      .withComments("STAFF : info for staff \n PATRON : info for patron")
+    );
 
     JsonObject actualCostRecord = actualCostRecordsClient.getById(recordId).getJson();
     actualCostRecord.getJsonObject("feeFine").put("accountId", account.getId());

--- a/src/test/java/api/loans/scenarios/RefundDeclaredLostFeesTestBase.java
+++ b/src/test/java/api/loans/scenarios/RefundDeclaredLostFeesTestBase.java
@@ -12,6 +12,7 @@ import static api.support.matchers.LoanAccountMatcher.hasNoLostItemProcessingFee
 import static api.support.matchers.LoanAccountMatcher.hasNoOverdueFine;
 import static api.support.matchers.LoanAccountMatcher.hasOverdueFine;
 import static api.support.matchers.LoanMatchers.isClosed;
+import static java.lang.String.format;
 import static org.folio.circulation.domain.ActualCostRecord.Status.CANCELLED;
 import static org.folio.circulation.domain.ActualCostRecord.Status.OPEN;
 import static org.folio.circulation.support.utils.ClockUtil.getClock;
@@ -429,7 +430,7 @@ public abstract class RefundDeclaredLostFeesTestBase extends SpringApiTest {
   protected void useChargeableRefundableLostItemFee(double itemFee, double processingFee) {
     useLostItemPolicy(lostItemFeePoliciesFixture.create(
       lostItemFeePoliciesFixture.facultyStandardPolicy()
-        .withName(String.format("Test lost policy processing fee %s, item fee %s",
+        .withName(format("Test lost policy processing fee %s, item fee %s",
           itemFee, processingFee))
         .chargeProcessingFeeWhenDeclaredLost(processingFee)
         .withSetCost(itemFee)
@@ -439,7 +440,7 @@ public abstract class RefundDeclaredLostFeesTestBase extends SpringApiTest {
   protected void declareItemLostWithActualCost(double itemFee, double processingFee) {
     useLostItemPolicy(lostItemFeePoliciesFixture.create(lostItemFeePoliciesFixture
       .facultyStandardPolicy()
-      .withName(String.format("Test lost policy processing fee %s, item fee %s",
+      .withName(format("Test lost policy processing fee %s, item fee %s",
         processingFee, itemFee))
       .chargeProcessingFeeWhenDeclaredLost(processingFee)
       .withActualCost(itemFee).refundFeesWithinMinutes(1)).getId());
@@ -454,6 +455,13 @@ public abstract class RefundDeclaredLostFeesTestBase extends SpringApiTest {
   }
 
   protected void createLostItemFeeActualCostAccount(double amount, UUID recordId) {
+    createLostItemFeeActualCostAccount(amount, recordId, "default info for staff",
+      "default info for patron");
+  }
+
+  protected void createLostItemFeeActualCostAccount(double amount, UUID recordId,
+    String infoForStaff, String infoForPatron) {
+
     IndividualResource account = accountsClient.create(new AccountBuilder()
       .withLoan(loan)
       .withAmount(amount)
@@ -466,7 +474,7 @@ public abstract class RefundDeclaredLostFeesTestBase extends SpringApiTest {
       .withBalance(amount)
       .withActionAmount(amount)
       .withActionType("Lost item fee (actual cost)")
-      .withComments("STAFF : info for staff \n PATRON : info for patron")
+      .withComments(format("STAFF : %s \n PATRON : %s", infoForStaff, infoForPatron))
     );
 
     JsonObject actualCostRecord = actualCostRecordsClient.getById(recordId).getJson();

--- a/src/test/java/api/support/builders/FeefineActionsBuilder.java
+++ b/src/test/java/api/support/builders/FeefineActionsBuilder.java
@@ -9,7 +9,13 @@ import java.util.UUID;
 import org.folio.circulation.support.utils.ClockUtil;
 
 import io.vertx.core.json.JsonObject;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.With;
 
+@AllArgsConstructor
+@NoArgsConstructor
+@With
 public class FeefineActionsBuilder extends JsonBuilder implements Builder {
 
   private String id;
@@ -20,23 +26,7 @@ public class FeefineActionsBuilder extends JsonBuilder implements Builder {
   private String actionType;
   private String createdAt;
   private UUID accountId;
-
-  public FeefineActionsBuilder() {
-  }
-
-  public FeefineActionsBuilder(ZonedDateTime dateAction, Double balance,
-    UUID accountId, Double actionAmount, String paymentMethod, String actionType,
-    String createdAt) {
-
-    this.dateAction = dateAction;
-    this.balance = balance;
-    this.accountId = accountId;
-    this.id = UUID.randomUUID().toString();
-    this.actionAmount = actionAmount;
-    this.paymentMethod = paymentMethod;
-    this.actionType = actionType;
-    this.createdAt = createdAt;
-  }
+  private String comments;
 
   @Override
   public JsonObject create() {
@@ -51,42 +41,9 @@ public class FeefineActionsBuilder extends JsonBuilder implements Builder {
     write(object, "createdAt", createdAt);
     write(object, "source", "Admin, Admin");
     write(object, "accountId", accountId);
+    write(object, "comments", comments);
 
     return object;
   }
 
-  public FeefineActionsBuilder withDate(ZonedDateTime dateAction) {
-    return new FeefineActionsBuilder(dateAction, balance, accountId, actionAmount,
-      paymentMethod, actionType, createdAt);
-  }
-
-  public FeefineActionsBuilder withBalance(double remaining) {
-    return new FeefineActionsBuilder(dateAction, remaining, accountId, actionAmount,
-      paymentMethod, actionType, createdAt);
-  }
-
-  public FeefineActionsBuilder withActionAmount(double amountAction) {
-    return new FeefineActionsBuilder(dateAction, balance, accountId, amountAction,
-      paymentMethod, actionType, createdAt);
-  }
-
-  public FeefineActionsBuilder withPaymentMethod(String paymentMethod) {
-    return new FeefineActionsBuilder(dateAction, balance, accountId, actionAmount,
-      paymentMethod, actionType, createdAt);
-  }
-
-  public FeefineActionsBuilder withActionType(String actionType) {
-    return new FeefineActionsBuilder(dateAction, balance, accountId, actionAmount,
-      paymentMethod, actionType, createdAt);
-  }
-
-  public FeefineActionsBuilder forAccount(UUID accountId) {
-    return new FeefineActionsBuilder(dateAction, balance, accountId, actionAmount,
-      paymentMethod, actionType, createdAt);
-  }
-
-  public FeefineActionsBuilder createdAt(String createdAt) {
-    return new FeefineActionsBuilder(dateAction, balance, accountId, actionAmount,
-      paymentMethod, actionType, createdAt);
-  }
 }

--- a/src/test/java/api/support/fixtures/FeeFineAccountFixture.java
+++ b/src/test/java/api/support/fixtures/FeeFineAccountFixture.java
@@ -42,12 +42,12 @@ public final class FeeFineAccountFixture {
     final String accountStatus = remaining == 0 ? "Closed" : "Open";
 
     accountActionsClient.create(new FeefineActionsBuilder()
-      .forAccount(accountUuid)
+      .withAccountId(accountUuid)
       .withBalance(remaining)
       .withActionAmount(amount)
       .withPaymentMethod("Bursar")
       .withActionType(actionType)
-      .createdAt(UUID.randomUUID().toString()));
+      .withCreatedAt(UUID.randomUUID().toString()));
 
     accountsClient.replace(accountUuid, account.copy()
       .put("remaining", remaining)
@@ -107,12 +107,12 @@ public final class FeeFineAccountFixture {
     final String accountStatus = remaining == 0 ? "Closed" : "Open";
 
     accountActionsClient.create(new FeefineActionsBuilder()
-      .forAccount(accountUuid)
+      .withAccountId(accountUuid)
       .withBalance(remaining)
       .withActionAmount(amount)
       .withPaymentMethod("Cash")
       .withActionType(actionType)
-      .createdAt(UUID.randomUUID().toString()));
+      .withCreatedAt(UUID.randomUUID().toString()));
 
     accountsClient.replace(accountUuid, account.copy()
       .put("remaining", remaining)
@@ -129,11 +129,11 @@ public final class FeeFineAccountFixture {
       .manualFeeFine());
 
     accountActionsClient.create(new FeefineActionsBuilder()
-      .forAccount(account.getId())
+      .withAccountId(account.getId())
       .withBalance(amount)
       .withActionAmount(amount)
       .withActionType("Manual fee fine")
-      .createdAt(UUID.randomUUID().toString()));
+      .withCreatedAt(UUID.randomUUID().toString()));
 
     return account;
   }

--- a/src/test/java/api/support/fixtures/TemplateContextMatchers.java
+++ b/src/test/java/api/support/fixtures/TemplateContextMatchers.java
@@ -280,6 +280,10 @@ public class TemplateContextMatchers {
     );
   }
 
+  public static Matcher<Object> getFeeChargeAdditionalInfoContextMatcher(String additionalInfo) {
+    return hasJsonPath("feeCharge.additionalInfo", is(additionalInfo));
+  }
+
   public static Matcher<?> getFeeActionContextMatcher(FeeFineAction action) {
     return allOf(
       hasJsonPath("feeAction.type", is(action.getActionType())),


### PR DESCRIPTION
Resolves [CIRC-1767](https://issues.folio.org/browse/CIRC-1767)

## Purpose
Users need to be able to include the "Additional information for patron" into their fee/fine related patron notice templates as feeCharge.additionalInformation

## Approach
Extend existing implementation