### PR TITLE
CIRC-2137: Allowed SPs: allow `replace` operation when requested instance has no items

### DIFF
--- a/src/main/java/org/folio/circulation/services/AllowedServicePointsService.java
+++ b/src/main/java/org/folio/circulation/services/AllowedServicePointsService.java
@@ -157,11 +157,6 @@ public class AllowedServicePointsService {
   getAllowedServicePoints(AllowedServicePointsRequest request, String patronGroupId,
     Collection<Item> items) {
 
-    if (items.isEmpty() && request.isForTitleLevelRequest()) {
-      log.info("getAllowedServicePoints:: requested instance has no items");
-      return getAllowedServicePointsForTitleWithNoItems(request);
-    }
-
     BiFunction<RequestPolicy, Set<Item>, CompletableFuture<Result<Map<RequestType,
       Set<AllowedServicePoint>>>>> mappingFunction = request.isImplyingItemStatusIgnore()
       ? this::extractAllowedServicePointsIgnoringItemStatus
@@ -171,6 +166,11 @@ public class AllowedServicePointsService {
       return requestPolicyRepository.lookupRequestPolicy(patronGroupId)
         .thenCompose(r -> r.after(policy -> extractAllowedServicePointsIgnoringItemStatus(
           policy, new HashSet<>())));
+    }
+
+    if (items.isEmpty() && request.isForTitleLevelRequest()) {
+      log.info("getAllowedServicePoints:: requested instance has no items");
+      return getAllowedServicePointsForTitleWithNoItems(request);
     }
 
     return requestPolicyRepository.lookupRequestPolicies(items, patronGroupId)

--- a/src/test/java/api/requests/AllowedServicePointsAPITests.java
+++ b/src/test/java/api/requests/AllowedServicePointsAPITests.java
@@ -241,6 +241,22 @@ class AllowedServicePointsAPITests extends APITests {
     assertThat(response, allowedServicePointMatcher(Map.of(requestType, allowedSpInResponse)));
   }
 
+  @Test
+  void shouldReturnListOfAllowedServicePointsForHoldRequestReplacementWhenInstanceHasNoItems() {
+    settingsFixture.configureTlrFeature(true, false, null, null, null);
+    var requester = usersFixture.steve();
+    var instanceId = instancesFixture.basedUponDunkirk().getId();
+    var servicePointId = servicePointsFixture.cd1().getId();
+    setRequestPolicyWithAllowedServicePoints(HOLD, Set.of(servicePointId));
+    IndividualResource request = requestsFixture.placeTitleLevelHoldShelfRequest(
+      instanceId, requester, ZonedDateTime.now(), servicePointId);
+
+    var response = get("replace", null, null, null, null, request.getId().toString(), "true", null,
+        HttpStatus.SC_OK).getJson();
+    var expectedServicePoint = new AllowedServicePoint(servicePointId.toString(), "Circ Desk 1");
+    assertThat(response, allowedServicePointMatcher(Map.of(HOLD, List.of(expectedServicePoint))));
+  }
+
   public static Object[] shouldReturnOnlyExistingAllowedServicePointForRequestParameters() {
     String sp1Id = randomId();
     String sp2Id = randomId();


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Currently, mod-circulation returns no allowed service points for operation `replace` when requested instance has no items in local tenant. This needs to be changed in order to support changes made in https://github.com/folio-org/mod-tlr/pull/57.

Resolves [CIRC-2137](https://folio-org.atlassian.net/browse/CIRC-2137).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
