### PR TITLE
[CIRC-2199] Avoid self-invocation for request rules while moving requests

### DIFF
--- a/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestPolicyRepository.java
@@ -4,7 +4,6 @@ import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
-import static org.folio.circulation.rules.RulesExecutionParameters.forRequest;
 import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.support.fetching.RecordFetching.findWithMultipleCqlIndexValues;
 import static org.folio.circulation.support.results.CommonFailures.failedDueToServerError;
@@ -34,6 +33,7 @@ import org.folio.circulation.domain.policy.RequestPolicy;
 import org.folio.circulation.rules.CirculationRuleCriteria;
 import org.folio.circulation.rules.CirculationRuleMatch;
 import org.folio.circulation.rules.CirculationRulesProcessor;
+import org.folio.circulation.rules.RulesExecutionParameters;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FindWithMultipleCqlIndexValues;
@@ -169,8 +169,8 @@ public class RequestPolicyRepository {
     log.debug("lookupRequestPolicyId:: parameters materialTypeId: {}, patronGroupId: {}," +
       "loanTypeId: {}, locationId: {}", materialTypeId, patronGroupId, loanTypeId, locationId);
 
-    return circulationRulesProcessor
-      .getRequestPolicyAndMatch(forRequest(patronGroupId, materialTypeId, loanTypeId, locationId))
+    var params = new RulesExecutionParameters(loanTypeId, locationId, materialTypeId, patronGroupId, null);
+    return circulationRulesProcessor.getRequestPolicyAndMatch(params)
       .thenCompose(this::processRulesResponse);
   }
 

--- a/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestPolicyRepository.java
@@ -4,6 +4,7 @@ import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
+import static org.folio.circulation.rules.ExecutableRules.MATCH_FAIL_MSG_REGEX;
 import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.support.fetching.RecordFetching.findWithMultipleCqlIndexValues;
 import static org.folio.circulation.support.results.CommonFailures.failedDueToServerError;
@@ -182,7 +183,7 @@ public class RequestPolicyRepository {
       log.info("processRulesResponse:: successfully applied request rules");
       future.complete(succeeded(response.value().getPolicyId()));
     } else {
-      if (response.cause() instanceof ServerErrorFailure) {
+      if (response.cause() instanceof ServerErrorFailure e && e.getReason().matches(MATCH_FAIL_MSG_REGEX)) {
         log.info("processRulesResponse:: no matching request rules found");
         future.complete(failedDueToServerError("Unable to find matching request rules"));
       } else {

--- a/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/requests/RequestPolicyRepository.java
@@ -4,6 +4,7 @@ import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
+import static org.folio.circulation.rules.RulesExecutionParameters.forRequest;
 import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.support.fetching.RecordFetching.findWithMultipleCqlIndexValues;
 import static org.folio.circulation.support.results.CommonFailures.failedDueToServerError;
@@ -31,13 +32,13 @@ import org.folio.circulation.domain.RequestAndRelatedRecords;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.policy.RequestPolicy;
 import org.folio.circulation.rules.CirculationRuleCriteria;
-import org.folio.circulation.support.CirculationRulesClient;
+import org.folio.circulation.rules.CirculationRuleMatch;
+import org.folio.circulation.rules.CirculationRulesProcessor;
 import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.FindWithMultipleCqlIndexValues;
-import org.folio.circulation.support.ForwardOnFailure;
+import org.folio.circulation.support.ServerErrorFailure;
 import org.folio.circulation.support.SingleRecordFetcher;
-import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.results.Result;
 
 import io.vertx.core.json.JsonObject;
@@ -45,12 +46,12 @@ import io.vertx.core.json.JsonObject;
 public class RequestPolicyRepository {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
-  private final CirculationRulesClient circulationRequestRulesClient;
+  private final CirculationRulesProcessor circulationRulesProcessor;
   private final CollectionResourceClient requestPoliciesStorageClient;
 
   public RequestPolicyRepository(Clients clients) {
-    this.circulationRequestRulesClient = clients.circulationRequestRules();
     this.requestPoliciesStorageClient = clients.requestPoliciesStorage();
+    this.circulationRulesProcessor = clients.circulationRulesProcessor();
   }
 
   public CompletableFuture<Result<RequestAndRelatedRecords>> lookupRequestPolicy(
@@ -168,24 +169,26 @@ public class RequestPolicyRepository {
     log.debug("lookupRequestPolicyId:: parameters materialTypeId: {}, patronGroupId: {}," +
       "loanTypeId: {}, locationId: {}", materialTypeId, patronGroupId, loanTypeId, locationId);
 
-    return circulationRequestRulesClient.applyRules(loanTypeId, locationId,
-        materialTypeId, patronGroupId)
-      .thenComposeAsync(r -> r.after(this::processRulesResponse));
+    return circulationRulesProcessor
+      .getRequestPolicyAndMatch(forRequest(patronGroupId, materialTypeId, loanTypeId, locationId))
+      .thenCompose(this::processRulesResponse);
   }
 
-  private CompletableFuture<Result<String>> processRulesResponse(Response response) {
-    log.debug("processRulesResponse:: parameters response: {}", response);
+  private CompletableFuture<Result<String>> processRulesResponse(Result<CirculationRuleMatch> response) {
+    log.debug("processRulesResponse:: parameters response successful: {}", response.succeeded());
     final CompletableFuture<Result<String>> future = new CompletableFuture<>();
 
-    if (response.getStatusCode() == 404) {
-      log.info("processRulesResponse:: no matching request rules found");
-      future.complete(failedDueToServerError("Unable to find matching request rules"));
-    } else if (response.getStatusCode() != 200) {
-      log.info("processRulesResponse:: failed to apply request rules");
-      future.complete(failed(new ForwardOnFailure(response)));
-    } else {
+    if (response.succeeded()) {
       log.info("processRulesResponse:: successfully applied request rules");
-      future.complete(succeeded(response.getJson().getString("requestPolicyId")));
+      future.complete(succeeded(response.value().getPolicyId()));
+    } else {
+      if (response.cause() instanceof ServerErrorFailure) {
+        log.info("processRulesResponse:: no matching request rules found");
+        future.complete(failedDueToServerError("Unable to find matching request rules"));
+      } else {
+        log.info("processRulesResponse:: failed to apply request rules");
+        future.complete(failed(response.cause()));
+      }
     }
 
     return future;

--- a/src/main/java/org/folio/circulation/rules/ExecutableRules.java
+++ b/src/main/java/org/folio/circulation/rules/ExecutableRules.java
@@ -21,6 +21,11 @@ import lombok.Getter;
 public class ExecutableRules {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
+  public static final String MATCH_FAIL_MSG =
+    "Executing circulation rules: `%s` with parameters: `%s` to determine %s did not find a match";
+  public static final String MATCH_FAIL_MSG_REGEX
+    = "Executing circulation rules: `.*` with parameters: `.*` to determine .* did not find a match";
+
   @Getter()
   private final String text;
   private final Drools drools;
@@ -75,9 +80,7 @@ public class ExecutableRules {
   private Function<CirculationRuleMatch, HttpFailure> fail(
     RulesExecutionParameters parameters, String policyType) {
 
-    return match -> new ServerErrorFailure(format(
-      "Executing circulation rules: `%s` with parameters: `%s` to determine %s did not find a match",
-      text, parameters, policyType));
+    return match -> new ServerErrorFailure(format(MATCH_FAIL_MSG, text, parameters, policyType));
   }
 
   private Result<Boolean> noMatch(CirculationRuleMatch match) {

--- a/src/main/java/org/folio/circulation/rules/RulesExecutionParameters.java
+++ b/src/main/java/org/folio/circulation/rules/RulesExecutionParameters.java
@@ -16,6 +16,7 @@ import org.folio.circulation.domain.User;
 import org.folio.circulation.support.http.server.WebContext;
 
 import io.vertx.core.MultiMap;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -23,7 +24,7 @@ import lombok.With;
 
 @Getter
 @ToString
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RulesExecutionParameters {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private final String loanTypeId;
@@ -49,8 +50,12 @@ public final class RulesExecutionParameters {
 
   public static RulesExecutionParameters forRequest(WebContext context) {
     log.debug("forRequest:: parameters requestId {}", context.getRequestId());
-    return new RulesExecutionParameters(context.getStringParameter(LOAN_TYPE_ID_NAME),
+    return forRequest(context.getStringParameter(LOAN_TYPE_ID_NAME),
       context.getStringParameter(LOCATION_ID_NAME), context.getStringParameter(ITEM_TYPE_ID_NAME),
-      context.getStringParameter(PATRON_TYPE_ID_NAME), null);
+      context.getStringParameter(PATRON_TYPE_ID_NAME));
+  }
+
+  public static RulesExecutionParameters forRequest(String loanTypeId, String locationId, String materialTypeId, String patronGroupId) {
+    return new RulesExecutionParameters(loanTypeId, locationId, materialTypeId, patronGroupId, null);
   }
 }

--- a/src/main/java/org/folio/circulation/rules/RulesExecutionParameters.java
+++ b/src/main/java/org/folio/circulation/rules/RulesExecutionParameters.java
@@ -16,7 +16,6 @@ import org.folio.circulation.domain.User;
 import org.folio.circulation.support.http.server.WebContext;
 
 import io.vertx.core.MultiMap;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -24,7 +23,7 @@ import lombok.With;
 
 @Getter
 @ToString
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public final class RulesExecutionParameters {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private final String loanTypeId;
@@ -50,12 +49,8 @@ public final class RulesExecutionParameters {
 
   public static RulesExecutionParameters forRequest(WebContext context) {
     log.debug("forRequest:: parameters requestId {}", context.getRequestId());
-    return forRequest(context.getStringParameter(LOAN_TYPE_ID_NAME),
+    return new RulesExecutionParameters(context.getStringParameter(LOAN_TYPE_ID_NAME),
       context.getStringParameter(LOCATION_ID_NAME), context.getStringParameter(ITEM_TYPE_ID_NAME),
-      context.getStringParameter(PATRON_TYPE_ID_NAME));
-  }
-
-  public static RulesExecutionParameters forRequest(String loanTypeId, String locationId, String materialTypeId, String patronGroupId) {
-    return new RulesExecutionParameters(loanTypeId, locationId, materialTypeId, patronGroupId, null);
+      context.getStringParameter(PATRON_TYPE_ID_NAME), null);
   }
 }

--- a/src/test/java/org/folio/circulation/infrastructure/storage/requests/RequestPolicyRepositoryTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/requests/RequestPolicyRepositoryTest.java
@@ -1,0 +1,171 @@
+package org.folio.circulation.infrastructure.storage.requests;
+
+import static org.folio.circulation.rules.ExecutableRules.MATCH_FAIL_MSG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.folio.circulation.domain.Holdings;
+import org.folio.circulation.domain.Item;
+import org.folio.circulation.domain.LoanType;
+import org.folio.circulation.domain.Location;
+import org.folio.circulation.domain.MaterialType;
+import org.folio.circulation.domain.Request;
+import org.folio.circulation.domain.RequestAndRelatedRecords;
+import org.folio.circulation.domain.User;
+import org.folio.circulation.domain.policy.RequestPolicy;
+import org.folio.circulation.rules.AppliedRuleConditions;
+import org.folio.circulation.rules.CirculationRuleMatch;
+import org.folio.circulation.rules.CirculationRulesProcessor;
+import org.folio.circulation.rules.RulesExecutionParameters;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.CollectionResourceClient;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.results.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.vertx.core.json.JsonObject;
+
+@ExtendWith(MockitoExtension.class)
+public class RequestPolicyRepositoryTest {
+
+  @Mock
+  private CirculationRulesProcessor circulationRulesProcessor;
+  @Mock
+  private CollectionResourceClient requestPoliciesStorageClient;
+  @Mock
+  private Clients clients;
+
+  private RequestPolicyRepository requestPolicyRepository;
+
+  @BeforeEach
+  void setUp() {
+    doReturn(requestPoliciesStorageClient).when(clients).requestPoliciesStorage();
+    doReturn(circulationRulesProcessor).when(clients).circulationRulesProcessor();
+    requestPolicyRepository = new RequestPolicyRepository(clients);
+  }
+
+  @Test
+  void testLookupRequestPolicy() throws ExecutionException, InterruptedException {
+    var item = Item.from(JsonObject.of(
+      "materialType", asJson(MaterialType.unknown()),
+      "loadType", asJson(LoanType.unknown()),
+      "location", asJson(Location.unknown()),
+      "holdings", asJson(Holdings.unknown()))
+    );
+    var user = new User(JsonObject.of("patronGroup", "sample-group"));
+
+    var request = Request.from(JsonObject.of()).withItem(item).withRequester(user);
+    var requestAndRelatedRecords = new RequestAndRelatedRecords(request);
+
+    var policyId = "policyId";
+    var ruleMatch = new CirculationRuleMatch(policyId, mock(AppliedRuleConditions.class));
+    when(circulationRulesProcessor.getRequestPolicyAndMatch(any(RulesExecutionParameters.class)))
+      .thenReturn(CompletableFuture.completedFuture(Result.succeeded(ruleMatch)));
+
+    var policy = RequestPolicy.from(JsonObject.of("id", policyId));
+    when(requestPoliciesStorageClient.get(policyId))
+      .thenReturn(CompletableFuture.completedFuture(Result.succeeded(asResponse(policy))));
+
+    var result = requestPolicyRepository.lookupRequestPolicy(requestAndRelatedRecords).get().value();
+
+    assertEquals(policyId, result.getRequestPolicy().getId());
+    assertEquals(item, result.getRequest().getItem());
+    assertEquals(user, result.getRequest().getUser());
+    verify(circulationRulesProcessor).getRequestPolicyAndMatch(any(RulesExecutionParameters.class));
+    verify(requestPoliciesStorageClient).get(policyId);
+  }
+
+  @Test
+  void testLookupRequestPolicyWhenItemIsNull() throws ExecutionException, InterruptedException {
+    var request = Request.from(JsonObject.of()).withItem(Item.from(null));
+
+    var result = requestPolicyRepository.lookupRequestPolicy(new RequestAndRelatedRecords(request)).get();
+
+    assertTrue(result.failed());
+    assertEquals(ServerErrorFailure.class, result.cause().getClass());
+    var cause = (ServerErrorFailure) result.cause();
+    assertEquals("Unable to find matching request rules for unknown item", cause.getReason());
+    verifyNoInteractions(circulationRulesProcessor);
+    verifyNoInteractions(requestPoliciesStorageClient);
+  }
+
+  @Test
+  void testLookupRequestPolicyWhenRequestPolicyIdNotFound() throws ExecutionException, InterruptedException {
+    var item = Item.from(JsonObject.of(
+      "materialType", asJson(MaterialType.unknown()),
+      "loadType", asJson(LoanType.unknown()),
+      "location", asJson(Location.unknown()),
+      "holdings", asJson(Holdings.unknown()))
+    );
+    var user = new User(JsonObject.of("patronGroup", "sample-group"));
+
+    var request = Request.from(JsonObject.of()).withItem(item).withRequester(user);
+    var requestAndRelatedRecords = new RequestAndRelatedRecords(request);
+
+    when(circulationRulesProcessor.getRequestPolicyAndMatch(any(RulesExecutionParameters.class)))
+      .thenReturn(CompletableFuture.completedFuture(Result.failed(
+        new ServerErrorFailure(MATCH_FAIL_MSG.formatted("rules", "params", "request policy")))));
+
+    var result = requestPolicyRepository.lookupRequestPolicy(requestAndRelatedRecords).get();
+
+    assertTrue(result.failed());
+    assertEquals(ServerErrorFailure.class, result.cause().getClass());
+    var cause = (ServerErrorFailure) result.cause();
+    assertEquals("Unable to find matching request rules", cause.getReason());
+    verify(circulationRulesProcessor).getRequestPolicyAndMatch(any(RulesExecutionParameters.class));
+    verifyNoInteractions(requestPoliciesStorageClient);
+  }
+
+  @Test
+  void testLookupRequestPolicyWhenRequestPolicyNotFound() throws ExecutionException, InterruptedException {
+    var item = Item.from(JsonObject.of(
+      "materialType", asJson(MaterialType.unknown()),
+      "loadType", asJson(LoanType.unknown()),
+      "location", asJson(Location.unknown()),
+      "holdings", asJson(Holdings.unknown()))
+    );
+    var user = new User(JsonObject.of("patronGroup", "sample-group"));
+
+    var request = Request.from(JsonObject.of()).withItem(item).withRequester(user);
+    var requestAndRelatedRecords = new RequestAndRelatedRecords(request);
+
+    var policyId = "policyId";
+    var ruleMatch = new CirculationRuleMatch(policyId, mock(AppliedRuleConditions.class));
+    when(circulationRulesProcessor.getRequestPolicyAndMatch(any(RulesExecutionParameters.class)))
+      .thenReturn(CompletableFuture.completedFuture(Result.succeeded(ruleMatch)));
+
+    var cause = new ServerErrorFailure("Not Found");
+    when(requestPoliciesStorageClient.get(policyId))
+      .thenReturn(CompletableFuture.completedFuture(Result.failed(cause)));
+
+    var result = requestPolicyRepository.lookupRequestPolicy(requestAndRelatedRecords).get();
+
+    assertTrue(result.failed());
+    assertEquals(cause, result.cause());
+    verify(circulationRulesProcessor).getRequestPolicyAndMatch(any(RulesExecutionParameters.class));
+    verify(requestPoliciesStorageClient).get(policyId);
+  }
+
+  private static <T> JsonObject asJson(T entity) {
+    return JsonObject.mapFrom(entity);
+  }
+
+  private static <T> Response asResponse(T entity) {
+    return new Response(200, JsonObject.mapFrom(entity).encode(), "application/json");
+  }
+
+}


### PR DESCRIPTION

## Purpose
Remove self invocations to avoid 401 error in sidecar module 
https://folio-org.atlassian.net/browse/CIRC-2199

## Approach
Change endpoint self invocation to use service directly
