### PR TITLE
CIRC-2168 Patron notices for the trigger “Item recalled” not sent if the item is not 1st in the title request queue

### DIFF
--- a/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
@@ -317,7 +317,7 @@ public class RequestNoticeSender {
     Loan loan = request.getLoan();
 
     if (!request.isRecall() || loan == null || loan.getUser() == null
-      || loan.getItem() == null || recallRequestCount > 1) {
+      || loan.getItem() == null || !loan.hasDueDateChanged()) {
       return ofAsync(null);
     }
 

--- a/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
@@ -101,7 +101,8 @@ public class RequestNoticeSender {
     Request request = records.getRequest();
     recallRequestCount = records.getRequestQueue().getRequests()
       .stream()
-      .filter(r -> r.getRequestType() == RequestType.RECALL && r.isNotYetFilled())
+      .filter(r -> r.getRequestType() == RequestType.RECALL && r.isNotYetFilled()
+        && r.getItemId().equals(request.getItemId()))
       .count();
 
     if (request.hasItemId()) {
@@ -317,7 +318,7 @@ public class RequestNoticeSender {
     Loan loan = request.getLoan();
 
     if (!request.isRecall() || loan == null || loan.getUser() == null
-      || loan.getItem() == null || !loan.hasDueDateChanged()) {
+      || loan.getItem() == null || recallRequestCount > 1) {
       return ofAsync(null);
     }
 

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -107,6 +107,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import lombok.val;
 import org.apache.http.HttpStatus;
 import org.awaitility.Awaitility;
 import org.folio.circulation.domain.ItemStatus;
@@ -3761,6 +3762,84 @@ public class RequestsAPICreationTests extends APITests {
     verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
     validateNoticeLogContextItem(noticeLogContextItemLogs.get(0), item);
     validateNoticeLogContextItem(noticeLogContextItemLogs.get(1), item);
+  }
+
+  @Test
+  void shouldTriggerNoticesForTitleLevelRecall() {
+    // Enable the Title Level Request feature
+    settingsFixture.enableTlrFeature();
+
+    // Configure recall notice for the loan owner (borrower)
+    JsonObject recallToLoaneeConfiguration = new NoticeConfigurationBuilder()
+      .withTemplateId(UUID.randomUUID())
+      .withEventType(NoticeEventType.ITEM_RECALLED.getRepresentation())
+      .create();
+
+    // Configure recall request notice for the requester
+    JsonObject recallRequestToRequesterConfiguration = new NoticeConfigurationBuilder()
+      .withTemplateId(UUID.randomUUID())
+      .withEventType(NoticeEventType.RECALL_REQUEST.getRepresentation())
+      .create();
+
+    // Create a notice policy with the above configurations
+    NoticePolicyBuilder noticePolicy = new NoticePolicyBuilder()
+      .withName("Policy with recall notice")
+      .withLoanNotices(List.of(recallToLoaneeConfiguration, recallRequestToRequesterConfiguration));
+
+    useFallbackPolicies(
+      loanPoliciesFixture.canCirculateRolling().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.create(noticePolicy).getId(),
+      overdueFinePoliciesFixture.facultyStandard().getId(),
+      lostItemFeePoliciesFixture.facultyStandard().getId());
+
+    // Create 3 items belonging to the same instance.
+    // The notice issue occurs only when the request queue has more than 1 item.
+    // So we need to create items under same instance to test that issue
+    val items = itemsFixture.createMultipleItemForTheSameInstance(3,
+      List.of(itemsFixture.addCallNumberStringComponents("1"),
+        itemsFixture.addCallNumberStringComponents("2"), itemsFixture.addCallNumberStringComponents("3")));
+
+    // Create borrowers who will loan the items
+    IndividualResource borrower1 = usersFixture.steve();
+    IndividualResource borrower2 = usersFixture.jessica();
+    IndividualResource borrower3 = usersFixture.james();
+
+    // Create requesters who will place title-level recall requests
+    IndividualResource requester1 = usersFixture.charlotte();
+    IndividualResource requester2 = usersFixture.rebecca();
+    IndividualResource requester3 = usersFixture.bobby();
+    IndividualResource requester4 = usersFixture.henry();
+
+    // Check out items for the borrowers
+    checkOutFixture.checkOutByBarcode(items.get(0), borrower1);
+    checkOutFixture.checkOutByBarcode(items.get(1), borrower2);
+    checkOutFixture.checkOutByBarcode(items.get(2), borrower3);
+
+    // Place title-level recall requests on the same instance
+    requestsFixture.placeTitleLevelRecallRequest(items.get(0).getInstanceId(), requester1);
+    requestsFixture.placeTitleLevelRecallRequest(items.get(0).getInstanceId(), requester2);
+    requestsFixture.placeTitleLevelRecallRequest(items.get(0).getInstanceId(), requester3);
+    requestsFixture.placeTitleLevelRecallRequest(items.get(0).getInstanceId(), requester4);
+
+
+    // Verify the notices are triggered as expected
+    // There should be 7 notices triggered: 4 recall request notices and 3 item recall notices
+    List<JsonObject> noticeLogContextItemLogs = Awaitility.waitAtMost(1, TimeUnit.SECONDS)
+      .until(() -> getPublishedEventsAsList(byLogEventType(NOTICE)), hasSize(7));
+
+    // Verify the number of notices sent and events published.
+    // Requester will receive the recall request notice and borrower will receive the item recalled notice
+    verifyNumberOfSentNotices(7);
+    verifyNumberOfNoticeEventsForUser(requester1.getId(), 1);
+    verifyNumberOfNoticeEventsForUser(requester2.getId(), 1);
+    verifyNumberOfNoticeEventsForUser(requester3.getId(), 1);
+    verifyNumberOfNoticeEventsForUser(requester4.getId(), 1);
+    verifyNumberOfNoticeEventsForUser(borrower1.getId(), 1);
+    verifyNumberOfNoticeEventsForUser(borrower2.getId(), 1);
+    verifyNumberOfNoticeEventsForUser(borrower3.getId(), 1);
+    verifyNumberOfPublishedEvents(NOTICE, 7);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
   }
 
   private void verifyNumberOfNoticeEventsForUser(UUID userId, int expectedNoticeEventsCount) {

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -3825,7 +3825,7 @@ public class RequestsAPICreationTests extends APITests {
 
     // Verify the notices are triggered as expected
     // There should be 7 notices triggered: 4 recall request notices and 3 item recall notices
-    List<JsonObject> noticeLogContextItemLogs = Awaitility.waitAtMost(1, TimeUnit.SECONDS)
+    Awaitility.waitAtMost(1, TimeUnit.SECONDS)
       .until(() -> getPublishedEventsAsList(byLogEventType(NOTICE)), hasSize(7));
 
     // Verify the number of notices sent and events published.


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
The purpose of the jira is to fix [CIRC-2168](https://folio-org.atlassian.net/browse/CIRC-2168)
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
In the current implementation, the request queue is checked, and a notice is triggered only if the number of openNotYetFilled recall requests is less than or equal to 1. However, this logic fails to trigger notices when multiple openNotYetFilled recall requests exist for different items because the request queue retrieves all requests associated with the instanceId when TLR is enabled.

To address this issue, the filtering process is updated to consider the itemId along with existing logic. This ensures that for a given itemId in the request queue, if there is exactly one openNotYetFilled recall request, the notice will be triggered as expected.

For the reported error scenario, test case was not present, hence added a new test case.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
