### PR TITLE
CIRC-2599 Ignore blank IDs when building CQL index

### DIFF
--- a/src/main/java/org/folio/circulation/support/fetching/CqlIndexValuesFinder.java
+++ b/src/main/java/org/folio/circulation/support/fetching/CqlIndexValuesFinder.java
@@ -15,8 +15,11 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -66,8 +69,8 @@ public class CqlIndexValuesFinder<T> implements FindWithMultipleCqlIndexValues<T
   public CompletableFuture<Result<MultipleRecords<T>>> find(
     MultipleCqlIndexValuesCriteria criteria) {
 
-    if (criteria.getValues().isEmpty()) {
-      log.info("find:: search criteria is empty");
+    if (hasNoValidValues(criteria)) {
+      log.info("find:: search criteria is empty or contains only blank values");
       return completedFuture(of(MultipleRecords::empty));
     }
 
@@ -87,8 +90,8 @@ public class CqlIndexValuesFinder<T> implements FindWithMultipleCqlIndexValues<T
   public CompletableFuture<Result<MultipleRecords<T>>> find(
     MultipleCqlIndexValuesCriteria criteria, int limit) {
 
-    if (criteria.getValues().isEmpty()) {
-      log.info("find:: search criteria is empty");
+    if (hasNoValidValues(criteria)) {
+      log.info("find:: search criteria is empty or contains only blank values");
       return completedFuture(of(MultipleRecords::empty));
     }
 
@@ -113,6 +116,12 @@ public class CqlIndexValuesFinder<T> implements FindWithMultipleCqlIndexValues<T
     return queries.stream()
       .map(query -> query.combine(commonQuery, CqlQuery::and))
       .toList();
+  }
+
+  private static boolean hasNoValidValues(MultipleCqlIndexValuesCriteria criteria) {
+    return criteria.getValues().stream()
+      .filter(Objects::nonNull)
+      .noneMatch(StringUtils::isNotBlank);
   }
 
   private List<Result<CqlQuery>> buildBatchQueriesByIndexName(MultipleCqlIndexValuesCriteria criteria) {

--- a/src/test/java/org/folio/circulation/support/fetching/FindMultipleRecordsByIdTests.java
+++ b/src/test/java/org/folio/circulation/support/fetching/FindMultipleRecordsByIdTests.java
@@ -135,6 +135,74 @@ class FindMultipleRecordsByIdTests {
     verify(queryFinder, times(0)).findByQuery(any(), any());
   }
 
+  @Test
+  void shouldAssumeNoRecordsAreFoundWhenSearchingForOnlyNullIds()
+      throws InterruptedException, ExecutionException, TimeoutException {
+
+    final FindWithMultipleCqlIndexValues<JsonObject> fetcher
+      = new CqlIndexValuesFinder<>(queryFinder);
+
+    final Collection<String> nullIds = new ArrayList<>();
+    nullIds.add(null);
+    nullIds.add(null);
+
+    final CompletableFuture<Result<MultipleRecords<JsonObject>>> futureResult
+      = fetcher.findByIds(nullIds);
+
+    final MultipleRecords<JsonObject> result = getFutureResultValue(futureResult);
+
+    assertThat("Should assume no records are found when all ids are null",
+        result.isEmpty(), is(true));
+
+    verify(queryFinder, times(0)).findByQuery(any(), any());
+  }
+
+  @Test
+  void shouldAssumeNoRecordsAreFoundWhenSearchingForOnlyBlankIds()
+      throws InterruptedException, ExecutionException, TimeoutException {
+
+    final FindWithMultipleCqlIndexValues<JsonObject> fetcher
+      = new CqlIndexValuesFinder<>(queryFinder);
+
+    final Collection<String> blankIds = new ArrayList<>();
+    blankIds.add("");
+    blankIds.add("   ");
+
+    final CompletableFuture<Result<MultipleRecords<JsonObject>>> futureResult
+      = fetcher.findByIds(blankIds);
+
+    final MultipleRecords<JsonObject> result = getFutureResultValue(futureResult);
+
+    assertThat("Should assume no records are found when all ids are blank",
+        result.isEmpty(), is(true));
+
+    verify(queryFinder, times(0)).findByQuery(any(), any());
+  }
+
+  @Test
+  void shouldAssumeNoRecordsAreFoundWhenSearchingForBlankItemIds()
+      throws InterruptedException, ExecutionException, TimeoutException {
+
+    final FindWithMultipleCqlIndexValues<JsonObject> fetcher
+      = new CqlIndexValuesFinder<>(queryFinder);
+
+    final Collection<String> blankIds = new ArrayList<>();
+    blankIds.add("");
+    blankIds.add(null);
+
+    final Result<CqlQuery> openStatusQuery = exactMatch("status", "Open");
+
+    final CompletableFuture<Result<MultipleRecords<JsonObject>>> futureResult
+      = fetcher.findByIdIndexAndQuery(blankIds, "itemId", openStatusQuery);
+
+    final MultipleRecords<JsonObject> result = getFutureResultValue(futureResult);
+
+    assertThat("Should assume no records are found when all item ids are blank or null",
+        result.isEmpty(), is(true));
+
+    verify(queryFinder, times(0)).findByQuery(any(), any());
+  }
+
   private Collection<String> generateIds(int size) {
     return Stream.generate(UUID::randomUUID)
       .map(UUID::toString)


### PR DESCRIPTION
## Purpose

Do not send a request from mod-circulation to mod-circulation-storage if the IDs list is empty
 
Resolves: [CIRC-2599](https://folio-org.atlassian.net/browse/CIRC-2599)