### PR TITLE
Sunflower Bugfix R1 release 24.4.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 24.4.5 2025-05-14
+* Log the stack trace and message for all 500 errors (CIRC-2212)
+
 ## 24.4.4 2025-05-12
 * Add item data to pick slips for title level requests (CIRC-2307)
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>24.4.5-SNAPSHOT</version>
+  <version>24.4.5</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -283,7 +283,7 @@
     <url>https://github.com/folio-org/mod-inventory</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory.git</developerConnection>
-    <tag>v24.4.0</tag>
+    <tag>v24.4.5</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-circulation</artifactId>
   <groupId>org.folio</groupId>
-  <version>24.4.5</version>
+  <version>24.4.6-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -283,7 +283,7 @@
     <url>https://github.com/folio-org/mod-inventory</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory.git</developerConnection>
-    <tag>v24.4.5</tag>
+    <tag>v24.4.0</tag>
   </scm>
 
   <build>

--- a/src/main/java/org/folio/circulation/domain/policy/FixedScheduleCheckOutDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/FixedScheduleCheckOutDueDateStrategy.java
@@ -52,7 +52,8 @@ class FixedScheduleCheckOutDueDateStrategy extends DueDateStrategy {
           errorForPolicy(NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE)));
     }
     catch(Exception e) {
-      log.error("calculateDueDate:: Error occurred during fixed schedule check out due date calculation", e);
+      log.error("calculateDueDate:: Error occurred during fixed schedule"
+          + " check out due date calculation:: {}", e.getMessage());
       return failedDueToServerError(e);
     }
   }

--- a/src/main/java/org/folio/circulation/domain/policy/FixedScheduleRenewalDueDateStrategy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/FixedScheduleRenewalDueDateStrategy.java
@@ -50,7 +50,8 @@ class FixedScheduleRenewalDueDateStrategy extends DueDateStrategy {
         .orElseGet(() -> failedValidation(
           errorForPolicy(NO_APPLICABLE_DUE_DATE_SCHEDULE_MESSAGE)));
     } catch (Exception e) {
-      log.error("calculateDueDate:: Error occurred during fixed schedule renewal due date calculation", e);
+      log.error("calculateDueDate:: Error occurred during fixed schedule "
+        + "renewal due date calculation: {}", e.getMessage());
       return failedDueToServerError(e);
     }
   }

--- a/src/main/java/org/folio/circulation/support/results/CommonFailures.java
+++ b/src/main/java/org/folio/circulation/support/results/CommonFailures.java
@@ -2,12 +2,15 @@ package org.folio.circulation.support.results;
 
 import static org.folio.circulation.support.results.Result.failed;
 
+import lombok.extern.slf4j.Slf4j;
 import org.folio.circulation.support.ServerErrorFailure;
 
+@Slf4j
 public class CommonFailures {
   private CommonFailures() {}
 
   public static <T> Result<T> failedDueToServerError(Throwable e) {
+    log.error("failedDueToServerError:: Internal server error occurred", e);
     return failed(new ServerErrorFailure(e));
   }
 

--- a/src/test/java/org/folio/circulation/domain/policy/FixedScheduleCheckOutDueDateStrategyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/FixedScheduleCheckOutDueDateStrategyTest.java
@@ -1,0 +1,92 @@
+package org.folio.circulation.domain.policy;
+
+import api.support.builders.LoanBuilder;
+import static java.time.ZoneOffset.UTC;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.when;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.ValidationErrorFailure;
+import org.folio.circulation.support.http.server.ValidationError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FixedScheduleCheckOutDueDateStrategyTest {
+
+  private static final UUID ITEM_ID = UUID.randomUUID();
+  private static final UUID CHECKOUT_SERVICE_POINT_ID = UUID.randomUUID();
+  public static final ZonedDateTime LOAN_DATE = ZonedDateTime.of(2018, 1, 20, 13, 45, 21, 0, UTC);
+  public static final ZonedDateTime DUE_DATE = ZonedDateTime.of(2018, 1, 31, 23, 59, 59, 0, UTC);
+
+  @Mock private FixedDueDateSchedules fixedDueDateSchedules;
+  @InjectMocks private FixedScheduleCheckOutDueDateStrategy strategy;
+
+  @BeforeEach
+  void setUp() {
+    strategy = new FixedScheduleCheckOutDueDateStrategy(
+      "testLoanPolicyId", "testLoanPolicyName", fixedDueDateSchedules, ValidationError::new);
+  }
+
+  @Test
+  void shouldReturnDueDateWhenScheduleIsFound() {
+    var loan = existingLoan();
+
+    when(fixedDueDateSchedules.findDueDateFor(LOAN_DATE)).thenReturn(Optional.of(DUE_DATE));
+
+    var result = strategy.calculateDueDate(loan);
+
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(DUE_DATE));
+  }
+
+  @Test
+  void shouldReturnFailedResultWhenScheduleIsNotFound() {
+    var loan = existingLoan();
+
+    when(fixedDueDateSchedules.findDueDateFor(LOAN_DATE)).thenReturn(Optional.empty());
+
+    var result = strategy.calculateDueDate(loan);
+
+    assertThat(result.failed(), is(true));
+
+    var cause = (ValidationErrorFailure) result.cause();
+    var expectedReason = "loan date falls outside of the date ranges in the loan policy";
+    assertThat(cause.hasErrorWithReason(expectedReason), is(true));
+  }
+
+  @Test
+  void shouldReturnFailedResultWhenExceptionOccurred() {
+    var loan = existingLoan();
+
+    var cause = new RuntimeException("Failed to find due date");
+    when(fixedDueDateSchedules.findDueDateFor(LOAN_DATE)).thenThrow(cause);
+
+    var result = strategy.calculateDueDate(loan);
+
+    assertThat(result.failed(), is(true));
+
+    var validationErrorFailure = (ServerErrorFailure) result.cause();
+    assertThat(validationErrorFailure.getReason(), startsWith("Failed to find due date"));
+  }
+
+  private static Loan existingLoan() {
+    return new LoanBuilder()
+      .open()
+      .withLoanDate(LOAN_DATE)
+      .withCheckoutServicePointId(CHECKOUT_SERVICE_POINT_ID)
+      .withItemId(ITEM_ID)
+      .asDomainObject();
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/policy/FixedScheduleRenewalDueDateStrategyTest.java
+++ b/src/test/java/org/folio/circulation/domain/policy/FixedScheduleRenewalDueDateStrategyTest.java
@@ -1,0 +1,94 @@
+package org.folio.circulation.domain.policy;
+
+import api.support.builders.LoanBuilder;
+import static java.time.ZoneOffset.UTC;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.when;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.ValidationErrorFailure;
+import org.folio.circulation.support.http.server.ValidationError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FixedScheduleRenewalDueDateStrategyTest {
+
+  private static final UUID ITEM_ID = UUID.randomUUID();
+  private static final UUID CHECKOUT_SERVICE_POINT_ID = UUID.randomUUID();
+  public static final ZonedDateTime LOAN_DATE = ZonedDateTime.of(2018, 1, 20, 13, 45, 21, 0, UTC);
+  public static final ZonedDateTime DUE_DATE = ZonedDateTime.of(2018, 1, 31, 23, 59, 59, 0, UTC);
+  public static final ZonedDateTime SYSTEM_DATE = ZonedDateTime.of(2018, 1, 31, 23, 59, 59, 0, UTC);
+
+  @Mock private FixedDueDateSchedules fixedDueDateSchedules;
+  @InjectMocks private FixedScheduleRenewalDueDateStrategy strategy;
+
+  @BeforeEach
+  void setUp() {
+    strategy = new FixedScheduleRenewalDueDateStrategy(
+      "testLoanPolicyId", "testLoanPolicyName",
+      fixedDueDateSchedules, SYSTEM_DATE, ValidationError::new);
+  }
+
+  @Test
+  void shouldReturnDueDateWhenScheduleIsFound() {
+    var loan = existingLoan();
+
+    when(fixedDueDateSchedules.findDueDateFor(SYSTEM_DATE)).thenReturn(Optional.of(DUE_DATE));
+
+    var result = strategy.calculateDueDate(loan);
+
+    assertThat(result.succeeded(), is(true));
+    assertThat(result.value(), is(DUE_DATE));
+  }
+
+  @Test
+  void shouldReturnFailedResultWhenScheduleIsNotFound() {
+    var loan = existingLoan();
+
+    when(fixedDueDateSchedules.findDueDateFor(SYSTEM_DATE)).thenReturn(Optional.empty());
+
+    var result = strategy.calculateDueDate(loan);
+
+    assertThat(result.failed(), is(true));
+
+    var cause = (ValidationErrorFailure) result.cause();
+    var expectedReason = "renewal date falls outside of date ranges in fixed loan policy";
+    assertThat(cause.hasErrorWithReason(expectedReason), is(true));
+  }
+
+  @Test
+  void shouldReturnFailedResultWhenExceptionOccurred() {
+    var loan = existingLoan();
+
+    var cause = new RuntimeException("Failed to find due date");
+    when(fixedDueDateSchedules.findDueDateFor(SYSTEM_DATE)).thenThrow(cause);
+
+    var result = strategy.calculateDueDate(loan);
+
+    assertThat(result.failed(), is(true));
+
+    var validationErrorFailure = (ServerErrorFailure) result.cause();
+    assertThat(validationErrorFailure.getReason(), startsWith("Failed to find due date"));
+  }
+
+  private static Loan existingLoan() {
+    return new LoanBuilder()
+      .open()
+      .withLoanDate(LOAN_DATE)
+      .withCheckoutServicePointId(CHECKOUT_SERVICE_POINT_ID)
+      .withItemId(ITEM_ID)
+      .asDomainObject();
+  }
+}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
https://folio-org.atlassian.net/browse/CIRC-2363
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
