### PR TITLE
CIRC-2633: Fix flaky tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 24.6.0-SNAPSHOT In progress
+* Fix flaky tests ([CIRC-2633](https://folio-org.atlassian.net/browse/CIRC-2633))
+
 ## 24.5.0 2026-04-14
 * Allow HTTP Connection Pool to be Configurable ([CIRC-2279](https://folio-org.atlassian.net/browse/CIRC-2279))
 * Fix TLRs in Search slips missing key tokens ([CIRC-2228](https://folio-org.atlassian.net/browse/CIRC-2228))

--- a/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
+++ b/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
@@ -53,8 +53,9 @@ class HoldShelfExpirationDateTests extends APITests {
 
   @BeforeEach
   void setUp() {
-    // reset the clock before each test (just in case)
-    setClock(Clock .fixed(getInstant(), UTC));
+    // Sync test clock with CalendarExamples so that calendar entries (built at class-load time
+    // via ClockUtil.getLocalDate()) always align with the clock seen by the test server.
+    setClock(Clock.fixed(CASE_CURRENT_DATE_CLOSE.atStartOfDay(UTC).toInstant(), UTC));
   }
 
   @AfterEach
@@ -115,7 +116,9 @@ class HoldShelfExpirationDateTests extends APITests {
   }
 
   private boolean isSameDay(ChronoUnit interval, int amount, ZonedDateTime zdtWithZoneOffset) {
-    return interval.addTo(getZonedDateTime(), amount).toLocalDate().equals(LocalDate.now(zdtWithZoneOffset.getZone()));
+    ZoneId zone = zdtWithZoneOffset.getZone();
+    return interval.addTo(getZonedDateTime(), amount).withZoneSameInstant(zone).toLocalDate()
+      .equals(getZonedDateTime().withZoneSameInstant(zone).toLocalDate());
   }
 
   private void assertHoldShelfExpirationDateBasedOnStrategy(JsonObject storedRequest, String servicePoint, int amount, ChronoUnit interval) {

--- a/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
+++ b/src/test/java/api/requests/scenarios/HoldShelfExpirationDateTests.java
@@ -28,7 +28,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalTime;
-import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -139,13 +138,13 @@ class HoldShelfExpirationDateTests extends APITests {
         storedRequest.getString("holdShelfExpirationDate"), isEquivalentTo(endOfServicePointHours));
         break;
       case "cd7" :
-        long spanToNextServicePointHours1 = Duration.between(CASE_CURRENT_DATE_CLOSE.atStartOfDay(),CASE_NEXT_DATE_OPEN.atStartOfDay()).toDays();
+        long spanToNextServicePointHours1 = Duration.between(CASE_CURRENT_DATE_CLOSE.atStartOfDay(UTC), CASE_NEXT_DATE_OPEN.atStartOfDay(UTC)).toDays();
         ZonedDateTime moveToBeginningOfNextServicePointHours1 = getZonedDateTime().plusDays(spanToNextServicePointHours1).with(LocalTime.of(5, 0, 0));
         assertThat("request hold shelf expiration date is " + amount + " " + interval.toString() + " in the future",
         storedRequest.getString("holdShelfExpirationDate"), isEquivalentTo(moveToBeginningOfNextServicePointHours1));
         break;
       case "cd8" :
-        long spanToNextServicePointHours2 = Duration.between(CASE_CURRENT_DATE_CLOSE.atStartOfDay(),CASE_NEXT_DATE_OPEN.atStartOfDay()).toDays();
+        long spanToNextServicePointHours2 = Duration.between(CASE_CURRENT_DATE_CLOSE.atStartOfDay(UTC), CASE_NEXT_DATE_OPEN.atStartOfDay(UTC)).toDays();
         ZonedDateTime moveToBeginningOfNextServicePointHours2 = getZonedDateTime().plusDays(spanToNextServicePointHours2).with(LocalTime.of(0, 10, 0));
         assertThat("request hold shelf expiration date is " + amount + " " + interval.toString() + " in the future",
         storedRequest.getString("holdShelfExpirationDate"), isEquivalentTo(moveToBeginningOfNextServicePointHours2));

--- a/src/test/java/api/support/fixtures/CalendarExamples.java
+++ b/src/test/java/api/support/fixtures/CalendarExamples.java
@@ -8,6 +8,7 @@ import api.support.builders.OpeningDayPeriodBuilder;
 import io.vertx.core.MultiMap;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.Month;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -53,16 +54,16 @@ public class CalendarExamples {
   static final String CASE_START_DATE_FRI_AND_END_DATE_NEXT_MONTHS = "88888888-2f09-4bc9-8924-3734882d44a3";
 
   public static final String CASE_CURRENT_IS_OPEN = "7a50ce1e-ce47-4841-a01f-fd771ff3da1b";
-  public static final LocalDate CASE_CURRENT_IS_OPEN_PREV_DAY = LocalDate.of(2019, 2, 4);
-  public static final LocalDate CASE_CURRENT_IS_OPEN_CURR_DAY = LocalDate.of(2019, 2, 5);
-  public static final LocalDate CASE_CURRENT_IS_OPEN_NEXT_DAY = LocalDate.of(2019, 2, 6);
-  public static final LocalDate CASE_CURRENT_IS_OPEN_IN_ONE_DAY = LocalDate.of(2019, 2, 7);
+  public static final LocalDate CASE_CURRENT_IS_OPEN_PREV_DAY = LocalDate.of(2019, Month.FEBRUARY, 4);
+  public static final LocalDate CASE_CURRENT_IS_OPEN_CURR_DAY = LocalDate.of(2019, Month.FEBRUARY, 5);
+  public static final LocalDate CASE_CURRENT_IS_OPEN_NEXT_DAY = LocalDate.of(2019, Month.FEBRUARY, 6);
+  public static final LocalDate CASE_CURRENT_IS_OPEN_IN_ONE_DAY = LocalDate.of(2019, Month.FEBRUARY, 7);
 
-  public static final LocalDate MONDAY_DATE = LocalDate.of(2018, 12, 9);
-  public static final LocalDate TUESDAY_DATE = LocalDate.of(2018, 12, 10);
-  public static final LocalDate WEDNESDAY_DATE = LocalDate.of(2018, 12, 11);
-  public static final LocalDate THURSDAY_DATE = LocalDate.of(2018, 12, 12);
-  public static final LocalDate FRIDAY_DATE = LocalDate.of(2018, 12, 13);
+  public static final LocalDate MONDAY_DATE = LocalDate.of(2018, Month.DECEMBER, 9);
+  public static final LocalDate TUESDAY_DATE = LocalDate.of(2018, Month.DECEMBER, 10);
+  public static final LocalDate WEDNESDAY_DATE = LocalDate.of(2018, Month.DECEMBER, 11);
+  public static final LocalDate THURSDAY_DATE = LocalDate.of(2018, Month.DECEMBER, 12);
+  public static final LocalDate FRIDAY_DATE = LocalDate.of(2018, Month.DECEMBER, 13);
 
   public static final LocalTime START_TIME_FIRST_PERIOD = LocalTime.of(8, 0);
   public static final LocalTime END_TIME_FIRST_PERIOD = LocalTime.of(12, 0);
@@ -70,12 +71,12 @@ public class CalendarExamples {
   public static final LocalTime START_TIME_SECOND_PERIOD = LocalTime.of(14, 0);
   public static final LocalTime END_TIME_SECOND_PERIOD = LocalTime.of(19, 0);
 
-  public static final LocalDate CASE_FRI_SAT_MON_SERVICE_POINT_PREV_DAY = LocalDate.of(2019, 2, 1);
-  public static final LocalDate CASE_FRI_SAT_MON_SERVICE_POINT_CURR_DAY = LocalDate.of(2019, 2, 2);
-  public static final LocalDate CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY = LocalDate.of(2019, 2, 4);
-  public static final LocalDate CASE_FRI_SAT_MON_DAY_ALL_PREV_DATE = LocalDate.of(2018, 12, 14);
-  public static final LocalDate CASE_FRI_SAT_MON_DAY_ALL_CURRENT_DATE = LocalDate.of(2018, 12, 15);
-  public static final LocalDate CASE_FRI_SAT_MON_DAY_ALL_NEXT_DATE = LocalDate.of(2018, 12, 17);
+  public static final LocalDate CASE_FRI_SAT_MON_SERVICE_POINT_PREV_DAY = LocalDate.of(2019, Month.FEBRUARY, 1);
+  public static final LocalDate CASE_FRI_SAT_MON_SERVICE_POINT_CURR_DAY = LocalDate.of(2019, Month.FEBRUARY, 2);
+  public static final LocalDate CASE_FRI_SAT_MON_SERVICE_POINT_NEXT_DAY = LocalDate.of(2019, Month.FEBRUARY, 4);
+  public static final LocalDate CASE_FRI_SAT_MON_DAY_ALL_PREV_DATE = LocalDate.of(2018, Month.DECEMBER, 14);
+  public static final LocalDate CASE_FRI_SAT_MON_DAY_ALL_CURRENT_DATE = LocalDate.of(2018, Month.DECEMBER, 15);
+  public static final LocalDate CASE_FRI_SAT_MON_DAY_ALL_NEXT_DATE = LocalDate.of(2018, Month.DECEMBER, 17);
 
   public static final LocalDate CASE_PREV_DATE_OPEN = ClockUtil.getLocalDate().minusDays(1L);
   public static final LocalDate CASE_CURRENT_DATE_CLOSE = ClockUtil.getLocalDate();
@@ -83,12 +84,12 @@ public class CalendarExamples {
 
   public static final LocalDate CASE_LONG_TERM_DAYS_PREV_OPEN = ClockUtil.getLocalDate().plusDays(1L);
 
-  public static final LocalDate FIRST_DAY_OPEN = LocalDate.of(2020, 10, 29);
-  public static final LocalDate SECOND_DAY_CLOSED = LocalDate.of(2020, 10, 30);
-  public static final LocalDate THIRD_DAY_CLOSED = LocalDate.of(2020, 10, 31);
-  public static final LocalDate THIRD_DAY_OPEN = LocalDate.of(2020, 10, 31);
+  public static final LocalDate FIRST_DAY_OPEN = LocalDate.of(2020, Month.OCTOBER, 29);
+  public static final LocalDate SECOND_DAY_CLOSED = LocalDate.of(2020, Month.OCTOBER, 30);
+  public static final LocalDate THIRD_DAY_CLOSED = LocalDate.of(2020, Month.OCTOBER, 31);
+  public static final LocalDate THIRD_DAY_OPEN = LocalDate.of(2020, Month.OCTOBER, 31);
 
-  public static final LocalDate FIRST_DAY = LocalDate.of(2023, 10, 29);
+  public static final LocalDate FIRST_DAY = LocalDate.of(2023, Month.OCTOBER, 29);
 
   private static final String REQUESTED_DATE_PARAM = "date";
 

--- a/src/test/java/api/support/fixtures/CalendarExamples.java
+++ b/src/test/java/api/support/fixtures/CalendarExamples.java
@@ -440,8 +440,19 @@ public class CalendarExamples {
         return new CalendarBuilder(fakeOpeningPeriods.get(serviceId));
       case CASE_FRI_SAT_MON_DAY_ALL_SERVICE_POINT_ID:
         return new CalendarBuilder(fakeOpeningPeriods.get(serviceId));
-      case CASE_CURRENT_CLOSE_SERVICE_POINT_ID:
-        return new CalendarBuilder(fakeOpeningPeriods.get(serviceId));
+      case CASE_CURRENT_CLOSE_SERVICE_POINT_ID: {
+        LocalDate closedDate = LocalDate.parse(queries.get(REQUESTED_DATE_PARAM));
+        return new CalendarBuilder(
+          new OpeningDayPeriodBuilder(
+            CASE_CURRENT_CLOSE_SERVICE_POINT_ID,
+            new AdjacentOpeningDays(
+              new OpeningDay(new ArrayList<>(), closedDate.minusDays(1), true, true),
+              new OpeningDay(new ArrayList<>(), closedDate, false, false),
+              new OpeningDay(new ArrayList<>(), closedDate.plusDays(1), true, true)
+            )
+          )
+        );
+      }
       case CASE_LONG_TERM_DAYS_CURRENT_CLOSE_SERVICE_POINT_ID:
         return new CalendarBuilder(fakeOpeningPeriods.get(serviceId));
       case CASE_LONG_TERM_WEEKS_CURRENT_CLOSE_SERVICE_POINT_ID:


### PR DESCRIPTION
## Purpose
Fix flaky HoldShelfExpirationDateTests that fail on CI when JVM class-loading and test execution happen across a midnight UTC boundary.

## Approach
  - CalendarExamples — for CASE_CURRENT_CLOSE_SERVICE_POINT_ID, the calendar period is now built dynamically from the date query parameter instead of the statically captured class-load date. This also keeps correctness for tests that use cd5–cd8 without a fake clock (e.g. RequestsAPICreationTests).                                                     
  - HoldShelfExpirationDateTests.setUp() — fake clock is pinned to CASE_CURRENT_DATE_CLOSE (the real date captured at class-load time) so the server-side logic and calendar data stay in sync.                                                                                                                                                                     
  - isSameDay() — replaced LocalDate.now() with the fake clock via getZonedDateTime().

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
[CIRC-2633](https://folio-org.atlassian.net/browse/CIRC-2633)
