### PR TITLE
[CIRC-1826] Fix issue with empty array in allowed service points when the service point does not exist

### DIFF
--- a/src/main/java/org/folio/circulation/services/AllowedServicePointsService.java
+++ b/src/main/java/org/folio/circulation/services/AllowedServicePointsService.java
@@ -165,11 +165,13 @@ public class AllowedServicePointsService {
       if (requestPolicy.allowsType(requestType)) {
         log.info("includeOnlyExistingServicePoints:: requestType={} is allowed",
           requestType.getValue());
-        allowedServicePoints.put(requestType,
-          uuidSet.stream()
-            .map(UUID::toString)
-            .filter(relevantSpIds::contains)
-            .collect(Collectors.toSet()));
+        Set<String> filteredIds = uuidSet.stream()
+          .map(UUID::toString)
+          .filter(relevantSpIds::contains)
+          .collect(Collectors.toSet());
+        if (!filteredIds.isEmpty()) {
+          allowedServicePoints.put(requestType, filteredIds);
+        }
       }
     });
 

--- a/src/test/java/api/requests/AllowedServicePointsAPITests.java
+++ b/src/test/java/api/requests/AllowedServicePointsAPITests.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -121,6 +122,24 @@ class AllowedServicePointsAPITests extends APITests {
     var allowedServicePoints = response.getJsonArray(requestType.getValue()).stream().toList();
     assertThat(allowedServicePoints, hasSize(1));
     assertThat(allowedServicePoints, hasItem(cd1Id.toString()));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+    value = RequestType.class,
+    names = {"NONE"},
+    mode = EnumSource.Mode.EXCLUDE
+  )
+  void shouldReturnNoAllowedServicePointsIfAllowedServicePointDoesNotExist(
+    RequestType requestType) {
+
+    var requesterId = usersFixture.steve().getId().toString();
+    var itemId = itemsFixture.basedUponNod().getId().toString();
+    setRequestPolicyWithAllowedServicePoints(requestType, UUID.randomUUID());
+
+    var response = get(requesterId, null, itemId, HttpStatus.SC_OK).getJson();
+    var allowedServicePoints = response.getJsonArray(requestType.getValue());
+    assertThat(allowedServicePoints, nullValue());
   }
 
   @ParameterizedTest

--- a/src/test/java/api/requests/AllowedServicePointsAPITests.java
+++ b/src/test/java/api/requests/AllowedServicePointsAPITests.java
@@ -148,7 +148,7 @@ class AllowedServicePointsAPITests extends APITests {
     names = {"NONE"},
     mode = EnumSource.Mode.EXCLUDE
   )
-  void shouldReturnNoAllowedServicePointsIfAllowedServicePointHasNoPickupLocation(
+  void shouldReturnNoAllowedServicePointsIfAllowedServicePointIsNotPickupLocation(
     RequestType requestType) {
 
     var requesterId = usersFixture.steve().getId().toString();

--- a/src/test/java/api/requests/AllowedServicePointsAPITests.java
+++ b/src/test/java/api/requests/AllowedServicePointsAPITests.java
@@ -148,6 +148,25 @@ class AllowedServicePointsAPITests extends APITests {
     names = {"NONE"},
     mode = EnumSource.Mode.EXCLUDE
   )
+  void shouldReturnNoAllowedServicePointsIfAllowedServicePointHasNoPickupLocation(
+    RequestType requestType) {
+
+    var requesterId = usersFixture.steve().getId().toString();
+    var itemId = itemsFixture.basedUponNod().getId().toString();
+    var servicePointWithNoPickupLocationId = servicePointsFixture.cd3().getId();
+    setRequestPolicyWithAllowedServicePoints(requestType, servicePointWithNoPickupLocationId);
+
+    var response = get(requesterId, null, itemId, HttpStatus.SC_OK).getJson();
+    var allowedServicePoints = response.getJsonArray(requestType.getValue());
+    assertThat(allowedServicePoints, nullValue());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+    value = RequestType.class,
+    names = {"NONE"},
+    mode = EnumSource.Mode.EXCLUDE
+  )
   void shouldReturnOnlyExistingServicePointsWhenRequestPolicyDoesNotHaveAny(
     RequestType requestType) {
 


### PR DESCRIPTION
## Purpose
 Fix issue with empty array in allowed service points when the service point does not exist

Resolves: [CIRC-1826](https://issues.folio.org/browse/CIRC-1826)
