### PR TITLE
CIRC-2273 tokens for due date receipt

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -204,7 +204,7 @@
     },
     {
       "id": "circulation",
-      "version": "14.4",
+      "version": "14.5",
       "handlers": [
         {
           "methods": [

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -147,6 +147,10 @@ public class Item {
     return instance.getIdentifiers().stream();
   }
 
+  public String getInstanceHrid() {
+    return instance.getHrid();
+  }
+
   public String getBarcode() {
     return description.getBarcode();
   }
@@ -165,6 +169,10 @@ public class Item {
 
   public Stream<Publication> getPublication() {
     return instance.getPublication().stream();
+  }
+
+  public Collection<String> getDatesOfPublication() {
+    return getPublication().map(Publication::getDateOfPublication).toList();
   }
 
   public String getCallNumber() {
@@ -266,6 +274,14 @@ public class Item {
 
   public String getAccessionNumber() {
     return description.getAccessionNumber();
+  }
+
+  public Collection<String> getEditions() {
+    return instance.getEditions();
+  }
+
+  public Collection<String> getPhysicalDescriptions() {
+    return instance.getPhysicalDescriptions();
   }
 
   public Collection<String> getAdministrativeNotes() {

--- a/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
@@ -34,6 +34,7 @@ public class ItemSummaryRepresentation {
     write(itemSummary, "id", item.getItemId());
     write(itemSummary, "holdingsRecordId", item.getHoldingsRecordId());
     write(itemSummary, "instanceId", item.getInstanceId());
+    write(itemSummary, "instanceHrid", item.getInstanceHrid());
     write(itemSummary, "title", item.isDcbItem() ? item.getDcbItemTitle() : item.getTitle());
     write(itemSummary, "barcode", item.getBarcode());
     write(itemSummary, "contributors", mapContributorNamesToJson(item));
@@ -44,6 +45,11 @@ public class ItemSummaryRepresentation {
     write(itemSummary, "displaySummary", item.getDisplaySummary());
     write(itemSummary, "volume", item.getVolume());
     write(itemSummary, "copyNumber", item.getCopyNumber());
+    write(itemSummary, "editions", item.getEditions());
+    write(itemSummary, "datesOfPublication", item.getDatesOfPublication());
+    write(itemSummary, "physicalDescriptions", item.getPhysicalDescriptions());
+    write(itemSummary, "administrativeNotes", item.getAdministrativeNotes());
+    write(itemSummary, "accessionNumber", item.getAccessionNumber());
     write(itemSummary, CALL_NUMBER_COMPONENTS,
       createCallNumberComponents(item.getCallNumberComponents()));
     write(itemSummary, "tenantId", item.getTenantId());

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -268,6 +268,12 @@ class LoanAPITests extends APITests {
 
     assertThat("Item has primaryContributor",
       loan.getJsonObject("item").containsKey("primaryContributor"), is(true));
+
+    assertThat("Item has editions",
+      loan.getJsonObject("item").containsKey("editions"), is(true));
+
+    assertThat("Item has publication years",
+      loan.getJsonObject("item").containsKey("datesOfPublication"), is(true));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
A number of instance and item properties should be available in staff slips, patron notices and due date receipts in support of a new reading room loans feature. 

A previous pull request have added the tokens in the internal, so called Item context to make them available in staff slips and notices.  This pull request is about adding them to the loan representation (displayed in circulation/loans) as well to make them available for due date receipts.
 
## Approach
Add the properties to the internal ItemSummaryRepresentation, which is part of the loan representation, which is returned in the response of /circulation/loans, which is used for populating due date receipts. 

Since this adds to the API response, the API version is increased a minor. 