### PR TITLE
CIRC-1788 Remove refreshing for loan update

### DIFF
--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
@@ -122,7 +122,7 @@ public class LoanRepository implements GetManyRecordsRepository<Loan> {
     JsonObject storageLoan = mapToStorageRepresentation(loan, loan.getItem());
 
     return loansStorageClient.put(loan.getId(), storageLoan)
-      .thenApply(r -> r.next(l -> succeeded(loan)));
+      .thenApply(r -> r.map(response -> loan));
   }
 
   /**

--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanRepository.java
@@ -16,7 +16,6 @@ import static org.folio.circulation.domain.representations.LoanProperties.PATRON
 import static org.folio.circulation.support.CqlSortBy.ascending;
 import static org.folio.circulation.support.CqlSortBy.descending;
 import static org.folio.circulation.support.fetching.RecordFetching.findWithMultipleCqlIndexValues;
-import static org.folio.circulation.support.http.CommonResponseInterpreters.noContentRecordInterpreter;
 import static org.folio.circulation.support.http.ResponseMapping.forwardOnFailure;
 import static org.folio.circulation.support.http.ResponseMapping.mapUsingJson;
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
@@ -58,7 +57,6 @@ import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FetchSingleRecord;
 import org.folio.circulation.support.FindWithMultipleCqlIndexValues;
 import org.folio.circulation.support.RecordNotFoundFailure;
-import org.folio.circulation.support.SingleRecordFetcher;
 import org.folio.circulation.support.fetching.GetManyRecordsRepository;
 import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.http.client.Offset;
@@ -124,8 +122,7 @@ public class LoanRepository implements GetManyRecordsRepository<Loan> {
     JsonObject storageLoan = mapToStorageRepresentation(loan, loan.getItem());
 
     return loansStorageClient.put(loan.getId(), storageLoan)
-      .thenApply(noContentRecordInterpreter(loan)::flatMap)
-      .thenComposeAsync(r -> r.after(this::refreshLoanRepresentation));
+      .thenApply(r -> r.next(l -> succeeded(loan)));
   }
 
   /**
@@ -182,13 +179,6 @@ public class LoanRepository implements GetManyRecordsRepository<Loan> {
       .mapTo(Loan::from)
       .whenNotFound(failed(new RecordNotFoundFailure("loan", id)))
       .fetch(id);
-  }
-
-  private CompletableFuture<Result<Loan>> refreshLoanRepresentation(Loan loan) {
-    return new SingleRecordFetcher<>(loansStorageClient, "loan",
-      new ResponseInterpreter<Loan>()
-        .flatMapOn(200, mapUsingJson(loan::replaceRepresentation)))
-      .fetch(loan.getId());
   }
 
   private CompletableFuture<Result<Loan>> fetchItem(Result<Loan> result) {


### PR DESCRIPTION
## Purpose

After investigating the issue ([CIRC-1777](https://issues.folio.org/browse/CIRC-1777)), it appears that the problem is related to the synchronization between the write and read database replicas, specifically with the DB_HOST_READER feature enabled. The issue occurs because the loan update logic used during checkout relies on refreshing, where an updated loan is first updated using the put method, and then the loan is refreshed by retrieving it with a GET request from the database and replacing it in the representation.

However, this causes a bug described in [CIRC-1666](https://issues.folio.org/browse/CIRC-1666) because at the moment it is read from the database, the "read" database replica is still not synchronized with the "write" one.

After analyzing the code, it was found that the issue is not limited to the checkout flow. It can also be reproduced in the following flows:

Recall
ChangeDueDate
Replace (LoanCollectionResource)
ChargeFeesFinesWhenAgedToLost

Resolves: [CIRC-1788](https://issues.folio.org/browse/CIRC-1788)

## Approach

To resolve this issue for the DB_HOST_READER feature, the refreshing logic should be removed