### PR TITLE
CIRC-2644: Fix matching ECS TLR request to item being checked out in non data tenant 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Refactor item location handling to use locationRepository directly for effective location retrieval ([CIRC-2538](https://folio-org.atlassian.net/browse/CIRC-2538))
 * Fail on startup if Kafka config is invalid ([CIRC-2003](https://folio-org.atlassian.net/browse/CIRC-2003))
 * Fix loan status in `AnonymizeLoansTests` fixture for closed loans with open fees ([CIRC-2641](https://folio-org.atlassian.net/browse/CIRC-2641))
+* Fix Item check-out for related ECS TLR Page request when ILR exist for different requester ([CIRC-2644](https://folio-org.atlassian.net/browse/CIRC-2644))
 
 ## 24.5.0 2026-04-14
 * Allow HTTP Connection Pool to be Configurable ([CIRC-2279](https://folio-org.atlassian.net/browse/CIRC-2279))

--- a/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
+++ b/src/main/java/org/folio/circulation/resources/CheckOutByBarcodeResource.java
@@ -32,6 +32,7 @@ import org.folio.circulation.domain.LoanRepresentation;
 import org.folio.circulation.domain.LoanService;
 import org.folio.circulation.domain.RequestQueue;
 import org.folio.circulation.domain.UpdateRequestQueue;
+import org.folio.circulation.domain.configuration.TlrSettingsConfiguration;
 import org.folio.circulation.domain.notice.schedule.LoanScheduledNoticeService;
 import org.folio.circulation.domain.notice.schedule.ReminderFeeScheduledNoticeService;
 import org.folio.circulation.domain.notice.schedule.RequestScheduledNoticeService;
@@ -416,9 +417,14 @@ public class CheckOutByBarcodeResource extends Resource {
     LoanAndRelatedRecords loanAndRelatedRecords, RequestQueueRepository requestQueueRepository) {
 
     Item item = loanAndRelatedRecords.getItem();
+    TlrSettingsConfiguration tlrSettings = loanAndRelatedRecords.getTlrSettings();
 
-    return loanAndRelatedRecords.getTlrSettings().isTitleLevelRequestsFeatureEnabled()
+    return (tlrSettings.isTitleLevelRequestsFeatureEnabled()
       ? requestQueueRepository.getByInstanceIdAndItemId(item.getInstanceId(), item.getItemId())
-      : requestQueueRepository.getByItemId(item.getItemId());
+      : requestQueueRepository.getByItemId(item.getItemId()))
+      .thenApply(r -> r.map(queue -> new RequestQueue(
+        queue.getRequests().stream()
+          .map(request -> request.withTlrSettingsConfiguration(tlrSettings))
+          .toList())));
   }
 }

--- a/src/main/java/org/folio/circulation/services/CheckOutRequestQueueService.java
+++ b/src/main/java/org/folio/circulation/services/CheckOutRequestQueueService.java
@@ -5,7 +5,7 @@ import static org.folio.circulation.support.results.Result.ofAsync;
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Item;
@@ -38,14 +38,14 @@ public class CheckOutRequestQueueService extends RequestQueueService {
     log.info("isTitleLevelRequestFulfillableByItem:: parameters itemId: {}, requestId: {}",
       item::getItemId, request::getId);
 
-    if (!StringUtils.equals(request.getInstanceId(), item.getInstanceId())) {
+    if (!Strings.CS.equals(request.getInstanceId(), item.getInstanceId()) && !item.isDcbItem()) {
       log.info("isTitleLevelRequestFulfillableByItem:: instanceId mismatch, not fulfillable");
       return ofAsync(false);
     }
 
     if (request.isRecall()) {
       log.info("isTitleLevelRequestFulfillableByItem:: recall request, checking itemId match");
-      return ofAsync(StringUtils.equals(request.getItemId(), item.getItemId()));
+      return ofAsync(Strings.CS.equals(request.getItemId(), item.getItemId()));
     }
 
     return canRequestBeFulfilledByItem(item, request);

--- a/src/main/java/org/folio/circulation/services/CheckOutRequestQueueService.java
+++ b/src/main/java/org/folio/circulation/services/CheckOutRequestQueueService.java
@@ -3,6 +3,7 @@ package org.folio.circulation.services;
 import static org.folio.circulation.support.results.Result.ofAsync;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.lang3.Strings;
@@ -10,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.Item;
 import org.folio.circulation.domain.Request;
+import org.folio.circulation.domain.configuration.TlrSettingsConfiguration;
 import org.folio.circulation.infrastructure.storage.loans.LoanPolicyRepository;
 import org.folio.circulation.infrastructure.storage.requests.RequestPolicyRepository;
 import org.folio.circulation.support.Clients;
@@ -38,7 +40,11 @@ public class CheckOutRequestQueueService extends RequestQueueService {
     log.info("isTitleLevelRequestFulfillableByItem:: parameters itemId: {}, requestId: {}",
       item::getItemId, request::getId);
 
-    if (!Strings.CS.equals(request.getInstanceId(), item.getInstanceId()) && !item.isDcbItem()) {
+    var tlrRequestsFeatureEnabled = Optional.ofNullable(request.getTlrSettingsConfiguration())
+      .map(TlrSettingsConfiguration::isTitleLevelRequestsFeatureEnabled)
+      .orElse(false);
+    boolean sameInstance = Strings.CS.equals(request.getInstanceId(), item.getInstanceId());
+    if (!sameInstance && (!tlrRequestsFeatureEnabled || !item.isDcbItem())) {
       log.info("isTitleLevelRequestFulfillableByItem:: instanceId mismatch, not fulfillable");
       return ofAsync(false);
     }

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -2346,8 +2346,7 @@ class CheckOutByBarcodeTests extends APITests {
   }
 
   @Test
-  public void
-  dueDateShouldBeTruncatedToTheEndOfPreviousServicePointHoursIfMoveToTheEndOfCurrentHoursStrategy() {
+  void dueDateShouldBeTruncatedToTheEndOfPreviousServicePointHoursIfMoveToTheEndOfCurrentHoursStrategy() {
     ZonedDateTime loanDate = atStartOfDay(FIRST_DAY_OPEN, UTC).plusHours(16);
     use(buildLoanPolicyWithRollingLoan(MOVE_TO_END_OF_CURRENT_SERVICE_POINT_HOURS, 1));
 
@@ -2446,8 +2445,7 @@ class CheckOutByBarcodeTests extends APITests {
   }
 
   @Test
-  public void
-  dueDateShouldBeTruncatedToTheEndOfPreviousServicePointHoursIfMoveToTheBeginningOfNextStrategy() {
+  void dueDateShouldBeTruncatedToTheEndOfPreviousServicePointHoursIfMoveToTheBeginningOfNextStrategy() {
     ZonedDateTime loanDate = atStartOfDay(FIRST_DAY_OPEN, UTC).plusHours(16);
     use(buildLoanPolicyWithRollingLoan(MOVE_TO_BEGINNING_OF_NEXT_OPEN_SERVICE_POINT_HOURS, 1));
 
@@ -2469,8 +2467,7 @@ class CheckOutByBarcodeTests extends APITests {
   }
 
   @Test
-  public void
-  shouldBeTruncatedToTheEndOfPrevOpenDayForMoveToTheEndOfPrevOpenDayStrategyWithTwoOpeningPeriods() {
+  void shouldBeTruncatedToTheEndOfPrevOpenDayForMoveToTheEndOfPrevOpenDayStrategyWithTwoOpeningPeriods() {
     ZonedDateTime loanDate = atStartOfDay(MONDAY_DATE, UTC).plusHours(16);
     use(buildLoanPolicyWithRollingLoan(MOVE_TO_THE_END_OF_THE_PREVIOUS_OPEN_DAY, 3));
 
@@ -2492,8 +2489,7 @@ class CheckOutByBarcodeTests extends APITests {
   }
 
   @Test
-  public void
-  shouldBeTruncatedToTheEndOfPrevOpenDayForMoveToTheEndOfNextOpenDayStrategyWithTwoOpeningPeriods() {
+  void shouldBeTruncatedToTheEndOfPrevOpenDayForMoveToTheEndOfNextOpenDayStrategyWithTwoOpeningPeriods() {
     ZonedDateTime loanDate = atStartOfDay(MONDAY_DATE, UTC).plusHours(16);
     use(buildLoanPolicyWithRollingLoan(MOVE_TO_THE_END_OF_THE_NEXT_OPEN_DAY, 3));
 
@@ -2816,9 +2812,8 @@ class CheckOutByBarcodeTests extends APITests {
   }
 
   @Test
-  void shouldCheckoutItemToRequesterOneWithTitleLevelPageAndDcbItemWhenItemLevelHoldExistForRequesterTwo() {
+  void shouldCheckoutItemToRequesterOneWithTitleLevelPageAndDcbItemWhenItemLevelHoldExistsForRequesterTwo() {
     circulationSettingsFixture.enableTlrFeature();
-
     IndividualResource realInstance = instancesFixture.basedUponDunkirk();
 
     UUID dcbInstanceId = UUID.randomUUID();
@@ -2856,7 +2851,6 @@ class CheckOutByBarcodeTests extends APITests {
 
     UserResource borrower = usersFixture.steve();
     checkOutFixture.checkOutByBarcode(dcbItem, borrower);
-
     assertThat(requestsFixture.getById(requestId).getJson(), isClosedFilled());
   }
 

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -2815,6 +2815,51 @@ class CheckOutByBarcodeTests extends APITests {
     assertThat(requestsFixture.getById(requestId).getJson(), isClosedFilled());
   }
 
+  @Test
+  void shouldCheckoutItemToRequesterOneWithTitleLevelPageAndDcbItemWhenItemLevelHoldExistForRequesterTwo() {
+    circulationSettingsFixture.enableTlrFeature();
+
+    IndividualResource realInstance = instancesFixture.basedUponDunkirk();
+
+    UUID dcbInstanceId = UUID.randomUUID();
+    IndividualResource dcbHoldings = holdingsFixture.defaultWithHoldings(dcbInstanceId);
+    String barcode = "00001";
+    IndividualResource dcbItem = circulationItemsFixture.createCirculationItem(
+      UUID.randomUUID(), barcode, dcbHoldings.getId(),
+      locationsFixture.mainFloor().getId(), "DCB instance");
+
+    IndividualResource firstRequest = requestsFixture.placeTitleLevelHoldShelfRequest(
+      realInstance.getId(), usersFixture.steve(), ZonedDateTime.now());
+    UUID requestId = firstRequest.getId();
+
+    requestsStorageClient.replace(requestId,
+      requestsStorageClient.get(requestId).getJson()
+        .put("itemId", dcbItem.getId().toString())
+        .put("holdingsRecordId", dcbHoldings.getId().toString())
+        .put("item", new JsonObject().put("barcode", barcode)));
+
+    UUID randomServicePointId = servicePointsFixture.cd2().getId();
+    checkInFixture.checkInByBarcode(dcbItem, randomServicePointId);
+    assertThat(requestsFixture.getById(requestId).getJson(), isOpenInTransit());
+
+    checkInFixture.checkInByBarcode(dcbItem, servicePointsFixture.cd1().getId());
+    assertThat(requestsFixture.getById(requestId).getJson(), isOpenAwaitingPickup());
+
+    requestsFixture.place(new RequestBuilder()
+      .hold()
+      .fulfillToHoldShelf()
+      .withItemId(dcbItem.getId())
+      .withInstanceId(realInstance.getId())
+      .withRequestDate(ZonedDateTime.now())
+      .withRequesterId(usersFixture.jessica().getId())
+      .withPickupServicePointId(servicePointsFixture.cd1().getId()));
+
+    UserResource borrower = usersFixture.steve();
+    checkOutFixture.checkOutByBarcode(dcbItem, borrower);
+
+    assertThat(requestsFixture.getById(requestId).getJson(), isClosedFilled());
+  }
+
   private IndividualResource placeRequest(String requestLevel, ItemResource item,
     IndividualResource requester) {
 

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -2823,8 +2823,9 @@ class CheckOutByBarcodeTests extends APITests {
       UUID.randomUUID(), barcode, dcbHoldings.getId(),
       locationsFixture.mainFloor().getId(), "DCB instance");
 
+    UserResource steve = usersFixture.steve();
     IndividualResource firstRequest = requestsFixture.placeTitleLevelHoldShelfRequest(
-      realInstance.getId(), usersFixture.steve(), ZonedDateTime.now());
+      realInstance.getId(), steve, ZonedDateTime.now());
     UUID requestId = firstRequest.getId();
 
     requestsStorageClient.replace(requestId,
@@ -2849,8 +2850,7 @@ class CheckOutByBarcodeTests extends APITests {
       .withRequesterId(usersFixture.jessica().getId())
       .withPickupServicePointId(servicePointsFixture.cd1().getId()));
 
-    UserResource borrower = usersFixture.steve();
-    checkOutFixture.checkOutByBarcode(dcbItem, borrower);
+    checkOutFixture.checkOutByBarcode(dcbItem, steve);
     assertThat(requestsFixture.getById(requestId).getJson(), isClosedFilled());
   }
 


### PR DESCRIPTION
## Purpose
For ECS TLR, checking-out item from the same title by barcode fails in a non-data tenant when an additional ILR Hold request for the same item but different requester exist. Mismatch between `instanceId`s for the DCB item and the one stored in request causes a false _"requested by another patron"_ validation error.

## Approach
Skip the comparison of DCB and real Item's instance IDs for DCB items (or in non-data tenants)

#### TODOS and Open Questions
- [ ] Check logging
- [x] Update NEWS.md
- [x] Add/Update tests

## Learning
[CIRC-2644](https://folio-org.atlassian.net/browse/CIRC-2644)
