### PR TITLE
CIRC-1981 Print AgencyCode in DCB CheckIn Print Slips

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -12,6 +12,7 @@ import static org.folio.circulation.domain.ItemStatus.PAGED;
 import static org.folio.circulation.domain.representations.ItemProperties.STATUS_PROPERTY;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getBooleanProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
 import java.util.Collection;
@@ -399,7 +400,11 @@ public class Item {
       this.instance, this.materialType, this.loanType, this.description);
   }
 
-  public boolean isDcbItem(){
+  public boolean isDcbItem() {
     return getBooleanProperty(itemRepresentation, "dcbItem");
+  }
+
+  public String getLendingLibraryCode() {
+    return getProperty(itemRepresentation, "lendingLibraryCode");
   }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -215,7 +215,7 @@ public class TemplateContextUtil {
         .put("effectiveLocationSpecific", location.getName())
         .put("effectiveLocationLibrary", location.getLibraryName())
         .put("effectiveLocationCampus", location.getCampusName())
-        .put("effectiveLocationInstitution", location.getInstitutionName())
+        .put("effectiveLocationInstitution", item.isDcbItem()?item.getLendingLibraryCode():location.getInstitutionName())
         .put("effectiveLocationDiscoveryDisplayName", location.getDiscoveryDisplayName());
 
       var primaryServicePoint = location.getPrimaryServicePoint();

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -440,6 +440,23 @@ void verifyItemEffectiveLocationIdAtCheckOut() {
   }
 
   @Test
+  void slipContainsLendingLibraryCodeForDcb() {
+    final UUID checkInServicePointId = servicePointsFixture.cd1().getId();
+    IndividualResource instance = instancesFixture.basedUponDunkirk();
+    IndividualResource holdings = holdingsFixture.defaultWithHoldings(instance.getId());
+    IndividualResource locationsResource = locationsFixture.mainFloor();
+    var barcode = "100002222";
+    var lendingLibraryCode = "11223";
+    final IndividualResource circulationItem = circulationItemsFixture.createCirculationItemWithLandingLibrary(barcode, holdings.getId(), locationsResource.getId(), lendingLibraryCode);
+
+    final CheckInByBarcodeResponse checkInResponse = checkInFixture.checkInByBarcode(circulationItem, ZonedDateTime.now(), checkInServicePointId);
+    JsonObject staffSlipContext = checkInResponse.getStaffSlipContext();
+    JsonObject itemContext = staffSlipContext.getJsonObject("item");
+
+    assertThat(itemContext.getString("effectiveLocationInstitution"), is(lendingLibraryCode));
+  }
+
+  @Test
   void canCheckInAnItemWithoutAnOpenLoan() {
     final UUID checkInServicePointId = servicePointsFixture.cd1().getId();
 

--- a/src/test/java/api/support/builders/CirculationItemsBuilder.java
+++ b/src/test/java/api/support/builders/CirculationItemsBuilder.java
@@ -109,6 +109,18 @@ public class CirculationItemsBuilder extends JsonBuilder implements Builder {
       this.lendingLibraryCode);
   }
 
+  public CirculationItemsBuilder withLendingLibraryCode(String lendingLibraryCode) {
+    return new CirculationItemsBuilder(
+      this.itemId,
+      this.barcode,
+      this.holdingId,
+      this.locationId,
+      this.materialTypeId,
+      this.loanTypeId,
+      this.isDcb,
+      lendingLibraryCode);
+  }
+
   public CirculationItemsBuilder withLoanType(UUID loanTypeId) {
     return new CirculationItemsBuilder(
       this.itemId,

--- a/src/test/java/api/support/fixtures/CirculationItemsFixture.java
+++ b/src/test/java/api/support/fixtures/CirculationItemsFixture.java
@@ -26,4 +26,11 @@ public class CirculationItemsFixture {
       .withLocationId(locationId);
     return circulationItemClient.create(circulationItemsBuilder);
   }
+
+  public IndividualResource createCirculationItemWithLandingLibrary(String barcode, UUID holdingId, UUID locationId, String landingLibrary) {
+    CirculationItemsBuilder circulationItemsBuilder = new CirculationItemsBuilder().withBarcode(barcode).withHoldingId(holdingId)
+      .withLoanType(loanTypesFixture.canCirculate().getId()).withMaterialType(materialTypesFixture.book().getId())
+      .withLocationId(locationId).withLendingLibraryCode(landingLibrary);
+    return circulationItemClient.create(circulationItemsBuilder);
+  }
 }


### PR DESCRIPTION
Covers: [CIRC-1981](https://issues.folio.org/browse/CIRC-1981)

Purpose
The purpose of the story is to display 5-digit agency name in DCB Virtual Item's check-in Print Slips as items.effectiveLocationInstitution field.{}

For more information, please refer to Edit Issue : [MODDCB-59](https://issues.folio.org/browse/MODDCB-59) - FOLIO Issue Tracker