### PR TITLE
CIRC-1977: Remove circulation rules cache update on GET and PUT

### DIFF
--- a/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
+++ b/src/main/java/org/folio/circulation/resources/CirculationRulesResource.java
@@ -29,7 +29,6 @@ import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.rules.CirculationRulesException;
 import org.folio.circulation.rules.CirculationRulesParser;
 import org.folio.circulation.rules.Text2Drools;
-import org.folio.circulation.rules.cache.CirculationRulesCache;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.ForwardOnFailure;
@@ -101,8 +100,6 @@ public class CirculationRulesResource extends Resource {
               return;
             }
             JsonObject circulationRules = new JsonObject(response.getBody());
-            CirculationRulesCache.getInstance()
-              .buildRules(context.getTenantId(), circulationRules.getString("rulesAsText"));
 
             context.write(ok(circulationRules));
           }
@@ -158,8 +155,6 @@ public class CirculationRulesResource extends Resource {
 
     clients.circulationRulesStorage().put(rulesInput.copy())
       .thenApply(this::failWhenResponseOtherThanNoContent)
-      .thenApply(result -> result.map(response -> CirculationRulesCache.getInstance()
-        .buildRules(webContext.getTenantId(), rulesAsText)))
       .thenApply(result -> result.map(response -> noContent()))
       .thenAccept(webContext::writeResultToHttpResponse);
   }

--- a/src/main/java/org/folio/circulation/rules/cache/CirculationRulesCache.java
+++ b/src/main/java/org/folio/circulation/rules/cache/CirculationRulesCache.java
@@ -59,7 +59,7 @@ public final class CirculationRulesCache {
     return circulationRules.getString("rulesAsText");
   }
 
-  public Result<Drools> buildRules(String tenantId, String rulesAsText) {
+  private Result<Drools> buildRules(String tenantId, String rulesAsText) {
     log.info("buildRules:: building rules for tenant {}", tenantId);
     log.debug("buildRules:: rules={}", rulesAsText);
 

--- a/src/test/java/api/CirculationRulesAPITests.java
+++ b/src/test/java/api/CirculationRulesAPITests.java
@@ -1,21 +1,16 @@
 package api;
 
-import static api.support.APITestContext.TENANT_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import org.folio.circulation.rules.cache.CirculationRulesCache;
 import org.folio.circulation.support.http.client.Response;
 import org.junit.jupiter.api.Test;
 
-import api.support.APITestContext;
 import api.support.APITests;
 import api.support.builders.LoanPolicyBuilder;
 import api.support.builders.LostItemFeePolicyBuilder;
@@ -430,15 +425,6 @@ class CirculationRulesAPITests extends APITests {
       is("Tabulator character is not allowed, use spaces instead."));
     assertThat(json.getInteger("line"), is(1));
     assertThat(json.getInteger("column"), is(2));
-  }
-
-  @Test
-  void getRefreshesCirculationRulesCache() {
-    CirculationRulesCache cache = CirculationRulesCache.getInstance();
-    cache.dropCache();
-    assertThat(cache.getRules(TENANT_ID), nullValue());
-    String rules = circulationRulesFixture.getCirculationRules();
-    assertThat(cache.getRules(TENANT_ID).getRulesAsText(), equalTo(rules));
   }
 
   /** @return rulesAsText field */


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Since #1371 circulation rules cache are updated by domain events published by mod-circulation storage, but also when GET or PUT `/circulation/rules` was called, which seems redundant and slows down the performance of these interfaces. Consuming domain events should be sufficient to cover our needs of keeping rules cache up to date, so we can safely remove cache updates from `/circulation/rules`  API.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
