### PR TITLE
CIRC-2282: Handle duplicate header keys

### DIFF
--- a/src/main/java/org/folio/circulation/support/http/server/WebContext.java
+++ b/src/main/java/org/folio/circulation/support/http/server/WebContext.java
@@ -104,6 +104,6 @@ public class WebContext {
 
   public Map<String, String> getHeaders() {
     return routingContext.request().headers().entries().stream()
-      .collect(toMap(entry -> entry.getKey().toLowerCase(), Map.Entry::getValue));
+      .collect(toMap(entry -> entry.getKey().toLowerCase(), Map.Entry::getValue, (a, b) -> b));
   }
 }

--- a/src/test/java/org/folio/circulation/support/http/server/AnonymousWebContextTest.java
+++ b/src/test/java/org/folio/circulation/support/http/server/AnonymousWebContextTest.java
@@ -2,6 +2,7 @@ package org.folio.circulation.support.http.server;
 
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -11,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.ext.web.RoutingContext;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,5 +34,14 @@ class AnonymousWebContextTest {
     // otherwise metadata.updatedByUserId might be corrupted
     // when we do crete or update a record in this process
     assertThat(new WebContext(routingContext).getUserId(), nullValue());
+  }
+
+  @Test
+  void getHeadersShouldNotFailOnDuplicateHeaderKeys() {
+    when(request.headers()).thenReturn(new HeadersMultiMap()
+      .add("test-header", "value1")
+      .add("TEST-HEADER", "value2"));
+
+    assertDoesNotThrow(() -> new WebContext(routingContext).getHeaders());
   }
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
[CIRC-2282](https://folio-org.atlassian.net/browse/CIRC-2282)
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
