### PR TITLE
CIRC-2277 Fix excessive logging issue

### DIFF
--- a/src/main/java/org/folio/circulation/domain/LoanRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/LoanRepresentation.java
@@ -33,31 +33,31 @@ public class LoanRepresentation {
     JsonObject extendedRepresentation = extendedLoan(loan.asJson(), loan.getItem());
 
     if(loan.isDueDateChangedByNearExpireUser()) {
-      log.info("extendedLoan:: due date changed by near expire user");
+      log.debug("extendedLoan:: due date changed by near expire user");
       extendedRepresentation.put("dueDateChangedByNearExpireUser", loan.isDueDateChangedByNearExpireUser());
     }
 
     if(loan.isDueDateChangedByHold()) {
-      log.info("extendedLoan:: due date changed by hold");
+      log.debug("extendedLoan:: due date changed by hold");
       extendedRepresentation.put("dueDateChangedByHold",loan.isDueDateChangedByHold());
     }
 
     if(loan.getCheckinServicePoint() != null) {
-      log.info("extendedLoan:: checkinServicePoint is not null");
+      log.debug("extendedLoan:: checkinServicePoint is not null");
       addAdditionalServicePointProperties(extendedRepresentation, loan.getCheckinServicePoint(), "checkinServicePoint");
     }
 
     if(loan.getCheckoutServicePoint() != null) {
-      log.info("extendedLoan:: checkoutServicePoint is not null");
+      log.debug("extendedLoan:: checkoutServicePoint is not null");
       addAdditionalServicePointProperties(extendedRepresentation, loan.getCheckoutServicePoint(), "checkoutServicePoint");
     }
 
     if (loan.getUser() != null) {
-      log.info("extendedLoan:: user is not null");
+      log.debug("extendedLoan:: user is not null");
       additionalBorrowerProperties(extendedRepresentation, loan.getUser());
     } else {
       //When there is no user, it means that the loan has been anonymized
-      log.info("extendedLoan:: there is no user, removing borrower");
+      log.debug("extendedLoan:: there is no user, removing borrower");
       extendedRepresentation.remove(BORROWER);
     }
 

--- a/src/main/java/org/folio/circulation/domain/mapper/InventoryMapper.java
+++ b/src/main/java/org/folio/circulation/domain/mapper/InventoryMapper.java
@@ -46,7 +46,7 @@ public class InventoryMapper {
       item.getFloatDestinationLocation() : item.getLocation();
 
     if (location != null) {
-      log.info("createItemContext:: location is not null");
+      log.debug("createItemContext:: location is not null");
 
       itemContext
         .put("effectiveLocationSpecific", location.getName())
@@ -57,14 +57,14 @@ public class InventoryMapper {
 
       var primaryServicePoint = location.getPrimaryServicePoint();
       if (primaryServicePoint != null) {
-        log.info("createItemContext:: primaryServicePoint is not null");
+        log.debug("createItemContext:: primaryServicePoint is not null");
         itemContext.put("effectiveLocationPrimaryServicePointName", primaryServicePoint.getName());
       }
     }
 
     CallNumberComponents callNumberComponents = item.getCallNumberComponents();
     if (callNumberComponents != null) {
-      log.info("createItemContext:: callNumberComponents is not null");
+      log.debug("createItemContext:: callNumberComponents is not null");
       itemContext
         .put("callNumber", callNumberComponents.getCallNumber())
         .put("callNumberPrefix", callNumberComponents.getPrefix())

--- a/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
@@ -25,7 +25,7 @@ public class ItemSummaryRepresentation {
     log.debug("createItemSummary:: parameters item: {}", item);
 
     if (item == null || item.isNotFound()) {
-      log.info("createItemSummary:: item is null or not found");
+      log.debug("createItemSummary:: item is null or not found");
       return new JsonObject();
     }
 
@@ -59,7 +59,7 @@ public class ItemSummaryRepresentation {
       .put("name", item.getStatus().getValue());
 
     if (Objects.nonNull(item.getStatus().getDate())){
-      log.info("createItemSummary:: item.getStatus().getDate() is not null");
+      log.debug("createItemSummary:: item.getStatus().getDate() is not null");
       status.put("date", item.getStatus().getDate());
     }
 
@@ -72,7 +72,7 @@ public class ItemSummaryRepresentation {
       = item.getInTransitDestinationServicePoint();
 
     if (inTransitDestinationServicePoint != null) {
-      log.info("createItemSummary:: inTransitDestinationServicePoint is not null");
+      log.debug("createItemSummary:: inTransitDestinationServicePoint is not null");
       final JsonObject destinationServicePointSummary = new JsonObject();
 
       write(destinationServicePointSummary, "id",
@@ -91,14 +91,14 @@ public class ItemSummaryRepresentation {
       itemSummary.put("location", new JsonObject()
         .put("name", item.getFloatDestinationLocation().getName()));
     } else if (location != null) {
-      log.info("createItemSummary:: location is not null");
+      log.debug("createItemSummary:: location is not null");
       itemSummary.put("location", new JsonObject()
         .put("name", location.getName()));
     }
 
     writeByPath(itemSummary, item.getMaterialTypeName(), "materialType", "name");
 
-    log.info("createItemSummary:: result {}", itemSummary);
+    log.debug("createItemSummary:: result {}", itemSummary);
     return itemSummary;
   }
 }

--- a/src/main/java/org/folio/circulation/domain/representations/ItemsInTransitReport.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemsInTransitReport.java
@@ -47,7 +47,7 @@ public class ItemsInTransitReport {
     JsonObject result = new JsonObject()
       .put("items", new JsonArray(reportEntries))
       .put("totalRecords", reportEntries.size());
-    log.info("build:: result {}", result);
+    log.debug("build:: result {}", result);
     return result;
   }
 
@@ -169,7 +169,7 @@ public class ItemsInTransitReport {
       writeLastCheckIn(entry, lastCheckIn);
     }
 
-    log.info("buildEntry:: result {}", entry);
+    log.debug("buildEntry:: result {}", entry);
     return entry;
   }
 

--- a/src/main/java/org/folio/circulation/domain/representations/ItemsInTransitReport.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemsInTransitReport.java
@@ -80,11 +80,11 @@ public class ItemsInTransitReport {
 
     Location location = null;
     if (item.getEffectiveLocationId() != null) {
-      log.info("buildEntry:: effectiveLocationId is not null");
+      log.debug("buildEntry:: effectiveLocationId is not null");
       location = reportContext.getLocations().get(item.getEffectiveLocationId());
     }
     if (location != null) {
-      log.info("buildEntry:: location is not null");
+      log.debug("buildEntry:: location is not null");
       item = ofNullable(location.getPrimaryServicePointId())
         .map(UUID::toString)
         .map(reportContext.getServicePoints()::get)
@@ -125,17 +125,17 @@ public class ItemsInTransitReport {
 
     ServicePoint inTransitDestinationServicePoint = item.getInTransitDestinationServicePoint();
     if (inTransitDestinationServicePoint != null) {
-      log.info("buildEntry:: inTransitDestinationServicePoint is not null");
+      log.debug("buildEntry:: inTransitDestinationServicePoint is not null");
       writeServicePoint(entry, inTransitDestinationServicePoint, "inTransitDestinationServicePoint");
     }
 
     if (location != null) {
-      log.info("buildEntry:: location is not null");
+      log.debug("buildEntry:: location is not null");
       writeLocation(entry, location);
     }
 
     if (request != null) {
-      log.info("buildEntry:: request is not null");
+      log.debug("buildEntry:: request is not null");
       User requester = reportContext.getUsers().get(request.getRequesterId());
 
       PatronGroup requesterPatronGroup = requester == null ? null :
@@ -152,7 +152,7 @@ public class ItemsInTransitReport {
     }
 
     if (loan != null) {
-      log.info("buildEntry:: loan is not null");
+      log.debug("buildEntry:: loan is not null");
       var checkoutServicePoint = getServicePoint(loan.getCheckoutServicePointId());
       var checkInServicePoint = getServicePoint(loan.getCheckInServicePointId());
 
@@ -165,7 +165,7 @@ public class ItemsInTransitReport {
 
     final LastCheckIn lastCheckIn = item.getLastCheckIn();
     if (lastCheckIn != null) {
-      log.info("buildEntry:: lastCheckIn is not null");
+      log.debug("buildEntry:: lastCheckIn is not null");
       writeLastCheckIn(entry, lastCheckIn);
     }
 
@@ -226,7 +226,7 @@ public class ItemsInTransitReport {
 
     final JsonObject tags = request.asJson().getJsonObject("tags");
     if (tags != null) {
-      log.info("writeRequest:: tags is not null");
+      log.debug("writeRequest:: tags is not null");
       final JsonArray tagsJson = tags.getJsonArray("tagList");
       write(requestJson, "tags", tagsJson);
     }
@@ -252,7 +252,7 @@ public class ItemsInTransitReport {
       servicePoint);
 
     if (servicePoint != null) {
-      log.info("writeCheckInServicePoint:: servicePoint is not null");
+      log.debug("writeCheckInServicePoint:: servicePoint is not null");
       final JsonObject checkInServicePointJson = new JsonObject();
       write(checkInServicePointJson, "name", servicePoint.getName());
       write(checkInServicePointJson, "code", servicePoint.getCode());

--- a/src/main/java/org/folio/circulation/domain/representations/logs/NoticeLogContext.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/NoticeLogContext.java
@@ -103,7 +103,7 @@ public class NoticeLogContext {
     log.debug("withUser:: parameters user: {}", user);
 
     if (user != null) {
-      log.info("from:: user is not null");
+      log.debug("from:: user is not null");
       return withUserBarcode(user.getBarcode())
         .withUserId(user.getId());
     }

--- a/src/main/java/org/folio/circulation/domain/representations/logs/NoticeLogContextItem.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/NoticeLogContextItem.java
@@ -89,7 +89,7 @@ public class NoticeLogContextItem {
     }
 
     if (Objects.nonNull(request.getPickupServicePointId())) {
-      log.info("from:: request.getPickupServicePointId() is not null");
+      log.debug("from:: request.getPickupServicePointId() is not null");
       logContextItem = logContextItem.withServicePointId(request.getPickupServicePointId());
     }
 

--- a/src/main/java/org/folio/circulation/rules/CirculationRulesProcessor.java
+++ b/src/main/java/org/folio/circulation/rules/CirculationRulesProcessor.java
@@ -118,7 +118,7 @@ public class CirculationRulesProcessor {
 
     return fetchLocation(params).thenCombine(rulesFuture, combined(
       (newParams, drools) -> {
-        log.info("Applying circulation rules with parameters: {}", newParams);
+        log.debug("Applying circulation rules with parameters: {}", newParams);
         return succeeded(droolsFunction.apply(drools, newParams));
       }));
   }

--- a/src/main/java/org/folio/circulation/rules/CirculationRulesProcessor.java
+++ b/src/main/java/org/folio/circulation/rules/CirculationRulesProcessor.java
@@ -140,7 +140,7 @@ public class CirculationRulesProcessor {
     log.debug("fetchLocation:: parameters params: {}", params);
 
     if (params.getLocation() != null) {
-      log.info("fetchLocation:: location is not null");
+      log.debug("fetchLocation:: location is not null");
       return ofAsync(() -> params);
     }
 

--- a/src/main/java/org/folio/circulation/rules/Drools.java
+++ b/src/main/java/org/folio/circulation/rules/Drools.java
@@ -77,7 +77,7 @@ public class Drools {
     kieSession.insert(new PatronGroup(patronGroupId));
     kieSession.insert(new ItemLocation(locationId));
     if (location != null) {
-      log.info("createSession:: location is not null");
+      log.debug("createSession:: location is not null");
       kieSession.insert(new Institution(location.getInstitutionId()));
       kieSession.insert(new Campus(location.getCampusId()));
       kieSession.insert(new Library(location.getLibraryId()));

--- a/src/main/java/org/folio/circulation/services/AllowedServicePointsService.java
+++ b/src/main/java/org/folio/circulation/services/AllowedServicePointsService.java
@@ -121,7 +121,7 @@ public class AllowedServicePointsService {
       return ofAsync(allowedServicePointsRequest);
     }
 
-    log.info("fetchRequest:: requestId is not null, fetching request");
+    log.debug("fetchRequest:: requestId is not null, fetching request");
 
     return requestRepository.getByIdWithoutRelatedRecords(requestId)
       .thenApply(r -> r.mapFailure(failure ->  failed(failure instanceof RecordNotFoundFailure ?


### PR DESCRIPTION
## Purpose
The log lines below can represent more than 50% of logs in mod-circulation for a duration of time. The log lines don’t have correlation id or any other tracking information, can contain PII & increase hosting costs for FOLIO by thousands of dollars.

[] [] [] [] INFO LoanRepresentation extendedLoan:: extendedLoan-2 is not <value>

[] [] [] [] INFO ummaryRepresentation createItemSummary:: createItemSummary-2 is not <value>

[] [] [] [] INFO ummaryRepresentation createItemSummary:: item.getStatus().getDate() is not <value>

[] [] [] [] INFO LoanRepresentation additionalPatronGroupProperties:: patronGroupAtCheckout is <value>

⁃ [] [] [] [] INFO onentsRepresentation createCallNumberComponents:: result {"callNumber":"callNumber"-2}

Remove the log lines above and similar lines in the java classes from the INFO log level.

Resolves: [CIRC-2277](https://folio-org.atlassian.net/browse/CIRC-2277)
