### PR TITLE
CIRC-2413: Fetch holdings in batches for staff slips

### DIFF
--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/HoldingsRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/HoldingsRepository.java
@@ -1,6 +1,7 @@
 package org.folio.circulation.infrastructure.storage.inventory;
 
 import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+import static org.folio.circulation.support.fetching.MultipleCqlIndexValuesCriteria.byIndex;
 import static org.folio.circulation.support.fetching.RecordFetching.findWithCqlQuery;
 import static org.folio.circulation.support.fetching.RecordFetching.findWithMultipleCqlIndexValues;
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
@@ -54,10 +55,10 @@ public class HoldingsRepository {
     Collection<String> instanceIds) {
 
     final var mapper = new HoldingsMapper();
-    final var holdingsRecordFetcher = findWithCqlQuery(
+    final var holdingsRecordFetcher = findWithMultipleCqlIndexValues(
       holdingsClient, HOLDINGS_RECORDS, mapper::toDomain);
 
-    return holdingsRecordFetcher.findByQuery(exactMatchAny("instanceId", instanceIds), maximumLimit());
+    return holdingsRecordFetcher.find(byIndex("instanceId", instanceIds));
   }
 
   CompletableFuture<Result<MultipleRecords<Holdings>>> fetchByIds(

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/HoldingsRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/HoldingsRepository.java
@@ -5,8 +5,6 @@ import static org.folio.circulation.support.fetching.MultipleCqlIndexValuesCrite
 import static org.folio.circulation.support.fetching.RecordFetching.findWithCqlQuery;
 import static org.folio.circulation.support.fetching.RecordFetching.findWithMultipleCqlIndexValues;
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatch;
-import static org.folio.circulation.support.http.client.CqlQuery.exactMatchAny;
-import static org.folio.circulation.support.http.client.PageLimit.maximumLimit;
 import static org.folio.circulation.support.results.ResultBinding.mapResult;
 
 import java.util.Collection;
@@ -43,12 +41,8 @@ public class HoldingsRepository {
   }
 
   CompletableFuture<Result<MultipleRecords<Holdings>>> fetchByInstanceId(String instanceId) {
-    final var mapper = new HoldingsMapper();
-
-    final var holdingsRecordFetcher = findWithCqlQuery(
-      holdingsClient, HOLDINGS_RECORDS, mapper::toDomain);
-
-    return holdingsRecordFetcher.findByQuery(exactMatch("instanceId", instanceId));
+    return findWithCqlQuery(holdingsClient, HOLDINGS_RECORDS, new HoldingsMapper()::toDomain)
+      .findByQuery(exactMatch("instanceId", instanceId));
   }
 
   public CompletableFuture<Result<MultipleRecords<Holdings>>> fetchByInstances(

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/HoldingsRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/HoldingsRepository.java
@@ -41,18 +41,19 @@ public class HoldingsRepository {
   }
 
   CompletableFuture<Result<MultipleRecords<Holdings>>> fetchByInstanceId(String instanceId) {
-    return findWithCqlQuery(holdingsClient, HOLDINGS_RECORDS, new HoldingsMapper()::toDomain)
-      .findByQuery(exactMatch("instanceId", instanceId));
+    final var mapper = new HoldingsMapper();
+
+    final var holdingsRecordFetcher = findWithCqlQuery(
+      holdingsClient, HOLDINGS_RECORDS, mapper::toDomain);
+
+    return holdingsRecordFetcher.findByQuery(exactMatch("instanceId", instanceId));
   }
 
   public CompletableFuture<Result<MultipleRecords<Holdings>>> fetchByInstances(
     Collection<String> instanceIds) {
 
-    final var mapper = new HoldingsMapper();
-    final var holdingsRecordFetcher = findWithMultipleCqlIndexValues(
-      holdingsClient, HOLDINGS_RECORDS, mapper::toDomain);
-
-    return holdingsRecordFetcher.find(byIndex("instanceId", instanceIds));
+    return findWithMultipleCqlIndexValues(holdingsClient, HOLDINGS_RECORDS, new HoldingsMapper()::toDomain)
+      .find(byIndex("instanceId", instanceIds));
   }
 
   CompletableFuture<Result<MultipleRecords<Holdings>>> fetchByIds(

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/HoldingsRepositoryTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/HoldingsRepositoryTest.java
@@ -37,7 +37,7 @@ class HoldingsRepositoryTest {
     Mockito.when(holdingsClient.getMany(any(CqlQuery.class), any(PageLimit.class)))
       .thenReturn(ofAsync(new Response(200, "{}", "application/json")));
 
-    int idsPerBatch = 50;
+    int idsPerBatch = 50; // default batch size from CqlIndexValuesFinder
     List<String> instanceIds = IntStream.range(0, idsPerBatch + 1)
       .boxed()
       .map(i -> UUID.randomUUID().toString())

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/HoldingsRepositoryTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/HoldingsRepositoryTest.java
@@ -2,10 +2,11 @@ package org.folio.circulation.infrastructure.storage.inventory;
 
 import static org.folio.circulation.support.http.client.CqlQuery.exactMatchAny;
 import static org.folio.circulation.support.results.Result.ofAsync;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.UUID;
@@ -20,7 +21,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,7 +34,7 @@ class HoldingsRepositoryTest {
 
   @Test
   void holdingsAreFetchedByInstanceIdsInBatches() {
-    Mockito.when(holdingsClient.getMany(any(CqlQuery.class), any(PageLimit.class)))
+    when(holdingsClient.getMany(any(CqlQuery.class), any(PageLimit.class)))
       .thenReturn(ofAsync(new Response(200, "{}", "application/json")));
 
     int idsPerBatch = 50; // default batch size from CqlIndexValuesFinder

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/HoldingsRepositoryTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/HoldingsRepositoryTest.java
@@ -1,0 +1,60 @@
+package org.folio.circulation.infrastructure.storage.inventory;
+
+import static org.folio.circulation.support.http.client.CqlQuery.exactMatchAny;
+import static org.folio.circulation.support.results.Result.ofAsync;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import org.folio.circulation.support.CollectionResourceClient;
+import org.folio.circulation.support.http.client.CqlQuery;
+import org.folio.circulation.support.http.client.PageLimit;
+import org.folio.circulation.support.http.client.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HoldingsRepositoryTest {
+
+  @Mock
+  private CollectionResourceClient holdingsClient;
+
+  @InjectMocks
+  private HoldingsRepository holdingsRepository;
+
+  @Test
+  void holdingsAreFetchedByInstanceIdsInBatches() {
+    Mockito.when(holdingsClient.getMany(any(CqlQuery.class), any(PageLimit.class)))
+      .thenReturn(ofAsync(new Response(200, "{}", "application/json")));
+
+    int idsPerBatch = 50;
+    List<String> instanceIds = IntStream.range(0, idsPerBatch + 1)
+      .boxed()
+      .map(i -> UUID.randomUUID().toString())
+      .toList();
+
+    holdingsRepository.fetchByInstances(instanceIds);
+
+    ArgumentCaptor<CqlQuery> queryCaptor = ArgumentCaptor.forClass(CqlQuery.class);
+    verify(holdingsClient, times(2)).getMany(queryCaptor.capture(), any(PageLimit.class));
+    List<CqlQuery> actualQueries = queryCaptor.getAllValues();
+    assertEquals(2, actualQueries.size());
+
+    CqlQuery expectedQuery1 = exactMatchAny("instanceId", instanceIds.subList(0, idsPerBatch)).value();
+    CqlQuery expectedQuery2 = exactMatchAny("instanceId", instanceIds.subList(idsPerBatch, instanceIds.size())).value();
+
+    assertEquals(expectedQuery1, actualQueries.get(0));
+    assertEquals(expectedQuery2, actualQueries.get(1));
+  }
+
+}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose

https://folio-org.atlassian.net/browse/CIRC-2413
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
