### PR TITLE
CIRC-1769: Add support for Actual Cost Records properties lost in deserialization

### DIFF
--- a/src/main/java/org/folio/circulation/storage/mappers/ActualCostRecordMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/ActualCostRecordMapper.java
@@ -1,6 +1,5 @@
 package org.folio.circulation.storage.mappers;
 
-import static java.util.stream.Collectors.toList;
 import static org.folio.circulation.domain.representations.CallNumberComponentsRepresentation.createCallNumberComponents;
 import static org.folio.circulation.domain.representations.ContributorsToNamesMapper.mapContributorNamesToJson;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getArrayProperty;
@@ -161,11 +160,11 @@ public class ActualCostRecordMapper {
         .withIdentifiers(getArrayProperty(instance, "identifiers").stream()
           .map(JsonObject.class::cast)
           .map(ActualCostRecordIdentifier::fromRepresentation)
-          .collect(toList()))
+          .toList())
         .withContributors(getArrayProperty(instance, "contributors").stream()
           .map(JsonObject.class::cast)
           .map(new ContributorMapper()::toDomain)
-          .collect(toList())),
+          .toList()),
       new ActualCostRecordFeeFine()
         .withAccountId(getProperty(feeFine, "accountId"))
         .withOwnerId(getProperty(feeFine, "ownerId"))
@@ -178,6 +177,6 @@ public class ActualCostRecordMapper {
   private static JsonArray mapIdentifiersToJson(Collection<ActualCostRecordIdentifier> identifiers) {
     return new JsonArray(identifiers.stream()
       .map(JsonObject::mapFrom)
-      .collect(toList()));
+      .toList());
   }
 }

--- a/src/test/java/api/loans/ExpiredActualCostRecordsProcessingTests.java
+++ b/src/test/java/api/loans/ExpiredActualCostRecordsProcessingTests.java
@@ -130,8 +130,8 @@ class ExpiredActualCostRecordsProcessingTests extends APITests {
     JsonObject openRecord = generateActualCostRecord(OPEN);
     UUID recordId = UUID.fromString(openRecord.getString("id"));
     runProcessingAfterExpirationDate();
-    assertThatActualCostRecordIsInStatus(openRecord, EXPIRED);
     JsonObject expiredRecord = actualCostRecordsClient.getById(recordId).getJson();
+    assertThat(expiredRecord, isInStatus(EXPIRED));
     openRecord.putNull("metadata");
     expiredRecord.putNull("metadata");
     assertThat(openRecord.put("status", "Expired"), equalTo(expiredRecord));

--- a/src/test/java/api/loans/ExpiredActualCostRecordsProcessingTests.java
+++ b/src/test/java/api/loans/ExpiredActualCostRecordsProcessingTests.java
@@ -8,6 +8,7 @@ import static org.folio.HttpStatus.HTTP_NO_CONTENT;
 import static org.folio.circulation.domain.ActualCostRecord.Status.EXPIRED;
 import static org.folio.circulation.domain.ActualCostRecord.Status.OPEN;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 
@@ -122,6 +123,18 @@ class ExpiredActualCostRecordsProcessingTests extends APITests {
     assertThatLoanIsClosedAsLostAndPaid(firstRecord);
     assertThatLoanIsClosedAsLostAndPaid(secondRecord);
     assertThatLoanIsClosedAsLostAndPaid(thirdRecord);
+  }
+
+  @Test
+  void expiredRecordHasSamePropertiesAsOriginalOpenRecord() {
+    JsonObject openRecord = generateActualCostRecord(OPEN);
+    UUID recordId = UUID.fromString(openRecord.getString("id"));
+    runProcessingAfterExpirationDate();
+    assertThatActualCostRecordIsInStatus(openRecord, EXPIRED);
+    JsonObject expiredRecord = actualCostRecordsClient.getById(recordId).getJson();
+    openRecord.putNull("metadata");
+    expiredRecord.putNull("metadata");
+    assertThat(openRecord.put("status", "Expired"), equalTo(expiredRecord));
   }
 
   private void assertThatActualCostRecordIsInStatus(JsonObject actualCostRecord,

--- a/src/test/java/org/folio/circulation/storage/mappers/ActualCostRecordMapperTest.java
+++ b/src/test/java/org/folio/circulation/storage/mappers/ActualCostRecordMapperTest.java
@@ -1,0 +1,73 @@
+package org.folio.circulation.storage.mappers;
+
+import static org.folio.circulation.storage.mappers.ActualCostRecordMapper.toDomain;
+import static org.folio.circulation.storage.mappers.ActualCostRecordMapper.toJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+class ActualCostRecordMapperTest {
+
+  @Test
+  void mappingTest() {
+    JsonObject actualCostRecordJson = new JsonObject()
+      .put("id", "c98215a8-987a-4ccd-9f3e-17b2f468d487")
+      .put("lossType", "Declared lost")
+      .put("lossDate", "2023-10-30T11:22:23.053Z")
+      .put("expirationDate", "2023-10-30T11:22:23.053Z")
+      .put("status", "Billed")
+      .put("user", new JsonObject()
+        .put("id", "72235d24-aead-4647-bad2-2febb12d940a")
+        .put("barcode", "1")
+        .put("firstName", "First")
+        .put("lastName", "Last")
+        .put("middleName", "Middle")
+        .put("patronGroupId", "503a81cd-6c26-400f-b620-14c08943697c")
+        .put("patronGroup", "Faculty"))
+      .put("loan", new JsonObject()
+        .put("id", "1e65b451-3cde-4575-93c1-9b7ff03db4fd"))
+      .put("item", new JsonObject()
+        .put("id", "bbe89d07-791a-48c5-86b1-79441f5fcd49")
+        .put("barcode", "abc123")
+        .put("materialTypeId", "d9acad2f-2aac-4b48-9097-e6ab85906b25")
+        .put("materialType", "text")
+        .put("permanentLocationId", "fcd64ce1-6995-48f0-840e-89ffa2288371")
+        .put("permanentLocation", "Main Library")
+        .put("effectiveLocationId", "a2a89dec-522b-4c1d-9690-a2f922869e68")
+        .put("effectiveLocation", "Annex")
+        .put("loanTypeId", "2b94c631-fca9-4892-a730-03ee529ffe27")
+        .put("loanType", "Can circulate")
+        .put("holdingsRecordId", "e6d7e91a-4dbc-4a70-9b38-e000d2fbdc79")
+        .put("volume", "vol")
+        .put("enumeration", "enum")
+        .put("chronology", "chrono")
+        .put("copyNumber", "copy")
+        .put("effectiveCallNumberComponents", new JsonObject()
+          .put("callNumber", "CN")
+          .put("prefix", "PFX")
+          .put("suffix", "SFX")))
+      .put("instance", new JsonObject()
+        .put("id", "cf23adf0-61ba-4887-bf82-956c4aae2260")
+        .put("title", "Test book")
+        .put("identifiers", new JsonArray()
+          .add(new JsonObject()
+            .put("value", "1447294130")
+            .put("identifierTypeId", "8261054f-be78-422d-bd51-4ed9f33c3422")
+            .put("identifierType", "ISBN")))
+        .put("contributors", new JsonArray()
+          .add(new JsonObject()
+            .put("name", "Test, Author"))))
+      .put("feeFine", new JsonObject()
+        .put("accountId", "cdac704f-17aa-57fa-9500-607c5fa792bd")
+        .put("ownerId", "94aecb81-b025-4eca-9e0e-14756d052836")
+        .put("owner", "Test owner")
+        .put("typeId", "73785370-d3bd-4d92-942d-ae2268e02ded")
+        .put("type", "Lost item fee (actual cost)"));
+
+    assertEquals(actualCostRecordJson, toJson(toDomain(actualCostRecordJson)));
+  }
+
+}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
[CIRC-1769](https://issues.folio.org/browse/CIRC-1769)

Method that converts ActualCostRecord from POJO to JSON ignores several properties:
- id
- user.patronGroup
- user.patronGroupId
- item.volume
- item.enumeration
- item.chronology
- item.copyNumber

This PR adds support for all these properties so that whenever mod-circulation updates an actual cost record (e.g. due to its expiration) these properties are not lost.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
