### PR TITLE
CIRC-1905 Fix NPE when getting address

### DIFF
--- a/src/main/java/org/folio/circulation/domain/User.java
+++ b/src/main/java/org/folio/circulation/domain/User.java
@@ -113,7 +113,7 @@ public class User {
   }
 
   public JsonArray getAddresses() {
-    JsonArray addresses = getPersonal().getJsonArray(ADDRESSES_PROPERTY_NAME);
+    JsonArray addresses = getPersonal() == null ? null : getPersonal().getJsonArray(ADDRESSES_PROPERTY_NAME);
     return addresses == null ? new JsonArray() : addresses;
   }
 


### PR DESCRIPTION
CIRC-1905 Fix NPE in User.getPersonal() method

## Purpose
When user is created with API it is not asking for mandatory fields like email. So User can be created without personal object which leads to NPE when getting address. This is fix for that 
