### PR TITLE
[CIRC-1985] - Incorrect information in the Circulation log for the user barcode for In-house check-in action.

### DIFF
--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -39,7 +39,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.CheckInContext;
 import org.folio.circulation.domain.EventType;
-import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.domain.Request;
@@ -133,7 +132,7 @@ public class EventPublisher {
         if (nonNull(lastLoan.value())) {
           return userRepository.getUser(lastLoan.value().getUserId())
             .thenApply(userFromLastLoan -> Result.succeeded(pubSubPublishingService.publishEvent(LOG_RECORD.name(),
-              mapToCheckInLogEventContent(checkInContext, userResult.value(), checkInContext.getItem().getStatus().equals(ItemStatus.AVAILABLE) ?
+              mapToCheckInLogEventContent(checkInContext, userResult.value(), checkInContext.isInHouseUse() ?
                 null : userFromLastLoan.value()))));
         }
         return userResult.after(loggedInUser -> CompletableFuture.completedFuture(

--- a/src/test/java/api/loans/CheckInByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckInByBarcodeTests.java
@@ -11,6 +11,7 @@ import static api.support.fixtures.TemplateContextMatchers.getLoanAdditionalInfo
 import static api.support.fixtures.TemplateContextMatchers.getUserContextMatchers;
 import static api.support.fixtures.TemplateContextMatchers.isPreferredName;
 import static api.support.matchers.CheckOutByBarcodeResponseMatchers.hasItemBarcodeParameter;
+import static api.support.matchers.EventMatchers.doesNotContainUserBarcode;
 import static api.support.matchers.EventMatchers.isValidCheckInLogEvent;
 import static api.support.matchers.EventMatchers.isValidItemCheckedInEvent;
 import static api.support.matchers.ItemMatchers.isAvailable;
@@ -61,9 +62,9 @@ import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -75,8 +76,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import api.support.builders.AddInfoRequestBuilder;
-import io.vertx.core.json.JsonArray;
 import org.folio.circulation.domain.ItemStatus;
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestStatus;
@@ -91,6 +90,7 @@ import api.support.APITests;
 import api.support.CheckInByBarcodeResponse;
 import api.support.MultipleJsonRecords;
 import api.support.TlrFeatureStatus;
+import api.support.builders.AddInfoRequestBuilder;
 import api.support.builders.Address;
 import api.support.builders.CheckInByBarcodeRequestBuilder;
 import api.support.builders.FeeFineBuilder;
@@ -110,6 +110,7 @@ import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
 import api.support.http.UserResource;
 import api.support.matchers.RequestMatchers;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import lombok.val;
 
@@ -1570,6 +1571,18 @@ void verifyItemEffectiveLocationIdAtCheckOut() {
 
     assertThat(checkInLogEvent, isValidCheckInLogEvent(checkedInLoan));
     assertThatPublishedLoanLogRecordEventsAreValid(checkedInLoan);
+
+    // Second CheckIn for In-House
+    checkInFixture.checkInByBarcode(
+      new CheckInByBarcodeRequestBuilder()
+        .forItem(nod)
+        .on(checkInDate)
+        .at(checkInServicePointId));
+
+    final var secondPublishedEvents = waitAtMost(2, SECONDS)
+      .until(FakePubSub::getPublishedEvents, hasSize(5));
+    final var checkedInEvent2 = secondPublishedEvents.findFirst(byEventType(ITEM_CHECKED_IN.name()));
+    assertThat(checkedInEvent2, doesNotContainUserBarcode());
   }
 
   @Test

--- a/src/test/java/api/support/matchers/EventMatchers.java
+++ b/src/test/java/api/support/matchers/EventMatchers.java
@@ -79,6 +79,13 @@ public class EventMatchers {
       isItemCheckedInEventType());
   }
 
+  public static Matcher<JsonObject> doesNotContainUserBarcode() {
+    return allOf(JsonObjectMatcher.allOfPaths(
+        hasJsonPath("eventPayload", allOf(
+          hasNoJsonPath("userBarcode")
+        ))),
+      isItemCheckedInEventType());
+  }
   public static Matcher<JsonObject> isValidCheckInLogEvent(JsonObject checkedInLoan) {
     return allOf(JsonObjectMatcher.allOfPaths(
       hasJsonPath("eventPayload", allOf(


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
The purpose of this PR is to fix the issue reported in CIRC-1985 in which its expected that user barcode be displayed as empty when an in-house checkin is performed.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
The approach taken is to check the checkin is for an inHouse case then the previous loan user barcode will be displayed empty (hyphen on the UI).
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
