### PR TITLE
CIRC-2209 additional template tokens

### DIFF
--- a/src/main/java/org/folio/circulation/domain/Instance.java
+++ b/src/main/java/org/folio/circulation/domain/Instance.java
@@ -13,17 +13,20 @@ import lombok.Value;
 @ToString(onlyExplicitlyIncluded = true)
 public class Instance {
   public static Instance unknown() {
-    return new Instance(null, null, emptyList(), emptyList(), emptyList(), emptyList());
+    return new Instance(null, null,null, emptyList(), emptyList(), emptyList(), emptyList(), emptyList());
   }
 
   @ToString.Include
   String id;
+  @ToString.Include
+  String hrid;
   @ToString.Include
   String title;
   @NonNull Collection<Identifier> identifiers;
   @NonNull Collection<Contributor> contributors;
   @NonNull Collection<Publication> publication;
   @NonNull Collection<String> editions;
+  @NonNull Collection<String> physicalDescriptions;
 
   public Stream<String> getContributorNames() {
     return contributors.stream()

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -264,6 +264,14 @@ public class Item {
     return description.getYearCaption();
   }
 
+  public String getAccessionNumber() {
+    return description.getAccessionNumber();
+  }
+
+  public Collection<String> getAdministrativeNotes() {
+    return description.getAdministrativeNotes();
+  }
+
   private ServicePoint getPrimaryServicePoint() {
     return location.getPrimaryServicePoint();
   }

--- a/src/main/java/org/folio/circulation/domain/ItemDescription.java
+++ b/src/main/java/org/folio/circulation/domain/ItemDescription.java
@@ -9,7 +9,7 @@ import lombok.Value;
 @Value
 public class ItemDescription {
   public static ItemDescription unknown() {
-    return new ItemDescription(null, null, null, null, null, null, null, null, List.of());
+    return new ItemDescription(null, null, null, null, null, null, null, null, List.of(), null, List.of());
   }
 
   String barcode;
@@ -21,4 +21,6 @@ public class ItemDescription {
   String descriptionOfPieces;
   String displaySummary;
   @NonNull Collection<String> yearCaption;
+  String accessionNumber;
+  @NonNull Collection<String> administrativeNotes;
 }

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -267,7 +267,7 @@ public class TemplateContextUtil {
         .put("instanceHrid", instance.getHrid())
         .put("primaryContributor", instance.getPrimaryContributorName())
         .put("allContributors", instance.getContributorNames().collect(joining("; ")))
-        .put("yearsOfPublication", instance.getPublication().stream().
+        .put("datesOfPublication", instance.getPublication().stream().
           map(Publication::getDateOfPublication).collect(joining("; ")))
         .put("editions", String.join("; ", instance.getEditions()))
         .put("physicalDescriptions", String.join("; ", instance.getPhysicalDescriptions()));

--- a/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
+++ b/src/main/java/org/folio/circulation/domain/notice/TemplateContextUtil.java
@@ -31,6 +31,7 @@ import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.ServicePoint;
 import org.folio.circulation.domain.User;
+import org.folio.circulation.domain.Publication;
 import org.folio.circulation.domain.policy.LoanPolicy;
 import org.folio.circulation.support.utils.ClockUtil;
 
@@ -199,6 +200,7 @@ public class TemplateContextUtil {
     log.debug("createItemContext:: parameters item: {}", item);
     String yearCaptionsToken = String.join("; ", item.getYearCaption());
     String copyNumber = item.getCopyNumber() != null ? item.getCopyNumber() : "";
+    String administrativeNotes = String.join("; ", item.getAdministrativeNotes());
 
     JsonObject itemContext = createInstanceContext(item.getInstance(), item)
       .put("barcode", item.getBarcode())
@@ -212,7 +214,9 @@ public class TemplateContextUtil {
       .put("copy", copyNumber)
       .put("numberOfPieces", item.getNumberOfPieces())
       .put("displaySummary", item.getDisplaySummary())
-      .put("descriptionOfPieces", item.getDescriptionOfPieces());
+      .put("descriptionOfPieces", item.getDescriptionOfPieces())
+      .put("accessionNumber", item.getAccessionNumber())
+      .put("administrativeNotes", administrativeNotes);
 
     Location location = (item.canFloatThroughCheckInServicePoint() && item.isInStatus(ItemStatus.AVAILABLE)) ?
       item.getFloatDestinationLocation() : item.getLocation();
@@ -260,8 +264,13 @@ public class TemplateContextUtil {
       instanceContext
         .put("title", item != null && item.isDcbItem() ?
           item.getDcbItemTitle() : instance.getTitle())
+        .put("instanceHrid", instance.getHrid())
         .put("primaryContributor", instance.getPrimaryContributorName())
-        .put("allContributors", instance.getContributorNames().collect(joining("; ")));
+        .put("allContributors", instance.getContributorNames().collect(joining("; ")))
+        .put("yearsOfPublication", instance.getPublication().stream().
+          map(Publication::getDateOfPublication).collect(joining("; ")))
+        .put("editions", String.join("; ", instance.getEditions()))
+        .put("physicalDescriptions", String.join("; ", instance.getPhysicalDescriptions()));
     }
 
     return instanceContext;

--- a/src/main/java/org/folio/circulation/storage/mappers/InstanceMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/InstanceMapper.java
@@ -17,9 +17,11 @@ import io.vertx.core.json.JsonObject;
 public class InstanceMapper {
   public Instance toDomain(JsonObject representation) {
     return new Instance(getProperty(representation, "id"),
+      getProperty(representation, "hrid"),
       getProperty(representation, "title"),
       mapIdentifiers(representation), mapContributors(representation),
-      mapPublication(representation), mapEditions(representation));
+      mapPublication(representation), mapEditions(representation),
+      mapPhysicalDescriptions(representation));
   }
 
   private List<Contributor> mapContributors(JsonObject representation) {
@@ -36,4 +38,12 @@ public class InstanceMapper {
       .map(String.class::cast)
       .collect(Collectors.toList());
   }
+
+  private List<String> mapPhysicalDescriptions(JsonObject representation) {
+    return getArrayProperty(representation, "physicalDescriptions")
+      .stream()
+      .map(String.class::cast)
+      .collect(Collectors.toList());
+  }
+
 }

--- a/src/main/java/org/folio/circulation/storage/mappers/ItemMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/ItemMapper.java
@@ -47,6 +47,9 @@ public class ItemMapper {
       getProperty(representation, "descriptionOfPieces"),
       getProperty(representation, "displaySummary"),
       toStream(representation, "yearCaption")
+        .collect(Collectors.toList()),
+      getProperty(representation, "accessionNumber"),
+      toStream(representation, "administrativeNotes")
         .collect(Collectors.toList()));
   }
 

--- a/src/test/java/org/folio/circulation/domain/InstanceTests.java
+++ b/src/test/java/org/folio/circulation/domain/InstanceTests.java
@@ -10,21 +10,21 @@ import org.junit.jupiter.api.Test;
 class InstanceTests {
   @Test
   void cannotHaveANullCollectionOfIdentifiers() {
-    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "Title", null, emptyList(), emptyList(), emptyList()));
+    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "1234", "Title", null, emptyList(), emptyList(), emptyList(), emptyList()));
   }
 
   @Test
   void cannotHaveANullCollectionOfContributors() {
-    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "Title", emptyList(), null, emptyList(), emptyList()));
+    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "1234", "Title", emptyList(), null, emptyList(), emptyList(), emptyList()));
   }
 
   @Test
   void cannotHaveANullCollectionOfPublication() {
-    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "Title", emptyList(), emptyList(), null, emptyList()));
+    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "1234", "Title", emptyList(), emptyList(), null, emptyList(), emptyList()));
   }
 
   @Test
   void cannotHaveANullCollectionOfEditions() {
-    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "Title", emptyList(), emptyList(), emptyList(), null));
+    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "1234", "Title", emptyList(), emptyList(), emptyList(), null, emptyList()));
   }
 }

--- a/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
@@ -73,6 +73,7 @@ class OverdueFineServiceTest {
   private static final String FEE_FINE_TYPE = "Overdue fine";
   private static final String ITEM_MATERIAL_TYPE_NAME = "book";
   private static final String TITLE = "title";
+  private static final String INSTANCE_HRID = "1234";
   private static final String BARCODE = "barcode";
   private static final String CALL_NUMBER = "call-number";
   private static final User LOGGED_IN_USER =
@@ -613,7 +614,7 @@ class OverdueFineServiceTest {
       .withLocation(new Location(null, LOCATION_NAME, null, null, emptyList(),
         SERVICE_POINT_ID, false, Institution.unknown(), Campus.unknown(), Library.unknown(),
         ServicePoint.unknown()))
-      .withInstance(new Instance(UUID.randomUUID().toString(), TITLE, emptyList(), contributors, emptyList(), emptyList()))
+      .withInstance(new Instance(UUID.randomUUID().toString(), INSTANCE_HRID, TITLE, emptyList(), contributors, emptyList(), emptyList(), emptyList()))
       .withMaterialType(new MaterialType(ITEM_MATERIAL_TYPE_ID.toString(), ITEM_MATERIAL_TYPE_NAME, null));
   }
 

--- a/src/test/java/org/folio/circulation/domain/RequestRepresentationTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestRepresentationTests.java
@@ -127,11 +127,12 @@ class RequestRepresentationTests {
       = new ServicePoint(SERVICE_POINT_ID.toString(), SERVICE_POINT_NAME_VALUE, "cd1", true,
       "Circulation Desk", null, null, null, null);
 
-    Instance instance = new Instance(UUID.randomUUID().toString(), null,
+    Instance instance = new Instance(UUID.randomUUID().toString(), "1234", null,
       List.of(new Identifier(IDENTIFIER_ID.toString(), IDENTIFIER_VALUE)),
       emptyList(),
       List.of(new Publication("fake publisher", "fake place", "2016", null)),
-      List.of("First American Edition"));
+      List.of("First American Edition"),
+      List.of("Hardback"));
 
     JsonObject itemJson = new JsonObject()
       .put("effectiveCallNumberComponents", new JsonObject()


### PR DESCRIPTION
## Purpose
The working group for reading room circulation has identified a number of instance and item properties that some FOLIO installations using reading room features require for patron notices and slips. This PR handles six of the requested new tokens (with a few more to come in subsequent developments).  

## Approach
The tokens are added to the item context, and the main work is thus being done in TemplateContextUtil. Due to the change to the structure of Instance and Item objects in Circulation, the addition of properties has cascading effects in  classes involved in instantiation of Instance or Item objects.
  

