### PR TITLE
CIRC-1965: Do not send "Aged to lost" notice for closed loan

### DIFF
--- a/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
@@ -173,10 +173,6 @@ public class LoanScheduledNoticeHandler extends ScheduledNoticeHandler {
     ScheduledNotice notice = context.getNotice();
     List<String> logMessages = new ArrayList<>();
 
-    if (!isRecurringAfterNotice(notice)) {
-      return false;
-    }
-
     if (loan.hasItemWithAnyStatus(DECLARED_LOST, CLAIMED_RETURNED)) {
       logMessages.add(
         String.format("Recurring notice for item in status \"%s\"", loan.getItemStatus()));
@@ -199,10 +195,6 @@ public class LoanScheduledNoticeHandler extends ScheduledNoticeHandler {
       notice.getId(), loan.getId(), logMessages);
 
     return true;
-  }
-
-  private static boolean isRecurringAfterNotice(ScheduledNotice notice) {
-    return notice.getConfiguration().isRecurring() && notice.getConfiguration().hasAfterTiming();
   }
 
   private static boolean nextRecurringNoticeIsNotRelevant(ScheduledNotice notice, Loan loan) {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Resolves [CIRC-1965](https://folio-org.atlassian.net/browse/CIRC-1965)
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
