### PR TITLE
[CIRC-1824] Add allowedServicePoints to request policy

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/RequestPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/RequestPolicy.java
@@ -1,7 +1,11 @@
 package org.folio.circulation.domain.policy;
 
 import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -9,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.RequestType;
 import org.folio.circulation.support.json.JsonStringArrayPropertyFetcher;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import lombok.Getter;
 
@@ -19,18 +24,25 @@ public class RequestPolicy {
   private final String id;
 
   private final List<String> requestTypes;
+  private final Map<RequestType, Set<UUID>> allowedServicePoints;
 
-  private RequestPolicy(String id, List<String> requestTypes) {
+  private RequestPolicy(String id, List<String> requestTypes,
+    Map<RequestType, Set<UUID>> allowedServicePoints) {
     this.id = id;
     this.requestTypes = requestTypes;
+    this.allowedServicePoints = allowedServicePoints;
   }
 
   public static RequestPolicy from(JsonObject representation) {
     log.debug("from:: parameters representation: {}", representation);
+
+    Map<RequestType, Set<UUID>> allowedServicePoints = extractAllowedServicePoints(
+      representation.getJsonObject("allowedServicePoints"));
+
     return new RequestPolicy(representation.getString("id"),
       JsonStringArrayPropertyFetcher
         .toStream(representation, "requestTypes")
-        .collect(Collectors.toList()));
+        .collect(Collectors.toList()), allowedServicePoints);
   }
 
   public boolean allowsType(RequestType type) {
@@ -43,5 +55,33 @@ public class RequestPolicy {
     }
     log.info("allowsType:: result: false");
     return false;
+  }
+
+  private static Map<RequestType, Set<UUID>> extractAllowedServicePoints(
+    JsonObject allowedServicePointsJson) {
+
+    log.debug("extractAllowedServicePoints:: parameters representation: {}",
+      allowedServicePointsJson);
+
+    Map<RequestType, Set<UUID>> allowedServicePoints = new HashMap<>();
+    if (allowedServicePointsJson != null) {
+      for (RequestType requestType : RequestType.values()) {
+        JsonArray jsonArray = allowedServicePointsJson.getJsonArray(requestType.getValue());
+        if (jsonArray != null) {
+          allowedServicePoints.put(requestType, extractServicePointIds(jsonArray));
+        }
+      }
+    }
+
+    return allowedServicePoints;
+  }
+
+  private static Set<UUID> extractServicePointIds(JsonArray jsonArray) {
+    log.debug("extractServicePointIds:: parameters jsonArray: {}", jsonArray);
+
+    return jsonArray.stream()
+      .map(String.class::cast)
+      .map(UUID::fromString)
+      .collect(Collectors.toSet());
   }
 }

--- a/src/test/java/api/support/builders/RequestPolicyBuilder.java
+++ b/src/test/java/api/support/builders/RequestPolicyBuilder.java
@@ -1,6 +1,8 @@
 package api.support.builders;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.folio.circulation.domain.RequestType;
@@ -13,6 +15,7 @@ public class RequestPolicyBuilder extends JsonBuilder implements Builder {
   private final String name;
   private final String description;
   private final List<RequestType> types;
+  private Map<RequestType, Set<UUID>> allowedServicePoints;
 
   public RequestPolicyBuilder(List<RequestType> requestTypes) {
 
@@ -35,6 +38,16 @@ public class RequestPolicyBuilder extends JsonBuilder implements Builder {
       description,
       requestTypes
     );
+  }
+
+  public RequestPolicyBuilder(UUID id, List<RequestType> requestTypes, String name,
+    String description, Map<RequestType, Set<UUID>> allowedServicePoints) {
+
+    this.id = id;
+    this.name = name;
+    this.description = description;
+    this.types = requestTypes;
+    this.allowedServicePoints = allowedServicePoints;
   }
 
   private RequestPolicyBuilder(
@@ -67,6 +80,14 @@ public class RequestPolicyBuilder extends JsonBuilder implements Builder {
     }
 
     put(requestPolicy, "requestTypes", requestTypes);
+
+    JsonObject allowedServicePointsJson = new JsonObject();
+    if (allowedServicePoints != null) {
+      for (RequestType t : allowedServicePoints.keySet()) {
+        allowedServicePointsJson.put(t.getValue(), allowedServicePoints.get(t));
+      }
+      requestPolicy.put("allowedServicePoints", allowedServicePointsJson);
+    }
 
     return requestPolicy;
   }

--- a/src/test/java/api/support/fixtures/RequestPoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/RequestPoliciesFixture.java
@@ -4,6 +4,8 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.folio.circulation.domain.RequestType;
@@ -87,6 +89,19 @@ public class RequestPoliciesFixture {
     requestTypesList.add(RequestType.PAGE);
 
     return customRequestPolicy(requestTypesList);
+  }
+
+  public IndividualResource pageRequestPolicyWithAllowedServicePoints(
+    Map<RequestType, Set<UUID>> allowedServicePoints, RequestType requestType) {
+
+    List<RequestType> requestTypesList = new ArrayList<>();
+    requestTypesList.add(requestType);
+    var policyId = UUID.randomUUID();
+    var customPolicy = new RequestPolicyBuilder(policyId, requestTypesList,
+      "Example Request Policy" + policyId,
+      "An example request policy with allowed Service Points", allowedServicePoints);
+
+    return requestPolicyRecordCreator.createIfAbsent(customPolicy);
   }
 
   public IndividualResource nonRequestableRequestPolicy() {


### PR DESCRIPTION
## Purpose
- change request policy format

Resolves: [CIRC-1824](https://issues.folio.org/browse/CIRC-1824)
## Approach
- add allowed service points to the request policy schema, RequestPolicy class, fixtures, builders etc. to make mod-circulation compatible with the new format described in [CIRCSTORE-424](https://issues.folio.org/browse/CIRCSTORE-424).
- create a test that would show that mod-circulation is working correctly with the new-style request policy (note that it should still work with old-style policies too because [CIRCSTORE-424](https://issues.folio.org/browse/CIRCSTORE-424) is NOT a breaking change)