### PR TITLE
CIRC-1950 publish check-out event asynchronously

### DIFF
--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -269,9 +269,11 @@ public class CheckOutByBarcodeResource extends Resource {
 
     log.debug("publishItemCheckedOutEvent:: parameters records: {}", () -> records);
 
-    return eventPublisher.publishItemCheckedOutEvent(records, userRepository)
+    eventPublisher.publishItemCheckedOutEvent(records, userRepository)
       .thenApply(r -> errorHandler.handleAnyResult(r, FAILED_TO_PUBLISH_CHECKOUT_EVENT,
         succeeded(records)));
+
+    return ofAsync(records);
   }
 
   private CompletableFuture<Result<LoanAndRelatedRecords>> lookupLoanPolicy(

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -269,11 +269,9 @@ public class CheckOutByBarcodeResource extends Resource {
 
     log.debug("publishItemCheckedOutEvent:: parameters records: {}", () -> records);
 
-    eventPublisher.publishItemCheckedOutEvent(records, userRepository)
+    return eventPublisher.publishItemCheckedOutEvent(records, userRepository)
       .thenApply(r -> errorHandler.handleAnyResult(r, FAILED_TO_PUBLISH_CHECKOUT_EVENT,
         succeeded(records)));
-
-    return ofAsync(records);
   }
 
   private CompletableFuture<Result<LoanAndRelatedRecords>> lookupLoanPolicy(

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -109,7 +109,8 @@ public class EventPublisher {
           succeeded(pubSubPublishingService.publishEvent(LOG_RECORD.name(),
             mapToCheckOutLogEventContent(loanAndRelatedRecords, loggedInUser)))))));
 
-      logger.info("publishItemCheckedOutEvent:: publishing ITEM_CHECKED_OUT event");
+      logger.info("publishItemCheckedOutEvent:: publishing ITEM_CHECKED_OUT event for loan {}",
+        loan.getId());
       pubSubPublishingService.publishEvent(ITEM_CHECKED_OUT.name(), payloadJsonObject.encode())
         .handle((result, error) -> handlePublishEventError(error, loanAndRelatedRecords));
     } else {

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -105,10 +105,11 @@ public class EventPublisher {
         .ifPresent(json -> write(payloadJsonObject, GRACE_PERIOD_FIELD, json));
 
       runAsync(() -> userRepository.getUser(loanAndRelatedRecords.getLoggedInUserId())
-        .thenApplyAsync(r -> r.after(loggedInUser -> CompletableFuture.completedFuture(
-          Result.succeeded(pubSubPublishingService.publishEvent(LOG_RECORD.name(), mapToCheckOutLogEventContent(loanAndRelatedRecords, loggedInUser)))))));
+        .thenApplyAsync(r -> r.after(loggedInUser -> completedFuture(
+          succeeded(pubSubPublishingService.publishEvent(LOG_RECORD.name(),
+            mapToCheckOutLogEventContent(loanAndRelatedRecords, loggedInUser)))))));
 
-      return pubSubPublishingService.publishEvent(ITEM_CHECKED_OUT.name(), payloadJsonObject.encode())
+      pubSubPublishingService.publishEvent(ITEM_CHECKED_OUT.name(), payloadJsonObject.encode())
         .handle((result, error) -> handlePublishEventError(error, loanAndRelatedRecords));
     }
     else {

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -109,10 +109,10 @@ public class EventPublisher {
           succeeded(pubSubPublishingService.publishEvent(LOG_RECORD.name(),
             mapToCheckOutLogEventContent(loanAndRelatedRecords, loggedInUser)))))));
 
+      logger.info("publishItemCheckedOutEvent:: publishing ITEM_CHECKED_OUT event");
       pubSubPublishingService.publishEvent(ITEM_CHECKED_OUT.name(), payloadJsonObject.encode())
         .handle((result, error) -> handlePublishEventError(error, loanAndRelatedRecords));
-    }
-    else {
+    } else {
       logger.error(FAILED_TO_PUBLISH_LOG_TEMPLATE, ITEM_CHECKED_OUT.name());
     }
 

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -111,8 +111,9 @@ public class EventPublisher {
 
       logger.info("publishItemCheckedOutEvent:: publishing ITEM_CHECKED_OUT event for loan {}",
         loan.getId());
-      pubSubPublishingService.publishEvent(ITEM_CHECKED_OUT.name(), payloadJsonObject.encode())
-        .handle((result, error) -> handlePublishEventError(error, loanAndRelatedRecords));
+      // run ITEM_CHECKED_OUT event publishing asynchronously to prevent any impact on the performance of check-out
+      runAsync(() -> pubSubPublishingService.publishEvent(ITEM_CHECKED_OUT.name(), payloadJsonObject.encode())
+        .handle((result, error) -> handlePublishEventError(error, loanAndRelatedRecords)));
     } else {
       logger.error(FAILED_TO_PUBLISH_LOG_TEMPLATE, ITEM_CHECKED_OUT.name());
     }

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -112,8 +112,8 @@ public class EventPublisher {
       logger.info("publishItemCheckedOutEvent:: publishing ITEM_CHECKED_OUT event for loan {}",
         loan.getId());
       // run ITEM_CHECKED_OUT event publishing asynchronously to prevent any impact on the performance of check-out
-      runAsync(() -> pubSubPublishingService.publishEvent(ITEM_CHECKED_OUT.name(), payloadJsonObject.encode())
-        .handle((result, error) -> handlePublishEventError(error, loanAndRelatedRecords)));
+      runAsync(() -> pubSubPublishingService.publishEvent(ITEM_CHECKED_OUT.name(),
+        payloadJsonObject.encode()));
     } else {
       logger.error(FAILED_TO_PUBLISH_LOG_TEMPLATE, ITEM_CHECKED_OUT.name());
     }

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -1607,6 +1607,7 @@ class CheckOutByBarcodeTests extends APITests {
     final IndividualResource steve = usersFixture.steve();
 
     FakePubSub.setFailPublishingWithBadRequestError(true);
+    // since ITEM_CHECKED_OUT event is published asynchronously it doesn't affect check-out response
     checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -1607,7 +1607,7 @@ class CheckOutByBarcodeTests extends APITests {
     final IndividualResource steve = usersFixture.steve();
 
     FakePubSub.setFailPublishingWithBadRequestError(true);
-    checkOutFixture.attemptCheckOutByBarcode(200,
+    checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
         .to(steve)


### PR DESCRIPTION
## Purpose
Investigated the reported performance issue and discovered that a significant portion of the processing time is consumed during the publication of check-out events through pub-sub. I conducted measurements on a check-out operation, revealing a total duration of 9 seconds, with 7.64 seconds attributed specifically to the pub-sub publishing process
`10.30.11.227, 10.30.15.46, 10.30.11.12, 10.30.11.12 - 10.30.15.136 - - [10/Nov/2023:10:29:27 +0000] "POST /mod-pubsub/pubsub/publish? HTTP/1.1" 204 0 rt=7.631 uct="0.000" uht="7.640" urt="7.640" "Vert.x-WebClient/4.3.5" "fs09000000" "9eb67301-6f6e-468f-9b1a-6134dc39a684" "612289/pubsub"`

Resolves: [CIRC-1950](https://issues.folio.org/browse/CIRC-1950)

## Approach
Publish check-out event asynchronously
