### PR TITLE
CIRC 1581 - CIRC 1582

### DIFF
--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -7,6 +7,7 @@ import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTime;
 import static org.folio.circulation.support.utils.FeeFineActionHelper.getPatronInfoFromComment;
 
 import java.lang.invoke.MethodHandles;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
@@ -44,6 +45,7 @@ public class TemplateContextUtil {
   private static final String FEE_CHARGE = "feeCharge";
   private static final String FEE_ACTION = "feeAction";
   private static final String UNLIMITED = "unlimited";
+  public static final String CURRENT_DATE_TIME = "currentDateTime";
 
   private TemplateContextUtil() {
   }
@@ -129,6 +131,9 @@ public class TemplateContextUtil {
         staffSlipContext.put(REQUESTER, createUserContext(requester, request.getDeliveryAddressTypeId()));
       }
     }
+
+    ZonedDateTime currentDateTime = ClockUtil.getZonedDateTime();
+    write(staffSlipContext,CURRENT_DATE_TIME,currentDateTime);
 
     return staffSlipContext;
   }

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -132,8 +132,7 @@ public class TemplateContextUtil {
       }
     }
 
-    ZonedDateTime currentDateTime = ClockUtil.getZonedDateTime();
-    write(staffSlipContext,CURRENT_DATE_TIME,currentDateTime);
+    write(staffSlipContext,CURRENT_DATE_TIME, ClockUtil.getZonedDateTime());
 
     return staffSlipContext;
   }

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -7,7 +7,6 @@ import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTime;
 import static org.folio.circulation.support.utils.FeeFineActionHelper.getPatronInfoFromComment;
 
 import java.lang.invoke.MethodHandles;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -132,7 +132,7 @@ public class TemplateContextUtil {
       }
     }
 
-    write(staffSlipContext,CURRENT_DATE_TIME, ClockUtil.getZonedDateTime());
+    write(staffSlipContext, CURRENT_DATE_TIME, ClockUtil.getZonedDateTime());
 
     return staffSlipContext;
   }

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -42,6 +42,7 @@ import static org.folio.circulation.domain.RequestStatus.CLOSED_PICKUP_EXPIRED;
 import static org.folio.circulation.domain.RequestStatus.CLOSED_UNFILLED;
 import static org.folio.circulation.domain.RequestType.HOLD;
 import static org.folio.circulation.domain.RequestType.RECALL;
+import static org.folio.circulation.domain.notice.TemplateContextUtil.CURRENT_DATE_TIME;
 import static org.folio.circulation.domain.representations.logs.LogEventType.CHECK_IN;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE;
 import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE_ERROR;
@@ -58,9 +59,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -313,6 +312,7 @@ void verifyItemEffectiveLocationIdAtCheckOut() {
     assertThat(requestContext.getString("requestID"), is(request.getId()));
     assertThat(requestContext.getString("servicePointPickup"), is(servicePoint.getJson().getString("name")));
     assertThat(requestContext.getString("patronComments"), is("I need the book"));
+    assertNotNull(staffSlipContext.getString(CURRENT_DATE_TIME));
   }
 
   @Test
@@ -772,6 +772,7 @@ void verifyItemEffectiveLocationIdAtCheckOut() {
     JsonObject staffSlipContext = response.getStaffSlipContext();
     JsonObject userContext = staffSlipContext.getJsonObject("requester");
     assertNull(userContext);
+    assertNotNull(staffSlipContext.getString(CURRENT_DATE_TIME));
 
     verifyNumberOfSentNotices(0);
     verifyNumberOfPublishedEvents(NOTICE, 0);
@@ -868,6 +869,7 @@ void verifyItemEffectiveLocationIdAtCheckOut() {
     JsonObject staffSlipContext = response.getStaffSlipContext();
     JsonObject userContext = staffSlipContext.getJsonObject("requester");
     assertThat(userContext.getString("departments"), is("test department1"));
+    assertNotNull(staffSlipContext.getString(CURRENT_DATE_TIME));
 
     item = itemsFixture.basedUponNod();
     // Requester with 2 Departments

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -59,7 +59,10 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.time.LocalDate;
 import java.time.ZoneOffset;

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -4,12 +4,15 @@ import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.time.ZoneOffset.UTC;
 import static java.util.stream.Collectors.joining;
+import static org.folio.circulation.domain.notice.TemplateContextUtil.CURRENT_DATE_TIME;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTimeProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
+
 
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -169,9 +172,10 @@ class PickSlipsTests extends APITests {
 
     JsonObject pickSlip = getPickSlipsList(response).get(0);
     JsonObject itemContext = pickSlip.getJsonObject(ITEM_KEY);
+    assertNotNull(pickSlip.getString(CURRENT_DATE_TIME));
 
     ZonedDateTime requestCheckinDateTime = getDateTimeProperty(itemContext, "lastCheckedInDateTime");
-    
+
     Item item = Item.from(itemResource.getJson())
       .withInstance(new InstanceMapper().toDomain(itemResource.getInstance().getJson()));
 


### PR DESCRIPTION
CIRC 1581 ( https://issues.folio.org/browse/CIRC-1581 )
CIRC 1582 ( https://issues.folio.org/browse/CIRC-1582 )



## Purpose
1. Add the field "currentDateTime" to the Staff Slip Object in the Staff Slip context, for pick slips generated in the Requests app
2. Add the field "currentDateTime" to the Staff Slip Object in the Staff Slip context, for hold, request delivery and transit slips generated in the Check in app

## Approach
1. currentDateTime for respective objects
2. Modified test cases 

Response : 

1. Request Page : 
![image](https://user-images.githubusercontent.com/103935659/234497451-51efbfee-c6ad-4fa7-8687-031a1646ca2c.png)


2. Checkin page : 

![image](https://user-images.githubusercontent.com/103935659/234498810-d3da5c65-219b-40e9-bde1-77398d8d1125.png)
