### PR TITLE
CIRC-2463 better hold-by-barcode response

### DIFF
--- a/src/main/java/org/folio/circulation/resources/foruseatlocation/HoldByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/resources/foruseatlocation/HoldByBarcodeRequest.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.Environment;
 import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.ServicePoint;
+import org.folio.circulation.domain.representations.ItemSummaryRepresentation;
 import org.folio.circulation.support.BadRequestFailure;
 import org.folio.circulation.support.HttpFailure;
 import org.folio.circulation.support.results.Result;
@@ -87,6 +88,17 @@ public class HoldByBarcodeRequest {
     String message = "For-use-at-location is not enabled for this tenant.";
     log.warn("forUseAtLocationIsNotEnabledFailure:: {}", message);
     return () -> new BadRequestFailure(format(message));
+  }
+
+  public JsonObject responseBody() {
+    JsonObject body = new JsonObject();
+    JsonObject loanJson = loan.asJson();
+    JsonObject itemJson = new ItemSummaryRepresentation().createItemSummary(loan.getItem());
+
+    loanJson.put("item", itemJson);
+    body.put("loan", loanJson);
+
+    return body;
   }
 
 }

--- a/src/main/java/org/folio/circulation/resources/foruseatlocation/HoldByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/foruseatlocation/HoldByBarcodeResource.java
@@ -39,7 +39,6 @@ import java.lang.invoke.MethodHandles;
 import java.time.ZonedDateTime;
 import java.util.concurrent.CompletableFuture;
 
-import static java.lang.String.format;
 import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.determineClosedLibraryStrategyForHoldShelfExpirationDate;
 import static org.folio.circulation.domain.representations.LoanProperties.*;
 import static org.folio.circulation.resources.foruseatlocation.HoldByBarcodeRequest.forUseAtLocationIsNotEnabledFailure;
@@ -90,10 +89,9 @@ public class HoldByBarcodeResource extends Resource {
       .thenCompose(request -> request.after(req -> findHoldShelfExpirationDate(req, calendarRepository)))
       .thenApply(this::setStatusToHeldWithExpirationDate)
       .thenApply(this::setActionToHeld)
-      .thenCompose(request -> request.after(req -> loanRepository.updateLoan(req.getLoan())))
-      .thenCompose(loanResult -> loanResult.after(
-        loan -> eventPublisher.publishUsageAtLocationEvent(loan, LogEventType.LOAN)))
-      .thenApply(loanResult -> loanResult.map(Loan::asJson).map(this::toResponse))
+      .thenCompose(request -> request.after(req -> updateLoan(req, loanRepository)))
+      .thenCompose(request -> request.after(req -> publishEvent(req, eventPublisher)))
+      .thenApply(request -> request.map(req -> toResponse(req.responseBody())))
       .thenAccept(webContext::writeResultToHttpResponse);
   }
 
@@ -162,6 +160,17 @@ public class HoldByBarcodeResource extends Resource {
     return request.map(req -> req.withLoan(req.getLoan().withAction(LoanAction.HELD_FOR_USE_AT_LOCATION)));
   }
 
+  private CompletableFuture<Result<HoldByBarcodeRequest>> updateLoan(HoldByBarcodeRequest request, LoanRepository loanRepository) {
+    log.debug("updateLoan:: loan parameter: {}", request.getLoan().asJson());
+    return loanRepository.updateLoan(request.getLoan())
+      .thenApply(loanResult -> loanResult.map(request::withLoan));
+  }
+
+  private CompletableFuture<Result<HoldByBarcodeRequest>> publishEvent (HoldByBarcodeRequest request, EventPublisher eventPublisher) {
+    return eventPublisher.publishUsageAtLocationEvent(request.getLoan(), LogEventType.LOAN)
+      .thenApply(loanResult -> loanResult.map(loan -> request));
+  }
+
   private static Result<HoldByBarcodeRequest> failWhenOpenLoanNotFoundForItem(Result<HoldByBarcodeRequest> request) {
     log.warn("failWhenOpenLoanNotFoundForItem");
     return request.failWhen(HoldByBarcodeRequest::loanIsNull, req -> noOpenLoanFailure(req).get());
@@ -177,8 +186,7 @@ public class HoldByBarcodeResource extends Resource {
     return request.failWhen(HoldByBarcodeRequest::forUseAtLocationIsNotEnabled, req -> forUseAtLocationIsNotEnabledFailure().get());
   }
   private HttpResponse toResponse(JsonObject body) {
-    return JsonHttpResponse.ok(body,
-      format("/circulation/loans/%s", body.getString("id")));
+    return JsonHttpResponse.ok(body);
   }
 
 

--- a/src/test/java/api/loans/LoansForUseAtLocationTests.java
+++ b/src/test/java/api/loans/LoansForUseAtLocationTests.java
@@ -138,7 +138,8 @@ public class LoansForUseAtLocationTests extends APITests {
     Response holdResponse = holdForUseAtLocationFixture.holdForUseAtLocation(
       new HoldByBarcodeRequestBuilder(item.getBarcode()));
 
-    JsonObject forUseAtLocation = holdResponse.getJson().getJsonObject("forUseAtLocation");
+    JsonObject forUseAtLocation = holdResponse.getJson()
+      .getJsonObject("loan").getJsonObject("forUseAtLocation");
 
     assertThat("loan.forUseAtLocation",
       forUseAtLocation, notNullValue());
@@ -180,7 +181,8 @@ public class LoansForUseAtLocationTests extends APITests {
         .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN));
 
     JsonObject forUseAtLocation = holdForUseAtLocationFixture.holdForUseAtLocation(
-      new HoldByBarcodeRequestBuilder(item.getBarcode())).getJson().getJsonObject("forUseAtLocation");
+      new HoldByBarcodeRequestBuilder(item.getBarcode()))
+      .getJson().getJsonObject("loan").getJsonObject("forUseAtLocation");
 
     ZonedDateTime expectedExpiryDateTime =
       atEndOfDay(holdShelfExpiryPeriod
@@ -221,7 +223,8 @@ public class LoansForUseAtLocationTests extends APITests {
         .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN));
 
     JsonObject forUseAtLocation = holdForUseAtLocationFixture.holdForUseAtLocation(
-      new HoldByBarcodeRequestBuilder(item.getBarcode())).getJson().getJsonObject("forUseAtLocation");
+        new HoldByBarcodeRequestBuilder(item.getBarcode()))
+      .getJson().getJsonObject("loan").getJsonObject("forUseAtLocation");
 
     ZonedDateTime expectedExpiryDateTime =
       atEndOfDay(holdShelfExpiryPeriod
@@ -258,7 +261,8 @@ public class LoansForUseAtLocationTests extends APITests {
         .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN));
 
     JsonObject forUseAtLocation = holdForUseAtLocationFixture.holdForUseAtLocation(
-      new HoldByBarcodeRequestBuilder(item.getBarcode())).getJson().getJsonObject("forUseAtLocation");
+        new HoldByBarcodeRequestBuilder(item.getBarcode()))
+      .getJson().getJsonObject("loan").getJsonObject("forUseAtLocation");
 
     assertThat("loan.forUseAtLocation.holdShelfExpirationDate",
       forUseAtLocation.getString("holdShelfExpirationDate"), nullValue());


### PR DESCRIPTION
CIRC-2463

## Purpose
The check-in UI needs a fuller item than initially provided in the response to hold-by-barcode requests, in order for the UI to render the result of the hold-by-barcode action. 

## Approach
The existing ItemSummaryRepresentation class is reused to create the response of hold-by-barcode. 

Also the response is restructured a to contain a loan object with the item object embedded, bringing it more in line with the structure of the response of a regular check-in action (which is performed through the same UI). 