### PR TITLE
CIRC-2448 Support boolean and string enablePrintLog

### DIFF
--- a/src/main/java/org/folio/circulation/resources/SlipsResource.java
+++ b/src/main/java/org/folio/circulation/resources/SlipsResource.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -176,7 +177,15 @@ public abstract class SlipsResource extends Resource {
       .filter(setting -> PRINT_EVENT_LOG_FEATURE.equals(setting.getName()))
       .findFirst()
       .map(CirculationSetting::getValue)
-      .map(setting -> !setting.getBoolean("enablePrintLog"))
+      .map(setting -> setting.getValue("enablePrintLog"))
+      .map(enablePrintLogValue -> {
+        if (enablePrintLogValue instanceof Boolean) {
+          return !(Boolean) enablePrintLogValue;
+        } else if (enablePrintLogValue instanceof String) {
+          return !BooleanUtils.toBoolean((String) enablePrintLogValue);
+        }
+        return false;
+      })
       .orElse(false);
   }
 

--- a/src/main/java/org/folio/circulation/resources/SlipsResource.java
+++ b/src/main/java/org/folio/circulation/resources/SlipsResource.java
@@ -179,10 +179,10 @@ public abstract class SlipsResource extends Resource {
       .map(CirculationSetting::getValue)
       .map(setting -> setting.getValue("enablePrintLog"))
       .map(enablePrintLogValue -> {
-        if (enablePrintLogValue instanceof Boolean) {
-          return !(Boolean) enablePrintLogValue;
-        } else if (enablePrintLogValue instanceof String) {
-          return !BooleanUtils.toBoolean((String) enablePrintLogValue);
+        if (enablePrintLogValue instanceof Boolean enablePrintLogBoolean) {
+          return !enablePrintLogBoolean;
+        } else if (enablePrintLogValue instanceof String enablePrintLogString) {
+          return !BooleanUtils.toBoolean(enablePrintLogString);
         }
         return false;
       })

--- a/src/test/java/api/printEvents/PrintEventsTests.java
+++ b/src/test/java/api/printEvents/PrintEventsTests.java
@@ -130,27 +130,5 @@ class PrintEventsTests extends APITests {
         .fulfillToHoldShelf()
         .withPickupServicePointId(pickupServicePointId)).getId()).toList();
   }
-//
-//  private static Stream<Arguments> provideTrueValues() {
-//    return Stream.of(
-//      Arguments.of(true),
-//      Arguments.of("true")
-//    );
-//  }
-//
-//  private static Stream<Arguments> provideFalseValues() {
-//    return Stream.of(
-//      Arguments.of(false),
-//      Arguments.of("false")
-//    );
-//  }
-//
-//  private static Stream<Arguments> provideTrueAndFalseValues() {
-//    return Stream.of(
-//      Arguments.of(true, false),
-//      Arguments.of("true", false),
-//      Arguments.of(true, "false"),
-//      Arguments.of("true", "false")
-//    );
-//  }
+
 }

--- a/src/test/java/api/printEvents/PrintEventsTests.java
+++ b/src/test/java/api/printEvents/PrintEventsTests.java
@@ -1,31 +1,34 @@
 package api.printEvents;
 
-import api.support.APITests;
-import api.support.builders.CirculationSettingBuilder;
-import api.support.builders.RequestBuilder;
-import io.vertx.core.json.JsonObject;
-import org.folio.circulation.support.http.client.Response;
-import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.IntStream;
-
 import static api.support.http.InterfaceUrls.printEventsUrl;
 import static api.support.matchers.ResponseStatusCodeMatcher.hasStatus;
 import static org.folio.HttpStatus.HTTP_NO_CONTENT;
 import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import org.folio.circulation.support.http.client.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import api.support.APITests;
+import api.support.builders.CirculationSettingBuilder;
+import api.support.builders.RequestBuilder;
+import io.vertx.core.json.JsonObject;
+
 class PrintEventsTests extends APITests {
 
-
-  @Test
-  void postPrintEventsTest() {
+  @ParameterizedTest
+  @MethodSource("api.support.utl.BooleanArgumentProvider#provideTrueValues")
+  void postPrintEventsTest(Object trueValue) {
     circulationSettingsClient.create(new CirculationSettingBuilder()
       .withName("printEventLogFeature")
-      .withValue(new JsonObject().put("enablePrintLog", true)));
+      .withValue(new JsonObject().put("enablePrintLog", trueValue)));
     JsonObject printRequest = getPrintEvent();
     printRequest.put("requestIds", createOneHundredRequests());
     Response response = restAssuredClient.post(printRequest, printEventsUrl("/print-events-entry"), "post-print-event");
@@ -40,14 +43,15 @@ class PrintEventsTests extends APITests {
     assertThat(response, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
   }
 
-  @Test
-  void postPrintEventsWhenDuplicateCirculationSettingFound() {
+  @ParameterizedTest
+  @MethodSource("api.support.utl.BooleanArgumentProvider#provideTrueAndFalseValues")
+  void postPrintEventsWhenDuplicateCirculationSettingFound(Object trueValue, Object falseValue) {
     circulationSettingsClient.create(new CirculationSettingBuilder()
       .withName("printEventLogFeature")
-      .withValue(new JsonObject().put("enablePrintLog", true)));
+      .withValue(new JsonObject().put("enablePrintLog", trueValue)));
     circulationSettingsClient.create(new CirculationSettingBuilder()
       .withName("printEventLogFeature")
-      .withValue(new JsonObject().put("Enable-Print-Event", false)));
+      .withValue(new JsonObject().put("Enable-Print-Event", falseValue)));
 
     JsonObject printRequest = getPrintEvent();
     printRequest.put("requestIds", List.of(UUID.randomUUID()));
@@ -55,11 +59,12 @@ class PrintEventsTests extends APITests {
     assertThat(response, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
   }
 
-  @Test
-  void postPrintEventsWhenPrintEventSettingIsDisable() {
+  @ParameterizedTest
+  @MethodSource("api.support.utl.BooleanArgumentProvider#provideFalseValues")
+  void postPrintEventsWhenPrintEventSettingIsDisable(Object falseValue) {
     circulationSettingsClient.create(new CirculationSettingBuilder()
       .withName("printEventLogFeature")
-      .withValue(new JsonObject().put("enablePrintLog", false)));
+      .withValue(new JsonObject().put("enablePrintLog", falseValue)));
 
     JsonObject printRequest = getPrintEvent();
     printRequest.put("requestIds", List.of(UUID.randomUUID()));
@@ -67,11 +72,12 @@ class PrintEventsTests extends APITests {
     assertThat(response, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
   }
 
-  @Test
-  void postPrintEventsWithInvalidRequestId() {
+  @ParameterizedTest
+  @MethodSource("api.support.utl.BooleanArgumentProvider#provideTrueValues")
+  void postPrintEventsWithInvalidRequestId(Object trueValue) {
     circulationSettingsClient.create(new CirculationSettingBuilder()
       .withName("printEventLogFeature")
-      .withValue(new JsonObject().put("enablePrintLog", true)));
+      .withValue(new JsonObject().put("enablePrintLog", trueValue)));
     JsonObject printRequest = getPrintEvent();
     List<UUID> requestIds = new ArrayList<>(createOneHundredRequests());
     requestIds.add(UUID.randomUUID());
@@ -79,7 +85,6 @@ class PrintEventsTests extends APITests {
     Response response = restAssuredClient.post(printRequest, printEventsUrl("/print-events-entry"), "post-print-event");
     assertThat(response, hasStatus(HTTP_UNPROCESSABLE_ENTITY));
   }
-
 
   @Test
   void postPrintEventsWithInvalidField() {
@@ -125,4 +130,27 @@ class PrintEventsTests extends APITests {
         .fulfillToHoldShelf()
         .withPickupServicePointId(pickupServicePointId)).getId()).toList();
   }
+//
+//  private static Stream<Arguments> provideTrueValues() {
+//    return Stream.of(
+//      Arguments.of(true),
+//      Arguments.of("true")
+//    );
+//  }
+//
+//  private static Stream<Arguments> provideFalseValues() {
+//    return Stream.of(
+//      Arguments.of(false),
+//      Arguments.of("false")
+//    );
+//  }
+//
+//  private static Stream<Arguments> provideTrueAndFalseValues() {
+//    return Stream.of(
+//      Arguments.of(true, false),
+//      Arguments.of("true", false),
+//      Arguments.of(true, "false"),
+//      Arguments.of("true", "false")
+//    );
+//  }
 }

--- a/src/test/java/api/requests/StaffSlipsTests.java
+++ b/src/test/java/api/requests/StaffSlipsTests.java
@@ -332,9 +332,10 @@ class StaffSlipsTests extends APITests {
     assertThat(requestContext.getString("requestDate"), isEquivalentTo(requestDate));
   }
 
-  @Test
-  void responseContainsPickSlipsForRequestsOfTypePageOnly() {
-    circulationSettingFixture.configurePrintEventLogFeature(true);
+  @ParameterizedTest
+  @MethodSource("api.support.utl.BooleanArgumentProvider#provideTrueValues")
+  void responseContainsPickSlipsForRequestsOfTypePageOnly(Object trueValue) {
+    circulationSettingFixture.configurePrintEventLogFeature(trueValue);
 
     UUID servicePointId = servicePointsFixture.cd1().getId();
     val item = itemsFixture.basedUponSmallAngryPlanet();
@@ -591,9 +592,10 @@ class StaffSlipsTests extends APITests {
       "The Long Way to a Small, Angry Planet"));
   }
 
-  @Test
-  void pickSlipForTitleLevelRequestContainsItemData() {
-    circulationSettingFixture.configurePrintEventLogFeature(true);
+  @ParameterizedTest
+  @MethodSource("api.support.utl.BooleanArgumentProvider#provideTrueValues")
+  void pickSlipForTitleLevelRequestContainsItemData(Object trueValue) {
+    circulationSettingFixture.configurePrintEventLogFeature(trueValue);
     settingsFixture.enableTlrFeature();
     var servicePointId = servicePointsFixture.cd1().getId();
     var requester = usersFixture.steve();
@@ -712,9 +714,12 @@ class StaffSlipsTests extends APITests {
     assertResponseHasItems(response, 0, SlipsType.PICK_SLIPS);
   }
 
-  @Test
-  void responseContainsPickSlipsForTitleLevelRequestsAssociatedWithMoreThan10DifferentHoldings() {
-    circulationSettingFixture.configurePrintEventLogFeature(true);
+  @ParameterizedTest
+  @MethodSource("api.support.utl.BooleanArgumentProvider#provideTrueValues")
+  void responseContainsPickSlipsForTitleLevelRequestsAssociatedWithMoreThan10DifferentHoldings(
+    Object trueValue) {
+
+    circulationSettingFixture.configurePrintEventLogFeature(trueValue);
     settingsFixture.enableTlrFeature();
     UserResource requester = usersFixture.steve();
     UUID servicePointId = servicePointsFixture.cd1().getId();
@@ -736,9 +741,12 @@ class StaffSlipsTests extends APITests {
     assertResponseHasItems(response, 11, SlipsType.PICK_SLIPS);
   }
 
-  @Test
-  void responseContainsPickSlipsForManyTitleLevelRequestsCreatedForSameHoldingAndInstance() {
-    circulationSettingFixture.configurePrintEventLogFeature(true);
+  @ParameterizedTest
+  @MethodSource("api.support.utl.BooleanArgumentProvider#provideTrueValues")
+  void responseContainsPickSlipsForManyTitleLevelRequestsCreatedForSameHoldingAndInstance(
+    Object trueValue) {
+
+    circulationSettingFixture.configurePrintEventLogFeature(trueValue);
     settingsFixture.enableTlrFeature();
     int batchSize = 50; // default value from CqlIndexValuesFinder
 
@@ -766,9 +774,10 @@ class StaffSlipsTests extends APITests {
     assertResponseHasItems(response, batchSize + 1, SlipsType.PICK_SLIPS);
   }
 
-  @Test
-  void responseContainsNoRecordsIfPickSlipsDisabled() {
-    circulationSettingFixture.configurePrintEventLogFeature(true);
+  @ParameterizedTest
+  @MethodSource("api.support.utl.BooleanArgumentProvider#provideTrueAndFalseValues")
+  void responseContainsNoRecordsIfPickSlipsDisabled(Object trueValue, Object falseValue) {
+    circulationSettingFixture.configurePrintEventLogFeature(trueValue);
 
     UUID servicePointId = servicePointsFixture.cd1().getId();
     val item = itemsFixture.basedUponSmallAngryPlanet();
@@ -788,7 +797,7 @@ class StaffSlipsTests extends APITests {
     assertResponseHasItems(response, 1, SlipsType.PICK_SLIPS);
     assertResponseContains(response, SlipsType.PICK_SLIPS, item, firstRequest, james);
 
-    circulationSettingFixture.configurePrintEventLogFeature(false);
+    circulationSettingFixture.configurePrintEventLogFeature(falseValue);
     response = SlipsType.PICK_SLIPS.get(servicePointId);
 
     assertThat(response.getStatusCode(), is(HTTP_OK));

--- a/src/test/java/api/support/fixtures/CirculationSettingFixture.java
+++ b/src/test/java/api/support/fixtures/CirculationSettingFixture.java
@@ -13,7 +13,7 @@ public class CirculationSettingFixture {
     this.client = circulationSettingsClient;
   }
 
-  public void configurePrintEventLogFeature(boolean enablePrintLog) {
+  public void configurePrintEventLogFeature(Object enablePrintLog) {
     deletePrintEventLogFeatureConfig();
     printEventLogFeatureConfigurationEntryId = client.create(
       setPrintEventLogFeatureEnabled(enablePrintLog)).getId();
@@ -26,7 +26,7 @@ public class CirculationSettingFixture {
     }
   }
 
-  private JsonObject setPrintEventLogFeatureEnabled(boolean enablePrintLog) {
+  private JsonObject setPrintEventLogFeatureEnabled(Object enablePrintLog) {
     return new JsonObject()
       .put("id", UUID.randomUUID())
       .put("name", "printEventLogFeature")

--- a/src/test/java/api/support/utl/BooleanArgumentProvider.java
+++ b/src/test/java/api/support/utl/BooleanArgumentProvider.java
@@ -1,0 +1,30 @@
+package api.support.utl;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.provider.Arguments;
+
+public class BooleanArgumentProvider {
+  private static Stream<Arguments> provideTrueValues() {
+    return Stream.of(
+      Arguments.of(true),
+      Arguments.of("true")
+    );
+  }
+
+  private static Stream<Arguments> provideFalseValues() {
+    return Stream.of(
+      Arguments.of(false),
+      Arguments.of("false")
+    );
+  }
+
+  private static Stream<Arguments> provideTrueAndFalseValues() {
+    return Stream.of(
+      Arguments.of(true, false),
+      Arguments.of("true", false),
+      Arguments.of(true, "false"),
+      Arguments.of("true", "false")
+    );
+  }
+}

--- a/src/test/java/api/support/utl/BooleanArgumentProvider.java
+++ b/src/test/java/api/support/utl/BooleanArgumentProvider.java
@@ -5,21 +5,21 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 
 public class BooleanArgumentProvider {
-  private static Stream<Arguments> provideTrueValues() {
+  public static Stream<Arguments> provideTrueValues() {
     return Stream.of(
       Arguments.of(true),
       Arguments.of("true")
     );
   }
 
-  private static Stream<Arguments> provideFalseValues() {
+  public static Stream<Arguments> provideFalseValues() {
     return Stream.of(
       Arguments.of(false),
       Arguments.of("false")
     );
   }
 
-  private static Stream<Arguments> provideTrueAndFalseValues() {
+  public static Stream<Arguments> provideTrueAndFalseValues() {
     return Stream.of(
       Arguments.of(true, false),
       Arguments.of("true", false),


### PR DESCRIPTION
[CIRC-2448](https://folio-org.atlassian.net/browse/CIRC-2448)
## Purpose
Some UI modules store boolean value for circulation setting `enablePrintLog `as strings in JSON - "true" and "false". mod-circulation needs to support both options.
