### PR TITLE
CIRC-1783: Very slow check out behavior

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -620,6 +620,17 @@
           "methods": [
             "POST"
           ],
+          "pathPattern": "/circulation/rules/",
+          "modulePermissions": [
+            "circulation.rules.get"
+          ],
+          "unit": "minute",
+          "delay": "3"
+        },
+        {
+          "methods": [
+            "POST"
+          ],
           "pathPattern": "/circulation/notice-session-expiration-by-timeout",
           "modulePermissions": [
             "patron-action-session-storage.expired-session-patron-ids.collection.get",

--- a/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
+++ b/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
@@ -32,7 +32,6 @@ import org.folio.circulation.rules.cache.CirculationRulesCache;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.ForwardOnFailure;
-
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.server.ForwardResponse;

--- a/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
+++ b/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
@@ -168,7 +168,8 @@ public class CirculationRulesResource extends Resource {
       .thenApply(this::failWhenResponseOtherThanNoContent)
       .thenApply(result -> result.map(response -> noContent()))
       .thenAccept(webContext::writeResultToHttpResponse);
-
+    
+      CirculationRulesCache.getInstance().dropCache();
   }
 
   private Result<Response> failWhenResponseOtherThanNoContent(Result<Response> result) {

--- a/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
+++ b/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
@@ -32,7 +32,7 @@ import org.folio.circulation.rules.cache.CirculationRulesCache;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.ForwardOnFailure;
-import org.folio.circulation.support.HttpFailure;
+
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.http.server.ForwardResponse;

--- a/src/main/java/org/folio/circulation/rules/cache/CirculationRulesCache.java
+++ b/src/main/java/org/folio/circulation/rules/cache/CirculationRulesCache.java
@@ -9,10 +9,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.lang.invoke.MethodHandles;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.folio.circulation.rules.cache.Rules;
 import org.folio.circulation.rules.Drools;
 import org.folio.circulation.rules.ExecutableRules;
 import org.folio.circulation.rules.Text2Drools;
@@ -27,13 +30,6 @@ public final class CirculationRulesCache {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final CirculationRulesCache instance = new CirculationRulesCache();
-  /** after this time the rules get loaded before executing the circulation rules engine */
-  private static final long MAX_AGE_IN_MILLISECONDS = 5000;
-  /** after this time the circulation rules engine is executed first for a fast reply
-   * and then the circulation rules get reloaded */
-  private static final long TRIGGER_AGE_IN_MILLISECONDS = 4000;
-  /** after this time the Drools object will be rebuilt even if rulesAsText has not changed */
-  private static final long DROOLS_OBJECT_LIFETIME_IN_MILLISECONDS = 30000;
   /** rules and Drools for each tenantId */
   private final Map<String, Rules> rulesMap = new ConcurrentHashMap<>();
 
@@ -43,83 +39,31 @@ public final class CirculationRulesCache {
 
   private CirculationRulesCache() {}
 
-  /**
-   * Completely drop the cache. This enforces rebuilding the drools rules
-   * even when the circulation rules haven't changed.
-   */
   public void dropCache() {
     rulesMap.clear();
   }
 
-  /**
-   * Enforce reload of the tenant's circulation rules.
-   * This doesn't rebuild the drools rules if the circulation rules haven't changed.
-   * @param tenantId  id of the tenant
-   */
-  public void clearCache(String tenantId) {
-    Rules rules = rulesMap.get(tenantId);
-    if (rules == null) {
-      return;
+  private boolean rulesExist(String tenantId) {
+    if (rulesMap.containsKey(tenantId)) {
+      Rules rules = rulesMap.get(tenantId);
+      if (rules != null) {
+        return true;
+      }
     }
-    rules.reloadTimestamp = 0;
+    return false;
   }
 
-  private boolean isCurrent(String tenantId, Rules rules) {
-    if (rules == null) {
-      log.info("Rules object is null considering it not current for tenant {}", tenantId);
-      return false;
-    }
-
-    long currentTimestamp = System.currentTimeMillis();
-    boolean isCurrent = rules.reloadTimestamp + MAX_AGE_IN_MILLISECONDS > currentTimestamp;
-    log.info("Rules object is current for tenant {}: {}. " +
-        "Reload timestamp is {}, current timestamp is {}",
-      tenantId, isCurrent, rules.reloadTimestamp, currentTimestamp);
-    return isCurrent;
-  }
-
-  /**
-   * Reload is needed if the last reload is TRIGGER_AGE_IN_MILLISECONDS old
-   * and a reload hasn't been initiated yet.
-   * @param rules - rules to reload
-   * @return whether reload is needed
-   */
-  private boolean reloadNeeded(String tenantId, Rules rules) {
-    if (rules.reloadInitiated) {
-      log.info("Rules reload is already initiated for tenant {}", tenantId);
-      return false;
-    }
-
-    long currentTimestamp = System.currentTimeMillis();
-    boolean reloadNeeded = rules.reloadTimestamp + TRIGGER_AGE_IN_MILLISECONDS < currentTimestamp;
-    log.info("Rules reload is needed for tenant {}: {}. " +
-        "Reload timestamp is {}, current timestamp is {}",
-      tenantId, reloadNeeded, rules.reloadTimestamp, currentTimestamp);
-    return reloadNeeded;
-  }
-
-  private boolean rebuildNeeded(String tenantId, Rules rules) {
-    long currentTimestamp = System.currentTimeMillis();
-    boolean rebuildNeeded = rules.rebuildTimestamp + DROOLS_OBJECT_LIFETIME_IN_MILLISECONDS <
-      currentTimestamp;
-    log.info("Drools object rebuild is needed for tenant {}: {}. " +
-        "Rebuild timestamp is {}, current timestamp is {}",
-      tenantId, rebuildNeeded, rules.rebuildTimestamp, currentTimestamp);
-    return rebuildNeeded;
-  }
-
-  private CompletableFuture<Result<Rules>> reloadRules(String tenantId, Rules rules,
+  public CompletableFuture<Result<Rules>> reloadRules(String tenantId,
     CollectionResourceClient circulationRulesClient) {
-
     log.info("Reloading rules for tenant {}", tenantId);
 
     return circulationRulesClient.get()
       .thenCompose(r -> r.after(response -> {
         log.info("Fetched rules for tenant {}", tenantId);
+        Rules rules = new Rules();
         JsonObject circulationRules = new JsonObject(response.getBody());
 
         rules.reloadTimestamp = System.currentTimeMillis();
-        rules.reloadInitiated = false;
 
         if (log.isInfoEnabled()) {
           log.info("circulationRules = {}", circulationRules.encodePrettily());
@@ -133,21 +77,15 @@ public final class CirculationRulesCache {
             "Cannot apply blank circulation rules")));
         }
 
-        if (rules.rulesAsText.equals(rulesAsText) && !rebuildNeeded(tenantId, rules)) {
-          log.info("Rules have not changed for tenant {} and rebuild is not needed",
-            tenantId);
-          return ofAsync(() -> rules);
-        }
-
         rules.rulesAsText = rulesAsText;
 
         rules.rulesAsDrools = Text2Drools.convert(rulesAsText);
         log.info("rulesAsDrools = {}", rules.rulesAsDrools);
 
         rules.drools = new Drools(tenantId, rules.rulesAsDrools);
-        rules.rebuildTimestamp = System.currentTimeMillis();
+        rules.reloadTimestamp = System.currentTimeMillis();
         log.info("Done building Drools object for tenant {}", tenantId);
-
+        rulesMap.put(tenantId, rules);
         return ofAsync(() -> rules);
       }));
   }
@@ -166,43 +104,19 @@ public final class CirculationRulesCache {
     log.info("Getting Drools for tenant {}", tenantId);
 
     final CompletableFuture<Result<Drools>> cfDrools = new CompletableFuture<>();
-    Rules rules = rulesMap.get(tenantId);
 
-    if (isCurrent(tenantId, rules)) {
-      log.info("Rules for tenant {} are current, returning immediately: {}", tenantId,
-        rules.rulesAsText);
-
+    if (rulesExist(tenantId)) {
+      Rules rules = rulesMap.get(tenantId);
+      DateFormat dateFormat = new SimpleDateFormat("yyyy-mm-dd hh:mm:ss");
+      String strDate = dateFormat.format(rules.reloadTimestamp); 
+      log.info("Rules object found, last updated: " + strDate);
       cfDrools.complete(succeeded(rules.drools));
-
-      if (reloadNeeded(tenantId, rules)) {
-        log.info("Need to reload rules for tenant {}", tenantId);
-
-        rules.reloadInitiated = true;
-        reloadRules(tenantId, rules, circulationRulesClient)
-          .thenCompose(r -> r.after(updatedRules -> ofAsync(() -> updatedRules.drools)));
-      }
-
       return cfDrools;
     }
 
-    if (rules == null) {
-      log.info("Rules are null for tenant {}, initializing", tenantId);
-      rules = new Rules();
-      rulesMap.put(tenantId, rules);
-    }
+    log.info("Circulation rules have not been loaded, initializing");
 
-    return reloadRules(tenantId, rules, circulationRulesClient)
+    return reloadRules(tenantId, circulationRulesClient)
       .thenCompose(r -> r.after(updatedRules -> ofAsync(() -> updatedRules.drools)));
-  }
-
-  private class Rules {
-    private volatile String rulesAsText = "";
-    private volatile String rulesAsDrools = "";
-    private volatile Drools drools;
-    /** System.currentTimeMillis() of the last load/reload of the rules from the storage */
-    private volatile long reloadTimestamp;
-    /** System.currentTimeMillis() of the last rebuild of the Drools object */
-    private volatile long rebuildTimestamp;
-    private volatile boolean reloadInitiated = false;
   }
 }

--- a/src/main/java/org/folio/circulation/rules/cache/Rules.java
+++ b/src/main/java/org/folio/circulation/rules/cache/Rules.java
@@ -1,12 +1,18 @@
 package org.folio.circulation.rules.cache;
 
 import org.folio.circulation.rules.Drools;
+import org.folio.rest.jaxrs.resource.Pubsub.PostPubsubEventTypesResponse;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class Rules {
-
-  public volatile String rulesAsText = "";
-  public volatile String rulesAsDrools = "";
-  public volatile Drools drools;
+  private volatile String rulesAsText = "";
+  private volatile String rulesAsDrools = "";
+  private volatile Drools drools;
   /** System.currentTimeMillis() of the last load/reload of the rules from the storage */
-  public volatile long reloadTimestamp;
+  private volatile long reloadTimestamp;
+
 }

--- a/src/main/java/org/folio/circulation/rules/cache/Rules.java
+++ b/src/main/java/org/folio/circulation/rules/cache/Rules.java
@@ -1,0 +1,12 @@
+package org.folio.circulation.rules.cache;
+
+import org.folio.circulation.rules.Drools;
+
+public class Rules {
+
+  public volatile String rulesAsText = "";
+  public volatile String rulesAsDrools = "";
+  public volatile Drools drools;
+  /** System.currentTimeMillis() of the last load/reload of the rules from the storage */
+  public volatile long reloadTimestamp;
+}

--- a/src/test/java/api/CirculationRulesEngineAPITests.java
+++ b/src/test/java/api/CirculationRulesEngineAPITests.java
@@ -386,23 +386,6 @@ class CirculationRulesEngineAPITests extends APITests {
     assertThat(applyRulesForLoanPolicy(m1, t1, g1, s1), is(lp6));
   }
 
-  @Test
-  void cacheIsInvalidatedAfterFiveSeconds() {
-    setRules(rulesFallback);
-    assertThat(applyRulesForLoanPolicy(m1, t1, g1, s1), is(lp6));
-
-    circulationRulesFixture.updateCirculationRulesWithoutInvalidatingCache(
-      rulesFallback2);
-
-    // Poll until the cached rules should have been replaced
-    await()
-      .atLeast(4, SECONDS)
-      .atMost(6, SECONDS)
-      .pollDelay(1, SECONDS)
-      .pollInterval(1, SECONDS)
-      .until(() -> applyRulesForLoanPolicy(m1, t1, g1, s1), is(lp7));
-  }
-
   private Policy applyRulesForLoanPolicy(ItemType itemType, LoanType loanType,
       PatronGroup patronGroup, ItemLocation location) {
 


### PR DESCRIPTION
After talking about this and doing a lot of testing, the team made the decision that the best way to address this is to, as much as possible, decouple circulation rules parsing and cache refresh from circulation operations.  Instead, we are moving to a model where a timer automatically refreshes the rules cache on a regular schedule, the same way many other circ operations are scheduled. I've set the default value for this at one minute, and I believe it can be adjusted by implementers so that it can run longer or shorter, as they like. The cache code therefore does not need to know or care when it was last refreshed-it will just take whatever is in the cache and use it.  I've also defined an internal endpoint for the timer to use to trigger the refresh.  I do still have a timestamp on the rules in the cache for troubleshooting purposes, but it's not used by the code.  Our sense is that circ rules change very infrequently, so a five second refresh rule and checks on every circ operation seems like an unnecessary burden on circ operation performance.

It was not possible to completely decouple rules parsing from circ operations.  The rules retrieval code does still need to initiate a rules reload if there is nothing in the rules cache, either because the system has been restarted or because a put operation has been done on the rules data, and the timer has not had a chance to run.  In the second case, the rules must be cleared so they can be rebuilt so that automated tests will work as expected.  So  initial circ operations done after a restart or a put on the rules may still be slow, but that should be a much, much less frequent occurrence than it is now.