### PR TITLE
CIRC-1925 Update reminder scheduler to handle printed notices

### DIFF
--- a/src/main/java/org/folio/circulation/CirculationVerticle.java
+++ b/src/main/java/org/folio/circulation/CirculationVerticle.java
@@ -45,7 +45,7 @@ import org.folio.circulation.resources.handlers.FeeFineBalanceChangedHandlerReso
 import org.folio.circulation.resources.handlers.LoanRelatedFeeFineClosedHandlerResource;
 import org.folio.circulation.resources.renewal.RenewByBarcodeResource;
 import org.folio.circulation.resources.renewal.RenewByIdResource;
-import org.folio.circulation.resources.ScheduledDigitalRemindersProcessingResource;
+import org.folio.circulation.resources.ScheduledRemindersProcessingResource;
 import org.folio.circulation.support.logging.LogHelper;
 import org.folio.circulation.support.logging.Logging;
 
@@ -127,7 +127,7 @@ public class CirculationVerticle extends AbstractVerticle {
       .register(router);
 
     new LoanScheduledNoticeProcessingResource(client).register(router);
-    new ScheduledDigitalRemindersProcessingResource(client).register(router);
+    new ScheduledRemindersProcessingResource(client).register(router);
     new DueDateNotRealTimeScheduledNoticeProcessingResource(client).register(router);
     new RequestScheduledNoticeProcessingResource(client).register(router);
     new FeeFineScheduledNoticeProcessingResource(client).register(router);

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledReminderHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledReminderHandler.java
@@ -43,7 +43,7 @@ import static org.folio.circulation.domain.notice.TemplateContextUtil.createFeeF
  * and to apply different isNoticeRelevant logic.
  * Reuses a handful of methods to set the notice contexts and fail if loan id is missing.
  */
-public class ScheduledDigitalReminderHandler extends LoanScheduledNoticeHandler {
+public class ScheduledReminderHandler extends LoanScheduledNoticeHandler {
 
   private final ZonedDateTime systemTime;
   private final LoanPolicyRepository loanPolicyRepository;
@@ -61,7 +61,7 @@ public class ScheduledDigitalReminderHandler extends LoanScheduledNoticeHandler 
 
 
 
-  public ScheduledDigitalReminderHandler(Clients clients, LoanRepository loanRepository) {
+  public ScheduledReminderHandler(Clients clients, LoanRepository loanRepository) {
     super(clients, loanRepository);
     this.systemTime = ClockUtil.getZonedDateTime();
     this.loanPolicyRepository = new LoanPolicyRepository(clients);

--- a/src/test/java/api/support/fixtures/OverdueFinePoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/OverdueFinePoliciesFixture.java
@@ -114,7 +114,7 @@ public class OverdueFinePoliciesFixture {
       .withAddedReminderEntry(1, "minute", 2.00,
         "Email", SECOND_REMINDER_TEMPLATE_ID.toString())
       .withAddedReminderEntry(1,"minute", 2.15,
-        "Email", THIRD_REMINDER_TEMPLATE_ID.toString());
+        "Mail", THIRD_REMINDER_TEMPLATE_ID.toString());
     return overdueFinePolicyRecordCreator.createIfAbsent(policy.create());
   }
 


### PR DESCRIPTION
CIRC-1925 Update reminder scheduler to handle printed notices

## Purpose
To handle email and mail types of reminder notices we need to enable mail notice handling 

## Approach
Remove notice type check in notice query 
