### PR TITLE
CIRC-2295: Replace deprecated mod-configuration with mod-settings for fetching tenant's locale settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 24.5.0-SNAPSHOT 2025-xx-xx
+* Replace deprecated mod-configuration with mod-settings for fetching tenant's locale settings ([CIRC-2295](https://folio-org.atlassian.net/browse/CIRC-2295))
+
 ## 24.4.0 2025-03-12
 * Patron notices for the trigger “Item recalled” not sent if the item is not 1st in the title request queue (CIRC-2168)
 * Fix automated patron blocks permission issue (CIRC-2185)

--- a/README.md
+++ b/README.md
@@ -258,17 +258,17 @@ Below is a short summary summary of most of the validation checks performed when
 
 Each includes an example of the error message provided and the parameter key included with the error.
 
-|Check|Example Message|Parameter Key|Notes|
-|---|---|---|---|
-|Item does not exist|No item with barcode 036000291452 exists|itemBarcode| |
-|Holding does not exist| | |otherwise it is not possible to lookup circulation rules|
-|Item is already checked out|Item is already checked out|itemBarcode| |
-|Existing open loan for item|Cannot check out item that already has an open loan|itemBarcode| |
-|Proxy relationship is valid|Cannot check out item via proxy when relationship is invalid| |only if proxying|
-|User must be requesting user|User checking out must be requester awaiting pickup|userBarcode|if there is an outstanding fulfillable request for item|
-|User does not exist|Could not find user with matching barcode|userBarcode| |
-|User needs to be active and not expired|Cannot check out to inactive user|userBarcode| |
-|Proxy user needs to be active and not expired|Cannot check out via inactive proxying user|proxyUserBarcode|only if proxying|
+| Check                                         | Example Message                                              | Parameter Key    | Notes                                                    |
+|-----------------------------------------------|--------------------------------------------------------------|------------------|----------------------------------------------------------|
+| Item does not exist                           | No item with barcode 036000291452 exists                     | itemBarcode      |                                                          |
+| Holding does not exist                        |                                                              |                  | otherwise it is not possible to lookup circulation rules |
+| Item is already checked out                   | Item is already checked out                                  | itemBarcode      |                                                          |
+| Existing open loan for item                   | Cannot check out item that already has an open loan          | itemBarcode      |                                                          |
+| Proxy relationship is valid                   | Cannot check out item via proxy when relationship is invalid |                  | only if proxying                                         |
+| User must be requesting user                  | User checking out must be requester awaiting pickup          | userBarcode      | if there is an outstanding fulfillable request for item  |
+| User does not exist                           | Could not find user with matching barcode                    | userBarcode      |                                                          |
+| User needs to be active and not expired       | Cannot check out to inactive user                            | userBarcode      |                                                          |
+| Proxy user needs to be active and not expired | Cannot check out via inactive proxying user                  | proxyUserBarcode | only if proxying                                         |
 
 ### Renew By Barcode
 
@@ -397,19 +397,19 @@ based on the patron's patron group and the item's material type, loan type, and 
 During the circulation process an item can change between a variety of states,
 below is a table describing the most common states defined at the moment.
 
-| Name | Description |
-|---|---|
-| Available | This item is available to be lent to a patron |
-| Checked out | This item is currently checked out to a patron |
-| Awaiting pickup | This item is awaiting pickup by a patron who has a request at the top of the queue|
+| Name            | Description                                                                        |
+|-----------------|------------------------------------------------------------------------------------|
+| Available       | This item is available to be lent to a patron                                      |
+| Checked out     | This item is currently checked out to a patron                                     |
+| Awaiting pickup | This item is awaiting pickup by a patron who has a request at the top of the queue |
 
 ### Request Status
 
-| Name | Description |
-|---|---|
-| Open - Not yet filled | The requested item is not yet available to the requesting user |
-| Open - Awaiting pickup | The item is available to the requesting user |
-| Closed - Filled | |
+| Name                   | Description                                                    |
+|------------------------|----------------------------------------------------------------|
+| Open - Not yet filled  | The requested item is not yet available to the requesting user |
+| Open - Awaiting pickup | The item is available to the requesting user                   |
+| Closed - Filled        |                                                                |
 
 ### Storing Information from Other Records
 
@@ -523,7 +523,7 @@ content-length: 230
 }
 ```
 ### Configuration setting for CheckoutLock Feature
-  To enable this feature for a tenant, we need to add the below configuration in mod-settings. See https://issues.folio.org/browse/UXPROD-3515 to know more about this feature.
+  To enable this feature for a tenant, we need to add the below configuration in mod-settings. See [UXPROD-3515](https://issues.folio.org/browse/UXPROD-3515) to know more about this feature.
 
 #### Permissions
   To make a post call to mod-settings, user should have below permissions.
@@ -544,19 +544,19 @@ POST https://{okapi-location}/settings/entries
 ```
 
 | parameter | Type        | Description                                                                                           |
-|---------|-------------|-------------------------------------------------------------------------------------------------------|
-| `id`    | UUID        | id should be provided of type UUID.                                                                   |
-| `scope` | String      | Scope should be the module name. Here, it will be "mod-circulation"                                   |
-| `key`   | String      | Key should be feature name which we are enabling the settings. Here, it will be "checkoutLockFeature" |
-| `value` | Json Object | Settings for checkout lock feature                                                                    |
+|-----------|-------------|-------------------------------------------------------------------------------------------------------|
+| `id`      | UUID        | id should be provided of type UUID.                                                                   |
+| `scope`   | String      | Scope should be the module name. Here, it will be "mod-circulation"                                   |
+| `key`     | String      | Key should be feature name which we are enabling the settings. Here, it will be "checkoutLockFeature" |
+| `value`   | Json Object | Settings for checkout lock feature                                                                    |
 
 
 | Value options                | Type    | Description                                                                                                                                                                                    |
 |------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `checkOutLockFeatureEnabled` | boolean | Indicates whether or not to enable this feature for the tenant. Default value is false(disabled).                                                                                              |
 | `noOfRetryAttempts`          | int     | The maximum number of times to retry the lock ackquiring process during checkout. Once the retry is exhausted, system will return error. Default value is 30.                                  |
-| `retryInterval`              | int | The amount of time to wait between retries in milliseconds. Default value is 250.                                                                                                              |
-| `lockTtl`                    | int | Maximum amount of time(milliseconds) that the lock should exist for a patron. After this time, the lock will gets deleted and lock will be provided for another request. Default value is 3000 |
+| `retryInterval`              | int     | The amount of time to wait between retries in milliseconds. Default value is 250.                                                                                                              |
+| `lockTtl`                    | int     | Maximum amount of time(milliseconds) that the lock should exist for a patron. After this time, the lock will gets deleted and lock will be provided for another request. Default value is 3000 |
 
 ## Additional Information
 

--- a/src/main/java/org/folio/circulation/domain/ConfigurationService.java
+++ b/src/main/java/org/folio/circulation/domain/ConfigurationService.java
@@ -1,16 +1,10 @@
 package org.folio.circulation.domain;
 
-import static org.folio.circulation.domain.MultipleRecords.from;
-
 import java.lang.invoke.MethodHandles;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.Collection;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import io.vertx.core.json.JsonObject;
 
 public class ConfigurationService {
@@ -18,29 +12,8 @@ public class ConfigurationService {
 
   private static final int DEFAULT_SCHEDULED_NOTICES_PROCESSING_LIMIT = 100;
   private static final int DEFAULT_CHECKOUT_TIMEOUT_DURATION_IN_MINUTES = 3;
-  private static final ZoneId DEFAULT_DATE_TIME_ZONE = ZoneOffset.UTC;
-  private static final String TIMEZONE_KEY = "timezone";
-  private static final String RECORDS_NAME = "configs";
   private static final String CHECKOUT_TIMEOUT_DURATION_KEY = "checkoutTimeoutDuration";
   private static final String CHECKOUT_TIMEOUT_KEY = "checkoutTimeout";
-
-  ZoneId findDateTimeZone(JsonObject representation) {
-    return from(representation, Configuration::new, RECORDS_NAME)
-      .map(MultipleRecords::getRecords)
-      .map(this::findDateTimeZone)
-      .orElse(DEFAULT_DATE_TIME_ZONE);
-  }
-
-  public ZoneId findDateTimeZone(Collection<Configuration> configurations) {
-    final ZoneId chosenTimeZone = configurations.stream()
-      .map(this::applyTimeZone)
-      .findFirst()
-      .orElse(DEFAULT_DATE_TIME_ZONE);
-
-    log.debug("findDateTimeZone:: timezone={}", chosenTimeZone);
-
-    return chosenTimeZone;
-  }
 
   public Integer findSchedulerNoticesLimit(Collection<Configuration> configurations) {
     final Integer noticesLimit = configurations.stream()
@@ -93,19 +66,5 @@ public class ConfigurationService {
     return StringUtils.isNumeric(value)
       ? Integer.valueOf(value)
       : DEFAULT_SCHEDULED_NOTICES_PROCESSING_LIMIT;
-  }
-
-  private ZoneId applyTimeZone(Configuration config) {
-    String value = config.getValue();
-    return StringUtils.isBlank(value)
-      ? DEFAULT_DATE_TIME_ZONE
-      : parseDateTimeZone(value);
-  }
-
-  private ZoneId parseDateTimeZone(String value) {
-    String timezone = new JsonObject(value).getString(TIMEZONE_KEY);
-    return StringUtils.isBlank(timezone)
-      ? DEFAULT_DATE_TIME_ZONE
-      : ZoneId.of(timezone);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/CreateRequestService.java
+++ b/src/main/java/org/folio/circulation/domain/CreateRequestService.java
@@ -83,7 +83,7 @@ public class CreateRequestService {
     log.debug("createRequest:: parameters requestAndRelatedRecords: {}", () -> requestAndRelatedRecords);
 
     final var requestRepository = repositories.getRequestRepository();
-    final var configurationRepository = repositories.getConfigurationRepository();
+    final var settingsRepository = repositories.getSettingsRepository();
     final var automatedBlocksValidator = requestBlockValidators.getAutomatedPatronBlocksValidator();
     final var manualBlocksValidator = requestBlockValidators.getManualPatronBlocksValidator();
 
@@ -103,7 +103,7 @@ public class CreateRequestService {
       .thenComposeAsync(r -> r.after(when(this::shouldCheckItem, this::checkItem, this::doNothing)))
       .thenComposeAsync(r -> r.after(this::checkPolicy))
       .thenApply(r -> r.next(this::refuseHoldOrRecallTlrWhenPageableItemExists))
-      .thenComposeAsync(r -> r.combineAfter(configurationRepository::findTimeZoneConfiguration,
+      .thenComposeAsync(r -> r.combineAfter(settingsRepository::lookupTimeZoneSettings,
         RequestAndRelatedRecords::withTimeZone))
       .thenApply(r -> r.next(errorHandler::failWithValidationErrors))
       .thenComposeAsync(r -> r.after(updateUponRequest.updateItem::onRequestCreateOrUpdate))

--- a/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
+++ b/src/main/java/org/folio/circulation/domain/UpdateRequestQueue.java
@@ -14,7 +14,6 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/org/folio/circulation/infrastructure/storage/CalendarRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/CalendarRepository.java
@@ -39,11 +39,11 @@ public class CalendarRepository {
     "%s/all-openings?startDate=%s&endDate=%s&includeClosed=false&limit=%d";
 
   private final CollectionResourceClient calendarClient;
-  private final ConfigurationRepository configurationRepository;
+  private final SettingsRepository settingsRepository;
 
   public CalendarRepository(Clients clients) {
     this.calendarClient = clients.calendarStorageClient();
-    this.configurationRepository = new ConfigurationRepository(clients);
+    this.settingsRepository = new SettingsRepository(clients);
   }
 
   public CompletableFuture<Result<AdjacentOpeningDays>> lookupOpeningDays(
@@ -75,7 +75,7 @@ public class CalendarRepository {
 
     return calendarClient.get(path)
       .thenCombineAsync(
-        configurationRepository.findTimeZoneConfiguration(),
+        settingsRepository.lookupTimeZoneSettings(),
         Result.combined(CalendarRepository::getOpeningDaysFromOpeningDayCollection)
       );
   }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/ConfigurationRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/ConfigurationRepository.java
@@ -3,7 +3,6 @@ package org.folio.circulation.infrastructure.storage;
 import static org.folio.circulation.domain.MultipleRecords.from;
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
 
-import java.time.ZoneId;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -92,13 +91,6 @@ public class ConfigurationRepository {
     return LoanAnonymizationConfiguration.from(period);
   }
 
-  public CompletableFuture<Result<ZoneId>> findTimeZoneConfiguration() {
-    Result<CqlQuery> cqlQueryResult = defineModuleNameAndConfigNameFilter(
-      "ORG", "localeSettings");
-
-    return lookupConfigurations(cqlQueryResult, applySearchDateTimeZone());
-  }
-
   private <T> CompletableFuture<Result<T>> lookupConfigurations(
     Result<CqlQuery> cqlQueryResult,
     Function<MultipleRecords<Configuration>, T> searchStrategy) {
@@ -117,11 +109,6 @@ public class ConfigurationRepository {
     final Result<CqlQuery> configNameQuery = exactMatch(CONFIG_NAME_KEY, configName);
 
     return moduleQuery.combine(configNameQuery, CqlQuery::and);
-  }
-
-  private Function<MultipleRecords<Configuration>, ZoneId> applySearchDateTimeZone() {
-    return configurations -> new ConfigurationService()
-      .findDateTimeZone(configurations.getRecords());
   }
 
   private Function<MultipleRecords<Configuration>, Integer> applySearchSchedulerNoticesLimit() {

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -16,7 +16,6 @@ import org.folio.circulation.domain.notice.session.PatronActionSessionService;
 import org.folio.circulation.domain.representations.CheckInByBarcodeRequest;
 import org.folio.circulation.domain.representations.CheckInByBarcodeResponse;
 import org.folio.circulation.domain.validation.CheckInValidators;
-import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.SettingsRepository;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
@@ -78,8 +77,6 @@ public class CheckInByBarcodeResource extends Resource {
         PatronActionSessionRepository.using(clients, loanRepository, userRepository));
 
     final RequestNoticeSender requestNoticeSender = RequestNoticeSender.using(clients);
-
-    final ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
     final SettingsRepository settingsRepository = new SettingsRepository(clients);
 
     refuseWhenLoggedInUserNotPresent(context)
@@ -92,7 +89,7 @@ public class CheckInByBarcodeResource extends Resource {
       .thenApply(checkInValidators::refuseWhenClaimedReturnedIsNotResolved)
       .thenComposeAsync(r -> r.combineAfter(settingsRepository::lookupTlrSettings,
         CheckInContext::withTlrSettings))
-      .thenComposeAsync(r -> r.combineAfter(configurationRepository::findTimeZoneConfiguration,
+      .thenComposeAsync(r -> r.combineAfter(settingsRepository::lookupTimeZoneSettings,
         CheckInContext::withTimeZone))
       .thenComposeAsync(findItemResult -> findItemResult.combineAfter(
         processAdapter::getRequestQueue, CheckInContext::withRequestQueue))

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -38,7 +38,6 @@ import org.folio.circulation.domain.policy.library.ClosedLibraryStrategyService;
 import org.folio.circulation.domain.representations.CheckOutByBarcodeRequest;
 import org.folio.circulation.domain.validation.CheckOutValidators;
 import org.folio.circulation.infrastructure.storage.CheckOutLockRepository;
-import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.SettingsRepository;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
@@ -120,7 +119,6 @@ public class CheckOutByBarcodeResource extends Resource {
     final var lostItemPolicyRepository = new LostItemPolicyRepository(clients);
     final var patronNoticePolicyRepository = new PatronNoticePolicyRepository(clients);
     final var patronGroupRepository = new PatronGroupRepository(clients);
-    final var configurationRepository = new ConfigurationRepository(clients);
     final var scheduledNoticesRepository = ScheduledNoticesRepository.using(clients);
     final var scheduledNoticeService = new LoanScheduledNoticeService(scheduledNoticesRepository,
       patronNoticePolicyRepository);
@@ -164,7 +162,7 @@ public class CheckOutByBarcodeResource extends Resource {
       .thenComposeAsync(validators::refuseWhenItemLimitIsReached)
       .thenCompose(validators::refuseWhenItemIsNotLoanable)
       .thenApply(r -> r.next(errorHandler::failWithValidationErrors))
-      .thenCompose(r -> r.combineAfter(configurationRepository::findTimeZoneConfiguration,
+      .thenCompose(r -> r.combineAfter(settingsRepository::lookupTimeZoneSettings,
         LoanAndRelatedRecords::withTimeZone))
       .thenComposeAsync(r -> r.after(overdueFinePolicyRepository::lookupOverdueFinePolicy))
       .thenComposeAsync(r -> r.after(lostItemPolicyRepository::lookupLostItemPolicy));

--- a/src/main/java/org/folio/circulation/resources/FeeFineScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/FeeFineScheduledNoticeProcessingResource.java
@@ -11,7 +11,7 @@ import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.notice.schedule.FeeFineScheduledNoticeHandler;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.domain.notice.schedule.TriggeringEvent;
-import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.SettingsRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
@@ -36,7 +36,7 @@ public class FeeFineScheduledNoticeProcessingResource extends ScheduledNoticePro
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNoticesToSend(
-    ConfigurationRepository configurationRepository,
+    SettingsRepository settingsRepository,
     ScheduledNoticesRepository scheduledNoticesRepository,
     PatronActionSessionRepository patronActionSessionRepository, PageLimit pageLimit) {
 

--- a/src/main/java/org/folio/circulation/resources/LoanScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/LoanScheduledNoticeProcessingResource.java
@@ -15,7 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.notice.schedule.LoanScheduledNoticeHandler;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
-import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.SettingsRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
@@ -37,7 +37,7 @@ public class LoanScheduledNoticeProcessingResource extends ScheduledNoticeProces
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNoticesToSend(
-    ConfigurationRepository configurationRepository,
+    SettingsRepository settingsRepository,
     ScheduledNoticesRepository scheduledNoticesRepository,
     PatronActionSessionRepository patronActionSessionRepository, PageLimit pageLimit) {
 

--- a/src/main/java/org/folio/circulation/resources/OverdueFineScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/OverdueFineScheduledNoticeProcessingResource.java
@@ -21,7 +21,7 @@ import org.folio.circulation.domain.notice.schedule.GroupedScheduledNoticeHandle
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.domain.notice.schedule.grouping.OverdueFineScheduledNoticeGroupDefinitionFactory;
 import org.folio.circulation.domain.notice.session.PatronSessionRecord;
-import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.SettingsRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.infrastructure.storage.sessions.PatronActionSessionRepository;
@@ -51,11 +51,11 @@ public class OverdueFineScheduledNoticeProcessingResource
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNoticesToSend(
-    ConfigurationRepository configurationRepository,
+    SettingsRepository settingsRepository,
     ScheduledNoticesRepository scheduledNoticesRepository,
     PatronActionSessionRepository patronActionSessionRepository, PageLimit pageLimit) {
 
-    return super.findNoticesToSend(configurationRepository, scheduledNoticesRepository,
+    return super.findNoticesToSend(settingsRepository, scheduledNoticesRepository,
         patronActionSessionRepository, pageLimit)
       .thenCompose(r -> r.after(notices -> filterNotices(notices, patronActionSessionRepository)));
   }

--- a/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestCollectionResource.java
@@ -32,7 +32,6 @@ import org.folio.circulation.domain.validation.ProxyRelationshipValidator;
 import org.folio.circulation.domain.validation.RequestLoanValidator;
 import org.folio.circulation.domain.validation.ServicePointPickupLocationValidator;
 import org.folio.circulation.infrastructure.storage.CalendarRepository;
-import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.ServicePointRepository;
 import org.folio.circulation.infrastructure.storage.SettingsRepository;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
@@ -218,7 +217,7 @@ public class RequestCollectionResource extends CollectionResource {
     final var requestQueueService = RequestQueueService.using(clients);
     final var updateRequestQueue = new UpdateRequestQueue(new RequestQueueRepository(
       requestRepository), requestRepository, new ServicePointRepository(clients),
-      new ConfigurationRepository(clients), requestQueueService, new CalendarRepository(clients));
+      new SettingsRepository(clients), requestQueueService, new CalendarRepository(clients));
 
     UpdateItem updateItem = new UpdateItem(itemRepository, requestQueueService);
 
@@ -280,7 +279,6 @@ public class RequestCollectionResource extends CollectionResource {
 
     final var loanPolicyRepository = new LoanPolicyRepository(clients);
     final var requestPolicyRepository = new RequestPolicyRepository(clients);
-    final var configurationRepository = new ConfigurationRepository(clients);
     final var settingsRepository = new SettingsRepository(clients);
 
     final var updateUponRequest = new UpdateUponRequest(new UpdateItem(itemRepository,
@@ -296,7 +294,7 @@ public class RequestCollectionResource extends CollectionResource {
     final var moveRequestService = new MoveRequestService(
       requestRepository, requestPolicyRepository,
       updateUponRequest, moveRequestProcessAdapter, new RequestLoanValidator(new ItemByInstanceIdFinder(clients.holdingsStorage(), itemRepository), loanRepository),
-      RequestNoticeSender.using(clients), configurationRepository, eventPublisher,
+      RequestNoticeSender.using(clients), eventPublisher,
       requestQueueRepository, settingsRepository);
 
     fromFutureResult(requestRepository.getById(id))

--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -2,7 +2,6 @@ package org.folio.circulation.resources;
 
 import static java.lang.String.join;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.folio.circulation.domain.EcsRequestPhase.INTERMEDIATE;

--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -67,7 +67,6 @@ import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.configuration.TlrSettingsConfiguration;
 import org.folio.circulation.domain.validation.ProxyRelationshipValidator;
 import org.folio.circulation.domain.validation.ServicePointPickupLocationValidator;
-import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.ServicePointRepository;
 import org.folio.circulation.infrastructure.storage.SettingsRepository;
 import org.folio.circulation.infrastructure.storage.inventory.HoldingsRepository;
@@ -98,7 +97,6 @@ class RequestFromRepresentationService {
   private final UserRepository userRepository;
   private final LoanRepository loanRepository;
   private final ServicePointRepository servicePointRepository;
-  private final ConfigurationRepository configurationRepository;
   private final SettingsRepository settingsRepository;
   private final RequestPolicyRepository requestPolicyRepository;
   private final ProxyRelationshipValidator proxyRelationshipValidator;
@@ -122,7 +120,6 @@ class RequestFromRepresentationService {
     this.userRepository = repositories.getUserRepository();
     this.loanRepository = repositories.getLoanRepository();
     this.servicePointRepository = repositories.getServicePointRepository();
-    this.configurationRepository = repositories.getConfigurationRepository();
     this.settingsRepository = repositories.getSettingsRepository();
     this.requestPolicyRepository = repositories.getRequestPolicyRepository();
 
@@ -148,7 +145,7 @@ class RequestFromRepresentationService {
       .thenApply(this::refuseWhenNoRequestDate)
       .thenApply(r -> r.map(this::removeRelatedRecordInformation))
       .thenApply(r -> r.map(this::removeProcessingParameters))
-      .thenCompose(r -> r.combineAfter(configurationRepository::findTimeZoneConfiguration,
+      .thenCompose(r -> r.combineAfter(settingsRepository::lookupTimeZoneSettings,
         Request::truncateRequestExpirationDateToTheEndOfTheDay))
       .thenComposeAsync(r -> r.after(when(
         this::shouldFetchInstance, this::fetchInstance, req -> ofAsync(() -> req))))
@@ -338,7 +335,7 @@ class RequestFromRepresentationService {
       .map(Item::getItemId)
       .filter(itemId -> request.getInstanceItemsRequestPolicies().get(itemId)
         .allowsType(RECALL))
-      .collect(toList());
+      .toList();
 
     return loanRepository.findLoanWithClosestDueDate(recallableItemIds, recalledLoansIds)
       //Loan is null means that we have no items that haven't been recalled. In this case we

--- a/src/main/java/org/folio/circulation/resources/RequestQueueResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestQueueResource.java
@@ -11,7 +11,6 @@ import static org.folio.circulation.support.results.Result.succeeded;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/org/folio/circulation/resources/RequestScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/RequestScheduledNoticeProcessingResource.java
@@ -29,7 +29,7 @@ import org.folio.circulation.domain.notice.schedule.InstanceAwareRequestSchedule
 import org.folio.circulation.domain.notice.schedule.ItemAwareRequestScheduledNoticeHandler;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.domain.notice.schedule.ScheduledNoticeContext;
-import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.SettingsRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
@@ -39,7 +39,6 @@ import org.folio.circulation.support.CqlSortBy;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.results.Result;
 import org.folio.circulation.support.utils.ClockUtil;
-import org.folio.circulation.support.utils.LogUtil;
 
 import io.vertx.core.http.HttpClient;
 
@@ -52,7 +51,7 @@ public class RequestScheduledNoticeProcessingResource extends ScheduledNoticePro
 
   @Override
   protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNoticesToSend(
-    ConfigurationRepository configurationRepository,
+    SettingsRepository settingsRepository,
     ScheduledNoticesRepository scheduledNoticesRepository,
     PatronActionSessionRepository patronActionSessionRepository, PageLimit pageLimit) {
 

--- a/src/main/java/org/folio/circulation/resources/ScheduledDigitalRemindersProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledDigitalRemindersProcessingResource.java
@@ -6,7 +6,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.notice.schedule.ScheduledDigitalReminderHandler;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
-import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.SettingsRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestRepository;
@@ -37,7 +37,7 @@ public class ScheduledDigitalRemindersProcessingResource extends ScheduledNotice
   }
 
   @Override
-  protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNoticesToSend(ConfigurationRepository configurationRepository, ScheduledNoticesRepository scheduledNoticesRepository, PatronActionSessionRepository patronActionSessionRepository, PageLimit pageLimit) {
+  protected CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNoticesToSend(SettingsRepository settingsRepository, ScheduledNoticesRepository scheduledNoticesRepository, PatronActionSessionRepository patronActionSessionRepository, PageLimit pageLimit) {
     return CqlQuery.lessThanOrEqualTo("nextRunTime", formatDateTime(ClockUtil.getZonedDateTime().withZoneSameInstant(ZoneOffset.UTC)))
       .combine(exactMatch("noticeConfig.sendInRealTime", "true"), CqlQuery::and)
       .combine(exactMatch("triggeringEvent", DUE_DATE_WITH_REMINDER_FEE.getRepresentation()), CqlQuery::and)

--- a/src/main/java/org/folio/circulation/resources/ScheduledNoticeProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledNoticeProcessingResource.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.SettingsRepository;
 import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
@@ -49,6 +50,7 @@ public abstract class ScheduledNoticeProcessingResource extends Resource {
       ScheduledNoticesRepository.using(clients);
     final ConfigurationRepository configurationRepository =
       new ConfigurationRepository(clients);
+    final var settingsRepository = new SettingsRepository(clients);
     final var itemRepository = new ItemRepository(clients);
     final var userRepository = new UserRepository(clients);
     final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
@@ -58,7 +60,7 @@ public abstract class ScheduledNoticeProcessingResource extends Resource {
       clients, loanRepository, userRepository);
 
     safelyInitialise(configurationRepository::lookupSchedulerNoticesProcessingLimit)
-      .thenCompose(r -> r.after(limit -> findNoticesToSend(configurationRepository,
+      .thenCompose(r -> r.after(limit -> findNoticesToSend(settingsRepository,
         scheduledNoticesRepository, patronActionSessionRepository, limit)))
       .thenCompose(r -> r.after(notices -> handleNotices(clients, requestRepository,
         loanRepository, notices)))
@@ -68,7 +70,7 @@ public abstract class ScheduledNoticeProcessingResource extends Resource {
   }
 
   protected abstract CompletableFuture<Result<MultipleRecords<ScheduledNotice>>> findNoticesToSend(
-    ConfigurationRepository configurationRepository,
+    SettingsRepository settingsRepository,
     ScheduledNoticesRepository scheduledNoticesRepository,
     PatronActionSessionRepository patronActionSessionRepository, PageLimit pageLimit);
 

--- a/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
+++ b/src/main/java/org/folio/circulation/resources/renewal/RenewalResource.java
@@ -69,7 +69,6 @@ import org.folio.circulation.domain.validation.overriding.BlockValidator;
 import org.folio.circulation.domain.validation.overriding.OverridingBlockValidator;
 import org.folio.circulation.infrastructure.storage.AutomatedPatronBlocksRepository;
 import org.folio.circulation.infrastructure.storage.CalendarRepository;
-import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
 import org.folio.circulation.infrastructure.storage.SettingsRepository;
 import org.folio.circulation.infrastructure.storage.feesandfines.FeeFineOwnerRepository;
 import org.folio.circulation.infrastructure.storage.feesandfines.FeeFineRepository;
@@ -150,7 +149,6 @@ public abstract class RenewalResource extends Resource {
     final StoreLoanAndItem storeLoanAndItem = new StoreLoanAndItem(loanRepository, itemRepository);
 
     final LoanRepresentation loanRepresentation = new LoanRepresentation();
-    final ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
     final SettingsRepository settingsRepository = new SettingsRepository(clients);
     final LoanScheduledNoticeService scheduledNoticeService = LoanScheduledNoticeService.using(clients);
     final ReminderFeeScheduledNoticeService scheduledRemindersService = new ReminderFeeScheduledNoticeService(clients);
@@ -193,7 +191,7 @@ public abstract class RenewalResource extends Resource {
         RenewalContext::withTlrSettings))
       .thenComposeAsync(r -> r.after(
         ctx -> lookupRequestQueue(ctx, requestQueueRepository, errorHandler)))
-      .thenCompose(r -> r.combineAfter(configurationRepository::findTimeZoneConfiguration,
+      .thenCompose(r -> r.combineAfter(settingsRepository::lookupTimeZoneSettings,
         RenewalContext::withTimeZone))
       .thenComposeAsync(r -> r.after(context -> renew(context, clients, errorHandler)))
       .thenApply(r -> r.next(errorHandler::failWithValidationErrors))
@@ -425,7 +423,7 @@ public abstract class RenewalResource extends Resource {
   }
 
   private BlockOverrides getOverrideBlocks(JsonObject request) {
-    return BlockOverrides.from(getObjectProperty(request, "overrideBlocks"));
+    return BlockOverrides.from(getObjectProperty(request, OVERRIDE_BLOCKS));
   }
 
   private CompletableFuture<Result<RenewalContext>> refuseIfNoPermissionsForRenewalOverride(
@@ -634,7 +632,7 @@ public abstract class RenewalResource extends Resource {
 
     if (errors.isEmpty()) {
       final BlockOverrides blockOverrides = BlockOverrides.from(getObjectProperty(
-        context.getRenewalRequest(), "overrideBlocks"));
+        context.getRenewalRequest(), OVERRIDE_BLOCKS));
 
       if (!blockOverrides.getPatronBlockOverride().isRequested() &&
         !blockOverrides.getRenewalBlockOverride().isRequested()) {

--- a/src/test/java/api/loans/CheckOutCalculateDueDateShortTermTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateDueDateShortTermTests.java
@@ -20,13 +20,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import api.support.fixtures.SettingsFixture;
 import org.folio.circulation.domain.policy.DueDateManagement;
 import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.support.http.client.Response;
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Test;
 import api.support.APITests;
 import api.support.builders.CheckOutByBarcodeRequestBuilder;
 import api.support.builders.LoanPolicyBuilder;
-import api.support.fixtures.ConfigurationExample;
 import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonObject;
 
@@ -64,7 +63,7 @@ class CheckOutCalculateDueDateShortTermTests extends APITests {
     String expectedTimeZone = "America/New_York";
     int duration = 24;
 
-    Response response = configClient.create(ConfigurationExample.newYorkTimezoneConfiguration())
+    Response response = settingsClient.create(SettingsFixture.newYorkTimezoneConfiguration())
       .getResponse();
     assertThat(response.getBody(), containsString(expectedTimeZone));
 
@@ -80,8 +79,8 @@ class CheckOutCalculateDueDateShortTermTests extends APITests {
   void testRespectUtcTimezoneForDueDateCalculations() throws Exception {
     int duration = 24;
 
-    Response response = configClient.create(ConfigurationExample.utcTimezoneConfiguration())
-      .getResponse();
+    Response response = settingsClient.create(SettingsFixture.utcTimezoneConfiguration()).getResponse();
+
     assertThat(response.getBody(), containsString(UTC.toString()));
 
     ZonedDateTime loanDate = ZonedDateTime.of(CASE_FRI_SAT_MON_DAY_ALL_PREV_DATE,
@@ -96,9 +95,8 @@ class CheckOutCalculateDueDateShortTermTests extends APITests {
   void testMoveToTheEndOfCurrentServicePointHoursRolloverScenario() throws Exception {
     int duration = 18;
 
-    Response response = configClient.create(ConfigurationExample.utcTimezoneConfiguration())
-      .getResponse();
-    assertThat(response.getBody(), containsString(ZoneOffset.UTC.toString()));
+    Response response = settingsClient.create(SettingsFixture.utcTimezoneConfiguration()).getResponse();
+    assertThat(response.getBody(), containsString(UTC.toString()));
 
     ZonedDateTime loanDate = ZonedDateTime.of(CASE_CURRENT_IS_OPEN_CURR_DAY, TEST_TIME_MORNING, UTC);
 
@@ -111,9 +109,8 @@ class CheckOutCalculateDueDateShortTermTests extends APITests {
   void testMoveToTheEndOfCurrentServicePointHoursNextDayIsClosed() throws Exception {
     int duration = 1;
 
-    Response response = configClient.create(ConfigurationExample.utcTimezoneConfiguration())
-      .getResponse();
-    assertThat(response.getBody(), containsString(ZoneOffset.UTC.toString()));
+    Response response = settingsClient.create(SettingsFixture.utcTimezoneConfiguration()).getResponse();
+    assertThat(response.getBody(), containsString(UTC.toString()));
 
     ZonedDateTime loanDate = ZonedDateTime.of(CASE_CURRENT_IS_OPEN_CURR_DAY, TEST_TIME_MORNING, UTC);
     ZonedDateTime expectedDueDate = atEndOfDay(CASE_CURRENT_IS_OPEN_CURR_DAY, UTC);

--- a/src/test/java/api/loans/CheckOutCalculateDueDateTests.java
+++ b/src/test/java/api/loans/CheckOutCalculateDueDateTests.java
@@ -15,9 +15,9 @@ import static api.support.fixtures.CalendarExamples.WEDNESDAY_DATE;
 import static api.support.fixtures.CalendarExamples.getCurrentAndNextFakeOpeningDayByServId;
 import static api.support.fixtures.CalendarExamples.getFirstFakeOpeningDayByServId;
 import static api.support.fixtures.CalendarExamples.getLastFakeOpeningDayByServId;
-import static api.support.fixtures.ConfigurationExample.newYorkTimezoneConfiguration;
-import static api.support.fixtures.ConfigurationExample.utcTimezoneConfiguration;
 import static api.support.fixtures.LibraryHoursExamples.CASE_CALENDAR_IS_UNAVAILABLE_SERVICE_POINT_ID;
+import static api.support.fixtures.SettingsFixture.newYorkTimezoneConfiguration;
+import static api.support.fixtures.SettingsFixture.utcTimezoneConfiguration;
 import static api.support.matchers.DateTimeMatchers.isEquivalentTo;
 import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static api.support.matchers.ValidationErrorMatchers.hasCode;
@@ -76,7 +76,7 @@ class CheckOutCalculateDueDateTests extends APITests {
 
   @Test
   void testRespectSelectedTimezoneForDueDateCalculations() {
-    configClient.create(newYorkTimezoneConfiguration());
+    settingsClient.create(newYorkTimezoneConfiguration());
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();
@@ -100,7 +100,7 @@ class CheckOutCalculateDueDateTests extends APITests {
 
   @Test
   void testRespectUtcTimezoneForDueDateCalculations() {
-    configClient.create(utcTimezoneConfiguration());
+    settingsClient.create(utcTimezoneConfiguration());
 
     final IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource steve = usersFixture.steve();

--- a/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
+++ b/src/test/java/api/loans/DueDateNotRealTimeScheduledNoticesProcessingTests.java
@@ -1,5 +1,7 @@
 package api.loans;
 
+import static api.support.fixtures.SettingsFixture.timezoneConfigurationFor;
+import static api.support.fixtures.SettingsFixture.utcTimezoneConfiguration;
 import static api.support.fixtures.TemplateContextMatchers.getLoanAdditionalInfoContextMatchers;
 import static api.support.fixtures.TemplateContextMatchers.getLoanPolicyContextMatchersForUnlimitedRenewals;
 import static api.support.fixtures.TemplateContextMatchers.getMultipleLoansContextMatcher;
@@ -49,12 +51,12 @@ import io.vertx.core.json.JsonObject;
 import lombok.val;
 
 class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests {
-  private final static UUID TEMPLATE_ID = UUID.randomUUID();
+  private static final UUID TEMPLATE_ID = UUID.randomUUID();
 
   private static final String LOAN_INFO_ADDED = "testing patron info";
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     templateFixture.createDummyNoticeTemplate(TEMPLATE_ID);
   }
 
@@ -127,7 +129,7 @@ class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests {
 
   @Test
   void beforeRecurringNoticesAreRescheduled() {
-    configClient.create(ConfigurationExample.utcTimezoneConfiguration());
+    settingsClient.create(utcTimezoneConfiguration());
 
     Period beforePeriod = Period.weeks(1);
     Period recurringPeriod = Period.days(1);
@@ -521,7 +523,7 @@ class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests {
 
     verifyNumberOfScheduledNotices(1);
 
-    ZonedDateTime dueDate = parseDateTime(nodToJamesLoan.getJson().getString("dueDate"));;
+    ZonedDateTime dueDate = parseDateTime(nodToJamesLoan.getJson().getString("dueDate"));
     ZonedDateTime afterLoanDueDateTime = dueDate.plusDays(1);
 
     scheduledNoticeProcessingClient.runDueDateNotRealTimeNoticesProcessing(afterLoanDueDateTime);
@@ -690,7 +692,7 @@ class DueDateNotRealTimeScheduledNoticesProcessingTests extends APITests {
     ZonedDateTime systemTime = ZonedDateTime.of(2020, 6, 25, 0, 0, 0, 0, ZoneId.of(timeZoneId))
       .plusMinutes(plusMinutes);
     mockClockManagerToReturnFixedDateTime(systemTime);
-    configClient.create(ConfigurationExample.timezoneConfigurationFor(timeZoneId));
+    settingsClient.create(timezoneConfigurationFor(timeZoneId));
 
     JsonObject uponAtDueDateNoticeConfig = new NoticeConfigurationBuilder()
       .withTemplateId(TEMPLATE_ID)

--- a/src/test/java/api/loans/EndExpiredPatronActionSessionTests.java
+++ b/src/test/java/api/loans/EndExpiredPatronActionSessionTests.java
@@ -17,11 +17,9 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -55,7 +53,7 @@ class EndExpiredPatronActionSessionTests extends APITests {
   }
 
   @BeforeEach
-  public void before() {
+  void before() {
     JsonObject checkOutNoticeConfig = new NoticeConfigurationBuilder()
       .withTemplateId(CHECK_OUT_TEMPLATE_ID)
       .withCheckOutEvent()

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -2,6 +2,7 @@ package api.loans;
 
 import static api.requests.RequestsAPICreationTests.setupMissingItem;
 import static api.support.fakes.PublishedEvents.byEventType;
+import static api.support.fixtures.SettingsFixture.utcTimezoneConfiguration;
 import static api.support.http.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
 import static api.support.http.CqlQuery.queryFromTemplate;
 import static api.support.http.Limit.limit;
@@ -351,7 +352,7 @@ class LoanAPITests extends APITests {
 
   @Test
   void canGetMultipleFeesFinesForMultipleLoans() {
-    configClient.create(ConfigurationExample.utcTimezoneConfiguration());
+    settingsClient.create(utcTimezoneConfiguration());
     IndividualResource item1 = itemsFixture.basedUponSmallAngryPlanet();
     final ItemResource item2 = itemsFixture.basedUponNod();
 
@@ -1078,7 +1079,7 @@ class LoanAPITests extends APITests {
   @Test
   void canGetLoanPolicyPropertiesForMultipleLoans() {
 
-    configClient.create(ConfigurationExample.utcTimezoneConfiguration());
+    settingsClient.create(utcTimezoneConfiguration());
     IndividualResource item1 = itemsFixture.basedUponSmallAngryPlanet();
     final ItemResource item2 = itemsFixture.basedUponNod();
 

--- a/src/test/java/api/loans/RenewalAPITests.java
+++ b/src/test/java/api/loans/RenewalAPITests.java
@@ -22,6 +22,8 @@ import static api.support.fixtures.CalendarExamples.MONDAY_DATE;
 import static api.support.fixtures.CalendarExamples.START_TIME_FIRST_PERIOD;
 import static api.support.fixtures.CalendarExamples.START_TIME_SECOND_PERIOD;
 import static api.support.fixtures.CalendarExamples.WEDNESDAY_DATE;
+import static api.support.fixtures.SettingsFixture.newYorkTimezoneConfiguration;
+import static api.support.fixtures.SettingsFixture.utcTimezoneConfiguration;
 import static api.support.http.CqlQuery.queryFromTemplate;
 import static api.support.matchers.EventActionMatchers.ITEM_RENEWED;
 import static api.support.matchers.EventMatchers.isValidLoanDueDateChangedEvent;
@@ -106,7 +108,6 @@ import api.support.builders.RenewByBarcodeRequestBuilder;
 import api.support.builders.RequestBuilder;
 import api.support.fakes.FakeModNotify;
 import api.support.fakes.FakePubSub;
-import api.support.fixtures.ConfigurationExample;
 import api.support.fixtures.ItemExamples;
 import api.support.fixtures.TemplateContextMatchers;
 import api.support.http.IndividualResource;
@@ -189,7 +190,7 @@ public abstract class RenewalAPITests extends APITests {
 
   @Test
   void canRenewRollingLoanFromCurrentDueDate() {
-    configClient.create(ConfigurationExample.utcTimezoneConfiguration());
+    settingsClient.create(utcTimezoneConfiguration());
 
     IndividualResource smallAngryPlanet = itemsFixture.basedUponSmallAngryPlanet();
     final IndividualResource jessica = usersFixture.jessica();
@@ -867,7 +868,7 @@ public abstract class RenewalAPITests extends APITests {
     final Response response = attemptRenewal(smallAngryPlanet, jessica);
 
     assertThat(response.getJson(), hasErrorWith(allOf(
-      hasMessage("item is Declared lost"),
+      hasMessage(ITEM_IS_DECLARED_LOST),
       hasUUIDParameter("itemId", smallAngryPlanet.getId()))));
     assertThat(getOverridableBlockNames(response), hasItem("renewalBlock"));
   }
@@ -1134,7 +1135,7 @@ public abstract class RenewalAPITests extends APITests {
   void testRespectSelectedTimezoneForDueDateCalculations() {
     String expectedTimeZone = "America/New_York";
 
-    Response response = configClient.create(ConfigurationExample.newYorkTimezoneConfiguration())
+    Response response = settingsClient.create(newYorkTimezoneConfiguration())
       .getResponse();
     assertThat(response.getBody(), containsString(expectedTimeZone));
 

--- a/src/test/java/api/requests/RequestsAPIRetrievalTests.java
+++ b/src/test/java/api/requests/RequestsAPIRetrievalTests.java
@@ -20,7 +20,7 @@ import java.time.ZonedDateTime;
 import java.util.UUID;
 
 import static api.support.builders.ItemBuilder.CHECKED_OUT;
-import static api.support.fixtures.ConfigurationExample.newYorkTimezoneConfiguration;
+import static api.support.fixtures.SettingsFixture.newYorkTimezoneConfiguration;
 import static api.support.http.CqlQuery.noQuery;
 import static api.support.http.CqlQuery.queryFromTemplate;
 import static api.support.http.Limit.limit;
@@ -765,7 +765,7 @@ class RequestsAPIRetrievalTests extends APITests {
 
     proxyRelationshipsFixture.nonExpiringProxyFor(sponsor, proxy);
     checkOutFixture.checkOutByBarcode(smallAngryPlanet);
-    configClient.create(newYorkTimezoneConfiguration());
+    settingsClient.create(newYorkTimezoneConfiguration());
 
     final IndividualResource createdRequest = requestsFixture.place(
       new RequestBuilder()

--- a/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
+++ b/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
@@ -9,6 +9,7 @@ import static api.support.builders.RequestBuilder.OPEN_IN_TRANSIT;
 import static api.support.builders.RequestBuilder.OPEN_NOT_YET_FILLED;
 import static api.support.fixtures.CalendarExamples.CASE_CURRENT_DATE_CLOSE;
 import static api.support.fixtures.CalendarExamples.CASE_NEXT_DATE_OPEN;
+import static api.support.fixtures.SettingsFixture.timezoneConfigurationFor;
 import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
 import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
@@ -46,20 +47,19 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import api.support.APITests;
 import api.support.builders.CheckInByBarcodeRequestBuilder;
-import api.support.fixtures.ConfigurationExample;
 import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonObject;
 
 class HoldShelfExpirationDateTests extends APITests {
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     // reset the clock before each test (just in case)
     setClock(Clock .fixed(getInstant(), UTC));
   }
 
   @AfterEach
-  public void afterEach() {
+  void afterEach() {
     // The clock must be reset after each test.
     setDefaultClock();
   }
@@ -148,8 +148,7 @@ class HoldShelfExpirationDateTests extends APITests {
         assertThat("request hold shelf expiration date is " + amount + " " + interval.toString() + " in the future",
         storedRequest.getString("holdShelfExpirationDate"), isEquivalentTo(moveToBeginningOfNextServicePointHours2));
         break;
-      case "cd9" :
-      case "cd10" :
+      case "cd9", "cd10" :
         ZonedDateTime moveToTheNextOpenDay = atEndOfDay(interval.addTo(getZonedDateTime(), amount)).plusDays(1);
         assertThat("request hold shelf expiration date is " + amount + " " + interval.toString() + " in the future",
         storedRequest.getString("holdShelfExpirationDate"), isEquivalentTo(moveToTheNextOpenDay));
@@ -203,8 +202,9 @@ class HoldShelfExpirationDateTests extends APITests {
     final int amount = 30;
     final ZoneId tenantTimeZone = ZoneId.of("America/New_York");
 
-    IndividualResource updateTimeZoneConfig = configClient
-      .create(ConfigurationExample.timezoneConfigurationFor(tenantTimeZone.getId()));
+    IndividualResource updateTimeZoneConfig = settingsClient.create(
+      timezoneConfigurationFor(tenantTimeZone.getId())
+    );
     assertThat(updateTimeZoneConfig.getResponse().getStatusCode(), is(201));
 
     final IndividualResource checkInServicePoint = servicePointsFixture.cd1();
@@ -241,8 +241,8 @@ class HoldShelfExpirationDateTests extends APITests {
     final int amount = 42;
     final ZoneId tenantTimeZone = ZoneId.of("America/New_York");
 
-    IndividualResource updateTimeZoneConfig = configClient
-      .create(ConfigurationExample.timezoneConfigurationFor(tenantTimeZone.getId()));
+    IndividualResource updateTimeZoneConfig = settingsClient
+      .create(timezoneConfigurationFor(tenantTimeZone.getId()));
     assertThat(updateTimeZoneConfig.getResponse().getStatusCode(), is(201));
 
     final IndividualResource checkInServicePoint = servicePointsFixture.cd5();

--- a/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
+++ b/src/test/java/api/requests/scenarios/LoanDueDatesAfterRecallTests.java
@@ -4,7 +4,7 @@ import static api.support.fakes.FakePubSub.getPublishedEventsAsList;
 import static api.support.fakes.PublishedEvents.byLogEventType;
 import static api.support.fixtures.CalendarExamples.CASE_FRI_SAT_MON_SERVICE_POINT_ID;
 import static api.support.fixtures.CalendarExamples.CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY;
-import static api.support.fixtures.ConfigurationExample.timezoneConfigurationFor;
+import static api.support.fixtures.SettingsFixture.timezoneConfigurationFor;
 import static api.support.http.CqlQuery.queryFromTemplate;
 import static api.support.matchers.JsonObjectMatcher.hasJsonPath;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
@@ -80,12 +80,12 @@ class LoanDueDatesAfterRecallTests extends APITests {
   }
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     setClock(Clock.fixed(getInstant(), ZoneOffset.UTC));
   }
 
   @AfterEach
-  public void afterEach() {
+  void afterEach() {
     // The clock must be reset after each test.
     setDefaultClock();
   }
@@ -420,7 +420,7 @@ class LoanDueDatesAfterRecallTests extends APITests {
     final IndividualResource steve = usersFixture.steve();
     final IndividualResource jessica = usersFixture.jessica();
 
-    configClient.create(timezoneConfigurationFor(stockholmTimeZone));
+    settingsClient.create(timezoneConfigurationFor(stockholmTimeZone));
 
     final LoanPolicyBuilder canCirculateRollingPolicy = new LoanPolicyBuilder()
       .withName("Can Circulate Rolling With Recalls")

--- a/src/test/java/api/requests/scenarios/MoveRequestTests.java
+++ b/src/test/java/api/requests/scenarios/MoveRequestTests.java
@@ -3,7 +3,7 @@ package api.requests.scenarios;
 import static api.support.builders.ItemBuilder.AVAILABLE;
 import static api.support.builders.ItemBuilder.PAGED;
 import static api.support.builders.RequestBuilder.OPEN_AWAITING_PICKUP;
-import static api.support.fixtures.ConfigurationExample.timezoneConfigurationFor;
+import static api.support.fixtures.SettingsFixture.timezoneConfigurationFor;
 import static api.support.matchers.EventMatchers.isValidLoanDueDateChangedEvent;
 import static api.support.matchers.ItemStatusCodeMatcher.hasItemStatus;
 import static api.support.matchers.TextDateTimeMatcher.isEquivalentTo;
@@ -73,7 +73,7 @@ import lombok.val;
 class MoveRequestTests extends APITests {
 
   @AfterEach
-  public void afterEach() {
+  void afterEach() {
     // The clock must be reset after each test.
     setDefaultClock();
   }
@@ -1232,7 +1232,7 @@ class MoveRequestTests extends APITests {
     val steve = usersFixture.steve();
     val jessica = usersFixture.jessica();
 
-    configClient.create(timezoneConfigurationFor(stockholmTimeZone));
+    settingsClient.create(timezoneConfigurationFor(stockholmTimeZone));
 
     final LoanPolicyBuilder canCirculateRollingPolicy = new LoanPolicyBuilder()
       .withName("Can Circulate Rolling With Recalls")

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -113,6 +113,7 @@ public abstract class APITests {
   protected final ResourceClient locationsClient = ResourceClient.forLocations();
 
   protected final ResourceClient configClient = ResourceClient.forConfiguration();
+  protected final ResourceClient settingsClient = ResourceClient.forSettingsStorage();
 
   private final ResourceClient patronGroupsClient
     = ResourceClient.forPatronGroups();

--- a/src/test/java/api/support/fixtures/ConfigurationExample.java
+++ b/src/test/java/api/support/fixtures/ConfigurationExample.java
@@ -1,37 +1,14 @@
 package api.support.fixtures;
 
-import static org.folio.circulation.support.json.JsonPropertyWriter.write;
-
 import api.support.builders.ConfigRecordBuilder;
 import api.support.builders.PrintHoldRequestConfigurationBuilder;
-import io.vertx.core.json.JsonObject;
 
 public class ConfigurationExample {
-  private static final String DEFAULT_TIME_ZONE_MODULE_NAME = "ORG";
-  private static final String DEFAULT_TIME_ZONE_CONFIG_NAME = "localeSettings";
-  private static final String US_LOCALE = "en-US";
 
   private static final String DEFAULT_NOTIFICATION_SCHEDULER_MODULE_NAME = "NOTIFICATION_SCHEDULER";
   private static final String DEFAULT_NOTIFICATION_SCHEDULER_CONFIG_NAME = "noticesLimit";
 
   private ConfigurationExample() { }
-
-  public static ConfigRecordBuilder utcTimezoneConfiguration() {
-    return timezoneConfigurationFor("UTC");
-  }
-
-  public static ConfigRecordBuilder newYorkTimezoneConfiguration() {
-    return timezoneConfigurationFor("America/New_York");
-  }
-
-  public static ConfigRecordBuilder timezoneConfigurationFor(String timezone) {
-    return getLocaleAndTimeZoneConfiguration(timezone);
-  }
-
-  private static ConfigRecordBuilder getLocaleAndTimeZoneConfiguration(String timezone) {
-    return new ConfigRecordBuilder(DEFAULT_TIME_ZONE_MODULE_NAME, DEFAULT_TIME_ZONE_CONFIG_NAME,
-      combinedTimeZoneConfig(timezone).encodePrettily());
-  }
 
   public static ConfigRecordBuilder schedulerNoticesLimitConfiguration(String limit){
     return new ConfigRecordBuilder(DEFAULT_NOTIFICATION_SCHEDULER_MODULE_NAME,
@@ -44,13 +21,6 @@ public class ConfigurationExample {
         .withPrintHoldRequestsEnabled(enabled)
         .create()
         .encodePrettily());
-  }
-
-  private static JsonObject combinedTimeZoneConfig(String timezone) {
-    final JsonObject encodedValue = new JsonObject();
-    write(encodedValue, "locale", US_LOCALE);
-    write(encodedValue, "timezone", timezone);
-    return encodedValue;
   }
 
 }

--- a/src/test/java/api/support/fixtures/SettingsFixture.java
+++ b/src/test/java/api/support/fixtures/SettingsFixture.java
@@ -10,6 +10,9 @@ import io.vertx.core.json.JsonObject;
 public class SettingsFixture {
   private static final UUID GENERAL_TLR_SETTINGS_ID = UUID.randomUUID();
   private static final UUID REGULAR_TLR_SETTINGS_ID = UUID.randomUUID();
+  private static final String DEFAULT_TIME_ZONE_SCOPE = "stripes-core.prefs.manage";
+  private static final String DEFAULT_TIME_ZONE_KEY = "tenantLocaleSettings";
+  private static final String US_LOCALE = "en-US";
 
   private final ResourceClient settingsClient;
 
@@ -27,6 +30,27 @@ public class SettingsFixture {
         .put("lockTtl", 500)
         .put("retryInterval", 5)
         .put("noOfRetryAttempts", 10)
+        .encodePrettily()
+    );
+  }
+
+  public static SettingsBuilder utcTimezoneConfiguration() {
+    return timezoneConfigurationFor("UTC");
+  }
+
+  public static SettingsBuilder newYorkTimezoneConfiguration() {
+    return timezoneConfigurationFor("America/New_York");
+  }
+
+  public static SettingsBuilder timezoneConfigurationFor(String timezone) {
+    return getLocaleAndTimeZoneConfiguration(timezone);
+  }
+
+  private static SettingsBuilder getLocaleAndTimeZoneConfiguration(String timezone) {
+    return new SettingsBuilder(UUID.randomUUID(), DEFAULT_TIME_ZONE_SCOPE, DEFAULT_TIME_ZONE_KEY,
+      new JsonObject().put("locale", US_LOCALE)
+        .put("timezone", timezone)
+        .put("currency", "USD")
         .encodePrettily()
     );
   }

--- a/src/test/java/org/folio/circulation/domain/ConfigurationServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/ConfigurationServiceTest.java
@@ -1,23 +1,16 @@
 package org.folio.circulation.domain;
 
-import static java.time.ZoneOffset.UTC;
 import static org.folio.circulation.support.json.JsonPropertyWriter.write;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import api.support.builders.ConfigRecordBuilder;
-import api.support.builders.ConfigurationBuilder;
 import io.vertx.core.json.JsonObject;
 
 class ConfigurationServiceTest {
 
-  private static final String US_LOCALE = "en-US";
   private static final String VALUE = "value";
   private static final Integer DEFAULT_TIMEOUT_CONFIGURATION = 3;
 
@@ -27,46 +20,6 @@ class ConfigurationServiceTest {
   @BeforeAll
   public static void before() {
     service = new ConfigurationService();
-  }
-
-  @Test
-  void testUtcTimeZone() {
-    String zone = "UTC";
-    String timeZoneValue = getTimezoneValue(zone);
-    JsonObject jsonObject = getJsonObject(timeZoneValue);
-
-    assertEquals(ZoneId.of(zone), service.findDateTimeZone(jsonObject));
-  }
-
-  @Test
-  void testEuropeTimeZone() {
-    String zone = "Europe/Kiev";
-    String timeZoneValue = getTimezoneValue(zone);
-    JsonObject jsonObject = getJsonObject(timeZoneValue);
-
-    assertEquals(ZoneId.of(zone), service.findDateTimeZone(jsonObject));
-  }
-
-  @Test
-  void testEmptyTimeZoneValue() {
-    String timeZoneValue = getTimezoneValue("");
-    JsonObject jsonObject = getJsonObject(timeZoneValue);
-
-    assertEquals(UTC, service.findDateTimeZone(jsonObject));
-  }
-
-  @Test
-  void testEmptyJsonValue() {
-    JsonObject jsonObject = getJsonObject("");
-
-    assertEquals(UTC, service.findDateTimeZone(jsonObject));
-  }
-
-  @Test
-  void testEmptyJson() {
-    JsonObject jsonObject = new JsonObject();
-
-    assertEquals(UTC, service.findDateTimeZone(jsonObject));
   }
 
   @Test
@@ -100,18 +53,6 @@ class ConfigurationServiceTest {
     Integer actualSessionTimeout = service.findSessionTimeout(records);
 
     assertEquals(DEFAULT_TIMEOUT_CONFIGURATION, actualSessionTimeout);
-  }
-
-  private JsonObject getJsonObject(String timeZoneValue) {
-    ConfigRecordBuilder config = new ConfigRecordBuilder(timeZoneValue);
-    return new ConfigurationBuilder(Collections.singletonList(config)).create();
-  }
-
-  private String getTimezoneValue(String timezone) {
-    final JsonObject encodedValue = new JsonObject();
-    write(encodedValue, "locale", US_LOCALE);
-    write(encodedValue, "timezone", timezone);
-    return encodedValue.toString();
   }
 
   private String getJsonConfigWithCheckoutTimeoutDurationAsString(String checkoutTimeoutDuration) {


### PR DESCRIPTION
## Purpose
Settings for Tenant's locale is not being fetched from deprecated `mod-configuration` anymore in UI while it was the case in back-end which was a source for inconsistency for some date fields or description of them.

## Approach
replace the usage of `mod-configuration` with `mod-settings` for fetching the tenant's locale.

#### TODOS and Open Questions
- [ ] Check logging
- [x] Check tests / Introduce new ones

## Learning
[CIRC-2295](https://folio-org.atlassian.net/browse/CIRC-2295)
