### PR TITLE
CIRC-2109 Pass additional includeRoutingServicePoints parameter when needed

### DIFF
--- a/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/ServicePointRepository.java
@@ -41,7 +41,15 @@ public class ServicePointRepository {
   private final CollectionResourceClient servicePointsStorageClient;
 
   public ServicePointRepository(Clients clients) {
-    servicePointsStorageClient = clients.servicePointsStorage();
+    this(clients, false);
+  }
+
+  public ServicePointRepository(Clients clients, boolean includeRoutingServicePoints) {
+    if (includeRoutingServicePoints) {
+      servicePointsStorageClient = clients.routingServicePointsStorage();
+    } else {
+      servicePointsStorageClient = clients.servicePointsStorage();
+    }
   }
 
   public CompletableFuture<Result<ServicePoint>> getServicePointById(UUID id) {

--- a/src/main/java/org/folio/circulation/services/AllowedServicePointsService.java
+++ b/src/main/java/org/folio/circulation/services/AllowedServicePointsService.java
@@ -75,7 +75,7 @@ public class AllowedServicePointsService {
     userRepository = new UserRepository(clients);
     requestRepository = new RequestRepository(clients);
     requestPolicyRepository = new RequestPolicyRepository(clients);
-    servicePointRepository = new ServicePointRepository(clients);
+    servicePointRepository = new ServicePointRepository(clients, isEcsRequestRouting);
     settingsRepository = new SettingsRepository(clients);
     instanceRepository = new InstanceRepository(clients);
     itemFinder = new ItemByInstanceIdFinder(clients.holdingsStorage(), itemRepository);

--- a/src/main/java/org/folio/circulation/support/Clients.java
+++ b/src/main/java/org/folio/circulation/support/Clients.java
@@ -4,7 +4,9 @@ import java.net.MalformedURLException;
 
 import org.folio.circulation.rules.CirculationRulesProcessor;
 import org.folio.circulation.services.PubSubPublishingService;
+import org.folio.circulation.support.http.client.IncludeRoutingServicePoints;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
+import org.folio.circulation.support.http.client.QueryParameter;
 import org.folio.circulation.support.http.server.WebContext;
 
 import io.vertx.core.http.HttpClient;
@@ -40,6 +42,7 @@ public class Clients {
   private final CollectionResourceClient circulationRulesStorageClient;
   private final CollectionResourceClient requestPoliciesStorageClient;
   private final CollectionResourceClient servicePointsStorageClient;
+  private final CollectionResourceClient routingServicePointsStorageClient;
   private final CollectionResourceClient calendarStorageClient;
   private final CollectionResourceClient patronGroupsStorageClient;
   private final CollectionResourceClient patronNoticePolicesStorageClient;
@@ -112,6 +115,8 @@ public class Clients {
       requestPoliciesStorageClient = createRequestPoliciesStorageClient(client, context);
       fixedDueDateSchedulesStorageClient = createFixedDueDateSchedulesStorageClient(client, context);
       servicePointsStorageClient = createServicePointsStorageClient(client, context);
+      routingServicePointsStorageClient = createServicePointsStorageWithCustomParam(client,
+        context, IncludeRoutingServicePoints.enabled());
       patronGroupsStorageClient = createPatronGroupsStorageClient(client, context);
       calendarStorageClient = createCalendarStorageClient(client, context);
       patronNoticePolicesStorageClient = createPatronNoticePolicesStorageClient(client, context);
@@ -242,6 +247,10 @@ public class Clients {
 
   public CollectionResourceClient servicePointsStorage() {
     return servicePointsStorageClient;
+  }
+
+  public CollectionResourceClient routingServicePointsStorage() {
+    return routingServicePointsStorageClient;
   }
 
   public CollectionResourceClient patronGroupsStorage() {
@@ -390,6 +399,14 @@ public class Clients {
     throws MalformedURLException {
 
     return new CollectionResourceClient(client, context.getOkapiBasedUrl(path));
+  }
+
+  private static CollectionResourceClient getCollectionResourceClientWithCustomParam(
+    OkapiHttpClient client, WebContext context, String path, QueryParameter customParam)
+    throws MalformedURLException {
+
+    return new CustomParamCollectionResourceClient(client, context.getOkapiBasedUrl(path),
+      customParam);
   }
 
   public CollectionResourceClient noticeTemplatesClient() {
@@ -632,6 +649,14 @@ public class Clients {
       throws MalformedURLException {
 
     return getCollectionResourceClient(client, context, "/service-points");
+  }
+
+  private CollectionResourceClient createServicePointsStorageWithCustomParam(
+    OkapiHttpClient client, WebContext context, QueryParameter customParam)
+      throws MalformedURLException {
+
+    return getCollectionResourceClientWithCustomParam(client, context, "/service-points",
+      customParam);
   }
 
   private CollectionResourceClient createPatronGroupsStorageClient(

--- a/src/main/java/org/folio/circulation/support/CollectionResourceClient.java
+++ b/src/main/java/org/folio/circulation/support/CollectionResourceClient.java
@@ -109,7 +109,7 @@ public class CollectionResourceClient implements GetManyRecordsClient {
     return client.get(collectionRoot, cqlQuery, pageLimit, offset);
   }
 
-  private String individualRecordUrl(String id) {
+  String individualRecordUrl(String id) {
     return format("%s/%s", collectionRoot, id);
   }
 }

--- a/src/main/java/org/folio/circulation/support/CollectionResourceClient.java
+++ b/src/main/java/org/folio/circulation/support/CollectionResourceClient.java
@@ -18,8 +18,8 @@ import org.folio.circulation.support.results.Result;
 import io.vertx.core.json.JsonObject;
 
 public class CollectionResourceClient implements GetManyRecordsClient {
-  private final OkapiHttpClient client;
-  private final URL collectionRoot;
+  final OkapiHttpClient client;
+  final URL collectionRoot;
 
   public CollectionResourceClient(OkapiHttpClient client, URL collectionRoot) {
     this.collectionRoot = collectionRoot;

--- a/src/main/java/org/folio/circulation/support/CustomParamCollectionResourceClient.java
+++ b/src/main/java/org/folio/circulation/support/CustomParamCollectionResourceClient.java
@@ -39,14 +39,14 @@ public class CustomParamCollectionResourceClient extends CollectionResourceClien
 
   @Override
   public CompletableFuture<Result<Response>> getMany(CqlQuery cqlQuery,
-      PageLimit pageLimit) {
+    PageLimit pageLimit) {
 
     return getMany(cqlQuery, pageLimit, noOffset());
   }
 
   @Override
   public CompletableFuture<Result<Response>> getMany(CqlQuery cqlQuery,
-      PageLimit pageLimit, Offset offset) {
+    PageLimit pageLimit, Offset offset) {
 
     return client.get(collectionRoot, cqlQuery, pageLimit, offset, customQueryParameter);
   }

--- a/src/main/java/org/folio/circulation/support/CustomParamCollectionResourceClient.java
+++ b/src/main/java/org/folio/circulation/support/CustomParamCollectionResourceClient.java
@@ -1,6 +1,5 @@
 package org.folio.circulation.support;
 
-import static java.lang.String.format;
 import static org.folio.circulation.support.http.client.Offset.noOffset;
 
 import java.net.URL;
@@ -49,9 +48,5 @@ public class CustomParamCollectionResourceClient extends CollectionResourceClien
     PageLimit pageLimit, Offset offset) {
 
     return client.get(collectionRoot, cqlQuery, pageLimit, offset, customQueryParameter);
-  }
-
-  private String individualRecordUrl(String id) {
-    return format("%s/%s", collectionRoot, id);
   }
 }

--- a/src/main/java/org/folio/circulation/support/CustomParamCollectionResourceClient.java
+++ b/src/main/java/org/folio/circulation/support/CustomParamCollectionResourceClient.java
@@ -24,14 +24,17 @@ public class CustomParamCollectionResourceClient extends CollectionResourceClien
     this.customQueryParameter = customQueryParameter;
   }
 
+  @Override
   public CompletableFuture<Result<Response>> get() {
     return client.get(collectionRoot.toString(), customQueryParameter);
   }
 
+  @Override
   public CompletableFuture<Result<Response>> get(PageLimit pageLimit) {
     return client.get(collectionRoot, pageLimit, customQueryParameter);
   }
 
+  @Override
   public CompletableFuture<Result<Response>> get(String id) {
     return client.get(individualRecordUrl(id), customQueryParameter);
   }

--- a/src/main/java/org/folio/circulation/support/CustomParamCollectionResourceClient.java
+++ b/src/main/java/org/folio/circulation/support/CustomParamCollectionResourceClient.java
@@ -1,0 +1,57 @@
+package org.folio.circulation.support;
+
+import static java.lang.String.format;
+import static org.folio.circulation.support.http.client.Offset.noOffset;
+
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.circulation.support.http.client.CqlQuery;
+import org.folio.circulation.support.http.client.Offset;
+import org.folio.circulation.support.http.client.OkapiHttpClient;
+import org.folio.circulation.support.http.client.PageLimit;
+import org.folio.circulation.support.http.client.QueryParameter;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.results.Result;
+
+public class CustomParamCollectionResourceClient extends CollectionResourceClient {
+
+  private QueryParameter customQueryParameter;
+
+  public CustomParamCollectionResourceClient(OkapiHttpClient client, URL collectionRoot,
+    QueryParameter customQueryParameter) {
+
+    super(client, collectionRoot);
+    this.customQueryParameter = customQueryParameter;
+  }
+
+  public CompletableFuture<Result<Response>> get() {
+    return client.get(collectionRoot.toString(), customQueryParameter);
+  }
+
+  public CompletableFuture<Result<Response>> get(PageLimit pageLimit) {
+    return client.get(collectionRoot, pageLimit, customQueryParameter);
+  }
+
+  public CompletableFuture<Result<Response>> get(String id) {
+    return client.get(individualRecordUrl(id), customQueryParameter);
+  }
+
+  @Override
+  public CompletableFuture<Result<Response>> getMany(CqlQuery cqlQuery,
+      PageLimit pageLimit) {
+
+    return getMany(cqlQuery, pageLimit, noOffset());
+  }
+
+  @Override
+  public CompletableFuture<Result<Response>> getMany(CqlQuery cqlQuery,
+      PageLimit pageLimit, Offset offset) {
+
+    return client.get(collectionRoot, cqlQuery, pageLimit, offset, customQueryParameter);
+  }
+
+  private String individualRecordUrl(String id) {
+    return format("%s/%s", collectionRoot, id);
+  }
+}

--- a/src/main/java/org/folio/circulation/support/CustomParamCollectionResourceClient.java
+++ b/src/main/java/org/folio/circulation/support/CustomParamCollectionResourceClient.java
@@ -1,7 +1,5 @@
 package org.folio.circulation.support;
 
-import static org.folio.circulation.support.http.client.Offset.noOffset;
-
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 
@@ -37,13 +35,6 @@ public class CustomParamCollectionResourceClient extends CollectionResourceClien
   @Override
   public CompletableFuture<Result<Response>> get(String id) {
     return client.get(individualRecordUrl(id), customQueryParameter);
-  }
-
-  @Override
-  public CompletableFuture<Result<Response>> getMany(CqlQuery cqlQuery,
-    PageLimit pageLimit) {
-
-    return getMany(cqlQuery, pageLimit, noOffset());
   }
 
   @Override

--- a/src/main/java/org/folio/circulation/support/http/client/IncludeRoutingServicePoints.java
+++ b/src/main/java/org/folio/circulation/support/http/client/IncludeRoutingServicePoints.java
@@ -1,7 +1,10 @@
 package org.folio.circulation.support.http.client;
 
+import static java.lang.String.format;
+
 public class IncludeRoutingServicePoints implements QueryParameter {
 
+  private static final String PARAM_NAME = "includeRoutingServicePoints";
   private final Boolean value;
 
   public static IncludeRoutingServicePoints enabled() {
@@ -15,16 +18,16 @@ public class IncludeRoutingServicePoints implements QueryParameter {
   @Override
   public void consume(QueryStringParameterConsumer consumer) {
     if (value != null) {
-      consumer.consume("includeRoutingServicePoints", value.toString());
+      consumer.consume(PARAM_NAME, value.toString());
     }
   }
 
   @Override
   public String toString() {
     if (value == null) {
-      return "No includeRoutingServicePoints";
+      return format("No %s", PARAM_NAME);
     }
 
-    return String.format("includeRoutingServicePoints = \"%s\"", value);
+    return format("%s = \"%s\"", PARAM_NAME, value);
   }
 }

--- a/src/main/java/org/folio/circulation/support/http/client/IncludeRoutingServicePoints.java
+++ b/src/main/java/org/folio/circulation/support/http/client/IncludeRoutingServicePoints.java
@@ -1,0 +1,30 @@
+package org.folio.circulation.support.http.client;
+
+public class IncludeRoutingServicePoints implements QueryParameter {
+
+  private final Boolean value;
+
+  public static IncludeRoutingServicePoints enabled() {
+    return new IncludeRoutingServicePoints(true);
+  }
+
+  private IncludeRoutingServicePoints(Boolean value) {
+    this.value = value;
+  }
+
+  @Override
+  public void consume(QueryStringParameterConsumer consumer) {
+    if (value != null) {
+      consumer.consume("includeRoutingServicePoints", value.toString());
+    }
+  }
+
+  @Override
+  public String toString() {
+    if (value == null) {
+      return "No includeRoutingServicePoints";
+    }
+
+    return String.format("includeRoutingServicePoints = \"%s\"", value);
+  }
+}

--- a/src/test/java/api/support/fakes/FakeCQLToJSONInterpreter.java
+++ b/src/test/java/api/support/fakes/FakeCQLToJSONInterpreter.java
@@ -27,14 +27,13 @@ public class FakeCQLToJSONInterpreter {
     var initiallyFilteredRecords = execute(records, query);
 
     // Routing SP filtering
-    String includeRoutingServicePointsParam =
-      context.getStringParameter("includeRoutingServicePoints");
-    if (includeRoutingServicePointsParam != null) {
-      var includeRoutingServicePoints = Boolean.parseBoolean(includeRoutingServicePointsParam);
-      if (includeRoutingServicePoints) {
+    String includeRoutingServicePointsParam = context.getStringParameter(
+      "includeRoutingServicePoints");
+    if (Boolean.parseBoolean(includeRoutingServicePointsParam)) {
         return records.stream()
           .filter(json -> json.containsKey("ecsRequestRouting")
-            ? json.getBoolean("ecsRequestRouting") : false)
+            ? json.getBoolean("ecsRequestRouting") 
+            : false)
           .collect(Collectors.toList());
       }
     }

--- a/src/test/java/api/support/fakes/FakeCQLToJSONInterpreter.java
+++ b/src/test/java/api/support/fakes/FakeCQLToJSONInterpreter.java
@@ -34,7 +34,7 @@ public class FakeCQLToJSONInterpreter {
           .filter(json -> json.containsKey("ecsRequestRouting")
             ? json.getBoolean("ecsRequestRouting") 
             : false)
-          .collect(Collectors.toList());
+          .toList();
       }
     }
 

--- a/src/test/java/api/support/fakes/FakeCQLToJSONInterpreter.java
+++ b/src/test/java/api/support/fakes/FakeCQLToJSONInterpreter.java
@@ -14,13 +14,36 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.circulation.support.http.server.WebContext;
 
 import io.vertx.core.json.JsonObject;
 
 public class FakeCQLToJSONInterpreter {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
+  public List<JsonObject> execute(Collection<JsonObject> records, String query,
+    WebContext context) {
+
+    var initiallyFilteredRecords = execute(records, query);
+
+    // Routing SP filtering
+    String includeRoutingServicePointsParam =
+      context.getStringParameter("includeRoutingServicePoints");
+    if (includeRoutingServicePointsParam != null) {
+      var includeRoutingServicePoints = Boolean.parseBoolean(includeRoutingServicePointsParam);
+      if (includeRoutingServicePoints) {
+        return records.stream()
+          .filter(json -> json.containsKey("ecsRequestRouting")
+            ? json.getBoolean("ecsRequestRouting") : false)
+          .collect(Collectors.toList());
+      }
+    }
+
+    return initiallyFilteredRecords;
+  }
+
   public List<JsonObject> execute(Collection<JsonObject> records, String query) {
+
     final var queryAndSort = splitQueryAndSort(query);
     final var cqlPredicate = new CqlPredicate(queryAndSort.left);
 

--- a/src/test/java/api/support/fakes/FakeCQLToJSONInterpreter.java
+++ b/src/test/java/api/support/fakes/FakeCQLToJSONInterpreter.java
@@ -35,7 +35,6 @@ public class FakeCQLToJSONInterpreter {
             ? json.getBoolean("ecsRequestRouting") 
             : false)
           .toList();
-      }
     }
 
     return initiallyFilteredRecords;

--- a/src/test/java/api/support/fakes/FakeOkapi.java
+++ b/src/test/java/api/support/fakes/FakeOkapi.java
@@ -23,11 +23,11 @@ import java.util.Collection;
 import java.util.Objects;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.client.OkapiHttpClient;
 import org.folio.circulation.support.results.Result;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
@@ -282,6 +282,7 @@ public class FakeOkapi extends AbstractVerticle {
       .withRootPath("/service-points")
       .withRequiredProperties("name", "code", "discoveryDisplayName")
       .withUniqueProperties("name")
+      .withQueryParameters("includeRoutingServicePoints")
       .withChangeMetadata()
       .disallowCollectionDelete()
       .create()

--- a/src/test/java/api/support/fakes/FakeStorageModule.java
+++ b/src/test/java/api/support/fakes/FakeStorageModule.java
@@ -378,8 +378,8 @@ public class FakeStorageModule extends AbstractVerticle {
 
     Map<String, JsonObject> resourcesForTenant = getResourcesForTenant(context);
 
-    List<JsonObject> filteredItems = new FakeCQLToJSONInterpreter()
-      .execute(resourcesForTenant.values(), query);
+    List<JsonObject> filteredItems = getFakeCQLToJSONInterpreter()
+      .execute(resourcesForTenant.values(), query, context);
 
     List<JsonObject> pagedItems = filteredItems.stream()
       .skip(offset)
@@ -408,6 +408,10 @@ public class FakeStorageModule extends AbstractVerticle {
     response.end();
   }
 
+  FakeCQLToJSONInterpreter getFakeCQLToJSONInterpreter() {
+    return new FakeCQLToJSONInterpreter();
+  }
+
   private void empty(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
 
@@ -430,7 +434,7 @@ public class FakeStorageModule extends AbstractVerticle {
 
     Map<String, JsonObject> resourcesForTenant = getResourcesForTenant(context);
 
-    new FakeCQLToJSONInterpreter()
+    getFakeCQLToJSONInterpreter()
       .execute(resourcesForTenant.values(), query)
       .forEach(item -> resourcesForTenant.remove(item.getString("id")));
 

--- a/src/test/java/api/support/fakes/FakeStorageModuleBuilder.java
+++ b/src/test/java/api/support/fakes/FakeStorageModuleBuilder.java
@@ -15,22 +15,22 @@ import api.support.APITestContext;
 import io.vertx.core.json.JsonObject;
 
 public class FakeStorageModuleBuilder {
-  final String rootPath;
-  final String collectionPropertyName;
-  final String tenantId;
-  final Collection<String> requiredProperties;
-  final Collection<String> uniqueProperties;
-  final Collection<String> disallowedProperties;
-  final Boolean hasCollectionDelete;
-  final Boolean hasDeleteByQuery;
-  final String recordName;
-  final Boolean includeChangeMetadata;
-  final BiFunction<Collection<JsonObject>, JsonObject, Result<Object>> constraint;
-  final JsonSchemaValidator recordValidator;
-  final String updateBatchPath;
-  final Function<JsonObject, JsonObject> batchUpdatePreProcessor;
-  final List<BiFunction<JsonObject, JsonObject, JsonObject>> recordPreProcessors;
-  final Collection<String> queryParameters;
+  private final String rootPath;
+  private final String collectionPropertyName;
+  private final String tenantId;
+  private final Collection<String> requiredProperties;
+  private final Collection<String> uniqueProperties;
+  private final Collection<String> disallowedProperties;
+  private final Boolean hasCollectionDelete;
+  private final Boolean hasDeleteByQuery;
+  private final String recordName;
+  private final Boolean includeChangeMetadata;
+  private final BiFunction<Collection<JsonObject>, JsonObject, Result<Object>> constraint;
+  private final JsonSchemaValidator recordValidator;
+  private final String updateBatchPath;
+  private final Function<JsonObject, JsonObject> batchUpdatePreProcessor;
+  private final List<BiFunction<JsonObject, JsonObject, JsonObject>> recordPreProcessors;
+  private final Collection<String> queryParameters;
 
   FakeStorageModuleBuilder() {
     this(

--- a/src/test/java/api/support/fakes/FakeStorageModuleBuilder.java
+++ b/src/test/java/api/support/fakes/FakeStorageModuleBuilder.java
@@ -15,22 +15,22 @@ import api.support.APITestContext;
 import io.vertx.core.json.JsonObject;
 
 public class FakeStorageModuleBuilder {
-  private final String rootPath;
-  private final String collectionPropertyName;
-  private final String tenantId;
-  private final Collection<String> requiredProperties;
-  private final Collection<String> uniqueProperties;
-  private final Collection<String> disallowedProperties;
-  private final Boolean hasCollectionDelete;
-  private final Boolean hasDeleteByQuery;
-  private final String recordName;
-  private final Boolean includeChangeMetadata;
-  private final BiFunction<Collection<JsonObject>, JsonObject, Result<Object>> constraint;
-  private final JsonSchemaValidator recordValidator;
-  private final String updateBatchPath;
-  private final Function<JsonObject, JsonObject> batchUpdatePreProcessor;
-  private final List<BiFunction<JsonObject, JsonObject, JsonObject>> recordPreProcessors;
-  private final Collection<String> queryParameters;
+  final String rootPath;
+  final String collectionPropertyName;
+  final String tenantId;
+  final Collection<String> requiredProperties;
+  final Collection<String> uniqueProperties;
+  final Collection<String> disallowedProperties;
+  final Boolean hasCollectionDelete;
+  final Boolean hasDeleteByQuery;
+  final String recordName;
+  final Boolean includeChangeMetadata;
+  final BiFunction<Collection<JsonObject>, JsonObject, Result<Object>> constraint;
+  final JsonSchemaValidator recordValidator;
+  final String updateBatchPath;
+  final Function<JsonObject, JsonObject> batchUpdatePreProcessor;
+  final List<BiFunction<JsonObject, JsonObject, JsonObject>> recordPreProcessors;
+  final Collection<String> queryParameters;
 
   FakeStorageModuleBuilder() {
     this(


### PR DESCRIPTION
[CIRC-2109](https://folio-org.atlassian.net/browse/CIRC-2109)

## Purpose
After [MODINVSTOR-1219](https://folio-org.atlassian.net/browse/MODINVSTOR-1219) was implemented, we need to pass `includeRoutingServicePoints=true` parameter to `/service-points` endpoint if we don't want routing service points to be ignored.

## Approach
A new class `CustomParamCollectionResourceClient` is allowing to add custom query parameters to the regular "collection resource" calls.