### PR TITLE
[CIRC-2026] Alternate loan period applied when multiple requests in fulfillment in progress

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.Loan;
-import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestQueue;
 import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.domain.RequestType;

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -160,7 +160,7 @@ public class LoanPolicy extends Policy {
       else {
         boolean useAlternatePeriod = false;
         Period rollingPeriod = getPeriod(loansPolicy);
-        if(isAlternatePeriod(requestQueue, itemId)) {
+        if (isAlternatePeriod(requestQueue, itemId)) {
           rollingPeriod = getPeriod(holds, ALTERNATE_CHECKOUT_LOAN_PERIOD_KEY);
           useAlternatePeriod = true;
         }
@@ -175,7 +175,7 @@ public class LoanPolicy extends Policy {
           getRenewalFixedDueDateSchedules(), systemDate, this::loanPolicyValidationError);
       }
       else {
-        if(isAlternatePeriod(requestQueue, itemId)) {
+        if (isAlternatePeriod(requestQueue, itemId)) {
           return new RollingCheckOutDueDateStrategy(getId(), getName(),
             getPeriod(holds, ALTERNATE_CHECKOUT_LOAN_PERIOD_KEY),
               fixedDueDateSchedules, this::loanPolicyValidationError, false);

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -200,22 +200,15 @@ public class LoanPolicy extends Policy {
   }
 
   private boolean isAlternatePeriod(RequestQueue requestQueue) {
-    final JsonObject holds = getHolds();
-    if(Objects.isNull(requestQueue)
-      || !holds.containsKey(ALTERNATE_CHECKOUT_LOAN_PERIOD_KEY)) {
+    if (Objects.isNull(requestQueue) || !getHolds().containsKey(
+      ALTERNATE_CHECKOUT_LOAN_PERIOD_KEY)) {
+
       return false;
     }
-    Optional<Request> potentialRequest = requestQueue.getRequests().stream().skip(1).findFirst();
-    boolean isAlternateDueDateSchedule = false;
-    if(potentialRequest.isPresent()) {
-      Request request = potentialRequest.get();
-      boolean isHold = request.getRequestType() == RequestType.HOLD;
-      boolean isOpenNotYetFilled = request.getStatus() == RequestStatus.OPEN_NOT_YET_FILLED;
-      if(isHold && isOpenNotYetFilled) {
-        isAlternateDueDateSchedule = true;
-      }
-    }
-    return isAlternateDueDateSchedule;
+
+    return requestQueue.getRequests().stream()
+      .anyMatch(request -> request.getRequestType() == RequestType.HOLD &&
+        request.getStatus() == RequestStatus.OPEN_NOT_YET_FILLED);
   }
 
   private JsonObject getLoansPolicy() {

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -537,7 +537,8 @@ public abstract class RenewalResource extends Resource {
 
   private Result<ZonedDateTime> calculateProposedDueDate(Loan loan, ZonedDateTime systemDate) {
     return loan.getLoanPolicy()
-      .determineStrategy(null, true, false, systemDate).calculateDueDate(loan);
+      .determineStrategy(null, true, false, systemDate, loan.getItemId())
+      .calculateDueDate(loan);
   }
 
   private boolean newDueDateAfterCurrentDueDate(Loan loan, Result<ZonedDateTime> proposedDueDateResult) {
@@ -665,7 +666,7 @@ public abstract class RenewalResource extends Resource {
     final var loanPolicy = loan.getLoanPolicy();
     final var isRenewalWithHoldRequest = firstRequestForLoanedItemIsHold(requestQueue, loan);
 
-    return loanPolicy.determineStrategy(null, true, isRenewalWithHoldRequest, systemDate)
+    return loanPolicy.determineStrategy(null, true, isRenewalWithHoldRequest, systemDate, loan.getItemId())
       .calculateDueDate(loan);
   }
 

--- a/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
+++ b/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
@@ -164,7 +164,7 @@ class CheckoutWithRequestScenarioTests extends APITests {
   }
 
   @Test
-  void alternatePeriodWithHoldRequestShouldBeAppliedForBothItemsInTheQueue() {
+  void alternatePeriodShouldBeAppliedWhenRequestQueueContainsHoldTlr() {
     configurationsFixture.enableTlrFeature();
     List<ItemResource> items = itemsFixture.createMultipleItemsForTheSameInstance(2);
     var firstItem = items.get(0);
@@ -244,7 +244,7 @@ class CheckoutWithRequestScenarioTests extends APITests {
   }
 
   @Test
-  void alternatePeriodWithItemLevelHoldRequestShouldNotBeAppliedForTitleLevelPageRequest() {
+  void alternatePeriodShouldNotBeAppliedWhenRequestQueueContainsHoldIlrForDifferentItem() {
     configurationsFixture.enableTlrFeature();
     List<ItemResource> items = itemsFixture.createMultipleItemsForTheSameInstance(2);
     var firstItem = items.get(0);

--- a/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
+++ b/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
@@ -166,7 +166,7 @@ class CheckoutWithRequestScenarioTests extends APITests {
   }
 
   @Test
-  void checkingOutWithHoldRequestAppliesAlternatePeriod1() {
+  void alternatePeriodWithHoldRequestShouldBeAppliedForBothItemsInTheQueue() {
     configurationsFixture.enableTlrFeature();
     List<ItemResource> items = itemsFixture.createMultipleItemsForTheSameInstance(2);
     var firstItem = items.get(0);

--- a/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
+++ b/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
@@ -24,8 +24,6 @@ import api.support.builders.RequestBuilder;
 import api.support.http.CqlQuery;
 import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
-import api.support.http.UserResource;
-import io.vertx.core.json.JsonObject;
 
 class CheckoutWithRequestScenarioTests extends APITests {
 
@@ -243,5 +241,62 @@ class CheckoutWithRequestScenarioTests extends APITests {
         .on(loanDate));
     assertThat(secondLoan.getJson().getString("dueDate"), isEquivalentTo(
       ZonedDateTime.of(2024, 1, 11, 23, 59, 59, 0, UTC)));
+  }
+
+  @Test
+  void alternatePeriodWithItemLevelHoldRequestShouldNotBeAppliedForTitleLevelPageRequest() {
+    configurationsFixture.enableTlrFeature();
+    List<ItemResource> items = itemsFixture.createMultipleItemsForTheSameInstance(2);
+    var firstItem = items.get(0);
+    var secondItem = items.get(1);
+    var instanceId = firstItem.getInstanceId();
+
+    var james = usersFixture.james();
+    var charlotte = usersFixture.charlotte();
+    var pickupServicePointId = servicePointsFixture.cd1().getId();
+
+    var loanPolicy = loanPoliciesFixture.create(new LoanPolicyBuilder()
+      .withName("Limited loan period for items with hold requests")
+      .rolling(days(5))
+      .withAlternateCheckoutLoanPeriod(days(1))
+      .withClosedLibraryDueDateManagement(KEEP_THE_CURRENT_DUE_DATE.getValue()));
+    useFallbackPolicies(
+      loanPolicy.getId(),
+      requestPoliciesFixture.allowPageAndHoldRequestPolicy().getId(),
+      noticePoliciesFixture.inactiveNotice().getId(),
+      overdueFinePoliciesFixture.facultyStandard().getId(),
+      lostItemFeePoliciesFixture.facultyStandard().getId());
+
+    checkOutFixture.checkOutByBarcode(secondItem);
+    requestsClient.create(new RequestBuilder()
+      .page()
+      .titleRequestLevel()
+      .withNoItemId()
+      .withNoHoldingsRecordId()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .by(charlotte));
+    requestsClient.create(new RequestBuilder()
+      .hold()
+      .itemRequestLevel()
+      .withItemId(secondItem.getId())
+      .withInstanceId(secondItem.getInstanceId())
+      .withPickupServicePointId(pickupServicePointId)
+      .by(james));
+
+    checkInFixture.checkInByBarcode(firstItem);
+
+    String firstRequesterBarcode = requestsClient.getMany(CqlQuery.exactMatch(
+        "itemId", firstItem.getId().toString())).getFirst().getJsonObject("requester")
+      .getString("barcode");
+    ZonedDateTime loanDate = ZonedDateTime.of(2024, 1, 1, 11, 0, 0, 0, UTC);
+    final IndividualResource firstLoan = checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(firstItem)
+        .to(firstRequesterBarcode)
+        .at(pickupServicePointId)
+        .on(loanDate));
+    assertThat(firstLoan.getJson().getString("dueDate"), isEquivalentTo(
+      ZonedDateTime.of(2024, 1, 6, 23, 59, 59, 0, UTC)));
   }
 }

--- a/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
+++ b/src/test/java/api/loans/scenarios/CheckoutWithRequestScenarioTests.java
@@ -4,11 +4,13 @@ import static api.support.builders.FixedDueDateSchedule.wholeMonth;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
 import static java.time.ZoneOffset.UTC;
 import static org.folio.circulation.domain.policy.DueDateManagement.KEEP_THE_CURRENT_DUE_DATE;
+import static org.folio.circulation.domain.policy.Period.days;
 import static org.folio.circulation.domain.policy.Period.weeks;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import org.folio.circulation.support.http.client.Response;
@@ -19,8 +21,11 @@ import api.support.builders.CheckOutByBarcodeRequestBuilder;
 import api.support.builders.FixedDueDateSchedulesBuilder;
 import api.support.builders.LoanPolicyBuilder;
 import api.support.builders.RequestBuilder;
+import api.support.http.CqlQuery;
 import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
+import api.support.http.UserResource;
+import io.vertx.core.json.JsonObject;
 
 class CheckoutWithRequestScenarioTests extends APITests {
 
@@ -158,5 +163,85 @@ class CheckoutWithRequestScenarioTests extends APITests {
 
     assertThat(changedItem.getJson().getJsonObject("status").getString("name"),
       is("Checked out"));
+  }
+
+  @Test
+  void checkingOutWithHoldRequestAppliesAlternatePeriod1() {
+    configurationsFixture.enableTlrFeature();
+    List<ItemResource> items = itemsFixture.createMultipleItemsForTheSameInstance(2);
+    var firstItem = items.get(0);
+    var secondItem = items.get(1);
+    var instanceId = firstItem.getInstanceId();
+
+    var james = usersFixture.james();
+    var charlotte = usersFixture.charlotte();
+    var steve = usersFixture.steve();
+    var pickupServicePointId = servicePointsFixture.cd1().getId();
+
+    var loanPolicy = loanPoliciesFixture.create(new LoanPolicyBuilder()
+      .withName("Limited loan period for items with hold requests")
+      .rolling(days(5))
+      .withAlternateCheckoutLoanPeriod(days(1))
+      .withClosedLibraryDueDateManagement(KEEP_THE_CURRENT_DUE_DATE.getValue()));
+    useFallbackPolicies(
+      loanPolicy.getId(),
+      requestPoliciesFixture.allowPageAndHoldRequestPolicy().getId(),
+      noticePoliciesFixture.inactiveNotice().getId(),
+      overdueFinePoliciesFixture.facultyStandard().getId(),
+      lostItemFeePoliciesFixture.facultyStandard().getId());
+
+    requestsClient.create(new RequestBuilder()
+      .page()
+      .titleRequestLevel()
+      .withNoItemId()
+      .withNoHoldingsRecordId()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .by(charlotte));
+    requestsClient.create(new RequestBuilder()
+      .page()
+      .titleRequestLevel()
+      .withNoItemId()
+      .withNoHoldingsRecordId()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .by(james));
+    requestsClient.create(new RequestBuilder()
+      .hold()
+      .titleRequestLevel()
+      .withNoItemId()
+      .withNoHoldingsRecordId()
+      .withInstanceId(instanceId)
+      .withPickupServicePointId(pickupServicePointId)
+      .by(steve));
+
+    checkInFixture.checkInByBarcode(firstItem);
+    checkInFixture.checkInByBarcode(secondItem);
+
+    String firstRequesterBarcode = requestsClient.getMany(CqlQuery.exactMatch(
+      "itemId", firstItem.getId().toString())).getFirst().getJsonObject("requester")
+      .getString("barcode");
+    ZonedDateTime loanDate = ZonedDateTime.of(2024, 1, 1, 11, 0, 0, 0, UTC);
+    final IndividualResource firstLoan = checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(firstItem)
+        .to(firstRequesterBarcode)
+        .at(pickupServicePointId)
+        .on(loanDate));
+    assertThat(firstLoan.getJson().getString("dueDate"), isEquivalentTo(
+      ZonedDateTime.of(2024, 1, 2, 23, 59, 59, 0, UTC)));
+
+    String secondRequesterBarcode = requestsClient.getMany(CqlQuery.exactMatch(
+        "itemId", secondItem.getId().toString())).getFirst().getJsonObject("requester")
+      .getString("barcode");
+    loanDate = ZonedDateTime.of(2024, 1, 10, 11, 0, 0, 0, UTC);
+    final IndividualResource secondLoan = checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(secondItem)
+        .to(secondRequesterBarcode)
+        .at(pickupServicePointId)
+        .on(loanDate));
+    assertThat(secondLoan.getJson().getString("dueDate"), isEquivalentTo(
+      ZonedDateTime.of(2024, 1, 11, 23, 59, 59, 0, UTC)));
   }
 }

--- a/src/test/java/api/support/builders/CheckOutByBarcodeRequestBuilder.java
+++ b/src/test/java/api/support/builders/CheckOutByBarcodeRequestBuilder.java
@@ -70,6 +70,16 @@ public class CheckOutByBarcodeRequestBuilder extends JsonBuilder implements Buil
       this.overrideBlocks);
   }
 
+  public CheckOutByBarcodeRequestBuilder to(String userBarcode) {
+    return new CheckOutByBarcodeRequestBuilder(
+      this.itemBarcode,
+      userBarcode,
+      this.proxyBarcode,
+      this.loanDate,
+      this.servicePointId,
+      this.overrideBlocks);
+  }
+
   public CheckOutByBarcodeRequestBuilder on(ZonedDateTime loanDate) {
     return new CheckOutByBarcodeRequestBuilder(
       this.itemBarcode,

--- a/src/test/java/api/support/fixtures/RequestPoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/RequestPoliciesFixture.java
@@ -56,6 +56,15 @@ public class RequestPoliciesFixture {
     return requestPolicyRecordCreator.createIfAbsent(new RequestPolicyBuilder(types, id));
   }
 
+  public IndividualResource allowPageAndHoldRequestPolicy() {
+    ArrayList<RequestType> types = new ArrayList<>();
+    types.add(RequestType.HOLD);
+    types.add(RequestType.PAGE);
+    final RequestPolicyBuilder allowPageAndHoldPolicy = new RequestPolicyBuilder(types);
+
+    return requestPolicyRecordCreator.createIfAbsent(allowPageAndHoldPolicy);
+  }
+
   public IndividualResource customRequestPolicy(ArrayList<RequestType> types) {
 
     final RequestPolicyBuilder customPolicy = new RequestPolicyBuilder(types);


### PR DESCRIPTION
## Purpose
Steps to Reproduce:

Log into some FOLIO environment
Title level requests must be allowed.
Set a request policy to allow page and hold.
Create a loan policy with Alternate loan period at checkout for items with an active, pending hold request set to a value that differs from the Loan period.
Create three title level requests on an instance with two items. Make two requests have the status fulfillment in progress and have one Open – Not yet filled hold request.
Check out one of the items with request status fulfillment in progress.  

Expected Results:
Since there are Open – Not yet filled requests the alternate loan period should be granted.

Actual Results:
Standard loan period is granted.

Resolves: [CIRC-2026](https://folio-org.atlassian.net/browse/CIRC-2026)