### PR TITLE
CIRC-2538: Implement shadow location handling for DCB items in fetchItemRelatedRecords

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 24.6.0-SNAPSHOT In progress
 * Fix flaky tests ([CIRC-2633](https://folio-org.atlassian.net/browse/CIRC-2633))
+* Implement shadow location handling for DCB items in fetchItemRelatedRecords ([CIRC-2538](https://folio-org.atlassian.net/browse/CIRC-2538))
 
 ## 24.5.0 2026-04-14
 * Allow HTTP Connection Pool to be Configurable ([CIRC-2279](https://folio-org.atlassian.net/browse/CIRC-2279))

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -401,10 +401,16 @@ public class ItemRepository {
   public CompletableFuture<Result<Item>> fetchItemRelatedRecords(Result<Item> itemResult) {
     return itemResult.combineAfter(this::fetchHoldingsRecord, Item::withHoldings)
       .thenComposeAsync(combineAfter(this::fetchInstance, Item::withInstance))
-      .thenComposeAsync(combineAfter(locationRepository::getEffectiveLocation, Item::withLocation))
+      .thenComposeAsync(combineAfter(this::getEffectiveLocation, Item::withLocation))
       .thenComposeAsync(combineAfter(materialTypeRepository::getFor, Item::withMaterialType))
       .thenComposeAsync(combineAfter(this::fetchLoanType, Item::withLoanType))
       .thenCompose(CompletableFuture::completedFuture);
+  }
+
+  private CompletableFuture<Result<Location>> getEffectiveLocation(Item item) {
+    return item.isDcbItem()
+      ? shadowLocationRepository.getEffectiveLocation(item)
+      : locationRepository.getEffectiveLocation(item);
   }
 
   private CompletableFuture<Result<Holdings>> fetchHoldingsRecord(Item item) {

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,6 +26,7 @@ import org.folio.circulation.domain.ItemDescription;
 import org.folio.circulation.domain.LoanType;
 import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.MaterialType;
+import org.folio.circulation.storage.mappers.ItemMapper;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.results.Result;
@@ -136,6 +138,68 @@ class ItemRepositoryTests {
     assertThat(updateResult, succeeded());
   }
 
+  @Test
+  void fetchItemRelatedRecordsShouldUseShadowLocationRepoForDcbItem() {
+    final var locationRepository = mock(LocationRepository.class);
+    final var shadowLocationRepository = mock(ShadowLocationRepository.class);
+    final var materialTypeRepository = mock(MaterialTypeRepository.class);
+    final var instanceRepository = mock(InstanceRepository.class);
+    final var holdingsRepository = mock(HoldingsRepository.class);
+    final var loanTypeRepository = mock(LoanTypeRepository.class);
+
+    when(locationRepository.getEffectiveLocation(any())).thenReturn(ofAsync(Location::unknown));
+    when(shadowLocationRepository.getEffectiveLocation(any())).thenReturn(ofAsync(Location::unknown));
+    when(materialTypeRepository.getFor(any())).thenReturn(ofAsync(MaterialType::unknown));
+    when(instanceRepository.fetchById(anyString())).thenReturn(ofAsync(Instance::unknown));
+    when(holdingsRepository.fetchById(anyString())).thenReturn(ofAsync(Holdings::unknown));
+
+    final var repository = new ItemRepository(null, locationRepository, shadowLocationRepository,
+      materialTypeRepository, instanceRepository, holdingsRepository, loanTypeRepository, null);
+
+    final var dcbItemJson = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("dcbItem", true)
+      .put("holdingsRecordId", UUID.randomUUID().toString())
+      .put("effectiveLocationId", UUID.randomUUID().toString());
+    final var dcbItem = new ItemMapper().toDomain(dcbItemJson);
+
+    get(repository.fetchItemRelatedRecords(Result.succeeded(dcbItem)));
+
+    verify(shadowLocationRepository).getEffectiveLocation(any());
+    verify(locationRepository, never()).getEffectiveLocation(any());
+  }
+
+  @Test
+  void fetchItemRelatedRecordsShouldUseRegularLocationRepoForNonDcbItem() {
+    final var locationRepository = mock(LocationRepository.class);
+    final var shadowLocationRepository = mock(ShadowLocationRepository.class);
+    final var materialTypeRepository = mock(MaterialTypeRepository.class);
+    final var instanceRepository = mock(InstanceRepository.class);
+    final var holdingsRepository = mock(HoldingsRepository.class);
+    final var loanTypeRepository = mock(LoanTypeRepository.class);
+
+    when(locationRepository.getEffectiveLocation(any())).thenReturn(ofAsync(Location::unknown));
+    when(shadowLocationRepository.getEffectiveLocation(any())).thenReturn(ofAsync(Location::unknown));
+    when(materialTypeRepository.getFor(any())).thenReturn(ofAsync(MaterialType::unknown));
+    when(instanceRepository.fetchById(anyString())).thenReturn(ofAsync(Instance::unknown));
+    when(holdingsRepository.fetchById(anyString())).thenReturn(ofAsync(Holdings::unknown));
+
+    final var repository = new ItemRepository(null, locationRepository, shadowLocationRepository,
+      materialTypeRepository, instanceRepository, holdingsRepository, loanTypeRepository, null);
+
+    final var regularItemJson = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("dcbItem", false)
+      .put("holdingsRecordId", UUID.randomUUID().toString())
+      .put("effectiveLocationId", UUID.randomUUID().toString());
+    final var regularItem = new ItemMapper().toDomain(regularItemJson);
+
+    get(repository.fetchItemRelatedRecords(Result.succeeded(regularItem)));
+
+    verify(locationRepository).getEffectiveLocation(any());
+    verify(shadowLocationRepository, never()).getEffectiveLocation(any());
+  }
+
   private void mockedClientGet(CollectionResourceClient client, String body) {
     when(client.get(anyString())).thenReturn(ofAsync(
       () -> new Response(200, body, "application/json")));
@@ -151,6 +215,9 @@ class ItemRepositoryTests {
 
 
     when(locationRepository.getEffectiveLocation(any()))
+      .thenReturn(ofAsync(Location::unknown));
+
+    when(shadowLocationRepository.getEffectiveLocation(any()))
       .thenReturn(ofAsync(Location::unknown));
 
     when(materialTypeRepository.getFor(any()))


### PR DESCRIPTION
## Purpose
Fix retrievalServicePointName storing "DCB" instead of the real service point name for ECS Page requests in Central tenant.

## Approach
fetchItemRelatedRecords (single-item path) was using locationRepository (regular /locations) to resolve a DCB shadow item's location, which returns the DCB virtual service point as primary. The fix mirrors the existing pattern from the batch fetchLocations path — routing DCB items (isDcbItem() == true) to shadowLocationRepository (/locations?includeShadowLocations=true), which returns the correct primary service point.

#### TODOS and Open Questions
- [ ] Check logging
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
[CIRC-2538](https://folio-org.atlassian.net/browse/CIRC-2538)

