### PR TITLE
CIRC-2398: Add missing retrieval service point name for created page request

### DIFF
--- a/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
+++ b/src/main/java/org/folio/circulation/resources/RequestFromRepresentationService.java
@@ -55,6 +55,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.EcsRequestPhase;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.MultipleRecords;
 import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.RequestAndRelatedRecords;
@@ -303,7 +304,17 @@ class RequestFromRepresentationService {
         NO_AVAILABLE_ITEMS_FOR_TLR, r))))
       .flatMapFuture(this::fetchFirstLoanForUserWithTheSameInstanceId)
       .flatMapFuture(this::fetchUserForLoan)
+      .flatMapFuture(this::fetchPrimaryServicePointForLocation)
       .toCompletableFuture();
+  }
+
+  private CompletableFuture<Result<Request>> fetchPrimaryServicePointForLocation(Request request) {
+    Location location = request.getItem().getLocation();
+
+    return servicePointRepository.getServicePointById(location.getPrimaryServicePointId())
+      .thenApply(mapResult(location::withPrimaryServicePoint))
+      .thenApply(mapResult(request.getItem()::withLocation))
+      .thenApply(mapResult(request::withItem));
   }
 
   private CompletableFuture<Result<Request>> fetchItemAndLoanForPageTlrReplacement(

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -1518,6 +1518,7 @@ public class RequestsAPICreationTests extends APITests {
     assertThat(json.getJsonObject("item")
       .getString("status"), is(ItemStatus.PAGED.getValue()));
     assertThat(json.getString("requestLevel"), is(RequestLevel.TITLE.getValue()));
+    assertThat(json.getJsonObject("item").getString("retrievalServicePointName"), is("Circ Desk 1"));
   }
 
   @Test


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/CIRC-2398

## Purpose
Fixes missing retrieval service point name for created page request

## Approach
- Fetch the primary location for the item by `primaryServicePointId` from item during page request creation
