### PR TITLE
CIRC-1832 Pickup notices not sent when another item is Awaiting pickup

### DIFF
--- a/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
@@ -156,7 +156,6 @@ public class RequestNoticeSender {
     }
     else if (item.isAwaitingPickup()) {
       requestQueue.getRequests().stream()
-        .filter(Request::hasTopPriority)
         .filter(Request::isAwaitingPickup)
         .filter(Request::hasChangedStatus)
         .findFirst()

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -3395,6 +3395,67 @@ public class RequestsAPICreationTests extends APITests {
   }
 
   @Test
+  void awaitingPickupNoticesShouldBeSentToMultiplePatronsDuringPagedItemsCheckIn() {
+    configurationsFixture.enableTlrFeature();
+    NoticePolicyBuilder noticePolicy = new NoticePolicyBuilder()
+      .withName("Policy with available notice")
+      .withLoanNotices(Collections.singletonList(new NoticeConfigurationBuilder()
+        .withTemplateId(UUID.randomUUID())
+        .withAvailableEvent()
+        .create()));
+    use(noticePolicy);
+
+    final UUID pickupServicePointId = servicePointsFixture.cd1().getId();
+    final var patron1 = usersFixture.charlotte();
+    final var patron2 = usersFixture.jessica();
+
+    final var items = itemsFixture.createMultipleItemsForTheSameInstance(2);
+    final var itemA = items.get(0);
+    final var itemB = items.get(1);
+    final UUID instanceId = items.get(0).getInstanceId();
+
+
+    IndividualResource pageTlr1 = requestsClient.create(new RequestBuilder()
+      .page()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron1.getId()));
+
+    var itemAUpdated = itemsFixture.getById(itemA.getId());
+    var pagedItem = "Paged".equals(itemAUpdated.getStatusName())
+      ? itemA : itemB;
+    var notPagedItem = itemA == pagedItem ? itemB : itemA;
+
+    assertThat(pageTlr1.getJson().getString("status"), is(OPEN_NOT_YET_FILLED));
+    assertThat(pageTlr1.getJson().getString("itemId"), is(pagedItem.getId()));
+    checkInFixture.checkInByBarcode(pagedItem,pickupServicePointId);
+    var updatedFirstRequest = requestsFixture.getRequests(
+      exactMatch("itemId", pagedItem.getId().toString()), limit(1), noOffset()).getFirst();
+    assertThat(updatedFirstRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
+
+    IndividualResource pageTlr2 = requestsClient.create(new RequestBuilder()
+      .page()
+      .withNoHoldingsRecordId()
+      .withNoItemId()
+      .titleRequestLevel()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .withRequesterId(patron2.getId()));
+
+    assertThat(pageTlr2.getJson().getString("status"), is(OPEN_NOT_YET_FILLED));
+    assertThat(pageTlr2.getJson().getString("itemId"), is(notPagedItem.getId()));
+    checkInFixture.checkInByBarcode(notPagedItem,pickupServicePointId);
+    var updatedSecondRequest = requestsFixture.getRequests(
+      exactMatch("itemId", notPagedItem.getId().toString()), limit(1), noOffset()).getFirst();
+    assertThat(updatedSecondRequest.getString("status"), is(OPEN_AWAITING_PICKUP));
+
+    verifyNumberOfSentNotices(2);
+  }
+
+  @Test
   void pageRequestShouldNotChangeItemStatusIfFailsWithoutRequestDate() {
     var item = itemsFixture.basedUponSmallAngryPlanet();
 
@@ -4329,7 +4390,6 @@ public class RequestsAPICreationTests extends APITests {
       .withRequesterId(patron1.getId()));
 
     var itemAUpdated = itemsFixture.getById(itemA.getId());
-    var itemBUpdated = itemsFixture.getById(itemB.getId());
     var pagedItem = "Paged".equals(itemAUpdated.getStatusName())
       ? itemA : itemB;
     var notPagedItem = itemA == pagedItem ? itemB : itemA;

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -4390,6 +4390,7 @@ public class RequestsAPICreationTests extends APITests {
       .withRequesterId(patron1.getId()));
 
     var itemAUpdated = itemsFixture.getById(itemA.getId());
+    var itemBUpdated = itemsFixture.getById(itemB.getId());
     var pagedItem = "Paged".equals(itemAUpdated.getStatusName())
       ? itemA : itemB;
     var notPagedItem = itemA == pagedItem ? itemB : itemA;


### PR DESCRIPTION
Resolves: https://issues.folio.org/browse/CIRC-1832

## Purpose
The purpose of this PR is to get the awaiting pickup notices when paged items checked in by multiple users.

## Approach
When we create a new TLR page request with service point X for User1, "ItemA" is paged. 
When "ItemA" is checked in at service point X, the User1 will get pickup notice email.
But when we create a new TLR page request with service point X for User1, "ItemB" is paged. 
When "ItemB" is checked in service point X, the User2 is not receiving any pickup notice email.

To address this issue, we have removed a filter called "hasTopPriority" in the "sendRequestAwaitingPickupNotice" method. 
This filter was previously preventing the pickup notices from being sent to other users who were in the queue waiting. 
By removing this filter, the pickup notices can now be sent to all users in the queue, ensuring that everyone receives. 
a pickup notice when they checked in the paged items.
 
 



#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->


## Evidence
**Circulation log records**
![circ-1832-evidence](https://github.com/folio-org/mod-circulation/assets/127184919/be48606e-d4b2-4f21-a783-c85e892dc936)


**Pickup notice sent to user1.**
![circ-1832-evidence-user1](https://github.com/folio-org/mod-circulation/assets/127184919/af7954aa-e25d-4f54-a5cf-1843a583c24a)


**pickup notice sent to user2.**
![circ-1832-evidence-user2](https://github.com/folio-org/mod-circulation/assets/127184919/fffb65c9-3da8-40dc-a0f1-772f28742d23)



