### PR TITLE
CIRC-1766 Add the field "feeCharge.additionalInfo" to the Fee/Fine Charge object in the Notice context

### DIFF
--- a/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
@@ -202,4 +202,57 @@ class CheckInDeclaredLostItemTest extends RefundDeclaredLostFeesTestBase {
       hasEmailNoticeProperties(user.getId(), templateId, getFeeChargeAdditionalInfoContextMatcher(
         "AC info for patron"))));
   }
+
+  @Test
+  void shouldCancelAndRefundLostItemFeeActualCostAndProcessingFee() {
+    final double itemFeeActualCost = 15.00;
+    final double itemProcessingFee = 10.00;
+    final UUID servicePointId = servicePointsFixture.cd1().getId();
+    UserResource user = usersFixture.charlotte();
+    feeFineOwnerFixture.ownerForServicePoint(servicePointId);
+
+    var templateId = UUID.randomUUID();
+    templateFixture.createDummyNoticeTemplate(templateId);
+
+    use(PoliciesToActivate.builder()
+      .lostItemPolicy(lostItemFeePoliciesFixture.create(
+        lostItemFeePoliciesFixture.facultyStandardPolicy()
+          .withName("Lost item fee actual cost policy")
+          .chargeProcessingFeeWhenDeclaredLost(itemProcessingFee)
+          .withActualCost(itemFeeActualCost)))
+      .noticePolicy(noticePoliciesFixture.create(
+        new NoticePolicyBuilder()
+          .withName("Patron notice policy with fee/fine notices")
+          .withFeeFineNotices(List.of(new NoticeConfigurationBuilder()
+            .withAgedToLostReturnedEvent()
+            .withTemplateId(templateId)
+            .withUponAtTiming()
+            .sendInRealTime(true)
+            .create())))));
+
+    loan = checkOutFixture.checkOutByBarcode(item, user);
+    declareLostFixtures.declareItemLost(new DeclareItemLostRequestBuilder()
+      .withServicePointId(servicePointId)
+      .forLoanId(loan.getId()));
+    assertThat(accountsClient.getAll(), hasSize(1));
+    assertThat(actualCostRecordsClient.getAll(), hasSize(1));
+    String recordId = actualCostRecordsClient.getAll().get(0).getString("id");
+    runWithTimeOffset(() -> createLostItemFeeActualCostAccount(itemFeeActualCost,
+      UUID.fromString(recordId), "AC info for staff", "AC info for patron"), ofMinutes(2));
+
+    resolveLostItemFeeActualCostAndProcessingFee();
+
+    checkInFixture.checkInByBarcode(new CheckInByBarcodeRequestBuilder()
+      .forItem(item)
+      .at(servicePointsFixture.cd1()));
+    assertThat(loan, hasLostItemFeeActualCost(isClosedCancelled(itemFeeActualCost)));
+    assertThat(loan, hasLostItemProcessingFee(isClosedCancelled(itemProcessingFee)));
+
+    verifyNumberOfScheduledNotices(4);
+    scheduledNoticeProcessingClient.runFeeFineNoticesProcessing(ZonedDateTime.now().plusHours(1));
+    verifyNumberOfSentNotices(4);
+    assertThat(FakeModNotify.getSentPatronNotices(), hasItems(
+      hasEmailNoticeProperties(user.getId(), templateId, getFeeChargeAdditionalInfoContextMatcher(
+        "AC info for patron"))));
+  }
 }

--- a/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
+++ b/src/test/java/api/loans/scenarios/CheckInDeclaredLostItemTest.java
@@ -253,6 +253,9 @@ class CheckInDeclaredLostItemTest extends RefundDeclaredLostFeesTestBase {
     verifyNumberOfSentNotices(4);
     assertThat(FakeModNotify.getSentPatronNotices(), hasItems(
       hasEmailNoticeProperties(user.getId(), templateId, getFeeChargeAdditionalInfoContextMatcher(
-        "AC info for patron"))));
+        "AC info for patron", "15.00", "Refunded fully")),
+      hasEmailNoticeProperties(user.getId(), templateId, getFeeChargeAdditionalInfoContextMatcher(
+        "AC info for patron", "15.00", "Cancelled item returned"))
+      ));
   }
 }

--- a/src/test/java/api/loans/scenarios/RefundDeclaredLostFeesTestBase.java
+++ b/src/test/java/api/loans/scenarios/RefundDeclaredLostFeesTestBase.java
@@ -410,6 +410,15 @@ public abstract class RefundDeclaredLostFeesTestBase extends SpringApiTest {
     assertThat(loansFixture.getLoanById(loan.getId()).getJson(), isClosed());
   }
 
+  protected void resolveLostItemFeeActualCostAndProcessingFee() {
+    feeFineAccountFixture.payLostItemActualCostFee(loan.getId());
+    feeFineAccountFixture.payLostItemProcessingFee(loan.getId());
+    eventSubscribersFixture.publishLoanRelatedFeeFineClosedEvent(loan.getId());
+
+    assertThat(itemsClient.getById(item.getId()).getJson(), isLostAndPaid());
+    assertThat(loansFixture.getLoanById(loan.getId()).getJson(), isClosed());
+  }
+
   protected IndividualResource declareItemLost() {
     loan = checkOutFixture.checkOutByBarcode(item, usersFixture.charlotte());
 

--- a/src/test/java/api/support/fixtures/TemplateContextMatchers.java
+++ b/src/test/java/api/support/fixtures/TemplateContextMatchers.java
@@ -284,6 +284,14 @@ public class TemplateContextMatchers {
     return hasJsonPath("feeCharge.additionalInfo", is(additionalInfo));
   }
 
+  public static Matcher<Object> getFeeChargeAdditionalInfoContextMatcher(String additionalInfo,
+    String amount, String actionType) {
+
+    return allOf(hasJsonPath("feeCharge.additionalInfo", is(additionalInfo)),
+      hasJsonPath("feeCharge.amount", is(amount)),
+      hasJsonPath("feeAction.type", is(actionType)));
+  }
+
   public static Matcher<?> getFeeActionContextMatcher(FeeFineAction action) {
     return allOf(
       hasJsonPath("feeAction.type", is(action.getActionType())),


### PR DESCRIPTION
## Purpose
Add the field "feeCharge.additionalInfo" to the Fee/Fine Charge object in the Notice context.

## Approach
This mentioned scenario has already been addressed by [CIRC-1767](https://issues.folio.org/browse/CIRC-1767).
So added the test cases required for that scenario

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
