### PR TITLE
Schedule reminder fee processing to run daily (CIRC-1528)

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1057,8 +1057,10 @@
             "feefineactions.item.post",
             "circulation-storage.loans-history.collection.get"
           ],
-          "unit": "minute",
-          "delay": "5"
+          "schedule": {
+            "cron": "1 0 * * *",
+            "zone": "CET"
+          }
         }
       ]
     },


### PR DESCRIPTION
 - set default schedule for digital reminder fee processing to once a day, one minute after midnight, Central European time

Purpose: 

Reminder fee processing is a timed back-ground process, and the immediate adopter and funding organisation (Hebis) would like it to happen once a day after midnight, Central European time. The scheduling can be changed (or disabled) any time for any given tenant, using the timer API. 