### PR TITLE
Circ 1886 add dropdown for item service point

### DIFF
--- a/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
@@ -148,6 +148,7 @@ public class RequestRepresentation {
     write(locationSummary, "name", location.getName());
     write(locationSummary, "libraryName", location.getLibraryName());
     write(locationSummary, "code", location.getCode());
+    write(locationSummary, "effectiveLocationPrimaryServicePointName", location.getPrimaryServicePoint().getName());
     return locationSummary;
   }
 

--- a/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
@@ -148,7 +148,9 @@ public class RequestRepresentation {
     write(locationSummary, "name", location.getName());
     write(locationSummary, "libraryName", location.getLibraryName());
     write(locationSummary, "code", location.getCode());
-    write(locationSummary, "effectiveLocationPrimaryServicePointName", location.getPrimaryServicePoint().getName());
+    if(location.getPrimaryServicePoint() != null) {
+      write(locationSummary, "effectiveLocationPrimaryServicePointName", location.getPrimaryServicePoint().getName());
+    }
     return locationSummary;
   }
 

--- a/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
@@ -210,7 +210,7 @@ public class ServicePointRepository {
       .collect(Collectors.toList());
 
     if(servicePointsToFetch.isEmpty()) {
-      log.info("findServicePointsForRequests:: No service points to query");
+      log.info("findPrimaryServicePointsForRequests:: No service points to query");
       return completedFuture(succeeded(multipleRequests));
     }
 
@@ -223,7 +223,7 @@ public class ServicePointRepository {
           Collection<ServicePoint> spCollection = multipleServicePoints.getRecords();
           for(Request request : requests) {
             Request newRequest = null;
-            boolean foundSP = false; //Have we found a matching service point for the request?
+            boolean foundSP = false;
             for(ServicePoint servicePoint : spCollection) {
               if(request.getItem().getLocation().getPrimaryServicePointId() != null &&
                 request.getItem().getLocation().getPrimaryServicePointId().toString().equals(servicePoint.getId())) {

--- a/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
@@ -195,16 +195,17 @@ public class ServicePointRepository {
   }
 
   public CompletableFuture<Result<MultipleRecords<Request>>> findPrimaryServicePointsForRequests(
-    MultipleRecords<Request> multipleRequests) {
+    final MultipleRecords<Request> multipleRequests) {
 
     log.debug("findServicePointsForRequests:: parameters multipleRequests: {}", () -> multipleRecordsAsString(multipleRequests));
 
-    Collection<Request> requests = multipleRequests.getRecords();
+    final Collection<Request> requests = multipleRequests.getRecords();
 
     final List<String> servicePointsToFetch = requests.stream()
       .filter(Objects::nonNull)
-      .map(r -> r.getItem().getLocation().getPrimaryServicePointId().toString())
+      .map(r -> r.getItem() != null ? r.getItem().getLocation().getPrimaryServicePointId() : null)
       .filter(Objects::nonNull)
+      .map(Object::toString)
       .distinct()
       .collect(Collectors.toList());
 
@@ -226,15 +227,15 @@ public class ServicePointRepository {
             for(ServicePoint servicePoint : spCollection) {
               if(request.getItem().getLocation().getPrimaryServicePointId() != null &&
                 request.getItem().getLocation().getPrimaryServicePointId().toString().equals(servicePoint.getId())) {
-                Location l = request.getItem().getLocation().withPrimaryServicePoint(servicePoint);
-                Item i = request.getItem().withLocation(l);
-                newRequest = request.withItem(i);
+                Location location = request.getItem().getLocation().withPrimaryServicePoint(servicePoint);
+                Item item = request.getItem().withLocation(location);
+                newRequest = request.withItem(item);
                 foundSP = true;
                 break;
               }
             }
             if(!foundSP) {
-              log.info("No service point (out of {}) found for request {} (pickupServicePointId {})",
+              log.info("No service point (out of {}) found for request {} (primaryServicePointId {})",
                 spCollection.size(), request.getId(), request.getPickupServicePointId());
               newRequest = request;
             }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
@@ -219,11 +219,13 @@ public class ServicePointRepository {
         multipleServicePoints -> {
           List<Request> newRequestList = new ArrayList<>();
           Collection<ServicePoint> spCollection = multipleServicePoints.getRecords();
+
           for(Request request : requests) {
             Request newRequest = null;
             boolean foundSP = false;
+
             for(ServicePoint servicePoint : spCollection) {
-              if(request.getItem().getLocation().getPrimaryServicePointId() != null &&
+              if(request.getItem() != null && request.getItem().getLocation() != null && request.getItem().getLocation().getPrimaryServicePointId() != null &&
                 request.getItem().getLocation().getPrimaryServicePointId().toString().equals(servicePoint.getId())) {
                 Location location = request.getItem().getLocation().withPrimaryServicePoint(servicePoint);
                 Item item = request.getItem().withLocation(location);

--- a/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
@@ -207,7 +207,7 @@ public class ServicePointRepository {
       .filter(Objects::nonNull)
       .map(Object::toString)
       .distinct()
-      .collect(Collectors.toList());
+      .toList();
 
     if(servicePointsToFetch.isEmpty()) {
       log.info("findPrimaryServicePointsForRequests:: No service points to query");

--- a/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
@@ -214,9 +214,7 @@ public class ServicePointRepository {
       return completedFuture(succeeded(multipleRequests));
     }
 
-    final FindWithMultipleCqlIndexValues<ServicePoint> fetcher = createServicePointsFetcher();
-
-    return fetcher.findByIds(servicePointsToFetch)
+    return createServicePointsFetcher().findByIds(servicePointsToFetch)
       .thenApply(multipleServicePointsResult -> multipleServicePointsResult.next(
         multipleServicePoints -> {
           List<Request> newRequestList = new ArrayList<>();

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -253,7 +253,7 @@ public class RequestCollectionResource extends CollectionResource {
   }
 
   List<String> parseEffectiveLocationIds(String itemQueryDecoded) {
-    itemQueryDecoded = itemQueryDecoded.replace(" sortby requestDate", StringUtils.EMPTY);
+    itemQueryDecoded = StringUtils.substringBefore(itemQueryDecoded, "sortby").trim();
     itemQueryDecoded = itemQueryDecoded.replace(EFFECTIVE_LOCATION_PRIMARY_SERVICE_POINT_ID + "==", StringUtils.EMPTY);
     itemQueryDecoded = itemQueryDecoded.replace("(", StringUtils.EMPTY);
     itemQueryDecoded = itemQueryDecoded.replace(")", StringUtils.EMPTY);

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -261,7 +261,7 @@ public class RequestCollectionResource extends CollectionResource {
     results.removeAll(Arrays.asList("", null));
     final List<String> parsedLocationIds = new ArrayList<>();
     for(String result : results) {
-      parsedLocationIds.add(result. replaceAll("\"", StringUtils.EMPTY));
+      parsedLocationIds.add(result. replace("\"", StringUtils.EMPTY));
     }
     return parsedLocationIds;
   }

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -66,6 +66,7 @@ import java.util.*;
 public class RequestCollectionResource extends CollectionResource {
 
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+  private static final String EFFECTIVE_LOCATION_PRIMARY_SERVICE_POINT_ID = "effectiveLocationPrimaryServicePointId";
   public RequestCollectionResource(HttpClient client) {
     super(client, "/circulation/requests");
   }
@@ -242,7 +243,7 @@ public class RequestCollectionResource extends CollectionResource {
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
     final var requestRepository = RequestRepository.using(clients,
       itemRepository, userRepository, loanRepository);
-    final var encodedQuery = routingContext.request().getParam("effectiveLocationPrimaryServicePointId");
+    final var encodedQuery = routingContext.request().getParam(EFFECTIVE_LOCATION_PRIMARY_SERVICE_POINT_ID);
     final var effectiveLocationIds = parseEffectiveLocationIds(dec(encodedQuery));
     fromFutureResult(requestRepository.findBy(routingContext.request().query())
       .thenComposeAsync(result -> result.after(servicePointRepository::findPrimaryServicePointsForRequests)))
@@ -253,7 +254,7 @@ public class RequestCollectionResource extends CollectionResource {
 
   List<String> parseEffectiveLocationIds(String itemQueryDecoded) {
     itemQueryDecoded = itemQueryDecoded.replace(" sortby requestDate", StringUtils.EMPTY);
-    itemQueryDecoded = itemQueryDecoded.replace("effectiveLocationPrimaryServicePointId==", StringUtils.EMPTY);
+    itemQueryDecoded = itemQueryDecoded.replace(EFFECTIVE_LOCATION_PRIMARY_SERVICE_POINT_ID + "==", StringUtils.EMPTY);
     itemQueryDecoded = itemQueryDecoded.replace("(", StringUtils.EMPTY);
     itemQueryDecoded = itemQueryDecoded.replace(")", StringUtils.EMPTY);
 

--- a/src/test/java/org/folio/circulation/infrastructure/storage/ServicePointRepositoryTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/ServicePointRepositoryTest.java
@@ -36,12 +36,14 @@ class ServicePointRepositoryTest {
     Institution institution = new Institution(StringUtils.EMPTY, StringUtils.EMPTY);
     Campus campus = new Campus(StringUtils.EMPTY, StringUtils.EMPTY);
     Library library = new Library(StringUtils.EMPTY, StringUtils.EMPTY);
+
     ServicePoint primaryServicePoint = ServicePoint.unknown(primaryServicePointId.toString(), name);
     Location location = new Location("11", null, null, null, List.of(UUID.randomUUID()), primaryServicePointId, institution, campus, library, primaryServicePoint);
     when(request.getItem()).thenReturn(item);
     when(item.getLocation()).thenReturn(location);
     when(item.withLocation(any())).thenReturn(item);
     when(request.withItem(any())).thenReturn(request);
+
     CollectionResourceClient client = mock(CollectionResourceClient.class);
     MultipleRecords<Request> multipleRequests = new MultipleRecords<>(List.of(request), 1);
     Clients clients = mock(Clients.class);
@@ -74,10 +76,12 @@ class ServicePointRepositoryTest {
     Institution institution = new Institution(StringUtils.EMPTY, StringUtils.EMPTY);
     Campus campus = new Campus(StringUtils.EMPTY, StringUtils.EMPTY);
     Library library = new Library(StringUtils.EMPTY, StringUtils.EMPTY);
+
     ServicePoint primaryServicePoint = ServicePoint.unknown(primaryServicePointId.toString(), name);
     Location location = new Location("11", null, null, null, List.of(UUID.randomUUID()), primaryServicePointId, institution, campus, library, primaryServicePoint);
     when(request.getItem()).thenReturn(item);
     when(item.getLocation()).thenReturn(location);
+
     CollectionResourceClient client = mock(CollectionResourceClient.class);
     MultipleRecords<Request> multipleRequests = new MultipleRecords<>(List.of(request), 1);
     Clients clients = mock(Clients.class);

--- a/src/test/java/org/folio/circulation/infrastructure/storage/ServicePointRepositoryTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/ServicePointRepositoryTest.java
@@ -1,0 +1,103 @@
+package org.folio.circulation.infrastructure.storage;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang.StringUtils;
+import org.folio.circulation.domain.*;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.CollectionResourceClient;
+import org.folio.circulation.support.GetManyRecordsClient;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.results.Result;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ServicePointRepositoryTest {
+
+  @Test
+  void findPrimaryServicePointsForRequestsTest() throws Exception {
+    UUID primaryServicePointId = UUID.randomUUID();
+    String name = "test name";
+
+    Request request = mock(Request.class);
+    Item item = mock(Item.class);
+    Institution institution = new Institution(StringUtils.EMPTY, StringUtils.EMPTY);
+    Campus campus = new Campus(StringUtils.EMPTY, StringUtils.EMPTY);
+    Library library = new Library(StringUtils.EMPTY, StringUtils.EMPTY);
+    ServicePoint primaryServicePoint = ServicePoint.unknown(primaryServicePointId.toString(), name);
+    Location location = new Location("11", null, null, null, List.of(UUID.randomUUID()), primaryServicePointId, institution, campus, library, primaryServicePoint);
+    when(request.getItem()).thenReturn(item);
+    when(item.getLocation()).thenReturn(location);
+    when(item.withLocation(any())).thenReturn(item);
+    when(request.withItem(any())).thenReturn(request);
+    CollectionResourceClient client = mock(CollectionResourceClient.class);
+    MultipleRecords<Request> multipleRequests = new MultipleRecords<>(List.of(request), 1);
+    Clients clients = mock(Clients.class);
+    when(clients.servicePointsStorage()).thenReturn(client);
+    JsonObject automatedPatronBlocks = new JsonObject()
+      .put("servicepoints", new JsonArray(Arrays.asList(
+        new JsonObject().put("id", primaryServicePointId.toString())
+          .put("name", name)
+      )))
+      .put("totalRecords", 1);
+
+    mockedClientGet(client, automatedPatronBlocks.encodePrettily());
+    ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
+    CompletableFuture<Result<MultipleRecords<Request>>> result =  servicePointRepository.findPrimaryServicePointsForRequests(multipleRequests);
+
+    MultipleRecords<Request> mRecords = result.get().value();
+    Collection<Request> coll = mRecords.getRecords();
+
+    Request receivedRequest = coll.stream().findFirst().get();
+    assertEquals(name, receivedRequest.getItem().getLocation().getPrimaryServicePoint().getName());
+  }
+
+  @Test
+  void findPrimaryServicePointsForRequests_mismatchTest() throws Exception {
+    UUID primaryServicePointId = UUID.randomUUID();
+    String name = "test name";
+
+    Request request = mock(Request.class);
+    Item item = mock(Item.class);
+    Institution institution = new Institution(StringUtils.EMPTY, StringUtils.EMPTY);
+    Campus campus = new Campus(StringUtils.EMPTY, StringUtils.EMPTY);
+    Library library = new Library(StringUtils.EMPTY, StringUtils.EMPTY);
+    ServicePoint primaryServicePoint = ServicePoint.unknown(primaryServicePointId.toString(), name);
+    Location location = new Location("11", null, null, null, List.of(UUID.randomUUID()), primaryServicePointId, institution, campus, library, primaryServicePoint);
+    when(request.getItem()).thenReturn(item);
+    when(item.getLocation()).thenReturn(location);
+    CollectionResourceClient client = mock(CollectionResourceClient.class);
+    MultipleRecords<Request> multipleRequests = new MultipleRecords<>(List.of(request), 1);
+    Clients clients = mock(Clients.class);
+    when(clients.servicePointsStorage()).thenReturn(client);
+    JsonObject automatedPatronBlocks = new JsonObject()
+      .put("servicepoints", new JsonArray(Arrays.asList(
+        new JsonObject().put("id", UUID.randomUUID())
+          .put("name", name)
+      )))
+      .put("totalRecords", 1);
+
+    mockedClientGet(client, automatedPatronBlocks.encodePrettily());
+    ServicePointRepository servicePointRepository = new ServicePointRepository(clients);
+    CompletableFuture<Result<MultipleRecords<Request>>> result =  servicePointRepository.findPrimaryServicePointsForRequests(multipleRequests);
+
+    verify(item, never()).withLocation(any());
+  }
+
+  private void mockedClientGet(GetManyRecordsClient client, String body) {
+    when(client.getMany(any(), any())).thenReturn(Result.ofAsync(
+      () -> new Response(200, body, "application/json")));
+  }
+}

--- a/src/test/java/org/folio/circulation/resources/RequestCollectionResourceTest.java
+++ b/src/test/java/org/folio/circulation/resources/RequestCollectionResourceTest.java
@@ -33,6 +33,7 @@ class RequestCollectionResourceTest {
   String queryWithTwoPSPIds = "(effectiveLocationPrimaryServicePointId==(\"a9b8247d-3a7a-410e-8df6-1c5af342aa77\" or \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\")) sortby requestDate";
   String queryWithThreePSPIds = "(effectiveLocationPrimaryServicePointId==(\"a9b8247d-3a7a-410e-8df6-1c5af342aa77\" or \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\" or \"c4c90014-c8c9-4ade-8f24-b5e313319f4b\")) sortby requestDate";
   String queryWithNoPSPIds = "() sortby requestDate";
+  String queryWithNoPSPIdsSortByDesc = "() sortby requestDate/sort.descending";
 
   RequestCollectionResource requestCollectionResource = new RequestCollectionResource(mock(HttpClient.class));
 
@@ -63,6 +64,12 @@ class RequestCollectionResourceTest {
   @Test
   void parseQueryWithNoPSPIds() {
     List<String> tokens = requestCollectionResource.parseEffectiveLocationIds(queryWithNoPSPIds);
+    assertEquals(0, tokens.size());
+  }
+
+  @Test
+  void parseQueryWithNoPSPIds_with_desc() {
+    List<String> tokens = requestCollectionResource.parseEffectiveLocationIds(queryWithNoPSPIdsSortByDesc);
     assertEquals(0, tokens.size());
   }
 

--- a/src/test/java/org/folio/circulation/resources/RequestCollectionResourceTest.java
+++ b/src/test/java/org/folio/circulation/resources/RequestCollectionResourceTest.java
@@ -1,0 +1,111 @@
+package org.folio.circulation.resources;
+
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang.StringUtils;
+import org.folio.circulation.domain.*;
+import org.folio.circulation.infrastructure.storage.ServicePointRepository;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.CollectionResourceClient;
+import org.folio.circulation.support.GetManyRecordsClient;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.results.Result;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RequestCollectionResourceTest {
+
+  String queryWithOnePSPId = "(effectiveLocationPrimaryServicePointId==\"a9b8247d-3a7a-410e-8df6-1c5af342aa77\") sortby requestDate";
+  String queryWithTwoPSPIds = "(effectiveLocationPrimaryServicePointId==(\"a9b8247d-3a7a-410e-8df6-1c5af342aa77\" or \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\")) sortby requestDate";
+  String queryWithThreePSPIds = "(effectiveLocationPrimaryServicePointId==(\"a9b8247d-3a7a-410e-8df6-1c5af342aa77\" or \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\" or \"c4c90014-c8c9-4ade-8f24-b5e313319f4b\")) sortby requestDate";
+  String queryWithNoPSPIds = "() sortby requestDate";
+
+  RequestCollectionResource requestCollectionResource = new RequestCollectionResource(mock(HttpClient.class));
+
+  @Test
+  void parseQueryWithOnePSPId() {
+    List<String> tokens = requestCollectionResource.parseEffectiveLocationIds(queryWithOnePSPId);
+    assertEquals(1, tokens.size());
+    assertEquals("a9b8247d-3a7a-410e-8df6-1c5af342aa77", tokens.get(0));
+  }
+
+  @Test
+  void parseQueryWithTwoPSPIds() {
+    List<String> tokens = requestCollectionResource.parseEffectiveLocationIds(queryWithTwoPSPIds);
+    assertEquals(2, tokens.size());
+    assertEquals("a9b8247d-3a7a-410e-8df6-1c5af342aa77", tokens.get(0));
+    assertEquals("3a40852d-49fd-4df2-a1f9-6e2641a6e91f", tokens.get(1));
+  }
+
+  @Test
+  void parseQueryWithThreePSPIds() {
+    List<String> tokens = requestCollectionResource.parseEffectiveLocationIds(queryWithThreePSPIds);
+    assertEquals(3, tokens.size());
+    assertEquals("a9b8247d-3a7a-410e-8df6-1c5af342aa77", tokens.get(0));
+    assertEquals("3a40852d-49fd-4df2-a1f9-6e2641a6e91f", tokens.get(1));
+    assertEquals("c4c90014-c8c9-4ade-8f24-b5e313319f4b", tokens.get(2));
+  }
+
+  @Test
+  void parseQueryWithNoPSPIds() {
+    List<String> tokens = requestCollectionResource.parseEffectiveLocationIds(queryWithNoPSPIds);
+    assertEquals(0, tokens.size());
+  }
+
+  @Test
+  void mapToJson_matched() {
+    UUID primaryServicePointId = UUID.randomUUID();
+    Request request = mock(Request.class);
+    when(request.asJson()).thenReturn(new JsonObject());
+    Item item = mock(Item.class);
+    Institution institution = new Institution(StringUtils.EMPTY, StringUtils.EMPTY);
+    Campus campus = new Campus(StringUtils.EMPTY, StringUtils.EMPTY);
+    Library library = new Library(StringUtils.EMPTY, StringUtils.EMPTY);
+    ServicePoint primaryServicePoint = ServicePoint.unknown(primaryServicePointId.toString(), StringUtils.EMPTY);
+    Location location = new Location("11", null, null, null, List.of(UUID.randomUUID()), primaryServicePointId, institution, campus, library, primaryServicePoint);
+    when(item.getLocation()).thenReturn(location);
+    when(request.getItem()).thenReturn(item);
+
+    MultipleRecords<Request> requests = new MultipleRecords<>(List.of(request), 1);
+    final List<String> effectiveLocationIds = List.of(primaryServicePointId.toString());
+
+    JsonObject result = requestCollectionResource.mapToJson(requests, effectiveLocationIds);
+    assertEquals(2, result.getMap().size());
+    assertEquals(1, result.getMap().get("totalRecords"));
+  }
+
+  @Test
+  void mapToJson_mismatched() {
+    UUID primaryServicePointId = UUID.randomUUID();
+    Request request = mock(Request.class);
+    Item item = mock(Item.class);
+    Institution institution = new Institution(StringUtils.EMPTY, StringUtils.EMPTY);
+    Campus campus = new Campus(StringUtils.EMPTY, StringUtils.EMPTY);
+    Library library = new Library(StringUtils.EMPTY, StringUtils.EMPTY);
+    ServicePoint primaryServicePoint = ServicePoint.unknown(primaryServicePointId.toString(), StringUtils.EMPTY);
+    Location location = new Location("11", null, null, null, List.of(UUID.randomUUID()), primaryServicePointId, institution, campus, library, primaryServicePoint);
+    when(item.getLocation()).thenReturn(location);
+    when(request.getItem()).thenReturn(item);
+
+    MultipleRecords<Request> requests = new MultipleRecords<>(List.of(request), 1);
+    final List<String> effectiveLocationIds = List.of("random id");
+
+    JsonObject result = requestCollectionResource.mapToJson(requests, effectiveLocationIds);
+    assertEquals(2, result.getMap().size());
+    assertEquals(0, result.getMap().get("totalRecords"));
+  }
+}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
https://issues.folio.org/browse/CIRC-1886
To populate the drop down the (ServicePoint) code will need to be used, this allows the already existing service point code to be leveraged. 

User must have the view request permission. Users: View requests, this should also limit them to their assigned service point/s. (This may need to be updated to suit general open source) This does match the generic permission in snapshot. 

## Approach
The request list is filtered in the backend based on the item selected in Primary Service Point name dropdown. 

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning

![image](https://github.com/folio-org/mod-circulation/assets/127274721/6863462a-c023-404a-9df2-6b810f8d8e2b)

