### PR TITLE
CIRC-2077 fix empty token in notice

### DIFF
--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledDigitalReminderHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledDigitalReminderHandler.java
@@ -211,7 +211,7 @@ public class ScheduledDigitalReminderHandler extends LoanScheduledNoticeHandler 
       return ofAsync(() -> context);
     }
     return accountsStorageClient.post(context.getAccount().toJson())
-      .thenApply(r -> Result.succeeded(context));
+      .thenApply(r -> Result.succeeded(context.withAccount(Account.from(r.value().getJson()))));
   }
 
   private CompletableFuture<Result<ScheduledNoticeContext>> createFeeFineAction(ScheduledNoticeContext context) {


### PR DESCRIPTION
## Purpose
Ensure that template token feeCharge.chargeDate is populated in reminder notices. 

## Approach
The chargeDate is really account's  metadata.createdDate, so unlike other properties of the account object that are know up-front, the charge date is not known until after the record is persisted. Thus, take the response of the account POST so the createdDate can be picked from that.  

