### PR TITLE
CIRC-2019 Support renewal by overriding reminders block

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -501,6 +501,7 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
     changeDueDate(dueDate);
     incrementRenewalCount();
     changeActionComment(actionComment);
+    resetReminders();
 
     return this;
   }

--- a/src/main/java/org/folio/circulation/domain/LoanRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepresentation.java
@@ -6,6 +6,8 @@ import static org.folio.circulation.domain.representations.LoanProperties.LOAN_P
 import static org.folio.circulation.domain.representations.LoanProperties.LOST_ITEM_POLICY;
 import static org.folio.circulation.domain.representations.LoanProperties.OVERDUE_FINE_POLICY;
 import static org.folio.circulation.domain.representations.LoanProperties.PATRON_GROUP_ID_AT_CHECKOUT;
+import static org.folio.circulation.domain.representations.LoanProperties.REMINDERS;
+
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 
 import java.lang.invoke.MethodHandles;
@@ -58,6 +60,15 @@ public class LoanRepresentation {
       log.info("extendedLoan:: there is no user, removing borrower");
       extendedRepresentation.remove(BORROWER);
     }
+
+    if (loan.getOverdueFinePolicy().isReminderFeesPolicy()
+      && loan.getLastReminderFeeBilledNumber() != null) {
+      extendedRepresentation.getJsonObject(REMINDERS)
+        .put("renewalBlocked",
+          !loan.getOverdueFinePolicy()
+            .getRemindersPolicy().getAllowRenewalOfItemsWithReminderFees());
+    }
+
 
     addPolicy(extendedRepresentation, loan.getLoanPolicy(), LOAN_POLICY);
     addPolicy(extendedRepresentation, loan.getOverdueFinePolicy(), OVERDUE_FINE_POLICY);

--- a/src/main/java/org/folio/circulation/domain/validation/RenewalOfItemsWithReminderFeesValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/RenewalOfItemsWithReminderFeesValidator.java
@@ -3,6 +3,7 @@ package org.folio.circulation.domain.validation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.override.BlockOverrides;
 import org.folio.circulation.domain.policy.OverdueFinePolicy;
 import org.folio.circulation.resources.context.RenewalContext;
 import org.folio.circulation.support.HttpFailure;
@@ -14,6 +15,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.support.ValidationErrorFailure.singleValidationError;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getObjectProperty;
 import static org.folio.circulation.support.results.Result.failed;
 import static org.folio.circulation.support.results.Result.succeeded;
 
@@ -27,25 +29,34 @@ public class RenewalOfItemsWithReminderFeesValidator {
 
   Result<RenewalContext> blockRenewalIfRuledByRemindersFeePolicy(RenewalContext renewalContext) {
     log.debug("blockRenewalIfRuledByRemindersFeePolicy:: parameters: renewalContext: {}", renewalContext);
-
-    Loan loan = renewalContext.getLoan();
-    Integer lastFeeBilledCount = loan.getLastReminderFeeBilledNumber();
-    OverdueFinePolicy overdueFinePolicy = loan.getOverdueFinePolicy();
-    Boolean allowRenewalWithReminders = overdueFinePolicy.getRemindersPolicy().getAllowRenewalOfItemsWithReminderFees();
-
-    if ((lastFeeBilledCount != null && lastFeeBilledCount > 0) && Boolean.FALSE.equals(allowRenewalWithReminders)) {
-      String reason = "Renewals not allowed for loans with reminders.";
-      log.info("createBlockedRenewalDueToReminderFeesPolicyError:: {}", reason);
-      return failed(createBlockedRenewalDueToReminderFeesPolicyError("Renewals not allowed for loans with reminders.", reason));
+    BlockOverrides overrides = BlockOverrides.from(getObjectProperty(renewalContext.getRenewalRequest(), "overrideBlocks"));
+    final boolean overrideRenewalBlock = overrides.getRenewalBlockOverride().isRequested();
+    final boolean overrideRenewalBlockDueDateRequired = overrides.getRenewalDueDateRequiredBlockOverride().isRequested();
+    if (overrideRenewalBlock || overrideRenewalBlockDueDateRequired) {
+      return succeeded(renewalContext);
+    } else if (renewalBlockedDueToReminders(renewalContext)) {
+      return failed(createBlockedRenewalDueToReminderFeesPolicyError());
     } else {
       return succeeded(renewalContext);
     }
   }
 
-  private HttpFailure createBlockedRenewalDueToReminderFeesPolicyError(String message, String reason) {
-    log.debug("createBlockedRenewalDueToReminderFeesPolicyError:: parameters message: {}, reason: {}", message,
-      reason);
+  private HttpFailure createBlockedRenewalDueToReminderFeesPolicyError() {
+    String reasonAndMessage = "Renewals not allowed for loans with reminders.";
+    log.debug("createBlockedRenewalDueToReminderFeesPolicyError");
+    return singleValidationError(new ValidationError(reasonAndMessage, "reason", reasonAndMessage));
+  }
 
-    return singleValidationError(new ValidationError(message, "reason", reason));
+  private static boolean renewalBlockedDueToReminders(RenewalContext renewalContext) {
+    Loan loan = renewalContext.getLoan();
+    return loanHasReminders(loan) && policyBlocksRenewalWithReminders(loan);
+  }
+  private static Boolean loanHasReminders(Loan loan) {
+    return loan.getLastReminderFeeBilledNumber() != null && loan.getLastReminderFeeBilledNumber() > 0;
+  }
+  private static boolean policyBlocksRenewalWithReminders (Loan loan) {
+    OverdueFinePolicy overdueFinePolicy = loan.getOverdueFinePolicy();
+    Boolean allowRenewalWithReminders = overdueFinePolicy.getRemindersPolicy().getAllowRenewalOfItemsWithReminderFees();
+    return Boolean.FALSE.equals(allowRenewalWithReminders);
   }
 }

--- a/src/main/java/org/folio/circulation/resources/RenewalValidator.java
+++ b/src/main/java/org/folio/circulation/resources/RenewalValidator.java
@@ -103,7 +103,8 @@ public final class RenewalValidator {
       "renewal date falls outside of the date ranges in the loan policy, " +
       "items cannot be renewed when there is an active recall request, " +
       DECLARED_LOST_ITEM_RENEWED_ERROR + ", item is Aged to lost, " +
-      "renewal would not change the due date";
+      "renewal would not change the due date, " +
+      "loan has reminder fees";
 
     return loanPolicyValidationError(loanPolicy, reason);
   }

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -492,6 +492,9 @@ public abstract class RenewalResource extends Resource {
         return processRenewal(newDueDateResult, loan, comment);
       }
 
+      if (loan.getLastReminderFeeBilledNumber() != null && loan.getLastReminderFeeBilledNumber()>0) {
+        return processRenewal(newDueDateResult, loan, comment);
+      }
       return failedValidation(errorForNotMatchingOverrideCases(loanPolicy));
 
     } catch (Exception e) {

--- a/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
+++ b/src/test/java/api/loans/OverrideRenewByBarcodeTests.java
@@ -521,7 +521,8 @@ class OverrideRenewByBarcodeTests extends APITests {
         "renewal date falls outside of the date ranges in the loan policy, " +
         "items cannot be renewed when there is an active recall request, " +
         "item is Declared lost, item is Aged to lost, " +
-        "renewal would not change the due date"))));
+        "renewal would not change the due date, " +
+        "loan has reminder fees"))));
   }
 
   @Test

--- a/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
+++ b/src/test/java/api/requests/RequestsAPILoanRenewalTests.java
@@ -592,7 +592,8 @@ class RequestsAPILoanRenewalTests extends APITests {
         "renewal date falls outside of the date ranges in the loan policy, " +
         "items cannot be renewed when there is an active recall request, " +
         "item is Declared lost, item is Aged to lost, " +
-        "renewal would not change the due date"))));
+        "renewal would not change the due date, " +
+        "loan has reminder fees"))));
   }
 
   @Test
@@ -623,7 +624,8 @@ class RequestsAPILoanRenewalTests extends APITests {
         "renewal date falls outside of the date ranges in the loan policy, " +
         "items cannot be renewed when there is an active recall request, " +
         "item is Declared lost, item is Aged to lost, " +
-        "renewal would not change the due date"))));
+        "renewal would not change the due date, " +
+        "loan has reminder fees"))));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
The purpose is to allow the user to override a block on renewal if the block is due to outstanding reminders, and if the overdue fine policy is blocking renewals in that case. 

## Approach
In RenewalValidator there will be a new reason to override a renewal block:  "loan has reminder fees". 
RenewalOfItemsWithReminderFeesValidator will process the override renewal request accordingly.  

This renewal block is an item level block, as opposed to manual and automated blocks, which are on the patron level. Thus, for the UI to know if it should present the override modal for renewal of loans with reminders, there is a new flag in the loan's "reminders" section -- "renewalBlocked".   

The direct unit test of the feature is ReminderFeeTests.willRenewWithOverride(). The feature is user tested by Hebis in their development FOLIO instance.  

