### PR TITLE
CIRC-2350: Added discoveryDisplayName in AllowedServicePointsResource response

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -678,7 +678,7 @@
     },
     {
       "id": "allowed-service-points",
-      "version": "1.1",
+      "version": "1.2",
       "handlers": [
         {
           "methods": [

--- a/ramls/allowed-service-points.json
+++ b/ramls/allowed-service-points.json
@@ -16,6 +16,10 @@
       "name": {
         "type": "string",
         "description": "Service point name"
+      },
+      "discoveryDisplayName": {
+        "type": "string",
+        "description": "discoveryDisplayName of Service point"
       }
     },
     "additionalProperties": false,

--- a/src/main/java/org/folio/circulation/domain/AllowedServicePoint.java
+++ b/src/main/java/org/folio/circulation/domain/AllowedServicePoint.java
@@ -10,9 +10,11 @@ import lombok.ToString;
 public class AllowedServicePoint {
   private String id;
   private String name;
+  private String discoveryDisplayName;
 
   public AllowedServicePoint(ServicePoint servicePoint) {
     this.id = servicePoint.getId();
     this.name = servicePoint.getName();
+    this.discoveryDisplayName = servicePoint.getDiscoveryDisplayName();
   }
 }

--- a/src/test/java/api/requests/AllowedServicePointsAPITests.java
+++ b/src/test/java/api/requests/AllowedServicePointsAPITests.java
@@ -917,17 +917,24 @@ class AllowedServicePointsAPITests extends APITests {
     final List<String> servicePointIds = response.stream()
       .map(JsonObject.class::cast)
       .map(sp -> sp.getString("id"))
-      .collect(Collectors.toList());
+            .toList();
 
     final List<String> servicePointNames = response.stream()
       .map(JsonObject.class::cast)
       .map(allowedSp -> allowedSp.getString("name"))
-      .collect(Collectors.toList());
+            .toList();
+
+    final List<String> servicePointDiscoveryDisplayName = response.stream()
+            .map(JsonObject.class::cast)
+            .map(allowedSp -> allowedSp.getString("discoveryDisplayName"))
+            .toList();
 
     // order is important: service points must be sorted by name
     assertThat(servicePointIds, contains(expectedIds.toArray(String[]::new)));
     assertThat(servicePointNames, contains(expectedServicePoints.stream()
       .map(sp -> sp.getJson().getString("name")).toArray(String[]::new)));
+    assertThat(servicePointDiscoveryDisplayName, contains(expectedServicePoints.stream()
+            .map(sp -> sp.getJson().getString("discoveryDisplayName")).toArray(String[]::new)));
   }
 
   private Response getCreateOp(String requesterId, String instanceId, String itemId,

--- a/src/test/java/api/requests/AllowedServicePointsAPITests.java
+++ b/src/test/java/api/requests/AllowedServicePointsAPITests.java
@@ -917,17 +917,17 @@ class AllowedServicePointsAPITests extends APITests {
     final List<String> servicePointIds = response.stream()
       .map(JsonObject.class::cast)
       .map(sp -> sp.getString("id"))
-            .toList();
+      .toList();
 
     final List<String> servicePointNames = response.stream()
       .map(JsonObject.class::cast)
       .map(allowedSp -> allowedSp.getString("name"))
-            .toList();
+      .toList();
 
     final List<String> servicePointDiscoveryDisplayName = response.stream()
-            .map(JsonObject.class::cast)
-            .map(allowedSp -> allowedSp.getString("discoveryDisplayName"))
-            .toList();
+      .map(JsonObject.class::cast)
+      .map(allowedSp -> allowedSp.getString("discoveryDisplayName"))
+      .toList();
 
     // order is important: service points must be sorted by name
     assertThat(servicePointIds, contains(expectedIds.toArray(String[]::new)));


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
https://folio-org.atlassian.net/browse/CIRC-2350
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
