### PR TITLE
CIRC-2141 Allow specifying item location when creating title-level re…

### DIFF
--- a/ramls/request.json
+++ b/ramls/request.json
@@ -17,7 +17,7 @@
     "requestLevel": {
       "description": "Level of the request - Item or Title",
       "type": "string",
-      "enum": ["Item"]
+      "enum": ["Item", "Title"]
     },
     "requestDate": {
       "description": "Date the request was made",

--- a/ramls/request.json
+++ b/ramls/request.json
@@ -433,6 +433,10 @@
       "description": "Request fields used for search",
       "type": "object",
       "$ref": "request-search-index.json"
+    },
+    "itemLocationCode": {
+      "description": "Allow specifying item location when creating title-level requests",
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/src/main/java/org/folio/circulation/domain/Campus.java
+++ b/src/main/java/org/folio/circulation/domain/Campus.java
@@ -9,9 +9,10 @@ public class Campus {
   }
 
   public static Campus unknown(String id) {
-    return new Campus(id, null);
+    return new Campus(id, null, null);
   }
 
   String id;
   String name;
+  String code;
 }

--- a/src/main/java/org/folio/circulation/domain/Institution.java
+++ b/src/main/java/org/folio/circulation/domain/Institution.java
@@ -9,9 +9,10 @@ public class Institution {
   }
 
   public static Institution unknown(String id) {
-    return new Institution(id, null);
+    return new Institution(id, null, null);
   }
 
   String id;
   String name;
+  String code;
 }

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -417,14 +417,10 @@ public class Item {
   }
 
   public boolean isAtLocation(String locationCode) {
-    if (locationCode == null || locationCode.isEmpty()) {
-      return true;
-    } else {
-      return getLocation() != null && (
-        locationCode.equals(getLocation().getCode()) ||
-        locationCode.equals(getLocation().getLibrary().getCode()) ||
-        locationCode.equals(getLocation().getCampus().getCode()) ||
-        locationCode.equals(getLocation().getInstitution().getCode()));
-    }
+    return locationCode != null && getLocation() != null && (
+      locationCode.equals(getLocation().getCode()) ||
+      locationCode.equals(getLocation().getLibrary().getCode()) ||
+      locationCode.equals(getLocation().getCampus().getCode()) ||
+      locationCode.equals(getLocation().getInstitution().getCode()));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -415,4 +415,16 @@ public class Item {
   public String getDcbItemTitle() {
     return getProperty(itemRepresentation, "instanceTitle");
   }
+
+  public boolean isAtLocation(String locationCode) {
+    if (locationCode == null || locationCode.isEmpty()) {
+      return true;
+    } else {
+      return getLocation() != null && (
+        locationCode.equals(getLocation().getCode()) ||
+        locationCode.equals(getLocation().getLibrary().getCode()) ||
+        locationCode.equals(getLocation().getCampus().getCode()) ||
+        locationCode.equals(getLocation().getInstitution().getCode()));
+    }
+  }
 }

--- a/src/main/java/org/folio/circulation/domain/Library.java
+++ b/src/main/java/org/folio/circulation/domain/Library.java
@@ -9,9 +9,10 @@ public class Library {
   }
 
   public static Library unknown(String id) {
-    return new Library(id, null);
+    return new Library(id, null, null);
   }
 
   String id;
   String name;
+  String code;
 }

--- a/src/main/java/org/folio/circulation/domain/Request.java
+++ b/src/main/java/org/folio/circulation/domain/Request.java
@@ -17,6 +17,7 @@ import static org.folio.circulation.domain.representations.RequestProperties.CAN
 import static org.folio.circulation.domain.representations.RequestProperties.CANCELLATION_REASON_ID;
 import static org.folio.circulation.domain.representations.RequestProperties.CANCELLATION_REASON_NAME;
 import static org.folio.circulation.domain.representations.RequestProperties.CANCELLATION_REASON_PUBLIC_DESCRIPTION;
+import static org.folio.circulation.domain.representations.RequestProperties.ITEM_LOCATION_CODE;
 import static org.folio.circulation.domain.representations.RequestProperties.HOLDINGS_RECORD_ID;
 import static org.folio.circulation.domain.representations.RequestProperties.HOLD_SHELF_EXPIRATION_DATE;
 import static org.folio.circulation.domain.representations.RequestProperties.INSTANCE_ID;
@@ -386,6 +387,10 @@ public class Request implements ItemRelatedRecord, UserRelatedRecord {
 
   public String getPatronComments() {
     return getProperty(requestRepresentation, "patronComments");
+  }
+
+  public String geItemLocationCode() {
+    return getProperty(requestRepresentation, ITEM_LOCATION_CODE);
   }
 
   public Request truncateRequestExpirationDateToTheEndOfTheDay(ZoneId zone) {

--- a/src/main/java/org/folio/circulation/domain/representations/RequestProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/RequestProperties.java
@@ -21,4 +21,5 @@ public class RequestProperties {
   public static final String REQUESTER_ID = "requesterId";
   public static final String FULFILLMENT_PREFERENCE = "fulfillmentPreference";
   public static final String PICKUP_SERVICE_POINT_ID = "pickupServicePointId";
+  public static final String ITEM_LOCATION_CODE = "itemLocationCode";
 }

--- a/src/main/java/org/folio/circulation/storage/mappers/CampusMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/CampusMapper.java
@@ -9,6 +9,7 @@ import io.vertx.core.json.JsonObject;
 public class CampusMapper {
   public Campus toDomain(JsonObject representation) {
     return new Campus(getProperty(representation, "id"),
-      getProperty(representation, "name"));
+      getProperty(representation, "name"),
+      getProperty(representation, "code"));
   }
 }

--- a/src/main/java/org/folio/circulation/storage/mappers/InstitutionMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/InstitutionMapper.java
@@ -9,6 +9,7 @@ import io.vertx.core.json.JsonObject;
 public class InstitutionMapper {
   public Institution toDomain(JsonObject representation) {
     return new Institution(getProperty(representation, "id"),
-      getProperty(representation, "name"));
+      getProperty(representation, "name"),
+      getProperty(representation, "code"));
   }
 }

--- a/src/main/java/org/folio/circulation/storage/mappers/LibraryMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/LibraryMapper.java
@@ -9,6 +9,7 @@ import io.vertx.core.json.JsonObject;
 public class LibraryMapper {
   public Library toDomain(JsonObject representation) {
     return new Library(getProperty(representation, "id"),
-      getProperty(representation, "name"));
+      getProperty(representation, "name"),
+      getProperty(representation, "code"));
   }
 }

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -686,7 +686,7 @@ public class RequestsAPICreationTests extends APITests {
     assertThat(response.getStatusCode(), is(422));
     assertThat(response.getJson(), hasErrorWith(
       hasMessage("Cannot create page TLR for this instance ID - no pageable " +
-        "available items found in forced location")));
+        "available items found in requested location")));
   }
 
   @Test

--- a/src/test/java/api/support/builders/RequestBuilder.java
+++ b/src/test/java/api/support/builders/RequestBuilder.java
@@ -333,4 +333,35 @@ public class RequestBuilder extends JsonBuilder implements Builder {
   public static class Tags {
     private final List<String> tagList;
   }
+
+  @AllArgsConstructor
+  @Getter
+  public static class PrintDetails {
+    private final Integer printCount;
+    private final String requesterId;
+    private final Boolean isPrinted;
+    private final String printEventDate;
+
+    public static PrintDetails fromRepresentation(JsonObject representation) {
+      JsonObject printDetails = representation.getJsonObject("printDetails");
+      if (printDetails != null) {
+        final Integer printCount = printDetails.getInteger("printCount");
+        final String requesterId = printDetails.getString("requesterId");
+        final Boolean isPrinted = printDetails.getBoolean("isPrinted");
+        final String printEventDate = printDetails.getString("printEventDate");
+        return new PrintDetails(printCount, requesterId, isPrinted,
+          printEventDate);
+      }
+      return null;
+    }
+
+    public JsonObject toJsonObject() {
+      JsonObject printDetails = new JsonObject();
+      printDetails.put("printCount", printCount);
+      printDetails.put("requesterId", requesterId);
+      printDetails.put("isPrinted", isPrinted);
+      printDetails.put("printEventDate", printEventDate);
+      return  printDetails;
+    }
+  }
 }

--- a/src/test/java/api/support/builders/RequestBuilder.java
+++ b/src/test/java/api/support/builders/RequestBuilder.java
@@ -3,6 +3,7 @@ package api.support.builders;
 import static api.support.utl.DateTimeUtils.getLocalDatePropertyForDateWithTime;
 import static java.time.ZoneOffset.UTC;
 import static java.util.stream.Collectors.toList;
+import static org.folio.circulation.domain.representations.RequestProperties.ITEM_LOCATION_CODE;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTimeProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getIntegerProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getLocalDateProperty;
@@ -63,6 +64,7 @@ public class RequestBuilder extends JsonBuilder implements Builder {
   private final Tags tags;
   private final String patronComments;
   private final BlockOverrides blockOverrides;
+  private final String itemLocationCode;
   private final PrintDetails printDetails;
 
   public RequestBuilder() {
@@ -75,6 +77,7 @@ public class RequestBuilder extends JsonBuilder implements Builder {
       UUID.randomUUID(),
       UUID.randomUUID(),
       "Hold Shelf",
+      null,
       null,
       null,
       null,
@@ -123,6 +126,7 @@ public class RequestBuilder extends JsonBuilder implements Builder {
       new Tags((toStream(representation.getJsonObject("tags"), "tagList").collect(toList()))),
       getProperty(representation, "patronComments"),
       null,
+      getProperty(representation, ITEM_LOCATION_CODE),
       PrintDetails.fromRepresentation(representation)
     );
   }
@@ -152,6 +156,7 @@ public class RequestBuilder extends JsonBuilder implements Builder {
     put(request, "cancelledDate", formatDateTimeOptional(cancelledDate));
     put(request, "pickupServicePointId", this.pickupServicePointId);
     put(request, "patronComments", this.patronComments);
+    put(request, ITEM_LOCATION_CODE, this.itemLocationCode);
 
     if (itemSummary != null) {
       final JsonObject itemRepresentation = new JsonObject();
@@ -327,36 +332,5 @@ public class RequestBuilder extends JsonBuilder implements Builder {
   @AllArgsConstructor
   public static class Tags {
     private final List<String> tagList;
-  }
-
-  @AllArgsConstructor
-  @Getter
-  public static class PrintDetails {
-    private final Integer printCount;
-    private final String requesterId;
-    private final Boolean isPrinted;
-    private final String printEventDate;
-
-    public static PrintDetails fromRepresentation(JsonObject representation) {
-      JsonObject printDetails = representation.getJsonObject("printDetails");
-      if (printDetails != null) {
-       final Integer printCount = printDetails.getInteger("printCount");
-       final String requesterId = printDetails.getString("requesterId");
-       final Boolean isPrinted = printDetails.getBoolean("isPrinted");
-       final String printEventDate = printDetails.getString("printEventDate");
-       return new PrintDetails(printCount, requesterId, isPrinted,
-         printEventDate);
-      }
-      return null;
-    }
-
-    public JsonObject toJsonObject() {
-      JsonObject printDetails = new JsonObject();
-      printDetails.put("printCount", printCount);
-      printDetails.put("requesterId", requesterId);
-      printDetails.put("isPrinted", isPrinted);
-      printDetails.put("printEventDate", printEventDate);
-      return  printDetails;
-    }
   }
 }


### PR DESCRIPTION
CIRC-2141 Allow specifying item location when creating title-level requests


## Purpose
Currently, it’s possible to specify the service point ID when creating the request and select the item with the “nearest” location. However, when the “nearest” location search does not result in a match, the system will create the request for the first item available. The additional filter will allow it to succeed only if the requested item is in the specified location. 

This is useful when the request is sent from an ILL system to a FOLIO system that serves multiple institutions and where those ILL requests should be considered independently for each institution.

## Approach
Add an optional parameter that allows the client to specify the item’s location code when creating a title-level request. The requested location code should allow to match the item location on any level (institution, campus, library, location).

