### PR TITLE
CIRC-2030  Reschedule reminder notices on recall.

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -577,7 +577,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     write(representation, "renewalCount", getRenewalCount() + 1);
   }
 
-  private void resetReminders() {
+  public void resetReminders() {
     remove(representation, "reminders");
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ReminderFeeScheduledNoticeService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ReminderFeeScheduledNoticeService.java
@@ -48,27 +48,6 @@ public class ReminderFeeScheduledNoticeService {
     return succeeded(records);
   }
 
-  /**
-   * Schedules first reminder after renewal
-   * @param renewalContext passed in from the renewal process
-   * @return the renewal context back to the renewal process
-   */
-  public Result<RenewalContext> rescheduleFirstReminder(RenewalContext renewalContext) {
-    Loan loan = renewalContext.getLoan();
-    OverdueFinePolicy policy = loan.getOverdueFinePolicy();
-    if (policy.isReminderFeesPolicy()) {
-      log.debug("rescheduleFirstReminder:: Reschedule reminder on renewal: Loan has reminder policy. Barcode: {}. Renewal context: {}.",
-        loan.getItem().getBarcode(), renewalContext);
-      scheduledNoticesRepository.deleteByLoanIdAndTriggeringEvent(loan.getId(),
-          TriggeringEvent.DUE_DATE_WITH_REMINDER_FEE)
-        .thenAccept(r -> r.next(deleted -> scheduleFirstReminder(loan, renewalContext.getTimeZone())));
-    } else {
-      log.debug("rescheduleFirstReminder:: Reschedule reminder on renewal: The current item, barcode {}, is not subject to a reminder fees policy.",
-        loan.getItem().getBarcode());
-    }
-    return succeeded(renewalContext);
-  }
-
   private Result<Void> scheduleFirstReminder(Loan loan, ZoneId timeZone) {
     log.debug("scheduleFirstReminder:: parameters loan: {}, timeZone: {}",
       loan, timeZone);
@@ -79,11 +58,42 @@ public class ReminderFeeScheduledNoticeService {
     return succeeded(null);
   }
 
+  /**
+   * Re-schedules first reminder after manual due date change or recall
+   * @param relatedRecords context records passed in from the manual due date change or recall process
+   * @return the due date change context back to the manual due date change or recall process
+   */
+  public Result<LoanAndRelatedRecords> rescheduleFirstReminder(LoanAndRelatedRecords relatedRecords) {
+    return rescheduleFirstReminder(relatedRecords.getLoan(), relatedRecords.getTimeZone(), relatedRecords);
+  }
+
+  /**
+   * Re-schedules first reminder after renewal
+   * @param renewalContext passed in from the renewal process
+   * @return the renewal context back to the renewal process
+   */
+  public Result<RenewalContext> rescheduleFirstReminder(RenewalContext renewalContext) {
+    return rescheduleFirstReminder(renewalContext.getLoan(), renewalContext.getTimeZone(), renewalContext);
+  }
+
+  private <T> Result<T> rescheduleFirstReminder(Loan loan, ZoneId timeZone, T mapTo) {
+    OverdueFinePolicy policy = loan.getOverdueFinePolicy();
+    if (policy.isReminderFeesPolicy()) {
+      scheduledNoticesRepository.deleteByLoanIdAndTriggeringEvent(loan.getId(),
+          TriggeringEvent.DUE_DATE_WITH_REMINDER_FEE)
+        .thenAccept(r -> r.next(deleted -> scheduleFirstReminder(loan, timeZone)));
+    } else {
+      log.debug("rescheduleFirstReminder:: Reschedule reminder on due date change: The current item, barcode {}, is not subject to a reminder fees policy.",
+        loan.getItem().getBarcode());
+    }
+    return succeeded(mapTo);
+  }
+
   private CompletableFuture<Result<ScheduledNotice>> instantiateFirstScheduledNotice(
     Loan loan, ZoneId timeZone, ReminderConfig reminderConfig) {
 
     log.debug("instantiateFirstScheduledNotice:: parameters loanAndRelatedRecords: {}, " +
-        " timeZone: {}, reminderConfig: {}", loan, timeZone, reminderConfig);
+      " timeZone: {}, reminderConfig: {}", loan, timeZone, reminderConfig);
 
     return reminderConfig.nextNoticeDueOn(loan.getDueDate(), timeZone,
         loan.getCheckoutServicePointId(), calendarRepository)

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -487,6 +487,7 @@ public class LoanPolicy extends Policy {
   private Loan changeDueDate(ZonedDateTime dueDate, Loan loan) {
     if (!loan.wasDueDateChangedByRecall()) {
       loan.changeDueDate(dueDate);
+      loan.resetReminders();
       loan.setDueDateChangedByRecall();
     }
 

--- a/src/test/java/api/loans/ReminderFeeTests.java
+++ b/src/test/java/api/loans/ReminderFeeTests.java
@@ -783,7 +783,7 @@ class ReminderFeeTests extends APITests {
       scheduledNoticeSecondReminder.getInstant("nextRunTime").toString(),
       is(not(equalTo(rescheduledNotice.getInstant("nextRunTime").toString()))));
     assertThat("Loan should have no reminders after recall",
-      not(loanAfterRecall.containsKey("reminders")));
+      !loanAfterRecall.containsKey("reminders"));
     assertThat("a new, rescheduled notice with a new ID should be created",
       rescheduledNotice.getString("id"),
         is(not(equalTo(initialScheduledNotice.getString("id")))));

--- a/src/test/java/api/loans/ReminderFeeTests.java
+++ b/src/test/java/api/loans/ReminderFeeTests.java
@@ -1,10 +1,7 @@
 package api.loans;
 
 import api.support.APITests;
-import api.support.builders.CheckOutByBarcodeRequestBuilder;
-import api.support.builders.FeeFineOwnerBuilder;
-import api.support.builders.HoldingBuilder;
-import api.support.builders.ItemBuilder;
+import api.support.builders.*;
 import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
 import api.support.http.UserResource;
@@ -725,6 +722,60 @@ class ReminderFeeTests extends APITests {
         .isAfter(initialScheduledNotice.getInstant("nextRunTime")));
     assertThat("Loan should have no reminders after renewal",
       not(loanAfterRenewal.containsKey("reminders")));
+  }
+
+  @Test
+  void willResetRemindersRescheduleNoticeOnRecall() {
+    useFallbackPolicies(
+      loanPolicyId,
+      requestPolicyId,
+      noticePolicyId,
+      remindersOneDayBetweenNotOnClosedDaysId,
+      lostItemFeePolicyId);
+
+    // Check out item, all days open service point
+    final IndividualResource response = checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .on(loanDate)
+        .at(servicePointsFixture.cd1()));
+    final JsonObject loan = response.getJson();
+    ZonedDateTime dueDate = DateFormatUtil.parseDateTime(loan.getString("dueDate"));
+
+    waitAtMost(1, SECONDS).until(scheduledNoticesClient::getAll, hasSize(1));
+    JsonObject initialScheduledNotice = scheduledNoticesClient.getAll().get(0);
+
+    ZonedDateTime latestRunTime = dueDate.plusDays(2).truncatedTo(DAYS.toChronoUnit()).plusMinutes(1);
+    scheduledNoticeProcessingClient.runScheduledDigitalRemindersProcessing(latestRunTime);
+
+    verifyNumberOfScheduledNotices(1);
+    verifyNumberOfSentNotices(1);
+    verifyNumberOfPublishedEvents(NOTICE, 1);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(1));
+
+    JsonObject loanAfterReminder = loansClient.getById(UUID.fromString(loan.getString("id"))).getJson();
+    assertThat("loan should have first reminder", loanAfterReminder.encode(),
+      hasJsonPath("reminders.lastFeeBilled.number", is(1)));
+
+    requestsFixture.place(new RequestBuilder()
+      .open()
+      .recall()
+      .forItem(item)
+      .by(usersFixture.james())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId()));
+
+    waitAtMost(1, SECONDS).until(scheduledNoticesClient::getAll, hasSize(1));
+    JsonObject loanAfterRecall = loansClient.getById(UUID.fromString(loan.getString("id"))).getJson();
+
+    JsonObject rescheduledNotice = scheduledNoticesClient.getAll().get(0);
+
+    assertThat("rescheduled notice should be scheduled later than initial notice",
+      rescheduledNotice.getInstant("nextRunTime")
+        .isAfter(initialScheduledNotice.getInstant("nextRunTime")));
+    assertThat("Loan should have no reminders after renewal",
+      not(loanAfterRecall.containsKey("reminders")));
   }
 
 }

--- a/src/test/java/api/loans/ReminderFeeTests.java
+++ b/src/test/java/api/loans/ReminderFeeTests.java
@@ -38,6 +38,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.equalTo;
 
 class ReminderFeeTests extends APITests {
 
@@ -710,6 +711,8 @@ class ReminderFeeTests extends APITests {
     assertThat("loan should have first reminder", loanAfterReminder.encode(),
       hasJsonPath("reminders.lastFeeBilled.number", is(1)));
 
+    JsonObject scheduledNoticeSecondReminder = scheduledNoticesClient.getAll().get(0);
+
     JsonObject loanAfterRenewal = loansFixture.attemptRenewal(200,
       item, borrower).getJson();
     waitAtMost(1, SECONDS).until(scheduledNoticesClient::getAll, hasSize(1));
@@ -717,6 +720,9 @@ class ReminderFeeTests extends APITests {
 
     assertThat("renewal count should be 1 after renewal",
       loanAfterRenewal.getInteger("renewalCount"), is(1));
+    assertThat("rescheduled reminder should have different runtime than previous, second reminder",
+      scheduledNoticeSecondReminder.getInstant("nextRunTime").toString(),
+      is(not(equalTo(rescheduledNotice.getInstant("nextRunTime").toString()))));
     assertThat("rescheduled notice should be scheduled later than initial notice",
       rescheduledNotice.getInstant("nextRunTime")
         .isAfter(initialScheduledNotice.getInstant("nextRunTime")));
@@ -755,6 +761,8 @@ class ReminderFeeTests extends APITests {
     verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
     waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(1));
 
+    JsonObject scheduledNoticeSecondReminder = scheduledNoticesClient.getAll().get(0);
+
     JsonObject loanAfterReminder = loansClient.getById(UUID.fromString(loan.getString("id"))).getJson();
     assertThat("loan should have first reminder", loanAfterReminder.encode(),
       hasJsonPath("reminders.lastFeeBilled.number", is(1)));
@@ -771,11 +779,14 @@ class ReminderFeeTests extends APITests {
 
     JsonObject rescheduledNotice = scheduledNoticesClient.getAll().get(0);
 
-    assertThat("rescheduled notice should be scheduled later than initial notice",
-      rescheduledNotice.getInstant("nextRunTime")
-        .isAfter(initialScheduledNotice.getInstant("nextRunTime")));
-    assertThat("Loan should have no reminders after renewal",
+    assertThat("rescheduled reminder should have different runtime than previous, second reminder",
+      scheduledNoticeSecondReminder.getInstant("nextRunTime").toString(),
+      is(not(equalTo(rescheduledNotice.getInstant("nextRunTime").toString()))));
+    assertThat("Loan should have no reminders after recall",
       not(loanAfterRecall.containsKey("reminders")));
+    assertThat("a new, rescheduled notice with a new ID should be created",
+      rescheduledNotice.getString("id"),
+        is(not(equalTo(initialScheduledNotice.getString("id")))));
   }
 
 }


### PR DESCRIPTION
## Purpose
When an item is recalled, and the due date thus changes, then the reminders must be rescheduled, similar to other patron notices related to the due date. In the case of reminder notices, this involves removing the existing next reminder notice and creating a new notice as with other patron notices, but then also resetting the reminder counter on the loan. 

See https://folio-org.atlassian.net/browse/CIRC-2030

## Approach
The rescheduling of reminders is inserted in the recall API flow of logic, alongside rescheduling of other patron notices. It requires an additional lookup of the loan's overdue fine policy to retrieve the reminder fees policy if any. 

This is all very similar to a previous pull request regarding rescheduling of reminders upon renewal (CIRC-1968), and this PR thus reuses some of the rescheduling logic first introduced for renewal. 