### PR TITLE
Circ 1784  Add Request Date as staff slip token for checkin and request app

### DIFF
--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -259,6 +259,9 @@ public class TemplateContextUtil {
       .map(ServicePoint::getName)
       .ifPresent(value -> requestContext.put("servicePointPickup", value));
     optionalRequest
+      .map(Request::getRequestDate)
+      .ifPresent(value -> write(requestContext, "requestDate", value));
+    optionalRequest
       .map(Request::getRequestExpirationDate)
       .ifPresent(value -> write(requestContext, "requestExpirationDate", value));
     optionalRequest

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -247,8 +247,7 @@ class PickSlipsTests extends APITests {
     assertThat(requestContext.getString("servicePointPickup"),
       is(servicePoint.getJson().getString("name")));
     assertThat(requestContext.getString("patronComments"), is("I need the book"));
-    assertThat(requestContext.getString("requestDate"),
-      isEquivalentTo(requestDate));
+    assertThat(requestContext.getString("requestDate"), isEquivalentTo(requestDate));
   }
 
   @Test

--- a/src/test/java/api/requests/PickSlipsTests.java
+++ b/src/test/java/api/requests/PickSlipsTests.java
@@ -247,6 +247,8 @@ class PickSlipsTests extends APITests {
     assertThat(requestContext.getString("servicePointPickup"),
       is(servicePoint.getJson().getString("name")));
     assertThat(requestContext.getString("patronComments"), is("I need the book"));
+    assertThat(requestContext.getString("requestDate"),
+      isEquivalentTo(requestDate));
   }
 
   @Test


### PR DESCRIPTION

## Purpose
https://issues.folio.org/browse/CIRC-1784
Add "request date" as staff slip token

Purpose
Purpose of this PR is to add "request" as staff slip token. The changes would reflect in staff slip produced in the Requests app (pick slip) and staff slip produced in the Check in app (hold, delivery request and transfer slips).


## Approach
The requestDate data is already available. We just add it to returned object. This is done for pick slip resource.

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
![image](https://github.com/folio-org/mod-circulation/assets/127274721/9969d3a9-5a75-4a40-973c-5753918f2c5d)
