### PR TITLE
CIRC-1970, skip account for reminders without fee

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicyRemindersPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicyRemindersPolicy.java
@@ -135,5 +135,9 @@ public class OverdueFinePolicyRemindersPolicy {
       return (capitalized.endsWith("s") ? capitalized : capitalized + "s");
     }
 
+    public boolean hasZeroFee () {
+      return reminderFee.doubleValue() == 0.0;
+    }
+
   }
 }

--- a/src/test/java/api/loans/ReminderFeeTests.java
+++ b/src/test/java/api/loans/ReminderFeeTests.java
@@ -107,7 +107,7 @@ class ReminderFeeTests extends APITests {
   }
 
   @Test
-  void willSendThreeRemindersAndCreateThreeAccountsThenStop() {
+  void willSendThreeRemindersAndCreateTwoAccountsThenStop() {
 
     final IndividualResource response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -137,7 +137,8 @@ class ReminderFeeTests extends APITests {
     verifyNumberOfSentNotices(2);
     verifyNumberOfPublishedEvents(NOTICE, 2);
     verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
-    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(2));
+    // Second reminder has zero fee, don't create account
+    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(1));
 
     ZonedDateTime thirdRunTime = dueDate.plusMinutes(6);
     scheduledNoticeProcessingClient.runScheduledDigitalRemindersProcessing(thirdRunTime);
@@ -146,7 +147,7 @@ class ReminderFeeTests extends APITests {
     verifyNumberOfSentNotices(3);
     verifyNumberOfPublishedEvents(NOTICE, 3);
     verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
-    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(3));
+    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(2));
 
     ZonedDateTime fourthRunTime = dueDate.plusMinutes(8);
     scheduledNoticeProcessingClient.runScheduledDigitalRemindersProcessing(fourthRunTime);
@@ -155,7 +156,7 @@ class ReminderFeeTests extends APITests {
     verifyNumberOfSentNotices(3);
     verifyNumberOfPublishedEvents(NOTICE, 3);
     verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
-    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(3));
+    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(2));
   }
 
   @Test

--- a/src/test/java/api/support/fixtures/OverdueFinePoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/OverdueFinePoliciesFixture.java
@@ -111,7 +111,7 @@ public class OverdueFinePoliciesFixture {
       .withAddedReminderEntry(
         1,"minute",1.50,
         "Email",FIRST_REMINDER_TEMPLATE_ID.toString())
-      .withAddedReminderEntry(1, "minute", 2.00,
+      .withAddedReminderEntry(1, "minute", 0.00,
         "Email", SECOND_REMINDER_TEMPLATE_ID.toString())
       .withAddedReminderEntry(1,"minute", 2.15,
         "Email", THIRD_REMINDER_TEMPLATE_ID.toString());


### PR DESCRIPTION
## Purpose
Bug fix: Some reminders have a fee of 0. However, creating an account and an action for a zero fee causes problems downstream, for example when attempting to clear outstanding fees by paying them. With this change the 0 fee reminder is sent but not charged.

See CIRC-1970 for details on how the issues appear in the UI.  

## Approach
Make the creation of accounts and actions conditional on the fee amount in the reminder fees process handler. 

Reminder fee unit tests are extended to test that accounts are not created for 0 fees. 

This change only touches reminder fees processing classes with no potential impact on other functions in circulation. 
