### PR TITLE
CIRC-1778 Actual cost records with "Open" status become "Expired"

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/lostitem/LostItemPolicy.java
@@ -170,6 +170,11 @@ public class LostItemPolicy extends Policy {
   }
 
   public ZonedDateTime calculateFeeFineChargingPeriodExpirationDateTime(ZonedDateTime lostTime) {
+
+    if(Period.zeroDurationPeriod().equals(lostItemChargeFeeFineInterval)){
+      return null;
+    }
+
     return lostItemChargeFeeFineInterval.plusDate(lostTime);
   }
 


### PR DESCRIPTION
Covers [CIRC-1778](https://issues.folio.org/browse/CIRC-1778)

## Purpose
Goal of this PR is to allow creation of Actual cost records with no Expiration date if in "Lost Item policy" option "For lost items not charged a fee/fine, close the loan after" not set.

## Approach
If in "Lost Item policy" option "For lost items not charged a fee/fine, close the loan after" not set we return null as expiration date

