### PR TITLE
CIRC-2538: Refactor item location handling to use locationRepository directly for effective location retrieval

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 24.6.0-SNAPSHOT In progress
 * Fix flaky tests ([CIRC-2633](https://folio-org.atlassian.net/browse/CIRC-2633))
-* Implement shadow location handling for DCB items in fetchItemRelatedRecords ([CIRC-2538](https://folio-org.atlassian.net/browse/CIRC-2538))
+* Refactor item location handling to use locationRepository directly for effective location retrieval ([CIRC-2538](https://folio-org.atlassian.net/browse/CIRC-2538))
 
 ## 24.5.0 2026-04-14
 * Allow HTTP Connection Pool to be Configurable ([CIRC-2279](https://folio-org.atlassian.net/browse/CIRC-2279))

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepository.java
@@ -401,16 +401,10 @@ public class ItemRepository {
   public CompletableFuture<Result<Item>> fetchItemRelatedRecords(Result<Item> itemResult) {
     return itemResult.combineAfter(this::fetchHoldingsRecord, Item::withHoldings)
       .thenComposeAsync(combineAfter(this::fetchInstance, Item::withInstance))
-      .thenComposeAsync(combineAfter(this::getEffectiveLocation, Item::withLocation))
+      .thenComposeAsync(combineAfter(locationRepository::getEffectiveLocation, Item::withLocation))
       .thenComposeAsync(combineAfter(materialTypeRepository::getFor, Item::withMaterialType))
       .thenComposeAsync(combineAfter(this::fetchLoanType, Item::withLoanType))
       .thenCompose(CompletableFuture::completedFuture);
-  }
-
-  private CompletableFuture<Result<Location>> getEffectiveLocation(Item item) {
-    return item.isDcbItem()
-      ? shadowLocationRepository.getEffectiveLocation(item)
-      : locationRepository.getEffectiveLocation(item);
   }
 
   private CompletableFuture<Result<Holdings>> fetchHoldingsRecord(Item item) {

--- a/src/main/java/org/folio/circulation/infrastructure/storage/inventory/LocationRepository.java
+++ b/src/main/java/org/folio/circulation/infrastructure/storage/inventory/LocationRepository.java
@@ -311,6 +311,11 @@ public class LocationRepository {
       log.info("Location was not found, aborting fetching primary service point");
       return ofAsync(() -> null);
     }
+    if (location.getPrimaryServicePoint() != null
+        && location.getPrimaryServicePoint().getName() != null) {
+      log.info("fetchPrimaryServicePoint:: using effectiveLocationPrimaryServicePointName");
+      return ofAsync(location::getPrimaryServicePoint);
+    }
 
     return servicePointRepository.getServicePointById(location.getPrimaryServicePointId());
   }

--- a/src/test/java/api/requests/RequestsAPICreationTests.java
+++ b/src/test/java/api/requests/RequestsAPICreationTests.java
@@ -5573,4 +5573,46 @@ public class RequestsAPICreationTests extends APITests {
     assertThat(itemResponse.getString("retrievalServicePointName"),
       is(pickupServicePoint.getJson().getString("name")));
   }
+
+  @Test
+  void retrievalServicePointNameUsesEffectiveLocationPrimaryServicePointNameForEcsItem() {
+    final String realSpName = "Member Circ Desk";
+
+    IndividualResource dcbServicePoint = servicePointsFixture.create(
+      new ServicePointBuilder("DCB", "DCB", "DCB"));
+
+    IndividualResource institution = locationsFixture.createInstitution("ECS Institution");
+    IndividualResource campus = locationsFixture.createCampus("ECS Campus", institution.getId());
+    IndividualResource library = locationsFixture.createLibrary("ECS Library", campus.getId());
+
+    IndividualResource ecsLocation = locationsFixture.createLocation(
+      new LocationBuilder()
+        .withName("ECS Shadow Location")
+        .withCode("ECS-SHADOW-" + UUID.randomUUID())
+        .forInstitution(institution.getId())
+        .forCampus(campus.getId())
+        .forLibrary(library.getId())
+        .withPrimaryServicePoint(dcbServicePoint.getId())
+        .withEffectiveLocationPrimaryServicePointName(realSpName));
+
+    IndividualResource instance = instancesFixture.basedUponDunkirk();
+    IndividualResource holdings = holdingsFixture.defaultWithHoldings(instance.getId());
+
+    IndividualResource item = itemsClient.create(new ItemBuilder()
+      .forHolding(holdings.getId())
+      .withMaterialType(materialTypesFixture.book().getId())
+      .withPermanentLoanType(loanTypesFixture.canCirculate().getId())
+      .withPermanentLocation(ecsLocation)
+      .create());
+
+    IndividualResource request = requestsClient.create(new RequestBuilder()
+      .page()
+      .forItem(item)
+      .withInstanceId(instance.getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId())
+      .by(usersFixture.james()));
+
+    assertThat(request.getJson().getJsonObject("item").getString("retrievalServicePointName"),
+      is(realSpName));
+  }
 }

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/ItemRepositoryTests.java
@@ -10,7 +10,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +25,6 @@ import org.folio.circulation.domain.ItemDescription;
 import org.folio.circulation.domain.LoanType;
 import org.folio.circulation.domain.Location;
 import org.folio.circulation.domain.MaterialType;
-import org.folio.circulation.storage.mappers.ItemMapper;
 import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.results.Result;
@@ -138,68 +136,6 @@ class ItemRepositoryTests {
     assertThat(updateResult, succeeded());
   }
 
-  @Test
-  void fetchItemRelatedRecordsShouldUseShadowLocationRepoForDcbItem() {
-    final var locationRepository = mock(LocationRepository.class);
-    final var shadowLocationRepository = mock(ShadowLocationRepository.class);
-    final var materialTypeRepository = mock(MaterialTypeRepository.class);
-    final var instanceRepository = mock(InstanceRepository.class);
-    final var holdingsRepository = mock(HoldingsRepository.class);
-    final var loanTypeRepository = mock(LoanTypeRepository.class);
-
-    when(locationRepository.getEffectiveLocation(any())).thenReturn(ofAsync(Location::unknown));
-    when(shadowLocationRepository.getEffectiveLocation(any())).thenReturn(ofAsync(Location::unknown));
-    when(materialTypeRepository.getFor(any())).thenReturn(ofAsync(MaterialType::unknown));
-    when(instanceRepository.fetchById(anyString())).thenReturn(ofAsync(Instance::unknown));
-    when(holdingsRepository.fetchById(anyString())).thenReturn(ofAsync(Holdings::unknown));
-
-    final var repository = new ItemRepository(null, locationRepository, shadowLocationRepository,
-      materialTypeRepository, instanceRepository, holdingsRepository, loanTypeRepository, null);
-
-    final var dcbItemJson = new JsonObject()
-      .put("id", UUID.randomUUID().toString())
-      .put("dcbItem", true)
-      .put("holdingsRecordId", UUID.randomUUID().toString())
-      .put("effectiveLocationId", UUID.randomUUID().toString());
-    final var dcbItem = new ItemMapper().toDomain(dcbItemJson);
-
-    get(repository.fetchItemRelatedRecords(Result.succeeded(dcbItem)));
-
-    verify(shadowLocationRepository).getEffectiveLocation(any());
-    verify(locationRepository, never()).getEffectiveLocation(any());
-  }
-
-  @Test
-  void fetchItemRelatedRecordsShouldUseRegularLocationRepoForNonDcbItem() {
-    final var locationRepository = mock(LocationRepository.class);
-    final var shadowLocationRepository = mock(ShadowLocationRepository.class);
-    final var materialTypeRepository = mock(MaterialTypeRepository.class);
-    final var instanceRepository = mock(InstanceRepository.class);
-    final var holdingsRepository = mock(HoldingsRepository.class);
-    final var loanTypeRepository = mock(LoanTypeRepository.class);
-
-    when(locationRepository.getEffectiveLocation(any())).thenReturn(ofAsync(Location::unknown));
-    when(shadowLocationRepository.getEffectiveLocation(any())).thenReturn(ofAsync(Location::unknown));
-    when(materialTypeRepository.getFor(any())).thenReturn(ofAsync(MaterialType::unknown));
-    when(instanceRepository.fetchById(anyString())).thenReturn(ofAsync(Instance::unknown));
-    when(holdingsRepository.fetchById(anyString())).thenReturn(ofAsync(Holdings::unknown));
-
-    final var repository = new ItemRepository(null, locationRepository, shadowLocationRepository,
-      materialTypeRepository, instanceRepository, holdingsRepository, loanTypeRepository, null);
-
-    final var regularItemJson = new JsonObject()
-      .put("id", UUID.randomUUID().toString())
-      .put("dcbItem", false)
-      .put("holdingsRecordId", UUID.randomUUID().toString())
-      .put("effectiveLocationId", UUID.randomUUID().toString());
-    final var regularItem = new ItemMapper().toDomain(regularItemJson);
-
-    get(repository.fetchItemRelatedRecords(Result.succeeded(regularItem)));
-
-    verify(locationRepository).getEffectiveLocation(any());
-    verify(shadowLocationRepository, never()).getEffectiveLocation(any());
-  }
-
   private void mockedClientGet(CollectionResourceClient client, String body) {
     when(client.get(anyString())).thenReturn(ofAsync(
       () -> new Response(200, body, "application/json")));
@@ -215,9 +151,6 @@ class ItemRepositoryTests {
 
 
     when(locationRepository.getEffectiveLocation(any()))
-      .thenReturn(ofAsync(Location::unknown));
-
-    when(shadowLocationRepository.getEffectiveLocation(any()))
       .thenReturn(ofAsync(Location::unknown));
 
     when(materialTypeRepository.getFor(any()))

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/LocationRepositoryTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/LocationRepositoryTest.java
@@ -92,6 +92,42 @@ class LocationRepositoryTest {
     verify(servicePointRepository, never()).getServicePointById(anyString());
   }
 
+  @Test
+  void getEffectiveLocationShouldFetchServicePointFromStorageWhenNameIsAbsent() {
+    final var spId = UUID.randomUUID().toString();
+    final var locationId = UUID.randomUUID().toString();
+
+    final var locationJson = new JsonObject()
+      .put("id", locationId)
+      .put("name", "Regular Location")
+      .put("code", "REG-LOC")
+      .put("primaryServicePoint", spId);
+
+    final var locationsClient = mock(CollectionResourceClient.class);
+    final var servicePointRepository = mock(ServicePointRepository.class);
+
+    when(locationsClient.get(anyString())).thenReturn(ofAsync(
+      () -> new Response(200, locationJson.encodePrettily(), "application/json")));
+    when(servicePointRepository.getServicePointById(any(UUID.class)))
+      .thenReturn(ofAsync(() -> null));
+
+    final var clients = mock(Clients.class);
+    when(clients.locationsStorage()).thenReturn(locationsClient);
+    when(clients.institutionsStorage()).thenReturn(mock(CollectionResourceClient.class));
+    when(clients.campusesStorage()).thenReturn(mock(CollectionResourceClient.class));
+    when(clients.librariesStorage()).thenReturn(mock(CollectionResourceClient.class));
+
+    final var itemJson = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("holdingsRecordId", UUID.randomUUID().toString())
+      .put("effectiveLocationId", locationId);
+    final Item item = new ItemMapper().toDomain(itemJson);
+
+    get(using(clients, servicePointRepository).getEffectiveLocation(item));
+
+    verify(servicePointRepository).getServicePointById(UUID.fromString(spId));
+  }
+
   @SneakyThrows
   private <T> Result<T> get(CompletableFuture<Result<T>> future) {
     return future.get(1, TimeUnit.SECONDS);

--- a/src/test/java/org/folio/circulation/infrastructure/storage/inventory/LocationRepositoryTest.java
+++ b/src/test/java/org/folio/circulation/infrastructure/storage/inventory/LocationRepositoryTest.java
@@ -1,23 +1,42 @@
 package org.folio.circulation.infrastructure.storage.inventory;
 
+import static api.support.matchers.ResultMatchers.succeeded;
 import static org.folio.circulation.infrastructure.storage.inventory.LocationRepository.using;
+import static org.folio.circulation.support.results.Result.ofAsync;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import org.folio.circulation.infrastructure.storage.ServicePointRepository;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Location;
+import org.folio.circulation.infrastructure.storage.ServicePointRepository;
+import org.folio.circulation.storage.mappers.ItemMapper;
 import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.CollectionResourceClient;
 import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.http.client.Response;
 import org.folio.circulation.support.results.Result;
 import org.junit.jupiter.api.Test;
 
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import lombok.SneakyThrows;
 import lombok.val;
 
 class LocationRepositoryTest {
+
   @Test
   void shouldReturnUnknownLocationWhenLocationIdIsNull() {
     final LocationRepository repository = using(mock(Clients.class),
@@ -29,5 +48,52 @@ class LocationRepositoryTest {
     assertTrue(result.succeeded());
     assertThat(result.value(), is(instanceOf(Location.class)));
     assertThat(result.value().getId(), is(nullValue()));
+  }
+
+  @Test
+  void getEffectiveLocationShouldUseEffectiveLocationPrimaryServicePointNameWithoutFetchingServicePoint() {
+    final var dcbSpId = UUID.randomUUID().toString();
+    final var realSpName = "Circ Desk 1";
+    final var locationId = UUID.randomUUID().toString();
+
+    final var locationJson = new JsonObject()
+      .put("id", locationId)
+      .put("name", "ECS Shadow Location")
+      .put("code", "ECS-SL")
+      .put("primaryServicePoint", dcbSpId)
+      .put("effectiveLocationPrimaryServicePointName", realSpName)
+      .put("servicePointIds", new JsonArray().add(dcbSpId));
+
+    final var locationsClient = mock(CollectionResourceClient.class);
+    final var servicePointRepository = mock(ServicePointRepository.class);
+
+    when(locationsClient.get(anyString())).thenReturn(ofAsync(
+      () -> new Response(200, locationJson.encodePrettily(), "application/json")));
+
+    final var clients = mock(Clients.class);
+    when(clients.locationsStorage()).thenReturn(locationsClient);
+    when(clients.institutionsStorage()).thenReturn(mock(CollectionResourceClient.class));
+    when(clients.campusesStorage()).thenReturn(mock(CollectionResourceClient.class));
+    when(clients.librariesStorage()).thenReturn(mock(CollectionResourceClient.class));
+
+    final var repository = using(clients, servicePointRepository);
+
+    final var itemJson = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("holdingsRecordId", UUID.randomUUID().toString())
+      .put("effectiveLocationId", locationId);
+    final Item item = new ItemMapper().toDomain(itemJson);
+
+    final Result<Location> result = get(repository.getEffectiveLocation(item));
+
+    assertThat(result, succeeded());
+    assertThat(result.value().getPrimaryServicePoint().getName(), is(realSpName));
+    verify(servicePointRepository, never()).getServicePointById(any(UUID.class));
+    verify(servicePointRepository, never()).getServicePointById(anyString());
+  }
+
+  @SneakyThrows
+  private <T> Result<T> get(CompletableFuture<Result<T>> future) {
+    return future.get(1, TimeUnit.SECONDS);
   }
 }


### PR DESCRIPTION
## Purpose
Fix retrievalServicePointName showing "DCB" instead of the real service point name for ECS LOC requests. In the Central tenant, shadow locations have primaryServicePoint pointing to the DCB service point UUID, but carry the real SP name in effectiveLocationPrimaryServicePointName. The previous fix (#1679) incorrectly targeted DCB virtual items via routing in ItemRepository and is reverted by this PR.

## Approach
The fix is in LocationRepository.fetchPrimaryServicePoint: if the location already has a ServicePoint stub with a non-null name (populated by LocationMapper from effectiveLocationPrimaryServicePointName), return it directly without fetching from storage — which would overwrite the correct name with "DCB"

#### TODOS and Open Questions
- [ ] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
[CIRC-2538](https://folio-org.atlassian.net/browse/CIRC-2538)
