### PR TITLE
CIRC-2385: Fix sending notifications to proxy user

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 24.5.0-SNAPSHOT 2025-xx-xx
 * Replace deprecated mod-configuration with mod-settings for fetching tenant's locale settings ([CIRC-2295](https://folio-org.atlassian.net/browse/CIRC-2295))
+* Fix sending notifications specified to be sent to proxy ([CIRC-2295](https://folio-org.atlassian.net/browse/CIRC-2385))
 
 ## 24.4.0 2025-03-12
 * Patron notices for the trigger “Item recalled” not sent if the item is not 1st in the title request queue (CIRC-2168)

--- a/src/main/java/org/folio/circulation/domain/ProxyRelationship.java
+++ b/src/main/java/org/folio/circulation/domain/ProxyRelationship.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain;
 
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTimeProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedDateTimeProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
@@ -7,29 +8,45 @@ import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
 
 import java.lang.invoke.MethodHandles;
 import java.time.ZonedDateTime;
-
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.support.utils.ClockUtil;
-
 import io.vertx.core.json.JsonObject;
 
 public class ProxyRelationship {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
+  private static final String NOTIFICATIONS_SENT_TO_PROPERTY_NAME = "notificationsTo";
+  private static final String EXPIRATION_DATE_PROPERTY_NAME = "expirationDate";
+  private static final String STATUS_PROPERTY_NAME = "status";
+
   private final ZonedDateTime expirationDate;
   private final boolean active;
+  private final String notificationsSentTo;
 
   public ProxyRelationship(JsonObject representation) {
     this.active = getActive(representation);
     this.expirationDate = getExpirationDate(representation);
+    this.notificationsSentTo = representation.getString(NOTIFICATIONS_SENT_TO_PROPERTY_NAME);
+  }
 
+  public boolean isActive() {
+    boolean expired = expirationDate != null
+      && isBeforeMillis(expirationDate, ClockUtil.getZonedDateTime());
+
+    return active && !expired;
+  }
+
+  public boolean notificationsSentToSponsor() {
+    return equalsIgnoreCase(notificationsSentTo, "Sponsor");
+  }
+
+  public boolean notificationsSentToProxy() {
+    return equalsIgnoreCase(notificationsSentTo, "Proxy");
   }
 
   private boolean getActive(JsonObject representation) {
     log.debug("getActive:: parameters representation: {}", () -> representation);
-    final String STATUS_PROPERTY_NAME = "status";
 
     if(representation.containsKey(STATUS_PROPERTY_NAME)) {
       return convertStatusToActive(
@@ -43,7 +60,6 @@ public class ProxyRelationship {
 
   private ZonedDateTime getExpirationDate(JsonObject representation) {
     log.debug("getExpirationDate:: parameters representation: {}", () -> representation);
-    final String EXPIRATION_DATE_PROPERTY_NAME = "expirationDate";
 
     if(representation.containsKey(EXPIRATION_DATE_PROPERTY_NAME) ) {
       return getDateTimeProperty(representation,
@@ -56,13 +72,6 @@ public class ProxyRelationship {
   }
 
   private boolean convertStatusToActive(String status) {
-    return StringUtils.equalsIgnoreCase(status, "Active");
-  }
-
-  public boolean isActive() {
-      boolean expired = expirationDate != null
-        && isBeforeMillis(expirationDate, ClockUtil.getZonedDateTime());
-
-      return active && !expired;
+    return equalsIgnoreCase(status, "Active");
   }
 }

--- a/src/main/java/org/folio/circulation/domain/ProxyRelationship.java
+++ b/src/main/java/org/folio/circulation/domain/ProxyRelationship.java
@@ -8,9 +8,11 @@ import static org.folio.circulation.support.utils.DateTimeUtil.isBeforeMillis;
 
 import java.lang.invoke.MethodHandles;
 import java.time.ZonedDateTime;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.support.utils.ClockUtil;
+
 import io.vertx.core.json.JsonObject;
 
 public class ProxyRelationship {

--- a/src/main/java/org/folio/circulation/domain/notice/ImmediatePatronNoticeService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/ImmediatePatronNoticeService.java
@@ -149,7 +149,7 @@ public class ImmediatePatronNoticeService extends PatronNoticeService {
 
     private static NoticeEventGroupDefinition from(PatronNoticeEvent event) {
       return new NoticeEventGroupDefinition(
-        event.getUser().getId(),
+        event.getRecipientId(),
         event.getPatronNoticePolicyId(),
         event.getEventType());
     }

--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticeEvent.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticeEvent.java
@@ -19,4 +19,5 @@ public class PatronNoticeEvent {
   private final JsonObject noticeContext;
   private final NoticeLogContext noticeLogContext;
   private final String patronNoticePolicyId;
+  private final String recipientId;
 }

--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticeEventBuilder.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticeEventBuilder.java
@@ -14,6 +14,7 @@ public class PatronNoticeEventBuilder {
   private JsonObject noticeContext;
   private NoticeLogContext noticeLogContext;
   private String patronNoticePolicyId;
+  private String recipientId;
 
   public PatronNoticeEventBuilder withItem(Item item) {
     this.item = item;
@@ -45,7 +46,12 @@ public class PatronNoticeEventBuilder {
     return this;
   }
 
+  public PatronNoticeEventBuilder withRecipientId(String recipientId) {
+    this.recipientId = recipientId;
+    return this;
+  }
+
   public PatronNoticeEvent build() {
-    return new PatronNoticeEvent(item, user, eventType, noticeContext, noticeLogContext, patronNoticePolicyId);
+    return new PatronNoticeEvent(item, user, eventType, noticeContext, noticeLogContext, patronNoticePolicyId, recipientId);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/session/PatronActionSessionService.java
@@ -237,7 +237,7 @@ public class PatronActionSessionService {
   private CompletableFuture<Result<String>> getRecipientId(Loan loan) {
     return proxyRelationshipValidator.hasActiveProxyRelationshipWithNotificationsSentToProxy(loan)
       .thenApply(result -> result.map(sentNoProxy -> {
-        if (sentNoProxy) {
+        if (Boolean.TRUE.equals(sentNoProxy)) {
           log.info("getRecipientId:: notice recipient is proxy user: {}", loan.getProxyUserId());
           return loan.getProxyUserId();
         }

--- a/src/main/java/org/folio/circulation/domain/representations/logs/NoticeLogContext.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/NoticeLogContext.java
@@ -16,7 +16,6 @@ import java.lang.invoke.MethodHandles;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Loan;
@@ -25,13 +24,13 @@ import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.domain.notice.session.PatronSessionRecord;
 import org.folio.circulation.support.utils.LogUtil;
-
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.With;
+
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -90,11 +89,11 @@ public class NoticeLogContext {
     }
 
     return new NoticeLogContext()
-      .withUserId(sessions.get(0).getPatronId().toString())
+      .withUserId(sessions.getFirst().getPatronId().toString())
       .withItems(
         sessions.stream()
           .map(NoticeLogContextItem::from)
-          .collect(toList())
+          .toList()
       );
   }
 
@@ -102,7 +101,7 @@ public class NoticeLogContext {
     log.debug("withUser:: parameters user: {}", user);
 
     if (user != null) {
-      log.info("from:: user is null");
+      log.info("from:: user is not null");
       return withUserBarcode(user.getBarcode())
         .withUserId(user.getId());
     }
@@ -115,7 +114,7 @@ public class NoticeLogContext {
 
     return withItems(items.stream()
       .map(item -> item.withNoticePolicyId(noticePolicyId))
-      .collect(toList()));
+      .toList());
   }
 
   public NoticeLogContext withTemplateId(String templateId) {
@@ -123,7 +122,7 @@ public class NoticeLogContext {
 
     return withItems(items.stream()
       .map(item -> item.withTemplateId(templateId))
-      .collect(toList()));
+      .toList());
   }
 
   public NoticeLogContext withTriggeringEvent(String triggeringEvent) {
@@ -131,7 +130,7 @@ public class NoticeLogContext {
 
     return withItems(items.stream()
       .map(item -> item.withTriggeringEvent(triggeringEvent))
-      .collect(toList()));
+      .toList());
   }
 
   public JsonObject asJson() {

--- a/src/main/java/org/folio/circulation/domain/representations/logs/NoticeLogContext.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/NoticeLogContext.java
@@ -16,6 +16,7 @@ import java.lang.invoke.MethodHandles;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Loan;
@@ -24,6 +25,7 @@ import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.notice.schedule.ScheduledNotice;
 import org.folio.circulation.domain.notice.session.PatronSessionRecord;
 import org.folio.circulation.support.utils.LogUtil;
+
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import lombok.AllArgsConstructor;

--- a/src/main/java/org/folio/circulation/domain/validation/ProxyRelationshipValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ProxyRelationshipValidator.java
@@ -67,20 +67,20 @@ public class ProxyRelationshipValidator {
   }
 
   public CompletableFuture<Result<Boolean>> hasActiveProxyRelationshipWithNotificationsSentToProxy(
-    UserRelatedRecord record) {
-    log.debug("hasActiveProxyRelationshipWithNotificationsSentToProxy:: parameters record: {}", record);
+    UserRelatedRecord userRecord) {
+    log.debug("hasActiveProxyRelationshipWithNotificationsSentToProxy:: parameters record: {}", userRecord);
 
-    if (record.getProxyUserId() == null || record.getUserId() == null) {
+    if (userRecord.getProxyUserId() == null || userRecord.getUserId() == null) {
       log.info("hasActiveProxyRelationshipWithNotificationsSentToProxy:: proxy user ID or user ID is null");
       return completedFuture(succeeded(false));
     }
 
-    if (record.getProxyUserId().equals(record.getUserId())) {
+    if (userRecord.getProxyUserId().equals(userRecord.getUserId())) {
       log.info("hasActiveProxyRelationshipWithNotificationsSentToProxy:: proxy user ID is equal to user ID");
       return completedFuture(succeeded(false));
     }
 
-    return proxyRelationshipQuery(record.getProxyUserId(), record.getUserId())
+    return proxyRelationshipQuery(userRecord.getProxyUserId(), userRecord.getUserId())
       .after(query -> proxyRelationshipsClient.getMany(query, PageLimit.oneThousand())
         .thenApply(result -> result.next(
             response -> MultipleRecords.from(response, ProxyRelationship::new, PROXIES_COLLECTION_RECORDS_PROPERTY_NAME))

--- a/src/main/java/org/folio/circulation/domain/validation/ProxyRelationshipValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ProxyRelationshipValidator.java
@@ -10,7 +10,6 @@ import static org.folio.circulation.support.results.Result.succeeded;
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,8 +26,10 @@ import org.folio.circulation.support.results.Result;
 public class ProxyRelationshipValidator {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
+  private static final String PROXIES_COLLECTION_RECORDS_PROPERTY_NAME = "proxiesFor";
+
   private final GetManyRecordsClient proxyRelationshipsClient;
-  private final Supplier<ValidationErrorFailure> invalidRelationshipErrorSupplier;
+  private Supplier<ValidationErrorFailure> invalidRelationshipErrorSupplier;
 
   public ProxyRelationshipValidator(
     Clients clients,
@@ -36,6 +37,10 @@ public class ProxyRelationshipValidator {
 
     this.proxyRelationshipsClient = clients.userProxies();
     this.invalidRelationshipErrorSupplier = invalidRelationshipErrorSupplier;
+  }
+
+  public ProxyRelationshipValidator(Clients clients) {
+    this.proxyRelationshipsClient = clients.userProxies();
   }
 
   public <T extends UserRelatedRecord> CompletableFuture<Result<T>> refuseWhenInvalid(
@@ -61,6 +66,29 @@ public class ProxyRelationshipValidator {
         v -> invalidRelationshipErrorSupplier.get());
   }
 
+  public CompletableFuture<Result<Boolean>> hasActiveProxyRelationshipWithNotificationsSentToProxy(
+    UserRelatedRecord record) {
+    log.debug("hasActiveProxyRelationshipWithNotificationsSentToProxy:: parameters record: {}", record);
+
+    if (record.getProxyUserId() == null || record.getUserId() == null) {
+      log.info("hasActiveProxyRelationshipWithNotificationsSentToProxy:: proxy user ID or user ID is null");
+      return completedFuture(succeeded(false));
+    }
+
+    if (record.getProxyUserId().equals(record.getUserId())) {
+      log.info("hasActiveProxyRelationshipWithNotificationsSentToProxy:: proxy user ID is equal to user ID");
+      return completedFuture(succeeded(false));
+    }
+
+    return proxyRelationshipQuery(record.getProxyUserId(), record.getUserId())
+      .after(query -> proxyRelationshipsClient.getMany(query, PageLimit.oneThousand())
+        .thenApply(result -> result.next(
+            response -> MultipleRecords.from(response, ProxyRelationship::new, PROXIES_COLLECTION_RECORDS_PROPERTY_NAME))
+          .map(MultipleRecords::getRecords)
+          .map(relationships -> relationships.stream()
+            .anyMatch(relationship -> relationship.isActive() && relationship.notificationsSentToProxy()))));
+  }
+
   private CompletableFuture<Result<Boolean>> doesNotHaveActiveProxyRelationship(
     UserRelatedRecord record) {
 
@@ -69,7 +97,7 @@ public class ProxyRelationshipValidator {
     return proxyRelationshipQuery(record.getProxyUserId(), record.getUserId())
       .after(query -> proxyRelationshipsClient.getMany(query, PageLimit.oneThousand())
       .thenApply(result -> result.next(
-        response -> MultipleRecords.from(response, ProxyRelationship::new, "proxiesFor"))
+        response -> MultipleRecords.from(response, ProxyRelationship::new, PROXIES_COLLECTION_RECORDS_PROPERTY_NAME))
       .map(MultipleRecords::getRecords)
         .map(relationships -> relationships.stream()
           .noneMatch(ProxyRelationship::isActive))));

--- a/src/main/java/org/folio/circulation/domain/validation/ProxyRelationshipValidator.java
+++ b/src/main/java/org/folio/circulation/domain/validation/ProxyRelationshipValidator.java
@@ -10,6 +10,7 @@ import static org.folio.circulation.support.results.Result.succeeded;
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanPolicyRepository.java
@@ -103,7 +103,8 @@ public class LoanPolicyRepository extends CirculationPolicyRepository<LoanPolicy
       () -> multipleRecordsAsString(multipleLoans));
     Collection<Loan> loans = multipleLoans.getRecords();
 
-    log.info("findLoanPoliciesForLoans:: loans: {}", loans.size());
+    log.info("findLoanPoliciesForLoans:: loans: {} - {}", loans.size(),
+      loans.stream().findFirst().map(Loan::asJson).map(JsonObject::toString).orElse(""));
 
     return getLoanPolicies(loans)
       .thenApply(r -> r.map(loanPolicies -> multipleLoans.mapRecords(

--- a/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanPolicyRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/loans/LoanPolicyRepository.java
@@ -103,8 +103,7 @@ public class LoanPolicyRepository extends CirculationPolicyRepository<LoanPolicy
       () -> multipleRecordsAsString(multipleLoans));
     Collection<Loan> loans = multipleLoans.getRecords();
 
-    log.info("findLoanPoliciesForLoans:: loans: {} - {}", loans.size(),
-      loans.stream().findFirst().map(Loan::asJson).map(JsonObject::toString).orElse(""));
+    log.info("findLoanPoliciesForLoans:: loans: {}", loans.size());
 
     return getLoanPolicies(loans)
       .thenApply(r -> r.map(loanPolicies -> multipleLoans.mapRecords(

--- a/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -60,6 +61,7 @@ import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.client.ResponseInterpreter;
 import org.folio.circulation.support.results.Result;
+
 import io.vertx.core.json.JsonObject;
 
 public class PatronActionSessionRepository {

--- a/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
@@ -34,8 +34,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -62,7 +60,6 @@ import org.folio.circulation.support.http.client.CqlQuery;
 import org.folio.circulation.support.http.client.PageLimit;
 import org.folio.circulation.support.http.client.ResponseInterpreter;
 import org.folio.circulation.support.results.Result;
-
 import io.vertx.core.json.JsonObject;
 
 public class PatronActionSessionRepository {
@@ -188,7 +185,7 @@ public class PatronActionSessionRepository {
     }
 
     Result<CqlQuery> actionTypeQuery = createActionTypeCqlQuery(
-      expiredSessions.get(0).getActionType());
+      expiredSessions.getFirst().getActionType());
 
     return findWithMultipleCqlIndexValues(patronActionSessionsStorageClient,
       PATRON_ACTION_SESSIONS, PatronSessionRecord::from)
@@ -269,7 +266,7 @@ public class PatronActionSessionRepository {
     List<String> loanIds = sessionRecords.getRecords().stream()
       .map(PatronSessionRecord::getLoanId)
       .map(UUID::toString)
-      .collect(Collectors.toList());
+      .toList();
 
     return loanRepository.findByIds(loanIds)
       .thenCompose(r -> r.after(this::fetchCampusesForLoanItems))
@@ -346,6 +343,10 @@ public class PatronActionSessionRepository {
   private static MultipleRecords<PatronSessionRecord> setLoansForSessionRecords(
     MultipleRecords<PatronSessionRecord> sessionRecords, MultipleRecords<Loan> loans) {
 
+    var loan = loans.getRecords().iterator().next();
+    log.info("setLoansForSessionRecords:: loan user {}", loan.getUserId());
+    log.info("setLoansForSessionRecords:: loan proxy {}", loan.getProxyUserId());
+
     Map<String, Loan> loanMap = loans.toMap(Loan::getId);
 
     return sessionRecords.mapRecords(r ->
@@ -358,6 +359,6 @@ public class PatronActionSessionRepository {
       .filter(Item::isFound)
       .map(Item::getLocation)
       .filter(Objects::nonNull)
-      .collect(Collectors.toList());
+      .toList();
   }
 }

--- a/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/sessions/PatronActionSessionRepository.java
@@ -343,10 +343,6 @@ public class PatronActionSessionRepository {
   private static MultipleRecords<PatronSessionRecord> setLoansForSessionRecords(
     MultipleRecords<PatronSessionRecord> sessionRecords, MultipleRecords<Loan> loans) {
 
-    var loan = loans.getRecords().iterator().next();
-    log.info("setLoansForSessionRecords:: loan user {}", loan.getUserId());
-    log.info("setLoansForSessionRecords:: loan proxy {}", loan.getProxyUserId());
-
     Map<String, Loan> loanMap = loans.toMap(Loan::getId);
 
     return sessionRecords.mapRecords(r ->

--- a/src/main/java/org/folio/circulation/resources/LoanNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/LoanNoticeSender.java
@@ -9,6 +9,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Loan;
@@ -27,6 +28,7 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.results.Result;
+
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor

--- a/src/main/java/org/folio/circulation/resources/LoanNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/LoanNoticeSender.java
@@ -15,7 +15,6 @@ import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.LoanAndRelatedRecords;
 import org.folio.circulation.domain.notice.ImmediatePatronNoticeService;
 import org.folio.circulation.domain.notice.NoticeEventType;
-import org.folio.circulation.domain.notice.PatronNoticeEvent;
 import org.folio.circulation.domain.notice.PatronNoticeEventBuilder;
 import org.folio.circulation.domain.notice.SingleImmediatePatronNoticeService;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
@@ -149,7 +148,7 @@ public class LoanNoticeSender {
   private CompletableFuture<Result<String>> getRecipientId(Loan loan) {
     return proxyRelationshipValidator.hasActiveProxyRelationshipWithNotificationsSentToProxy(loan)
       .thenApply(result -> result.map(sentNoProxy -> {
-        if (sentNoProxy) {
+        if (Boolean.TRUE.equals(sentNoProxy)) {
           log.info("getRecipientId:: notice recipient is proxy user: {}", loan.getProxyUserId());
           return loan.getProxyUserId();
         }

--- a/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
@@ -381,7 +381,7 @@ public class RequestNoticeSender {
   private CompletableFuture<Result<String>> getRecipientId(UserRelatedRecord userRelatedRecord) {
     return proxyRelationshipValidator.hasActiveProxyRelationshipWithNotificationsSentToProxy(userRelatedRecord)
       .thenApply(result -> result.map(sentNoProxy -> {
-        if (sentNoProxy) {
+        if (Boolean.TRUE.equals(sentNoProxy)) {
           log.info("getRecipientId:: notice recipient is proxy user: {}", userRelatedRecord.getProxyUserId());
           return userRelatedRecord.getProxyUserId();
         }

--- a/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
+++ b/src/main/java/org/folio/circulation/resources/RequestNoticeSender.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.CheckInContext;
@@ -51,6 +52,7 @@ import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.RecordNotFoundFailure;
 import org.folio.circulation.support.results.Result;
+
 import io.vertx.core.json.JsonObject;
 import lombok.RequiredArgsConstructor;
 

--- a/src/test/java/api/support/builders/ProxyRelationshipBuilder.java
+++ b/src/test/java/api/support/builders/ProxyRelationshipBuilder.java
@@ -207,4 +207,19 @@ public class ProxyRelationshipBuilder implements Builder {
       false
     );
   }
+
+  public ProxyRelationshipBuilder notificationsSentTo(String notificationsTo) {
+    return new ProxyRelationshipBuilder(
+      this.id,
+      this.userId,
+      this.proxyUserId,
+      this.requestForSponsor,
+      this.createdDate,
+      this.expirationDate,
+      this.status,
+      this.accrueTo,
+      notificationsTo,
+      false
+    );
+  }
 }

--- a/src/test/java/org/folio/circulation/domain/ProxyRelationshipTests.java
+++ b/src/test/java/org/folio/circulation/domain/ProxyRelationshipTests.java
@@ -4,9 +4,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
-
 import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import api.support.builders.ProxyRelationshipBuilder;
@@ -28,6 +28,26 @@ class ProxyRelationshipTests {
         .create());
 
     assertThat(relationship.isActive(), is(true));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "Sponsor, false",
+    "Proxy, true"
+  })
+  void shouldBeActiveAndNotificationsSentToSponsorOrProxy(String sentTo, boolean sentToProxy) {
+    final ProxyRelationship relationship = new ProxyRelationship(
+      new ProxyRelationshipBuilder()
+        .proxy(UUID.randomUUID())
+        .sponsor(UUID.randomUUID())
+        .active()
+        .doesNotExpire()
+        .notificationsSentTo(sentTo)
+        .create());
+
+    assertThat(relationship.isActive(), is(true));
+    assertThat(relationship.notificationsSentToSponsor(), is(!sentToProxy));
+    assertThat(relationship.notificationsSentToProxy(), is(sentToProxy));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/circulation/domain/ProxyRelationshipTests.java
+++ b/src/test/java/org/folio/circulation/domain/ProxyRelationshipTests.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
+
 import org.folio.circulation.support.utils.ClockUtil;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;


### PR DESCRIPTION
## Purpose
When proxy is acting on behalf of another user and it is specified that notifications should be sent to the proxy, the notifications are always sent to the user.

## Approach
- check the proxy user by `GET /proxiesfor` API and decide if it should be sent to the user or proxy where `notificationsTo` field specifies this info

#### TODOS and Open Questions
- [ ] Check logging

## Learning
[CIRC-2385](https://folio-org.atlassian.net/browse/CIRC-2385)
