### PR TITLE
CIRC-2225 Add missing required interfaces

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1362,6 +1362,22 @@
     {
       "id": "print-events-storage",
       "version": "1.0"
+    },
+    {
+      "id": "actual-cost-fee-fine",
+      "version": "0.3"
+    },
+    {
+      "id": "anonymize-storage-loans",
+      "version": "0.1"
+    },
+    {
+      "id": "identifier-types",
+      "version": "1.2"
+    },
+    {
+      "id": "template-engine",
+      "version": "2.2"
     }
   ],
   "optional": [


### PR DESCRIPTION
CIRC-2225

## Purpose
Add missing required interfaces.

Some required interfaces are not specified in Module Descriptor. This leads to excessive egress request routing though Kong, instead of direct calls to other module sidecars.

