### PR TITLE
CIRC-2469 add reading room support (use at location)

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -203,7 +203,7 @@
     },
     {
       "id": "circulation",
-      "version": "14.6",
+      "version": "14.7",
       "handlers": [
         {
           "methods": [
@@ -277,6 +277,26 @@
           ],
           "modulePermissions": [
             "circulation.renew-loan.all"
+          ]
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/circulation/pickup-by-barcode-for-use-at-location",
+          "permissionsRequired": ["circulation.pickup-by-barcode-for-use-at-location.post"],
+          "modulePermissions": [
+            "circulation.usage-at-location.all"
+          ]
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/circulation/hold-by-barcode-for-use-at-location",
+          "permissionsRequired": ["circulation.hold-by-barcode-for-use-at-location.post"],
+          "modulePermissions": [
+            "circulation.usage-at-location.all"
           ]
         },
         {
@@ -1446,6 +1466,16 @@
       "description": "renew a loan using IDs for item and loanee"
     },
     {
+      "permissionName": "circulation.pickup-by-barcode-for-use-at-location.post",
+      "displayName": "circulation - pick up from hold shelf for use at location",
+      "description": "pick up item of an existing loan from hold shelf for use at location (i.e. in reading room)"
+    },
+    {
+      "permissionName": "circulation.hold-by-barcode-for-use-at-location.post",
+      "displayName": "circulation - put item on hold shelf for another use at location",
+      "description": "put the item of an existing loan on the hold shelf for later use at location (i.e. in reading room)"
+    },
+    {
       "permissionName": "circulation.loans.collection.get",
       "displayName": "circulation - get loan collection",
       "description": "get loan collection"
@@ -1729,6 +1759,8 @@
         "circulation.check-in-by-barcode.post",
         "circulation.renew-by-barcode.post",
         "circulation.renew-by-id.post",
+        "circulation.hold-by-barcode-for-use-at-location.post",
+        "circulation.pickup-by-barcode-for-use-at-location.post",
         "circulation.loans.collection.get",
         "circulation.loans.item.get",
         "circulation.loans.item.post",
@@ -2108,6 +2140,23 @@
       ],
       "visible": false,
       "replaces": ["circulation.renew-loan"]
+    },
+    {
+      "permissionName": "circulation.usage-at-location.all",
+      "displayName" : "Put item on hold or pick it up for use at location",
+      "description" : "Permissions needed to take an item on or off hold shelf for use at location",
+      "subPermissions": [
+        "circulation-storage.loans.item.put",
+        "circulation-storage.loans.item.get",
+        "circulation-storage.loans.collection.get",
+        "circulation-storage.loan-policies.item.get",
+        "circulation-storage.loan-policies.collection.get",
+        "circulation.internal.fetch-items.collection.get",
+        "users.item.get",
+        "users.collection.get",
+        "pubsub.publish.post"
+      ],
+      "visible": false
     },
     {
       "permissionName": "perms.circulation.loans.anonymize.all",
@@ -2725,6 +2774,10 @@
       {
         "name": "ENABLE_FLOATING_COLLECTIONS",
         "value": "true"
+      },
+      {
+        "name": "ENABLE_FOR_USE_AT_LOCATION",
+        "value": "false"
       },
       {
         "name": "KAFKA_HOST",

--- a/ramls/examples/at-location-usage-status-change-error.json
+++ b/ramls/examples/at-location-usage-status-change-error.json
@@ -1,0 +1,13 @@
+{
+  "errors": [
+    {
+      "message": "TBD",
+      "parameters": [
+        {
+          "key": "itemId",
+          "value": "91719676-e7b5-4f83-bdab-cb70dd10c1e3"
+        }
+      ]
+    }
+  ]
+}

--- a/ramls/for-use-at-location-shelf.raml
+++ b/ramls/for-use-at-location-shelf.raml
@@ -1,0 +1,62 @@
+#%RAML 1.0
+title: Change usage status of items to be used at location (ie reading room)
+version: v0.1
+protocols: [ HTTP, HTTPS ]
+baseUri: http://localhost:9130
+
+documentation:
+  - title: API for changing usage status of items used at location
+    content: <b>Change usage status API</b>
+
+types:
+  errors: !include raml-util/schemas/errors.schema
+
+traits:
+  validate: !include raml-util/traits/validation.raml
+
+/circulation:
+  /hold-by-barcode-for-use-at-location:
+    post:
+      is: [validate]
+      body:
+        application/json:
+          type: !include hold-for-use-at-location-request.json
+      responses:
+        200:
+          description: "The at-location usage status of the loaned item set to held"
+        422:
+          description: "Unable to change the usage status for the loan"
+          body:
+            application/json:
+              type: errors
+              example: !include examples/at-location-usage-status-change-error.json
+        404:
+          description: "The loan is not found"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            text/plain:
+              example: "Internal server error, contact administrator"
+
+  /pickup-by-barcode-for-use-at-location:
+    post:
+      is: [validate]
+      body:
+        application/json:
+          type: !include pickup-for-use-at-location-request.json
+      responses:
+        200:
+          description: "The at-location usage status of the loaned item set to in-use"
+        422:
+          description: "Unable to change the usage status for the loan"
+          body:
+            application/json:
+              type: errors
+              example: !include examples/at-location-usage-status-change-error.json
+        404:
+          description: "The loan is not found"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            text/plain:
+              example: "Internal server error, contact administrator"

--- a/ramls/hold-for-use-at-location-request.json
+++ b/ramls/hold-for-use-at-location-request.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Request to switch status of use at location to 'Held'",
+  "properties": {
+    "itemBarcode": {
+      "description": "Barcode of the item being in use at location",
+      "type": "string"
+    }
+  },
+  "required": [
+    "itemBarcode"
+  ]
+}

--- a/ramls/loan.json
+++ b/ramls/loan.json
@@ -281,6 +281,26 @@
         }
       }
     },
+    "forUseAtLocation": {
+      "description": "Status of loan/item that is to be used in the library",
+      "type": "object",
+      "properties": {
+        "status": {
+          "description": "Indicates if the item is currently used by or being held for the patron",
+          "type": "string",
+          "enum": [
+            "In use",
+            "Held",
+            "Returned"
+          ]
+        },
+        "statusDate": {
+          "description": "Date and time the status was registered",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
     "loanDate": {
       "description": "Date and time when the loan began",
       "type": "string",

--- a/ramls/pickup-for-use-at-location-request.json
+++ b/ramls/pickup-for-use-at-location-request.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Request to switch status of use at location to 'In use'",
+  "properties": {
+    "itemBarcode": {
+      "description": "Barcode of the item lent to the patron for use at location",
+      "type": "string"
+    },
+    "userBarcode": {
+      "description": "Barcode of the user (representing the patron)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "itemBarcode",
+    "userBarcode"
+  ]
+}

--- a/ramls/put-on-hold-for-use-at-location.json
+++ b/ramls/put-on-hold-for-use-at-location.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Request to switch status of use at location to 'Held'",
+  "properties": {
+    "itemBarcode": {
+      "description": "Barcode of the item lent to the patron for use at location",
+      "type": "string"
+    }
+  },
+  "required": [
+    "itemBarcode"
+  ]
+}

--- a/src/main/java/org/folio/Environment.java
+++ b/src/main/java/org/folio/Environment.java
@@ -25,8 +25,16 @@ public class Environment {
     return getVariable("ENABLE_FLOATING_COLLECTIONS", false);
   }
 
+  public static boolean getForUseAtLocationEnabled() {
+    return getVariable("ENABLE_FOR_USE_AT_LOCATION", false);
+  }
+
   public static int getHttpMaxPoolSize() {
     return getVariable("HTTP_MAXPOOLSIZE", 100);
+  }
+
+  public static boolean getEcsTlrFeatureEnabled() {
+    return getVariable("ECS_TLR_FEATURE_ENABLED", false);
   }
 
   private static int getVariable(String key, int defaultValue) {

--- a/src/main/java/org/folio/circulation/CirculationVerticle.java
+++ b/src/main/java/org/folio/circulation/CirculationVerticle.java
@@ -52,6 +52,8 @@ import org.folio.circulation.resources.handlers.FeeFineBalanceChangedHandlerReso
 import org.folio.circulation.resources.handlers.LoanRelatedFeeFineClosedHandlerResource;
 import org.folio.circulation.resources.renewal.RenewByBarcodeResource;
 import org.folio.circulation.resources.renewal.RenewByIdResource;
+import org.folio.circulation.resources.foruseatlocation.HoldByBarcodeResource;
+import org.folio.circulation.resources.foruseatlocation.PickupByBarcodeResource;
 import org.folio.circulation.support.logging.LogHelper;
 import org.folio.circulation.support.logging.Logging;
 
@@ -97,7 +99,8 @@ public class CirculationVerticle extends AbstractVerticle {
 
     new RenewByBarcodeResource(client).register(router);
     new RenewByIdResource(client).register(router);
-
+    new HoldByBarcodeResource(client).register(router);
+    new PickupByBarcodeResource(client).register(router);
     new AllowedServicePointsResource(client).register(router);
     new LoanCollectionResource(client).register(router);
     new RequestCollectionResource(client).register(router);

--- a/src/main/java/org/folio/circulation/domain/Instance.java
+++ b/src/main/java/org/folio/circulation/domain/Instance.java
@@ -13,7 +13,7 @@ import lombok.Value;
 @ToString(onlyExplicitlyIncluded = true)
 public class Instance {
   public static Instance unknown() {
-    return new Instance(null, null,null, emptyList(), emptyList(), emptyList(), emptyList(), emptyList());
+    return new Instance(null, null,null, emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList());
   }
 
   @ToString.Include
@@ -27,6 +27,7 @@ public class Instance {
   @NonNull Collection<Publication> publication;
   @NonNull Collection<String> editions;
   @NonNull Collection<String> physicalDescriptions;
+  @NonNull Collection<SeriesStatement> series;
 
   public Stream<String> getContributorNames() {
     return contributors.stream()
@@ -39,6 +40,11 @@ public class Instance {
       .findFirst()
       .map(Contributor::getName)
       .orElse(null);
+  }
+
+  public Stream<String> getSeriesStatementValues() {
+    return series.stream()
+      .map(SeriesStatement::getValue);
   }
 
   // TODO: replace this stub with proper implementation

--- a/src/main/java/org/folio/circulation/domain/Item.java
+++ b/src/main/java/org/folio/circulation/domain/Item.java
@@ -288,6 +288,10 @@ public class Item {
     return description.getAdministrativeNotes();
   }
 
+  public Collection<String> getSeriesStatementValues() {
+    return instance.getSeriesStatementValues().toList();
+  }
+
   private ServicePoint getPrimaryServicePoint() {
     return location.getPrimaryServicePoint();
   }

--- a/src/main/java/org/folio/circulation/domain/Loan.java
+++ b/src/main/java/org/folio/circulation/domain/Loan.java
@@ -21,14 +21,19 @@ import static org.folio.circulation.domain.representations.LoanProperties.ACTION
 import static org.folio.circulation.domain.representations.LoanProperties.ACTION_COMMENT;
 import static org.folio.circulation.domain.representations.LoanProperties.AGED_TO_LOST_DATE;
 import static org.folio.circulation.domain.representations.LoanProperties.AGED_TO_LOST_DELAYED_BILLING;
+import static org.folio.circulation.domain.representations.LoanProperties.AT_LOCATION_USE_EXPIRY_DATE;
+import static org.folio.circulation.domain.representations.LoanProperties.AT_LOCATION_USE_STATUS;
+import static org.folio.circulation.domain.representations.LoanProperties.AT_LOCATION_USE_STATUS_DATE;
 import static org.folio.circulation.domain.representations.LoanProperties.BILL_DATE;
 import static org.folio.circulation.domain.representations.LoanProperties.BILL_NUMBER;
 import static org.folio.circulation.domain.representations.LoanProperties.CHECKIN_SERVICE_POINT_ID;
 import static org.folio.circulation.domain.representations.LoanProperties.CHECKOUT_SERVICE_POINT_ID;
 import static org.folio.circulation.domain.representations.LoanProperties.CLAIMED_RETURNED_DATE;
+import static org.folio.circulation.domain.representations.LoanProperties.CREATED_DATE;
 import static org.folio.circulation.domain.representations.LoanProperties.DATE_LOST_ITEM_SHOULD_BE_BILLED;
 import static org.folio.circulation.domain.representations.LoanProperties.DECLARED_LOST_DATE;
 import static org.folio.circulation.domain.representations.LoanProperties.DUE_DATE;
+import static org.folio.circulation.domain.representations.LoanProperties.FOR_USE_AT_LOCATION;
 import static org.folio.circulation.domain.representations.LoanProperties.ITEM_LOCATION_ID_AT_CHECKOUT;
 import static org.folio.circulation.domain.representations.LoanProperties.ITEM_STATUS;
 import static org.folio.circulation.domain.representations.LoanProperties.LAST_FEE_BILLED;
@@ -48,6 +53,7 @@ import static org.folio.circulation.support.json.JsonPropertyFetcher.getBooleanP
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTimeProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getDateTimePropertyByPath;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getIntegerProperty;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedDateTimeProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedObjectProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getNestedStringProperty;
 import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
@@ -203,6 +209,23 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   public String getAction() {
     return getProperty(representation, ACTION);
+  }
+
+  public Loan changeStatusOfUsageAtLocation(String usageStatus, ZonedDateTime holdShelfExpirationDate) {
+    log.info("changeStatusOfUsageAtLocation:: parameters usageStatus: {}  expiration date {}", usageStatus, holdShelfExpirationDate);
+    writeByPath(representation, usageStatus, FOR_USE_AT_LOCATION, AT_LOCATION_USE_STATUS);
+    writeByPath(representation, ClockUtil.getZonedDateTime().toString(), FOR_USE_AT_LOCATION, AT_LOCATION_USE_STATUS_DATE);
+    writeByPath(representation, holdShelfExpirationDate, FOR_USE_AT_LOCATION, AT_LOCATION_USE_EXPIRY_DATE);
+    return this;
+  }
+
+  public Loan changeStatusOfUsageAtLocation(String usageStatus) {
+    log.info("changeStatusOfUsageAtLocation:: parameters usageStatus: {}", usageStatus);
+    return changeStatusOfUsageAtLocation(usageStatus, null);  }
+
+
+  public boolean isForUseAtLocation() {
+    return representation.containsKey(FOR_USE_AT_LOCATION);
   }
 
   private void changeCheckInServicePointId(UUID servicePointId) {
@@ -833,6 +856,10 @@ public class Loan implements ItemRelatedRecord, UserRelatedRecord {
 
   public String getUpdatedByUserId() {
     return getNestedStringProperty(representation, METADATA, UPDATED_BY_USER_ID);
+  }
+
+  public ZonedDateTime getCreatedDate() {
+    return getNestedDateTimeProperty(representation, METADATA, CREATED_DATE);
   }
 
   public Loan setPreviousDueDate(ZonedDateTime previousDateTime) {

--- a/src/main/java/org/folio/circulation/domain/LoanAction.java
+++ b/src/main/java/org/folio/circulation/domain/LoanAction.java
@@ -23,9 +23,9 @@ public enum LoanAction {
   STAFF_INFO_ADDED("staffInfoAdded"),
   RESOLVE_CLAIM_AS_RETURNED_BY_PATRON("checkedInReturnedByPatron"),
   RESOLVE_CLAIM_AS_FOUND_BY_LIBRARY("checkedInFoundByLibrary"),
-
-  REMINDER_FEE("reminderFee");
-
+  REMINDER_FEE("reminderFee"),
+  HELD_FOR_USE_AT_LOCATION("heldForUseAtLocation"),
+  PICKED_UP_FOR_USE_AT_LOCATION ("pickedUpForUseAtLocation");
   private final String value;
 
   LoanAction(String value) {

--- a/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/RequestRepresentation.java
@@ -102,6 +102,8 @@ public class RequestRepresentation {
     write(itemSummary, "volume", item.getVolume());
     write(itemSummary, "chronology", item.getChronology());
     write(itemSummary, "displaySummary", item.getDisplaySummary());
+    write(itemSummary, "loanTypeId",  item.getLoanTypeId());
+    write(itemSummary, "loanTypeName",  item.getLoanTypeName());
 
     ItemStatus status = item.getStatus();
     if (status != null) {

--- a/src/main/java/org/folio/circulation/domain/SeriesStatement.java
+++ b/src/main/java/org/folio/circulation/domain/SeriesStatement.java
@@ -1,0 +1,9 @@
+package org.folio.circulation.domain;
+
+import lombok.Value;
+
+@Value
+public class SeriesStatement {
+  String authorityId;
+  String value;
+}

--- a/src/main/java/org/folio/circulation/domain/mapper/InventoryMapper.java
+++ b/src/main/java/org/folio/circulation/domain/mapper/InventoryMapper.java
@@ -23,6 +23,7 @@ public class InventoryMapper {
     String yearCaptionsToken = String.join("; ", item.getYearCaption());
     String copyNumber = item.getCopyNumber() != null ? item.getCopyNumber() : "";
     String administrativeNotes = String.join("; ", item.getAdministrativeNotes());
+    String series = String.join("; ", item.getSeriesStatementValues());
 
     JsonObject itemContext = createInstanceContext(item.getInstance(), item)
       .put("barcode", item.getBarcode())
@@ -38,13 +39,14 @@ public class InventoryMapper {
       .put("displaySummary", item.getDisplaySummary())
       .put("descriptionOfPieces", item.getDescriptionOfPieces())
       .put("accessionNumber", item.getAccessionNumber())
-      .put("administrativeNotes", administrativeNotes);
+      .put("administrativeNotes", administrativeNotes)
+      .put("seriesStatements", series);
 
     var location = (item.canFloatThroughCheckInServicePoint() && item.isInStatus(ItemStatus.AVAILABLE)) ?
       item.getFloatDestinationLocation() : item.getLocation();
 
     if (location != null) {
-      log.info("createItemContext:: location is not null");
+      log.debug("createItemContext:: location is not null");
 
       itemContext
         .put("effectiveLocationSpecific", location.getName())
@@ -55,14 +57,14 @@ public class InventoryMapper {
 
       var primaryServicePoint = location.getPrimaryServicePoint();
       if (primaryServicePoint != null) {
-        log.info("createItemContext:: primaryServicePoint is not null");
+        log.debug("createItemContext:: primaryServicePoint is not null");
         itemContext.put("effectiveLocationPrimaryServicePointName", primaryServicePoint.getName());
       }
     }
 
     CallNumberComponents callNumberComponents = item.getCallNumberComponents();
     if (callNumberComponents != null) {
-      log.info("createItemContext:: callNumberComponents is not null");
+      log.debug("createItemContext:: callNumberComponents is not null");
       itemContext
         .put("callNumber", callNumberComponents.getCallNumber())
         .put("callNumberPrefix", callNumberComponents.getPrefix())
@@ -88,6 +90,7 @@ public class InventoryMapper {
       .put("datesOfPublication", instance.getPublication().stream().
         map(Publication::getDateOfPublication).collect(joining("; ")))
       .put("editions", String.join("; ", instance.getEditions()))
+      .put("seriesStatements", instance.getSeriesStatementValues().collect(joining("; '")))
       .put("physicalDescriptions", String.join("; ", instance.getPhysicalDescriptions()));
   }
 }

--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -28,8 +28,10 @@ import org.folio.circulation.domain.Loan;
 import org.folio.circulation.domain.RequestQueue;
 import org.folio.circulation.domain.RequestStatus;
 import org.folio.circulation.domain.RequestType;
+import org.folio.circulation.domain.TimePeriod;
 import org.folio.circulation.resources.RenewalValidator;
 import org.folio.circulation.rules.AppliedRuleConditions;
+import org.folio.circulation.storage.mappers.TimePeriodMapper;
 import org.folio.circulation.support.ValidationErrorFailure;
 import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.results.Result;
@@ -50,6 +52,7 @@ public class LoanPolicy extends Policy {
   private static final String ALTERNATE_RENEWAL_LOAN_PERIOD_KEY = "alternateRenewalLoanPeriod";
   private static final String ALLOW_RECALLS_TO_EXTEND_OVERDUE_LOANS = "allowRecallsToExtendOverdueLoans";
   private static final String ALTERNATE_RECALL_RETURN_INTERVAL = "alternateRecallReturnInterval";
+  private static final String FOR_USE_AT_LOCATION = "forUseAtLocation";
 
   private static final String INTERVAL_ID = "intervalId";
   private static final String DURATION = "duration";
@@ -215,7 +218,7 @@ public class LoanPolicy extends Policy {
         (!request.hasItem() || itemId.equals(request.getItemId())));
   }
 
-  private JsonObject getLoansPolicy() {
+  public JsonObject getLoansPolicy() {
     return representation.getJsonObject(LOANS_POLICY_KEY);
   }
 
@@ -343,6 +346,30 @@ public class LoanPolicy extends Policy {
 
   public boolean isNotLoanable() {
     return !isLoanable();
+  }
+
+  public boolean isForUseAtLocation() {
+    return getBooleanProperty(getLoansPolicy(), FOR_USE_AT_LOCATION);
+  }
+
+  public Period getHoldShelfExpiryPeriodForUseAtLocation() {
+    if (isForUseAtLocation()) {
+      JsonObject holdShelfExpiryPeriod = getObjectProperty(getLoansPolicy(), "holdShelfExpiryPeriodForUseAtLocation");
+      if (holdShelfExpiryPeriod != null) {
+        return Period.from(holdShelfExpiryPeriod);
+      }
+    }
+    return null;
+  }
+
+  public TimePeriod getHoldShelfExpiryTimePeriodForUseAtLocation() {
+    if (isForUseAtLocation()) {
+      JsonObject holdShelfExpiryPeriod = getObjectProperty(getLoansPolicy(), "holdShelfExpiryPeriodForUseAtLocation");
+      if (holdShelfExpiryPeriod != null) {
+        return new TimePeriodMapper().toDomain(holdShelfExpiryPeriod);
+      }
+    }
+    return null;
   }
 
   public DueDateManagement getDueDateManagement() {

--- a/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
+++ b/src/main/java/org/folio/circulation/domain/representations/ItemSummaryRepresentation.java
@@ -25,7 +25,7 @@ public class ItemSummaryRepresentation {
     log.debug("createItemSummary:: parameters item: {}", item);
 
     if (item == null || item.isNotFound()) {
-      log.info("createItemSummary:: item is null or not found");
+      log.debug("createItemSummary:: item is null or not found");
       return new JsonObject();
     }
 
@@ -46,6 +46,7 @@ public class ItemSummaryRepresentation {
     write(itemSummary, "volume", item.getVolume());
     write(itemSummary, "copyNumber", item.getCopyNumber());
     write(itemSummary, "editions", item.getEditions());
+    write(itemSummary, "seriesStatements", item.getSeriesStatementValues());
     write(itemSummary, "datesOfPublication", item.getDatesOfPublication());
     write(itemSummary, "physicalDescriptions", item.getPhysicalDescriptions());
     write(itemSummary, "administrativeNotes", item.getAdministrativeNotes());
@@ -58,7 +59,7 @@ public class ItemSummaryRepresentation {
       .put("name", item.getStatus().getValue());
 
     if (Objects.nonNull(item.getStatus().getDate())){
-      log.info("createItemSummary:: item.getStatus().getDate() is not null");
+      log.debug("createItemSummary:: item.getStatus().getDate() is not null");
       status.put("date", item.getStatus().getDate());
     }
 
@@ -71,7 +72,7 @@ public class ItemSummaryRepresentation {
       = item.getInTransitDestinationServicePoint();
 
     if (inTransitDestinationServicePoint != null) {
-      log.info("createItemSummary:: inTransitDestinationServicePoint is not null");
+      log.debug("createItemSummary:: inTransitDestinationServicePoint is not null");
       final JsonObject destinationServicePointSummary = new JsonObject();
 
       write(destinationServicePointSummary, "id",
@@ -90,14 +91,14 @@ public class ItemSummaryRepresentation {
       itemSummary.put("location", new JsonObject()
         .put("name", item.getFloatDestinationLocation().getName()));
     } else if (location != null) {
-      log.info("createItemSummary:: location is not null");
+      log.debug("createItemSummary:: location is not null");
       itemSummary.put("location", new JsonObject()
         .put("name", location.getName()));
     }
 
     writeByPath(itemSummary, item.getMaterialTypeName(), "materialType", "name");
 
-    log.info("createItemSummary:: result {}", itemSummary);
+    log.debug("createItemSummary:: result {}", itemSummary);
     return itemSummary;
   }
 }

--- a/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
@@ -34,7 +34,14 @@ public class LoanProperties {
   public static final String DATE_LOST_ITEM_SHOULD_BE_BILLED = "dateLostItemShouldBeBilled";
   public static final String METADATA = "metadata";
   public static final String UPDATED_BY_USER_ID = "updatedByUserId";
-
+  public static final String FOR_USE_AT_LOCATION = "forUseAtLocation";
+  public static final String AT_LOCATION_USE_STATUS = "status";
+  public static final String AT_LOCATION_USE_STATUS_DATE = "statusDate";
+  public static final String AT_LOCATION_USE_EXPIRY_DATE = "holdShelfExpirationDate";
+  public static final String USAGE_STATUS_IN_USE = "In use";
+  public static final String USAGE_STATUS_HELD = "Held";
+  public static final String USAGE_STATUS_RETURNED = "Returned";
+  public static final String CREATED_DATE = "createdDate";
   public static final String REMINDERS = "reminders";
   public static final String LAST_FEE_BILLED = "lastFeeBilled";
   public static final String BILL_NUMBER = "number";

--- a/src/main/java/org/folio/circulation/domain/representations/logs/LogContextActionResolver.java
+++ b/src/main/java/org/folio/circulation/domain/representations/logs/LogContextActionResolver.java
@@ -7,8 +7,10 @@ import static org.folio.circulation.domain.LoanAction.CLAIMED_RETURNED;
 import static org.folio.circulation.domain.LoanAction.CLOSED_LOAN;
 import static org.folio.circulation.domain.LoanAction.DECLARED_LOST;
 import static org.folio.circulation.domain.LoanAction.DUE_DATE_CHANGED;
+import static org.folio.circulation.domain.LoanAction.HELD_FOR_USE_AT_LOCATION;
 import static org.folio.circulation.domain.LoanAction.ITEM_AGED_TO_LOST;
 import static org.folio.circulation.domain.LoanAction.MISSING;
+import static org.folio.circulation.domain.LoanAction.PICKED_UP_FOR_USE_AT_LOCATION;
 import static org.folio.circulation.domain.LoanAction.RECALLREQUESTED;
 import static org.folio.circulation.domain.LoanAction.RENEWED;
 import static org.folio.circulation.domain.LoanAction.RENEWED_THROUGH_OVERRIDE;
@@ -39,6 +41,8 @@ public class LogContextActionResolver {
     loanLogActions.put(DUE_DATE_CHANGED.getValue(), "Changed due date");
     loanLogActions.put(PATRON_INFO_ADDED.getValue(), "Patron info added");
     loanLogActions.put(STAFF_INFO_ADDED.getValue(), "Staff info added");
+    loanLogActions.put(HELD_FOR_USE_AT_LOCATION.getValue(),"Held for use at location");
+    loanLogActions.put(PICKED_UP_FOR_USE_AT_LOCATION.getValue(), "Picked up for use at location");
   }
 
   public static String resolveAction(String action) {

--- a/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInByBarcodeResource.java
@@ -105,6 +105,7 @@ public class CheckInByBarcodeResource extends Resource {
         processAdapter::findSingleOpenLoan, CheckInContext::withLoan))
       .thenComposeAsync(findLoanResult -> findLoanResult.combineAfter(
         processAdapter::checkInLoan, CheckInContext::withLoan))
+      .thenApply(r -> r.map(processAdapter::markReturnedIfForUseAtLocation))
       .thenComposeAsync(checkInLoan -> checkInLoan.combineAfter(
         processAdapter::updateRequestQueue, CheckInContext::withRequestQueue))
         .thenComposeAsync(r -> r.after(processAdapter::findFulfillableRequest))

--- a/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
+++ b/src/main/java/org/folio/circulation/resources/CheckInProcessAdapter.java
@@ -1,6 +1,7 @@
 package org.folio.circulation.resources;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.circulation.domain.representations.LoanProperties.USAGE_STATUS_RETURNED;
 import static org.folio.circulation.support.results.Result.succeeded;
 
 import java.lang.invoke.MethodHandles;
@@ -10,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.Environment;
 import org.folio.circulation.domain.CheckInContext;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Location;
@@ -272,6 +274,16 @@ class CheckInProcessAdapter {
         checkInContext.getItem(),
         checkInContext.getRequestQueue(),
         checkInContext.getCheckInRequest()));
+  }
+
+  CheckInContext markReturnedIfForUseAtLocation(CheckInContext checkInContext) {
+    log.debug("markReturnedIfForUseAtLocation:: parameters checkInContext: {}", checkInContext);
+
+    Loan loan = checkInContext.getLoan();
+    if (Environment.getForUseAtLocationEnabled() && loan != null && loan.isForUseAtLocation()) {
+      loan.changeStatusOfUsageAtLocation(USAGE_STATUS_RETURNED);
+    }
+    return checkInContext;
   }
 
   public CompletableFuture<Result<CheckInContext>> logCheckInOperation(

--- a/src/main/java/org/folio/circulation/resources/foruseatlocation/HoldByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/resources/foruseatlocation/HoldByBarcodeRequest.java
@@ -1,0 +1,104 @@
+package org.folio.circulation.resources.foruseatlocation;
+
+import io.vertx.core.json.JsonObject;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.With;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.Environment;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.ServicePoint;
+import org.folio.circulation.domain.representations.ItemSummaryRepresentation;
+import org.folio.circulation.support.BadRequestFailure;
+import org.folio.circulation.support.HttpFailure;
+import org.folio.circulation.support.results.Result;
+
+import java.lang.invoke.MethodHandles;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.results.Result.succeeded;
+
+@Getter
+@AllArgsConstructor
+@ToString
+public class HoldByBarcodeRequest {
+  private static final String ITEM_BARCODE = "itemBarcode";
+  private static final String SERVICE_POINT_ID = "servicePointId";
+  private final String itemBarcode;
+  @With
+  private Loan loan;
+  @With
+  private ServicePoint servicePoint;
+  @With
+  private ZonedDateTime holdShelfExpirationDate;
+  @With
+  private ZoneId tenantTimeZone;
+
+
+  public HoldByBarcodeRequest(String itemBarcode) {
+    this.itemBarcode = itemBarcode;
+  }
+
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+
+  static Result<HoldByBarcodeRequest> buildRequestFrom(JsonObject json) {
+    final String itemBarcode = getProperty(json, ITEM_BARCODE);
+    if (isBlank(itemBarcode)) {
+      String message = "Request to put item on hold shelf must have an item barcode";
+      log.warn("Missing information:: {}", message);
+      return failedValidation(message, ITEM_BARCODE, null);
+    }
+    return succeeded(new HoldByBarcodeRequest(itemBarcode));
+  }
+
+
+  static Result<Boolean> loanIsNull(HoldByBarcodeRequest request) {
+    return Result.succeeded(request.getLoan() == null);
+  }
+
+  static Result<Boolean> loanIsNotForUseAtLocation(HoldByBarcodeRequest request) {
+    return Result.succeeded(!request.getLoan().isForUseAtLocation());
+  }
+
+  static Supplier<HttpFailure> noOpenLoanFailure(HoldByBarcodeRequest request) {
+    String message = "No open loan found for the item barcode.";
+    log.warn("noOpenLoanFailure:: {}", message);
+    return () -> new BadRequestFailure(format(message + " (%s)", request.getItemBarcode()));
+  }
+
+  static Supplier<HttpFailure> loanIsNotForUseAtLocationFailure(HoldByBarcodeRequest request) {
+    String message = "The loan is open but is not for use at location.";
+    log.warn("loanIsNotForUseAtLocationFailure:: {}", message);
+    return () -> new BadRequestFailure(format(message + ", item barcode (%s)", request.getItemBarcode()));
+  }
+
+  Result<Boolean> forUseAtLocationIsNotEnabled() {
+    return Result.succeeded(!Environment.getForUseAtLocationEnabled());
+  }
+
+  static Supplier<HttpFailure> forUseAtLocationIsNotEnabledFailure() {
+    String message = "For-use-at-location is not enabled for this tenant.";
+    log.warn("forUseAtLocationIsNotEnabledFailure:: {}", message);
+    return () -> new BadRequestFailure(format(message));
+  }
+
+  public JsonObject responseBody() {
+    JsonObject body = new JsonObject();
+    JsonObject loanJson = loan.asJson();
+    JsonObject itemJson = new ItemSummaryRepresentation().createItemSummary(loan.getItem());
+
+    loanJson.put("item", itemJson);
+    body.put("loan", loanJson);
+
+    return body;
+  }
+
+}

--- a/src/main/java/org/folio/circulation/resources/foruseatlocation/HoldByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/foruseatlocation/HoldByBarcodeResource.java
@@ -1,0 +1,193 @@
+package org.folio.circulation.resources.foruseatlocation;
+
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.LoanAction;
+import org.folio.circulation.domain.TimePeriod;
+import org.folio.circulation.domain.policy.ExpirationDateManagement;
+import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.domain.policy.library.ClosedLibraryStrategy;
+import org.folio.circulation.domain.representations.logs.LogEventType;
+import org.folio.circulation.infrastructure.storage.CalendarRepository;
+import org.folio.circulation.infrastructure.storage.ConfigurationRepository;
+import org.folio.circulation.infrastructure.storage.ServicePointRepository;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
+import org.folio.circulation.resources.Resource;
+import org.folio.circulation.resources.handlers.error.CirculationErrorHandler;
+import org.folio.circulation.resources.handlers.error.OverridingErrorHandler;
+import org.folio.circulation.services.EventPublisher;
+import org.folio.circulation.storage.ItemByBarcodeInStorageFinder;
+import org.folio.circulation.storage.SingleOpenLoanForItemInStorageFinder;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.RouteRegistration;
+import org.folio.circulation.support.http.OkapiPermissions;
+import org.folio.circulation.support.http.server.HttpResponse;
+import org.folio.circulation.support.http.server.JsonHttpResponse;
+import org.folio.circulation.support.http.server.WebContext;
+import org.folio.circulation.support.results.Result;
+import org.folio.circulation.support.utils.ClockUtil;
+
+import java.lang.invoke.MethodHandles;
+import java.time.ZonedDateTime;
+import java.util.concurrent.CompletableFuture;
+
+import static org.folio.circulation.domain.policy.library.ClosedLibraryStrategyUtils.determineClosedLibraryStrategyForHoldShelfExpirationDate;
+import static org.folio.circulation.domain.representations.LoanProperties.*;
+import static org.folio.circulation.resources.foruseatlocation.HoldByBarcodeRequest.forUseAtLocationIsNotEnabledFailure;
+import static org.folio.circulation.resources.foruseatlocation.HoldByBarcodeRequest.loanIsNotForUseAtLocationFailure;
+import static org.folio.circulation.resources.foruseatlocation.HoldByBarcodeRequest.noOpenLoanFailure;
+import static org.folio.circulation.resources.handlers.error.CirculationErrorType.FAILED_TO_FIND_SINGLE_OPEN_LOAN;
+
+public class HoldByBarcodeResource extends Resource {
+  private static final String rootPath = "/circulation/hold-by-barcode-for-use-at-location";
+
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+
+  public HoldByBarcodeResource(HttpClient client) {
+    super(client);
+  }
+
+  @Override
+  public void register(Router router) {
+    new RouteRegistration(rootPath, router).create(this::markHeld);
+  }
+
+  private void markHeld(RoutingContext routingContext) {
+    final WebContext webContext = new WebContext(routingContext);
+    final Clients clients = Clients.create(webContext, client);
+    final OkapiPermissions okapiPermissions = OkapiPermissions.from(webContext.getHeaders());
+    final CirculationErrorHandler errorHandler = new OverridingErrorHandler(okapiPermissions);
+    final var itemRepository = new ItemRepository(clients);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final var loanPolicyRepository = new LoanPolicyRepository(clients);
+    final var servicePointRepository = new ServicePointRepository(clients);
+    final ConfigurationRepository configurationRepository = new ConfigurationRepository(clients);
+    final var calendarRepository = new CalendarRepository(clients);
+    final EventPublisher eventPublisher = new EventPublisher(routingContext);
+
+    JsonObject requestBodyAsJson = routingContext.body().asJsonObject();
+    log.debug("markHeld:: request body: {}", requestBodyAsJson);
+
+
+    HoldByBarcodeRequest.buildRequestFrom(requestBodyAsJson)
+      .after(request -> findLoan(request, loanRepository, itemRepository, userRepository, errorHandler))
+      .thenApply(HoldByBarcodeResource::failWhenForUseAtLocationIsNotEnabled)
+      .thenApply(HoldByBarcodeResource::failWhenOpenLoanNotFoundForItem)
+      .thenApply(HoldByBarcodeResource::failWhenOpenLoanIsNotForUseAtLocation)
+      .thenCompose(request -> request.after(req -> findPolicy(req, loanPolicyRepository)))
+      .thenCompose(request -> request.after(req -> findServicePoint(req, servicePointRepository)))
+      .thenCompose(request -> request.after(req -> findTenantTimeZone(req, configurationRepository)))
+      .thenCompose(request -> request.after(req -> findHoldShelfExpirationDate(req, calendarRepository)))
+      .thenApply(this::setStatusToHeldWithExpirationDate)
+      .thenApply(this::setActionToHeld)
+      .thenCompose(request -> request.after(req -> updateLoan(req, loanRepository)))
+      .thenCompose(request -> request.after(req -> publishEvent(req, eventPublisher)))
+      .thenApply(request -> request.map(req -> toResponse(req.responseBody())))
+      .thenAccept(webContext::writeResultToHttpResponse);
+  }
+
+  protected CompletableFuture<Result<HoldByBarcodeRequest>> findLoan(HoldByBarcodeRequest request,
+    LoanRepository loanRepository, ItemRepository itemRepository, UserRepository userRepository,
+    CirculationErrorHandler errorHandler) {
+    log.debug("findLoan:: main parameter: request {}", request);
+    final ItemByBarcodeInStorageFinder itemFinder =
+      new ItemByBarcodeInStorageFinder(itemRepository);
+
+    final SingleOpenLoanForItemInStorageFinder loanFinder =
+      new SingleOpenLoanForItemInStorageFinder(loanRepository, userRepository, false);
+
+    return itemFinder.findItemByBarcode(request.getItemBarcode())
+      .thenCompose(itemResult -> itemResult.after(loanFinder::findSingleOpenLoan)
+        .thenApply(loanResult -> loanResult.map(request::withLoan))
+        .thenApply(r -> errorHandler.handleValidationResult(r, FAILED_TO_FIND_SINGLE_OPEN_LOAN, request))
+      );
+  }
+
+  protected CompletableFuture<Result<HoldByBarcodeRequest>> findPolicy(HoldByBarcodeRequest request, LoanPolicyRepository loanPolicies) {
+    return loanPolicies.findPolicyForLoan(request.getLoan())
+      .thenApply(loanResult -> loanResult.map(request::withLoan));
+  }
+
+  protected CompletableFuture<Result<HoldByBarcodeRequest>> findServicePoint(HoldByBarcodeRequest request, ServicePointRepository servicePoints) {
+    return servicePoints.getServicePointById(request.getLoan().getCheckoutServicePointId())
+      .thenApply(servicePoint -> servicePoint.map(request::withServicePoint));
+  }
+
+  protected CompletableFuture<Result<HoldByBarcodeRequest>> findTenantTimeZone(HoldByBarcodeRequest request, ConfigurationRepository configurationRepository) {
+    return configurationRepository.findTimeZoneConfiguration()
+      .thenApply(zoneId -> zoneId.map(request::withTenantTimeZone));
+  }
+
+  protected CompletableFuture<Result<HoldByBarcodeRequest>> findHoldShelfExpirationDate(HoldByBarcodeRequest request, CalendarRepository calendars) {
+    log.debug("findHoldShelfExpirationDate:: parameters: request {} calendar repository {}", request, calendars);
+    Loan loan = request.getLoan();
+    Period expiry = loan.getLoanPolicy().getHoldShelfExpiryPeriodForUseAtLocation();
+    if (expiry == null) {
+      log.warn("No hold shelf expiry period for use at location defined in loan policy {}", loan.getLoanPolicy().getName());
+      return Result.ofAsync(request);
+    } else {
+      final ZonedDateTime baseExpirationDate = expiry.plusDate(ClockUtil.getZonedDateTime());
+      TimePeriod timePeriod = loan.getLoanPolicy().getHoldShelfExpiryTimePeriodForUseAtLocation();
+      ExpirationDateManagement expirationDateManagement = request.getServicePoint().getHoldShelfClosedLibraryDateManagement();
+      ClosedLibraryStrategy strategy = determineClosedLibraryStrategyForHoldShelfExpirationDate(
+        expirationDateManagement, baseExpirationDate, request.getTenantTimeZone(), timePeriod);
+
+      return calendars.lookupOpeningDays(baseExpirationDate.withZoneSameInstant(request.getTenantTimeZone()).toLocalDate(),
+          request.getServicePoint().getId())
+        .thenApply(adjacentOpeningDaysResult -> strategy.calculateDueDate(baseExpirationDate, adjacentOpeningDaysResult.value()))
+        .thenApply(dateTime -> dateTime.map(request::withHoldShelfExpirationDate));
+    }
+  }
+
+  private Result<HoldByBarcodeRequest> setStatusToHeldWithExpirationDate(Result<HoldByBarcodeRequest> request) {
+    log.debug("setStatusToHeldWithExpirationDate:: parameters: request {}", request);
+    return request.map (
+      req -> req.withLoan(req.getLoan().changeStatusOfUsageAtLocation(USAGE_STATUS_HELD, req.getHoldShelfExpirationDate())));
+  }
+
+
+  private Result<HoldByBarcodeRequest> setActionToHeld(Result<HoldByBarcodeRequest> request) {
+    log.debug("setActionToHeld:: parameters: request {}", request);
+    return request.map(req -> req.withLoan(req.getLoan().withAction(LoanAction.HELD_FOR_USE_AT_LOCATION)));
+  }
+
+  private CompletableFuture<Result<HoldByBarcodeRequest>> updateLoan(HoldByBarcodeRequest request, LoanRepository loanRepository) {
+    log.debug("updateLoan:: loan parameter: {}", request.getLoan().asJson());
+    return loanRepository.updateLoan(request.getLoan())
+      .thenApply(loanResult -> loanResult.map(request::withLoan));
+  }
+
+  private CompletableFuture<Result<HoldByBarcodeRequest>> publishEvent (HoldByBarcodeRequest request, EventPublisher eventPublisher) {
+    return eventPublisher.publishUsageAtLocationEvent(request.getLoan(), LogEventType.LOAN)
+      .thenApply(loanResult -> loanResult.map(loan -> request));
+  }
+
+  private static Result<HoldByBarcodeRequest> failWhenOpenLoanNotFoundForItem(Result<HoldByBarcodeRequest> request) {
+    log.warn("failWhenOpenLoanNotFoundForItem");
+    return request.failWhen(HoldByBarcodeRequest::loanIsNull, req -> noOpenLoanFailure(req).get());
+  }
+
+  private static Result<HoldByBarcodeRequest> failWhenOpenLoanIsNotForUseAtLocation (Result<HoldByBarcodeRequest> request) {
+    log.warn("failWhenOpenLoanIsNotForUseAtLocation");
+    return request.failWhen(HoldByBarcodeRequest::loanIsNotForUseAtLocation, req -> loanIsNotForUseAtLocationFailure(req).get());
+  }
+
+  private static Result<HoldByBarcodeRequest> failWhenForUseAtLocationIsNotEnabled (Result<HoldByBarcodeRequest> request) {
+    log.warn("failWhenForUseAtLocationIsNotEnabled:: cannot hold by barcode, for-use-at-location is not enabled for this tenant");
+    return request.failWhen(HoldByBarcodeRequest::forUseAtLocationIsNotEnabled, req -> forUseAtLocationIsNotEnabledFailure().get());
+  }
+  private HttpResponse toResponse(JsonObject body) {
+    return JsonHttpResponse.ok(body);
+  }
+
+
+}

--- a/src/main/java/org/folio/circulation/resources/foruseatlocation/PickupByBarcodeRequest.java
+++ b/src/main/java/org/folio/circulation/resources/foruseatlocation/PickupByBarcodeRequest.java
@@ -1,0 +1,50 @@
+package org.folio.circulation.resources.foruseatlocation;
+
+import io.vertx.core.json.JsonObject;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.circulation.support.results.Result;
+
+import java.lang.invoke.MethodHandles;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.folio.circulation.support.ValidationErrorFailure.failedValidation;
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+import static org.folio.circulation.support.results.Result.succeeded;
+
+@Getter
+@AllArgsConstructor
+@ToString
+public class PickupByBarcodeRequest {
+  private static final String ITEM_BARCODE = "itemBarcode";
+  private static final String USER_BARCODE = "userBarcode";
+
+  private final String itemBarcode;
+  private final String userBarcode;
+
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+
+  static Result<PickupByBarcodeRequest> buildRequestFrom(JsonObject json) {
+    final String itemBarcode = getProperty(json, ITEM_BARCODE);
+
+    if (isBlank(itemBarcode)) {
+      String message = "Request to pick up from hold shelf must have an item barcode";
+      log.warn("Missing information:: {}, parameter: {}", message, json);
+      return failedValidation(message, ITEM_BARCODE, null);
+    }
+
+    final String userBarcode = getProperty(json, USER_BARCODE);
+
+    if (isBlank(userBarcode)) {
+      String message = "Request to pick up from hold shelf must have a user barcode";
+      log.warn("Missing information:: {}, parameter: {}", message, json);
+      return failedValidation(message, USER_BARCODE, null);
+    }
+
+    return succeeded(new PickupByBarcodeRequest(itemBarcode, userBarcode));
+  }
+}
+

--- a/src/main/java/org/folio/circulation/resources/foruseatlocation/PickupByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/foruseatlocation/PickupByBarcodeResource.java
@@ -1,0 +1,145 @@
+package org.folio.circulation.resources.foruseatlocation;
+
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.Environment;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.LoanAction;
+import org.folio.circulation.domain.representations.logs.LogEventType;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
+import org.folio.circulation.resources.Resource;
+import org.folio.circulation.resources.handlers.error.CirculationErrorHandler;
+import org.folio.circulation.resources.handlers.error.OverridingErrorHandler;
+import org.folio.circulation.services.EventPublisher;
+import org.folio.circulation.storage.SingleOpenLoanByUserAndItemBarcodeFinder;
+import org.folio.circulation.support.BadRequestFailure;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.HttpFailure;
+import org.folio.circulation.support.RouteRegistration;
+import org.folio.circulation.support.http.OkapiPermissions;
+import org.folio.circulation.support.http.server.HttpResponse;
+import org.folio.circulation.support.http.server.JsonHttpResponse;
+import org.folio.circulation.support.http.server.WebContext;
+import org.folio.circulation.support.results.Result;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+import static org.folio.circulation.domain.representations.LoanProperties.USAGE_STATUS_IN_USE;
+import static org.folio.circulation.resources.foruseatlocation.PickupByBarcodeRequest.buildRequestFrom;
+
+import static org.folio.circulation.resources.handlers.error.CirculationErrorType.FAILED_TO_FIND_SINGLE_OPEN_LOAN;
+
+public class PickupByBarcodeResource extends Resource {
+
+  private static final String rootPath = "/circulation/pickup-by-barcode-for-use-at-location";
+
+  private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+
+  public PickupByBarcodeResource(HttpClient client) {
+    super(client);
+  }
+
+  @Override
+  public void register(Router router) {
+    new RouteRegistration(rootPath, router).create(this::markInUse);
+  }
+
+  private void markInUse(RoutingContext routingContext) {
+    final WebContext webContext = new WebContext(routingContext);
+    final Clients clients = Clients.create(webContext, client);
+    final OkapiPermissions okapiPermissions = OkapiPermissions.from(webContext.getHeaders());
+    final CirculationErrorHandler errorHandler = new OverridingErrorHandler(okapiPermissions);
+    final var itemRepository = new ItemRepository(clients);
+    final var userRepository = new UserRepository(clients);
+    final var loanRepository = new LoanRepository(clients, itemRepository, userRepository);
+    final EventPublisher eventPublisher = new EventPublisher(routingContext);
+
+    JsonObject requestBodyAsJson = routingContext.body().asJsonObject();
+    log.debug("markInUse:: request body: {}", requestBodyAsJson);
+
+    Result<PickupByBarcodeRequest> pickupByBarcodeRequest = buildRequestFrom(requestBodyAsJson);
+
+    pickupByBarcodeRequest
+      .after(request -> findLoan(request, loanRepository, itemRepository, userRepository, errorHandler))
+      .thenApply(PickupByBarcodeResource::failWhenForUseAtLocationIsNotEnabled)
+      .thenApply(loan -> failWhenOpenLoanForItemAndUserNotFound(loan, pickupByBarcodeRequest.value()))
+      .thenApply(loan -> failWhenOpenLoanIsNotForUseAtLocation(loan, pickupByBarcodeRequest.value()))
+      .thenApply(loanResult -> loanResult.map(loan ->
+        loan.changeStatusOfUsageAtLocation(USAGE_STATUS_IN_USE)
+          .withAction(LoanAction.PICKED_UP_FOR_USE_AT_LOCATION)))
+      .thenCompose(loanResult -> loanResult.after(
+        loan -> loanRepository.updateLoan(loanResult.value())))
+      .thenCompose(loanResult -> loanResult.after(
+        loan -> eventPublisher.publishUsageAtLocationEvent(loan, LogEventType.LOAN)))
+      .thenApply(loanResult -> loanResult.map(Loan::asJson))
+      .thenApply(jsonResult -> jsonResult.map(this::toResponse))
+      .thenAccept(webContext::writeResultToHttpResponse);
+  }
+
+  protected CompletableFuture<Result<Loan>> findLoan(PickupByBarcodeRequest request,
+    LoanRepository loanRepository, ItemRepository itemRepository, UserRepository userRepository,
+    CirculationErrorHandler errorHandler) {
+    log.debug("findLoan:: main parameter: request {}", request);
+    final SingleOpenLoanByUserAndItemBarcodeFinder loanFinder
+      = new SingleOpenLoanByUserAndItemBarcodeFinder(loanRepository,
+      itemRepository, userRepository);
+
+    return loanFinder.findLoan(request.getItemBarcode(), request.getUserBarcode())
+        .thenApply(r -> errorHandler.handleValidationResult(r, FAILED_TO_FIND_SINGLE_OPEN_LOAN, r.value()));
+  }
+
+  private static Result<Loan> failWhenForUseAtLocationIsNotEnabled (Result<Loan> loanResult) {
+    return loanResult.failWhen(PickupByBarcodeResource::forUseAtLocationIsNotEnabled, loan -> forUseAtLocationIsNotEnabledFailure().get());
+  }
+  private static Result<Loan> failWhenOpenLoanForItemAndUserNotFound (Result<Loan> loanResult, PickupByBarcodeRequest request) {
+    return loanResult.failWhen(PickupByBarcodeResource::loanIsNull, loan -> noOpenLoanFailure(request).get());
+  }
+
+  private static Result<Loan> failWhenOpenLoanIsNotForUseAtLocation (Result<Loan> loanResult, PickupByBarcodeRequest request) {
+    return loanResult.failWhen(PickupByBarcodeResource::loanIsNotForUseAtLocation, loan -> loanIsNotForUseAtLocationFailure(request).get());
+  }
+
+  private static Result<Boolean> loanIsNull (Loan loan) {
+    return Result.succeeded(loan == null);
+  }
+
+  private static Result<Boolean> loanIsNotForUseAtLocation(Loan loan) {
+    return Result.succeeded(!loan.isForUseAtLocation());
+  }
+
+  private static Result<Boolean> forUseAtLocationIsNotEnabled(Loan loan) {
+    return Result.succeeded(!Environment.getForUseAtLocationEnabled());
+  }
+
+  private static Supplier<HttpFailure> noOpenLoanFailure(PickupByBarcodeRequest request) {
+    String message =  "No open loan found for item barcode and user ";
+    log.warn("noOpenLoanFailure:: {}", message);
+    return () -> new BadRequestFailure(format(message + " (%s and %s).", request.getItemBarcode(), request.getUserBarcode()));
+  }
+
+  private static Supplier<HttpFailure> loanIsNotForUseAtLocationFailure(PickupByBarcodeRequest request) {
+    String message = "The loan is open but is not for use at location";
+    log.warn("loanIsNotForUseAtLocationFailure:: {}", message);
+    return () -> new BadRequestFailure(format(message + ", item barcode (%s)", request.getItemBarcode()));
+  }
+
+  private static Supplier<HttpFailure> forUseAtLocationIsNotEnabledFailure() {
+    String message = "For-use-at-location is not enabled for this tenant.";
+    log.warn("forUseAtLocationIsNotEnabledFailure:: {}", message);
+    return () -> new BadRequestFailure(format(message));
+  }
+
+  private HttpResponse toResponse(JsonObject body) {
+    return JsonHttpResponse.ok(body,
+      format("/circulation/loans/%s", body.getString("id")));
+  }
+}

--- a/src/main/java/org/folio/circulation/services/EventPublisher.java
+++ b/src/main/java/org/folio/circulation/services/EventPublisher.java
@@ -377,6 +377,12 @@ public class EventPublisher {
     return publishLogRecord(noticeLogContext.withDate(getZonedDateTime()).asJson(), eventType);
   }
 
+  public CompletableFuture<Result<Loan>> publishUsageAtLocationEvent(Loan loan, LogEventType eventType) {
+    return publishLogRecord((LoanLogContext.from(loan))
+      .withDescription(LogContextActionResolver.resolveAction(loan.getAction())).asJson(), eventType)
+      .thenApply(r -> succeeded(loan));
+  }
+
   public CompletableFuture<Result<Void>> publishNoticeErrorLogEvent(
     NoticeLogContext noticeLogContext, HttpFailure error) {
 

--- a/src/main/java/org/folio/circulation/storage/mappers/InstanceMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/InstanceMapper.java
@@ -13,6 +13,7 @@ import org.folio.circulation.domain.Instance;
 import org.folio.circulation.domain.Publication;
 
 import io.vertx.core.json.JsonObject;
+import org.folio.circulation.domain.SeriesStatement;
 
 public class InstanceMapper {
   public Instance toDomain(JsonObject representation) {
@@ -21,7 +22,7 @@ public class InstanceMapper {
       getProperty(representation, "title"),
       mapIdentifiers(representation), mapContributors(representation),
       mapPublication(representation), mapEditions(representation),
-      mapPhysicalDescriptions(representation));
+      mapPhysicalDescriptions(representation), mapSeries(representation));
   }
 
   private List<Contributor> mapContributors(JsonObject representation) {
@@ -44,6 +45,10 @@ public class InstanceMapper {
       .stream()
       .map(String.class::cast)
       .collect(Collectors.toList());
+  }
+
+  private List<SeriesStatement> mapSeries(JsonObject representation) {
+    return mapToList(representation, "series", new SeriesMapper()::toDomain);
   }
 
 }

--- a/src/main/java/org/folio/circulation/storage/mappers/SeriesMapper.java
+++ b/src/main/java/org/folio/circulation/storage/mappers/SeriesMapper.java
@@ -1,0 +1,15 @@
+package org.folio.circulation.storage.mappers;
+
+import io.vertx.core.json.JsonObject;
+import org.folio.circulation.domain.SeriesStatement;
+
+import static org.folio.circulation.support.json.JsonPropertyFetcher.getProperty;
+
+public class SeriesMapper {
+  public SeriesStatement toDomain(JsonObject representation) {
+
+    return new SeriesStatement(
+      getProperty(representation, "authorityId"),
+      getProperty(representation, "value"));
+  }
+}

--- a/src/test/java/api/loans/LoanAPITests.java
+++ b/src/test/java/api/loans/LoanAPITests.java
@@ -274,6 +274,9 @@ class LoanAPITests extends APITests {
 
     assertThat("Item has publication years",
       loan.getJsonObject("item").containsKey("datesOfPublication"), is(true));
+
+    assertThat("Item has series statement",
+      loan.getJsonObject("item").containsKey("seriesStatements"), is(true));
   }
 
   @Test

--- a/src/test/java/api/loans/LoansForUseAtLocationTests.java
+++ b/src/test/java/api/loans/LoansForUseAtLocationTests.java
@@ -1,0 +1,541 @@
+package api.loans;
+
+import api.support.APITests;
+import api.support.builders.*;
+import api.support.http.IndividualResource;
+import api.support.http.ItemResource;
+import api.support.http.UserResource;
+import io.vertx.core.json.JsonObject;
+import org.folio.Environment;
+import org.folio.circulation.domain.policy.ExpirationDateManagement;
+import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.support.http.client.Response;
+import org.hamcrest.core.Is;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.UUID;
+
+import static api.support.fixtures.CalendarExamples.*;
+import static api.support.fixtures.ItemExamples.basedUponSmallAngryPlanet;
+import static api.support.http.ResourceClient.forServicePoints;
+import static java.lang.Boolean.TRUE;
+import static java.time.ZoneOffset.UTC;
+import static org.folio.circulation.support.utils.DateTimeUtil.atEndOfDay;
+import static org.folio.circulation.support.utils.DateTimeUtil.atStartOfDay;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+public class LoansForUseAtLocationTests extends APITests {
+
+  private ItemResource item;
+  private UserResource borrower;
+
+  private static final String ENV_VAR_ENABLE_FOR_USE_AT_LOCATION = "ENABLE_FOR_USE_AT_LOCATION";
+
+
+  @BeforeEach
+  void beforeEach() {
+    Environment.MOCK_ENV.remove(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION);
+
+    HoldingBuilder holdingsBuilder = itemsFixture.applyCallNumberHoldings(
+      "CN",
+      "Prefix",
+      "Suffix",
+      Collections.singletonList("CopyNumbers"));
+
+    final IndividualResource homeLocation = locationsFixture.basedUponExampleLocation(
+      item -> item.withPrimaryServicePoint(UUID.fromString(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN)));
+
+    ItemBuilder itemBuilder = basedUponSmallAngryPlanet(
+      materialTypesFixture.book().getId(),
+      loanTypesFixture.canCirculate().getId())
+      .withPermanentLocation(homeLocation);
+
+    item = itemsFixture.basedUponSmallAngryPlanet(itemBuilder, holdingsBuilder);
+
+    borrower = usersFixture.steve();
+  }
+
+  @Test
+  void willSetAtLocationUsageStatusToInUseOnCheckoutIfEnabled() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true);
+
+    use(forUseAtLocationPolicyBuilder);
+
+    final IndividualResource response = checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    JsonObject loan = loansFixture.getLoanById(response.getId()).getJson();
+    JsonObject forUseAtLocation = loan.getJsonObject("forUseAtLocation");
+    assertThat("loan.forUseAtLocation",
+      forUseAtLocation, notNullValue());
+    assertThat("loan.forUseAtLocation.status",
+      forUseAtLocation.getString("status"), Is.is("In use"));
+  }
+
+  @Test
+  void willNotSetAtLocationUsageStatusOnCheckoutIfNotEnabled() {
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true);
+
+    use(forUseAtLocationPolicyBuilder);
+
+    final IndividualResource response = checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    JsonObject loan = loansFixture.getLoanById(response.getId()).getJson();
+    JsonObject forUseAtLocation = loan.getJsonObject("forUseAtLocation");
+    assertThat("loan.forUseAtLocation", forUseAtLocation, nullValue());
+  }
+
+
+  @Test
+  void willMarkItemHeldByBarcode() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    // Check item out and put it on hold at 2020-10-27 (two days before mock calendar starts)
+    ZonedDateTime dateOfHold = atStartOfDay(FIRST_DAY_OPEN.minusDays(2), UTC).plusHours(10).plusSeconds(10);
+    mockClockManagerToReturnFixedDateTime(dateOfHold);
+
+    Period holdShelfExpiryPeriod = Period.from(3, "Days");
+
+    forServicePoints().create(new ServicePointBuilder("Reading room", "RR",
+        "Circulation Desk -- Reading room").withPickupLocation(TRUE)
+        .withId(UUID.fromString(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN))
+        .withholdShelfClosedLibraryDateManagement(ExpirationDateManagement.KEEP_THE_CURRENT_DUE_DATE.name()));
+
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(holdShelfExpiryPeriod);
+    use(forUseAtLocationPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN));
+
+    Response holdResponse = holdForUseAtLocationFixture.holdForUseAtLocation(
+      new HoldByBarcodeRequestBuilder(item.getBarcode()));
+
+    JsonObject forUseAtLocation = holdResponse.getJson()
+      .getJsonObject("loan").getJsonObject("forUseAtLocation");
+
+    assertThat("loan.forUseAtLocation",
+      forUseAtLocation, notNullValue());
+    assertThat("loan.forUseAtLocation.status",
+      forUseAtLocation.getString("status"), Is.is("Held"));
+    assertThat("loan.forUseAtLocation.holdShelfExpirationDate",
+      forUseAtLocation.getString("holdShelfExpirationDate"), notNullValue());
+    assertThat("loan.forUseAtLocation.holdShelfExpirationDate",
+      forUseAtLocation.getString("holdShelfExpirationDate").replaceAll("\\.000",""),
+      Is.is(atEndOfDay(holdShelfExpiryPeriod.plusDate(dateOfHold),UTC).toString()));
+  }
+
+  @Test
+  void willSetHoldShelfExpiryToEndOfDayBeforeClosedDayOnPutOnHold() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    // Check item out and put it on hold at 2020-10-27 (two days before mock calendar starts)
+    ZonedDateTime dateOfHold = atStartOfDay(FIRST_DAY_OPEN.minusDays(2), UTC).plusHours(10).plusSeconds(10);
+    mockClockManagerToReturnFixedDateTime(dateOfHold);
+
+    Period holdShelfExpiryPeriod = Period.from(3, "Days");
+
+    forServicePoints().create(new ServicePointBuilder("Reading room", "RR",
+      "Circulation Desk -- Reading room").withPickupLocation(TRUE)
+      .withId(UUID.fromString(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN))
+      .withholdShelfClosedLibraryDateManagement(ExpirationDateManagement.MOVE_TO_THE_END_OF_THE_PREVIOUS_OPEN_DAY.name()));
+
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(holdShelfExpiryPeriod);
+    use(forUseAtLocationPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN));
+
+    JsonObject forUseAtLocation = holdForUseAtLocationFixture.holdForUseAtLocation(
+      new HoldByBarcodeRequestBuilder(item.getBarcode()))
+      .getJson().getJsonObject("loan").getJsonObject("forUseAtLocation");
+
+    ZonedDateTime expectedExpiryDateTime =
+      atEndOfDay(holdShelfExpiryPeriod
+        .plusDate(dateOfHold)
+        .minusDays(1),UTC);  // move back one day
+
+    assertThat("loan.forUseAtLocation.holdShelfExpirationDate",
+      forUseAtLocation.getString("holdShelfExpirationDate").replaceAll("\\.000",""),
+      Is.is(expectedExpiryDateTime.toString()));
+  }
+
+  @Test
+  void willSetHoldShelfExpiryToEndOfDayAfterClosedDayOnPutOnHold() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    // Check item out and put it on hold at 2020-10-27 (two days before mock calendar starts)
+    ZonedDateTime dateOfHold = atStartOfDay(FIRST_DAY_OPEN.minusDays(2), UTC).plusHours(10).plusSeconds(10);
+    mockClockManagerToReturnFixedDateTime(dateOfHold);
+
+    Period holdShelfExpiryPeriod = Period.from(3, "Days");
+
+    forServicePoints().create(new ServicePointBuilder("Reading room", "RR",
+      "Circulation Desk -- Reading room").withPickupLocation(TRUE)
+      .withId(UUID.fromString(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN))
+      .withholdShelfClosedLibraryDateManagement(ExpirationDateManagement.MOVE_TO_THE_END_OF_THE_NEXT_OPEN_DAY.name()));
+
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(holdShelfExpiryPeriod);
+    use(forUseAtLocationPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN));
+
+    JsonObject forUseAtLocation = holdForUseAtLocationFixture.holdForUseAtLocation(
+        new HoldByBarcodeRequestBuilder(item.getBarcode()))
+      .getJson().getJsonObject("loan").getJsonObject("forUseAtLocation");
+
+    ZonedDateTime expectedExpiryDateTime =
+      atEndOfDay(holdShelfExpiryPeriod
+        .plusDate(dateOfHold)
+        .plusDays(1),UTC);  // move forward one day
+
+    assertThat("loan.forUseAtLocation.holdShelfExpirationDate",
+      forUseAtLocation.getString("holdShelfExpirationDate").replaceAll("\\.000",""),
+      Is.is(expectedExpiryDateTime.toString()));
+  }
+
+  @Test
+  void willSetNoHoldShelfExpirationIfPolicyNotDefined() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    ZonedDateTime dateOfHold = atStartOfDay(FIRST_DAY_OPEN.minusDays(2), UTC).plusHours(10).plusSeconds(10);
+    mockClockManagerToReturnFixedDateTime(dateOfHold);
+
+    forServicePoints().create(new ServicePointBuilder("Reading room", "RR",
+      "Circulation Desk -- Reading room").withPickupLocation(TRUE)
+      .withId(UUID.fromString(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN))
+      .withholdShelfClosedLibraryDateManagement(ExpirationDateManagement.MOVE_TO_THE_END_OF_THE_NEXT_OPEN_DAY.name()));
+
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true);
+    use(forUseAtLocationPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(CASE_FIRST_DAY_OPEN_SECOND_CLOSED_THIRD_OPEN));
+
+    JsonObject forUseAtLocation = holdForUseAtLocationFixture.holdForUseAtLocation(
+        new HoldByBarcodeRequestBuilder(item.getBarcode()))
+      .getJson().getJsonObject("loan").getJsonObject("forUseAtLocation");
+
+    assertThat("loan.forUseAtLocation.holdShelfExpirationDate",
+      forUseAtLocation.getString("holdShelfExpirationDate"), nullValue());
+  }
+
+  @Test
+  void holdWillFailWithDifferentItem() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "Days"));
+
+    use(forUseAtLocationPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    holdForUseAtLocationFixture.holdForUseAtLocation(
+      new HoldByBarcodeRequestBuilder("different-item"), 400);
+  }
+
+  @Test
+  void holdWillFailIfForUseAtLocationNotEnabled() {
+    final LoanPolicyBuilder homeLoansPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "Days"));
+    use(homeLoansPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    holdForUseAtLocationFixture.holdForUseAtLocation(
+      new HoldByBarcodeRequestBuilder(item.getBarcode()), 400);
+  }
+
+
+  @Test
+  void holdWillFailIfLoanIsNotForUseAtLocation() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    final LoanPolicyBuilder homeLoansPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Home loans")
+      .withDescription("Policy for items that can be taken home")
+      .rolling(Period.days(30));
+
+    use(homeLoansPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    holdForUseAtLocationFixture.holdForUseAtLocation(
+      new HoldByBarcodeRequestBuilder(item.getBarcode()), 400);
+  }
+
+  @Test
+  void holdWillFailWithIncompleteRequest() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "Days"));
+
+    use(forUseAtLocationPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    holdForUseAtLocationFixture.holdForUseAtLocation(
+      new HoldByBarcodeRequestBuilder(null), 422);
+  }
+
+
+  @Test
+  void willMarkItemInUseByBarcode() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "Days"));
+
+    use(forUseAtLocationPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    Response pickupResponse = pickupForUseAtLocationFixture.pickupForUseAtLocation(
+      new PickupByBarcodeRequestBuilder(item.getBarcode(), borrower.getBarcode()));
+
+    JsonObject forUseAtLocation = pickupResponse.getJson().getJsonObject("forUseAtLocation");
+    assertThat("loan.forUseAtLocation",
+      forUseAtLocation, notNullValue());
+    assertThat("loan.forUseAtLocation.status",
+      forUseAtLocation.getString("status"), Is.is("In use"));
+  }
+
+  @Test
+  void pickupWillFailWithDifferentItemOrDifferentUser() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true);
+
+    use(forUseAtLocationPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    pickupForUseAtLocationFixture.pickupForUseAtLocation(
+      new PickupByBarcodeRequestBuilder("different-item", borrower.getBarcode()), 400);
+
+    pickupForUseAtLocationFixture.pickupForUseAtLocation(
+      new PickupByBarcodeRequestBuilder(item.getBarcode(), "different-user"), 400);
+
+  }
+
+  @Test
+  void pickupWillFailWithIncompleteRequestObject() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "Days"));
+
+    use(forUseAtLocationPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    pickupForUseAtLocationFixture.pickupForUseAtLocation(
+      new PickupByBarcodeRequestBuilder(null, borrower.getBarcode()), 422);
+
+    pickupForUseAtLocationFixture.pickupForUseAtLocation(
+      new PickupByBarcodeRequestBuilder(item.getBarcode(), null), 422);
+  }
+
+  @Test
+  void pickupWillFailIfLoanIsNotForUseAtLocation() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    final LoanPolicyBuilder homeLoansPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Home loans")
+      .withDescription("Policy for items that can be taken home")
+      .rolling(Period.days(30));
+
+    use(homeLoansPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    pickupForUseAtLocationFixture.pickupForUseAtLocation(
+      new PickupByBarcodeRequestBuilder(item.getBarcode(), borrower.getBarcode()), 400);
+  }
+
+  @Test
+  void pickupWillFailIfForUseAtLocationNotEnabled() {
+    // Create loan with for-use-at-location enabled
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    final LoanPolicyBuilder homeLoansPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "Days"));
+
+    use(homeLoansPolicyBuilder);
+    // Enabled, so can set for-use-at-location status during check-out
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"FALSE");
+    // If, in the meantime, for-use-at-location has been disabled, pickups should not be supported
+    pickupForUseAtLocationFixture.pickupForUseAtLocation(
+      new PickupByBarcodeRequestBuilder(item.getBarcode(), borrower.getBarcode()), 400);
+  }
+
+
+  @Test
+  void willSetAtLocationUsageStatusToReturnedOnCheckInIfEnabled() {
+    Environment.MOCK_ENV.put(ENV_VAR_ENABLE_FOR_USE_AT_LOCATION,"TRUE");
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "Days"));
+
+    use(forUseAtLocationPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    final IndividualResource response = checkInFixture.checkInByBarcode(item);
+
+    JsonObject loan = loansFixture.getLoanById(
+      UUID.fromString(response.getJson().getJsonObject("loan").getString("id")))
+      .getJson();
+    JsonObject forUseAtLocation = loan.getJsonObject("forUseAtLocation");
+    assertThat("loan.forUseAtLocation",
+      forUseAtLocation, notNullValue());
+    assertThat("loan.forUseAtLocation.status",
+      forUseAtLocation.getString("status"), Is.is("Returned"));
+    assertThat("loan.forUseAtLocation.holdShelfExpirationDate",
+      forUseAtLocation.getString("holdShelfExpirationDate"), nullValue());
+  }
+
+  @Test
+  void willNotSetAtLocationUsageStatusOnCheckInIfNotEnabled() {
+    final LoanPolicyBuilder forUseAtLocationPolicyBuilder = new LoanPolicyBuilder()
+      .withName("Reading room loans")
+      .withDescription("Policy for items to be used at location")
+      .rolling(Period.days(30))
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "Days"));
+
+    use(forUseAtLocationPolicyBuilder);
+
+    checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .at(servicePointsFixture.cd1()));
+
+    final IndividualResource response = checkInFixture.checkInByBarcode(item);
+
+    JsonObject loan = loansFixture.getLoanById(
+        UUID.fromString(response.getJson().getJsonObject("loan").getString("id")))
+      .getJson();
+    JsonObject forUseAtLocation = loan.getJsonObject("forUseAtLocation");
+    assertThat("loan.forUseAtLocation",
+      forUseAtLocation, nullValue());
+  }
+
+
+}

--- a/src/test/java/api/queue/RequestQueueResourceTest.java
+++ b/src/test/java/api/queue/RequestQueueResourceTest.java
@@ -43,7 +43,6 @@ import api.support.TlrFeatureStatus;
 import api.support.builders.ReorderQueueBuilder;
 import api.support.builders.RequestBuilder;
 import api.support.fakes.FakePubSub;
-import api.support.http.CheckOutResource;
 import api.support.http.IndividualResource;
 import api.support.http.ItemResource;
 import io.vertx.core.json.JsonArray;
@@ -280,7 +279,7 @@ class RequestQueueResourceTest extends APITests {
     assertThat(request.containsKey("item"), is(true));
     JsonObject item = request.getJsonObject("item");
     assertThat(item.fieldNames(), contains("barcode", "location",
-      "enumeration", "volume", "chronology", "status", "callNumber",
+      "enumeration", "volume", "chronology", "loanTypeId", "loanTypeName", "status", "callNumber",
       "callNumberComponents", "copyNumber", "itemEffectiveLocationId",
       "itemEffectiveLocationName", "retrievalServicePointId",
       "retrievalServicePointName"));

--- a/src/test/java/api/requests/StaffSlipsTests.java
+++ b/src/test/java/api/requests/StaffSlipsTests.java
@@ -262,6 +262,7 @@ class StaffSlipsTests extends APITests {
       .withInstance(new InstanceMapper().toDomain(itemResource.getInstance().getJson()));
 
     String contributorNames = item.getContributorNames().collect(joining("; "));
+    String seriesStatements = String.join("; ",item.getSeriesStatementValues());
 
     String yearCaptionsToken = String.join("; ", item.getYearCaption());
     String copyNumber = item.getCopyNumber() != null ? item.getCopyNumber() : "";
@@ -274,6 +275,7 @@ class StaffSlipsTests extends APITests {
     assertEquals(expectedItemStatus.getValue(), itemContext.getString("status"));
     assertEquals(item.getPrimaryContributorName(), itemContext.getString("primaryContributor"));
     assertEquals(contributorNames, itemContext.getString("allContributors"));
+    assertEquals(seriesStatements, itemContext.getString("seriesStatements"));
     assertEquals(item.getEnumeration(), itemContext.getString("enumeration"));
     assertEquals(item.getVolume(), itemContext.getString("volume"));
     assertEquals(item.getChronology(), itemContext.getString("chronology"));

--- a/src/test/java/api/support/APITests.java
+++ b/src/test/java/api/support/APITests.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import api.support.fixtures.SearchInstanceFixture;
-import org.folio.Environment;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -58,6 +57,8 @@ import api.support.fixtures.ExpiredSessionProcessingClient;
 import api.support.fixtures.FeeFineAccountFixture;
 import api.support.fixtures.FeeFineOwnerFixture;
 import api.support.fixtures.FeeFineTypeFixture;
+import api.support.fixtures.ForUseAtLocationHoldFixture;
+import api.support.fixtures.ForUseAtLocationPickupFixture;
 import api.support.fixtures.HoldingsFixture;
 import api.support.fixtures.IdentifierTypesFixture;
 import api.support.fixtures.InstancesFixture;
@@ -311,6 +312,9 @@ public abstract class APITests {
   protected final CirculationSettingFixture circulationSettingFixture = new CirculationSettingFixture(
     circulationSettingsClient);
   protected final SearchInstanceFixture searchFixture = new SearchInstanceFixture();
+
+  protected final ForUseAtLocationHoldFixture holdForUseAtLocationFixture = new ForUseAtLocationHoldFixture();
+  protected final ForUseAtLocationPickupFixture pickupForUseAtLocationFixture = new ForUseAtLocationPickupFixture();
 
   protected APITests() {
     this(true, false);

--- a/src/test/java/api/support/builders/HoldByBarcodeRequestBuilder.java
+++ b/src/test/java/api/support/builders/HoldByBarcodeRequestBuilder.java
@@ -1,0 +1,19 @@
+package api.support.builders;
+
+import io.vertx.core.json.JsonObject;
+
+public class HoldByBarcodeRequestBuilder extends JsonBuilder implements Builder {
+  private final String itemBarcode;
+
+  public HoldByBarcodeRequestBuilder(String itemBarcode) {
+    this.itemBarcode = itemBarcode;
+  }
+
+  @Override
+  public JsonObject create() {
+    final JsonObject request = new JsonObject();
+    put(request, "itemBarcode", this.itemBarcode);
+    return request;
+  }
+}
+

--- a/src/test/java/api/support/builders/InstanceBuilder.java
+++ b/src/test/java/api/support/builders/InstanceBuilder.java
@@ -22,13 +22,14 @@ public class InstanceBuilder extends JsonBuilder implements Builder {
   private final List<Pair<UUID, String>> identifiers;
   private final JsonArray publication;
   private final JsonArray editions;
+  private final List<Pair<UUID, String>> series;
 
   public InstanceBuilder(String title, UUID instanceTypeId) {
     this(UUID.randomUUID(), title, instanceTypeId);
   }
 
   public InstanceBuilder(UUID id, String title, UUID instanceTypeId) {
-    this(id, title, new JsonArray(), instanceTypeId, Collections.emptyList(), new JsonArray(), new JsonArray());
+    this(id, title, new JsonArray(), instanceTypeId, Collections.emptyList(), new JsonArray(), new JsonArray(), Collections.emptyList());
   }
 
   private InstanceBuilder(UUID id,
@@ -37,7 +38,8 @@ public class InstanceBuilder extends JsonBuilder implements Builder {
     UUID instanceTypeId,
     List<Pair<UUID, String>> identifiers,
     JsonArray publication,
-    JsonArray editions) {
+    JsonArray editions,
+    List<Pair<UUID, String>> series) {
 
     this.id = id;
     this.title = title;
@@ -46,6 +48,7 @@ public class InstanceBuilder extends JsonBuilder implements Builder {
     this.identifiers = identifiers;
     this.editions = editions;
     this.publication = publication;
+    this.series = series;
   }
 
   @Override
@@ -61,6 +64,7 @@ public class InstanceBuilder extends JsonBuilder implements Builder {
     put(instance, "identifiers", identifiersToJson());
     put(instance, "editions", editions);
     put(instance, "publication", publication);
+    put(instance, "series", seriesToJson());
 
     return instance;
   }
@@ -81,7 +85,8 @@ public class InstanceBuilder extends JsonBuilder implements Builder {
       this.instanceTypeId,
       this.identifiers,
       this.publication,
-      this.editions);
+      this.editions,
+      this.series);
   }
 
   public Builder withInstanceTypeId(UUID instanceTypeId) {
@@ -92,7 +97,8 @@ public class InstanceBuilder extends JsonBuilder implements Builder {
       instanceTypeId,
       this.identifiers,
       this.publication,
-      this.editions);
+      this.editions,
+      this.series);
   }
 
   public InstanceBuilder withContributor(String name, UUID typeId) {
@@ -117,7 +123,8 @@ public class InstanceBuilder extends JsonBuilder implements Builder {
       this.instanceTypeId,
       this.identifiers,
       this.publication,
-      this.editions);
+      this.editions,
+      this.series);
   }
 
   public InstanceBuilder withSinglePublication(String publisher, String place, String dateOfPublication) {
@@ -136,7 +143,8 @@ public class InstanceBuilder extends JsonBuilder implements Builder {
       this.instanceTypeId,
       this.identifiers,
       publication,
-      this.editions);
+      this.editions,
+      this.series);
   }
 
   public InstanceBuilder withSingleEdition(String edition) {
@@ -151,7 +159,30 @@ public class InstanceBuilder extends JsonBuilder implements Builder {
       this.instanceTypeId,
       this.identifiers,
       this.publication,
-      editions);
+      editions,
+      this.series);
+  }
+
+  public InstanceBuilder addSeriesStatement(UUID authorityId, String value) {
+    List<Pair<UUID, String>> seriesCopy = new ArrayList<>(series);
+    seriesCopy.add(new ImmutablePair<>(authorityId, value));
+    return new InstanceBuilder(
+      this.id,
+      this.title,
+      this.contributors,
+      this.instanceTypeId,
+      this.identifiers,
+      this.publication,
+      this.editions,
+      seriesCopy);
+  }
+
+  private JsonArray seriesToJson() {
+    return new JsonArray(series.stream()
+      .map(pair -> new JsonObject()
+        .put("authorityId", pair.getKey().toString())
+        .put("value", pair.getValue()))
+      .collect(Collectors.toList()));
   }
 
   public InstanceBuilder addIdentifier(UUID typeId, String value) {
@@ -165,6 +196,7 @@ public class InstanceBuilder extends JsonBuilder implements Builder {
       this.instanceTypeId,
       identifiersCopy,
       this.publication,
-      this.editions);
+      this.editions,
+      this.series);
   }
 }

--- a/src/test/java/api/support/builders/LoanPolicyBuilder.java
+++ b/src/test/java/api/support/builders/LoanPolicyBuilder.java
@@ -40,6 +40,8 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
   private final Period alternateCheckoutLoanPeriod;
   private final Integer itemLimit;
   private final Period gracePeriod;
+  private final boolean forUseAtLocation;
+  private final Period holdShelfExpiryPeriodForUseAtLocation;
 
   public LoanPolicyBuilder() {
     this(UUID.randomUUID(),
@@ -65,6 +67,8 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       null,
       null,
       null,
+      null,
+      false,
       null
     );
   }
@@ -88,6 +92,8 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       put(loansPolicy, "profileId", loansProfile);
       put(loansPolicy, "itemLimit", itemLimit);
       putIfNotNull(loansPolicy, "gracePeriod", gracePeriod, Period::asJson);
+      put(loansPolicy, "forUseAtLocation", forUseAtLocation);
+      putIfNotNull(loansPolicy, "holdShelfExpiryPeriodForUseAtLocation", holdShelfExpiryPeriodForUseAtLocation, Period::asJson);
 
       //TODO: Replace with sub-builders
       if(Objects.equals(loansProfile, "Rolling")) {
@@ -289,4 +295,5 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
 
     return withHolds(json);
   }
+
 }

--- a/src/test/java/api/support/builders/PickupByBarcodeRequestBuilder.java
+++ b/src/test/java/api/support/builders/PickupByBarcodeRequestBuilder.java
@@ -1,0 +1,23 @@
+package api.support.builders;
+
+import io.vertx.core.json.JsonObject;
+
+public class PickupByBarcodeRequestBuilder extends JsonBuilder implements Builder {
+  private final String itemBarcode;
+  private final String userBarcode;
+
+  public PickupByBarcodeRequestBuilder(
+    String itemBarcode,
+    String userBarcode) {
+    this.itemBarcode = itemBarcode;
+    this.userBarcode = userBarcode;
+  }
+  @Override
+  public JsonObject create() {
+    final JsonObject request = new JsonObject();
+
+    put(request, "itemBarcode", this.itemBarcode);
+    put(request, "userBarcode", this.userBarcode);
+    return request;
+  }
+}

--- a/src/test/java/api/support/fixtures/ForUseAtLocationHoldFixture.java
+++ b/src/test/java/api/support/fixtures/ForUseAtLocationHoldFixture.java
@@ -1,0 +1,27 @@
+package api.support.fixtures;
+
+import api.support.RestAssuredClient;
+import api.support.builders.HoldByBarcodeRequestBuilder;
+import org.folio.circulation.support.http.client.Response;
+
+import static api.support.APITestContext.getOkapiHeadersFromContext;
+import static api.support.http.InterfaceUrls.holdForUseAtLocationUrl;
+
+public class ForUseAtLocationHoldFixture {
+  private final RestAssuredClient restAssuredClient;
+
+  public ForUseAtLocationHoldFixture() {
+    restAssuredClient = new RestAssuredClient(getOkapiHeadersFromContext());
+  }
+
+  public Response holdForUseAtLocation(HoldByBarcodeRequestBuilder builder) {
+    return restAssuredClient.post(builder.create(), holdForUseAtLocationUrl(), 200,
+      "hold-for-use-at-location-by-barcode-request");
+  }
+
+  public void holdForUseAtLocation(HoldByBarcodeRequestBuilder builder, int expectedStatusCode) {
+    restAssuredClient.post(builder.create(), holdForUseAtLocationUrl(), expectedStatusCode,
+      "hold-for-use-at-location-by-barcode-request");
+  }
+
+}

--- a/src/test/java/api/support/fixtures/ForUseAtLocationPickupFixture.java
+++ b/src/test/java/api/support/fixtures/ForUseAtLocationPickupFixture.java
@@ -1,0 +1,27 @@
+package api.support.fixtures;
+
+import api.support.RestAssuredClient;
+import api.support.builders.PickupByBarcodeRequestBuilder;
+import org.folio.circulation.support.http.client.Response;
+
+import static api.support.APITestContext.getOkapiHeadersFromContext;
+import static api.support.http.InterfaceUrls.pickupForUseAtLocationUrl;
+
+public class ForUseAtLocationPickupFixture {
+  private final RestAssuredClient restAssuredClient;
+
+  public ForUseAtLocationPickupFixture() {
+    restAssuredClient = new RestAssuredClient(getOkapiHeadersFromContext());
+  }
+
+  public Response pickupForUseAtLocation(PickupByBarcodeRequestBuilder builder) {
+    return restAssuredClient.post(builder.create(), pickupForUseAtLocationUrl(), 200,
+      "pickup-for-use-at-location-by-barcode-request");
+  }
+
+  public void pickupForUseAtLocation(PickupByBarcodeRequestBuilder builder, int expectedStatusCode) {
+    restAssuredClient.post(builder.create(), pickupForUseAtLocationUrl(), expectedStatusCode,
+      "pickup-for-use-at-location-by-barcode-request");
+  }
+
+}

--- a/src/test/java/api/support/fixtures/InstanceExamples.java
+++ b/src/test/java/api/support/fixtures/InstanceExamples.java
@@ -13,7 +13,8 @@ public class InstanceExamples {
       booksInstanceTypeId)
       .withContributor("Chambers, Becky", personalContributorNameTypeId, true)
       .withSingleEdition("First American Edition")
-      .withSinglePublication("Alfred A. Knopf", "New York", "2016");
+      .withSinglePublication("Alfred A. Knopf", "New York", "2016")
+      .addSeriesStatement(UUID.randomUUID(),"Small, Angry Planet not part of any series");
   }
 
   public static InstanceBuilder basedUponNod(

--- a/src/test/java/api/support/http/InterfaceUrls.java
+++ b/src/test/java/api/support/http/InterfaceUrls.java
@@ -162,6 +162,14 @@ public class InterfaceUrls {
     return circulationModuleUrl("/circulation/renew-by-id");
   }
 
+  public static URL holdForUseAtLocationUrl() {
+    return circulationModuleUrl("/circulation/hold-by-barcode-for-use-at-location");
+  }
+
+  public static URL pickupForUseAtLocationUrl() {
+    return circulationModuleUrl("/circulation/pickup-by-barcode-for-use-at-location");
+  }
+
   public static URL loansUrl() {
     return loansUrl("");
   }

--- a/src/test/java/org/folio/circulation/domain/InstanceTests.java
+++ b/src/test/java/org/folio/circulation/domain/InstanceTests.java
@@ -10,21 +10,21 @@ import org.junit.jupiter.api.Test;
 class InstanceTests {
   @Test
   void cannotHaveANullCollectionOfIdentifiers() {
-    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "1234", "Title", null, emptyList(), emptyList(), emptyList(), emptyList()));
+    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "1234", "Title", null, emptyList(), emptyList(), emptyList(), emptyList(), emptyList()));
   }
 
   @Test
   void cannotHaveANullCollectionOfContributors() {
-    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "1234", "Title", emptyList(), null, emptyList(), emptyList(), emptyList()));
+    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "1234", "Title", emptyList(), null, emptyList(), emptyList(), emptyList(), emptyList()));
   }
 
   @Test
   void cannotHaveANullCollectionOfPublication() {
-    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "1234", "Title", emptyList(), emptyList(), null, emptyList(), emptyList()));
+    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "1234", "Title", emptyList(), emptyList(), null, emptyList(), emptyList(), emptyList()));
   }
 
   @Test
   void cannotHaveANullCollectionOfEditions() {
-    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "1234", "Title", emptyList(), emptyList(), emptyList(), null, emptyList()));
+    assertThrows(NullPointerException.class, () -> new Instance(UUID.randomUUID().toString(), "1234", "Title", emptyList(), emptyList(), emptyList(), null, emptyList(), emptyList()));
   }
 }

--- a/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/OverdueFineServiceTest.java
@@ -615,7 +615,7 @@ class OverdueFineServiceTest {
       .withLocation(new Location(null, LOCATION_NAME, null, null, emptyList(),
         SERVICE_POINT_ID, false, Institution.unknown(), Campus.unknown(), Library.unknown(),
         ServicePoint.unknown()))
-      .withInstance(new Instance(UUID.randomUUID().toString(), INSTANCE_HRID, TITLE, emptyList(), contributors, emptyList(), emptyList(), emptyList()))
+      .withInstance(new Instance(UUID.randomUUID().toString(), INSTANCE_HRID, TITLE, emptyList(), contributors, emptyList(), emptyList(), emptyList(), emptyList()))
       .withMaterialType(new MaterialType(ITEM_MATERIAL_TYPE_ID.toString(), ITEM_MATERIAL_TYPE_NAME, null));
   }
 

--- a/src/test/java/org/folio/circulation/domain/RequestRepresentationTests.java
+++ b/src/test/java/org/folio/circulation/domain/RequestRepresentationTests.java
@@ -132,7 +132,8 @@ class RequestRepresentationTests {
       emptyList(),
       List.of(new Publication("fake publisher", "fake place", "2016", null)),
       List.of("First American Edition"),
-      List.of("Hardback"));
+      List.of("Hardback"),
+      emptyList());
 
     JsonObject itemJson = new JsonObject()
       .put("effectiveCallNumberComponents", new JsonObject()

--- a/src/test/resources/storage-loan-7-3.json
+++ b/src/test/resources/storage-loan-7-3.json
@@ -37,6 +37,26 @@
       },
       "additionalProperties": false
     },
+    "forUseAtLocation": {
+      "description": "Status of loan/item that is to be used in the library",
+      "type": "object",
+      "properties": {
+        "status": {
+          "description": "Indicates if the item is currently used by or being held for the patron",
+          "type": "string",
+          "enum": [
+            "In use",
+            "Held",
+            "Returned"
+          ]
+        },
+        "statusDate": {
+          "description": "Date and time the status was registered",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
     "loanDate": {
       "description": "Date time when the loan began (typically represented according to rfc3339 section-5.6. Has not had the date-time format validation applied as was not supported at point of introduction and would now be a breaking change)",
       "type": "string"


### PR DESCRIPTION
Back-port reading room circulation (use at location) as defined by

   CIRC-2308 Extend circulation to accommodate use-at-location loans
    with further modifications per CIRC-2255, CIRC-2415, CIRC-2441, CIRC-2463
  And
   CIRC-2457 Disable for-use-at-location by default on deploy

These circulation changes depend on schema changes in mod-audit and mod-circulation-storage, pull requests for these were raised earlier today.  

