### PR TITLE
Fix getOpeningDayDurationTest

### DIFF
--- a/src/test/java/org/folio/circulation/domain/OverduePeriodCalculatorServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverduePeriodCalculatorServiceTest.java
@@ -123,15 +123,13 @@ class OverduePeriodCalculatorServiceTest {
       createOpeningDay(true, LocalDate.parse("2020-04-09"), LONDON),
       createOpeningDay(false, LocalDate.parse("2020-04-10"), LONDON));
 
-    LocalTime now = getLocalTime();
-
     List<OpeningDay> invalid = Arrays.asList(
       new OpeningDay(
         singletonList(new OpeningHour(null, null)), LocalDate.parse("2020-04-08"), false, true, UTC
       ),
-      new OpeningDay(
-        singletonList(new OpeningHour(now, now.minusHours(1))), LocalDate.parse("2020-04-09"),
-      false, true, UTC)
+      new OpeningDay(  // startTime after endTime
+        singletonList(new OpeningHour(LocalTime.of(6, 0), LocalTime.of(5, 0))),
+        LocalDate.parse("2020-04-09"), false, true, UTC)
     );
 
     List<OpeningDay> allDaysClosed = Arrays.asList(


### PR DESCRIPTION
When the test execution happens in the time range 00:00-00:59 the test fails because hour 0 minus one hour yields hour 23.

Fix: Hard-code the local time.