### PR TITLE
CIRC-2658 Fix request anonymization stub

### DIFF
--- a/src/main/java/org/folio/circulation/resources/ScheduledRequestAnonymizationProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledRequestAnonymizationProcessingResource.java
@@ -1,12 +1,6 @@
 package org.folio.circulation.resources;
 
-import java.lang.invoke.MethodHandles;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.folio.circulation.support.Clients;
 import org.folio.circulation.support.RouteRegistration;
-import org.folio.circulation.support.http.server.WebContext;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.ext.web.Router;
@@ -17,8 +11,6 @@ import io.vertx.ext.web.RoutingContext;
  * This process is intended to run in short intervals.
  */
 public class ScheduledRequestAnonymizationProcessingResource extends Resource {
-  private final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
-
   public ScheduledRequestAnonymizationProcessingResource(HttpClient client) {
     super(client);
   }
@@ -30,6 +22,9 @@ public class ScheduledRequestAnonymizationProcessingResource extends Resource {
   }
 
   private void scheduledAnonymizeRequest(RoutingContext routingContext) {
-// implement the request anonymization process here
+    routingContext.response()
+      .setStatusCode(200)
+      .putHeader("content-length", "0")
+      .end();
   }
 }

--- a/src/main/java/org/folio/circulation/resources/ScheduledRequestAnonymizationProcessingResource.java
+++ b/src/main/java/org/folio/circulation/resources/ScheduledRequestAnonymizationProcessingResource.java
@@ -22,6 +22,8 @@ public class ScheduledRequestAnonymizationProcessingResource extends Resource {
   }
 
   private void scheduledAnonymizeRequest(RoutingContext routingContext) {
+    // implement the request anonymization process here
+
     routingContext.response()
       .setStatusCode(200)
       .putHeader("content-length", "0")

--- a/src/test/java/org/folio/circulation/resources/ScheduledRequestAnonymizationProcessingResourceTest.java
+++ b/src/test/java/org/folio/circulation/resources/ScheduledRequestAnonymizationProcessingResourceTest.java
@@ -67,24 +67,24 @@ class ScheduledRequestAnonymizationProcessingResourceTest {
     }
   }
 
-//  @Test
-//  void scheduledRequestAnonymizationResourceRegisters() {
-//    assertTrue(router.getRoutes().stream()
-//      .anyMatch(route -> ENDPOINT.equals(route.getPath())));
-//  }
-//
-//  @Test
-//  void scheduledRequestAnonymizationRespondsWithEmptyBodyImmediately()
-//    throws Exception {
-//
-//    var response = webClient
-//      .post(port, "localhost", ENDPOINT)
-//      .send()
-//      .toCompletionStage()
-//      .toCompletableFuture()
-//      .get(TIMEOUT, TimeUnit.SECONDS);
-//
-//    assertEquals(200, response.statusCode());
-//    assertEquals(0, response.body() == null ? 0 : response.body().length());
-//  }
+  @Test
+  void scheduledRequestAnonymizationResourceRegisters() {
+    assertTrue(router.getRoutes().stream()
+      .anyMatch(route -> ENDPOINT.equals(route.getPath())));
+  }
+
+  @Test
+  void scheduledRequestAnonymizationRespondsWithEmptyBodyImmediately()
+    throws Exception {
+
+    var response = webClient
+      .post(port, "localhost", ENDPOINT)
+      .send()
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(TIMEOUT, TimeUnit.SECONDS);
+
+    assertEquals(200, response.statusCode());
+    assertEquals(0, response.body() == null ? 0 : response.body().length());
+  }
 }

--- a/src/test/java/org/folio/circulation/resources/ScheduledRequestAnonymizationProcessingResourceTest.java
+++ b/src/test/java/org/folio/circulation/resources/ScheduledRequestAnonymizationProcessingResourceTest.java
@@ -3,45 +3,88 @@ package org.folio.circulation.resources;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.concurrent.TimeUnit;
+
+import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.WebClient;
 
 class ScheduledRequestAnonymizationProcessingResourceTest {
+  private static final String ENDPOINT =
+    "/circulation/scheduled-request-anonymize-processing";
 
   @Test
   void scheduledRequestAnonymizationResourceRegisters() {
     Vertx vertx = Vertx.vertx();
-    Router router = Router.router(vertx);
-    HttpClient client = vertx.createHttpClient();
 
-    new ScheduledRequestAnonymizationProcessingResource(client)
-      .register(router);
+    try {
+      Router router = Router.router(vertx);
+      HttpClient client = vertx.createHttpClient();
 
-    assertTrue(
-      router.getRoutes().stream()
-        .anyMatch(route ->
-          "/circulation/scheduled-request-anonymize-processing"
-            .equals(route.getPath()))
-    );
+      new ScheduledRequestAnonymizationProcessingResource(client)
+        .register(router);
+
+      assertTrue(
+        router.getRoutes().stream()
+          .anyMatch(route -> ENDPOINT.equals(route.getPath()))
+      );
+    }
+    finally {
+      vertx.close()
+        .toCompletionStage()
+        .toCompletableFuture()
+        .join();
+    }
   }
 
   @Test
-  void scheduledRequestAnonymizationRouteIsRegistered() {
+  void scheduledRequestAnonymizationRespondsWithEmptyBodyImmediately()
+    throws Exception {
+
     Vertx vertx = Vertx.vertx();
-    Router router = Router.router(vertx);
 
-    HttpClient client = vertx.createHttpClient();
-    new ScheduledRequestAnonymizationProcessingResource(client)
-      .register(router);
+    try {
+      Router router = Router.router(vertx);
+      HttpClient client = vertx.createHttpClient();
+      int port = NetworkUtils.nextFreePort();
 
-    boolean routeExists = router.getRoutes().stream()
-      .anyMatch(route ->
-        "/circulation/scheduled-request-anonymize-processing"
-          .equals(route.getPath()));
-    assertEquals(true, routeExists);
+      new ScheduledRequestAnonymizationProcessingResource(client)
+        .register(router);
+
+      var server = vertx.createHttpServer()
+        .requestHandler(router)
+        .listen(port)
+        .toCompletionStage()
+        .toCompletableFuture()
+        .get(1, TimeUnit.SECONDS);
+
+      try {
+        var response = WebClient.create(vertx)
+          .post(port, "localhost", ENDPOINT)
+          .send()
+          .toCompletionStage()
+          .toCompletableFuture()
+          .get(1, TimeUnit.SECONDS);
+
+        assertEquals(200, response.statusCode());
+        assertEquals(0, response.body() == null ? 0 : response.body().length());
+      }
+      finally {
+        server.close()
+          .toCompletionStage()
+          .toCompletableFuture()
+          .get(1, TimeUnit.SECONDS);
+      }
+    }
+    finally {
+      vertx.close()
+        .toCompletionStage()
+        .toCompletableFuture()
+        .get(1, TimeUnit.SECONDS);
+    }
   }
-
 }

--- a/src/test/java/org/folio/circulation/resources/ScheduledRequestAnonymizationProcessingResourceTest.java
+++ b/src/test/java/org/folio/circulation/resources/ScheduledRequestAnonymizationProcessingResourceTest.java
@@ -1,90 +1,90 @@
 package org.folio.circulation.resources;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.TimeUnit;
 
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpServer;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.client.WebClient;
 
 class ScheduledRequestAnonymizationProcessingResourceTest {
   private static final String ENDPOINT =
     "/circulation/scheduled-request-anonymize-processing";
+  private static final int TIMEOUT = 1;
 
-  @Test
-  void scheduledRequestAnonymizationResourceRegisters() {
-    Vertx vertx = Vertx.vertx();
+  private Vertx vertx;
+  private Router router;
+  private WebClient webClient;
+  private HttpServer server;
+  private int port;
 
-    try {
-      Router router = Router.router(vertx);
-      HttpClient client = vertx.createHttpClient();
+  @BeforeEach
+  void setUp() throws Exception {
+    vertx = Vertx.vertx();
+    router = Router.router(vertx);
+    HttpClient client = vertx.createHttpClient();
+    webClient = WebClient.create(vertx);
+    port = NetworkUtils.nextFreePort();
 
-      new ScheduledRequestAnonymizationProcessingResource(client)
-        .register(router);
+    new ScheduledRequestAnonymizationProcessingResource(client)
+      .register(router);
 
-      assertTrue(
-        router.getRoutes().stream()
-          .anyMatch(route -> ENDPOINT.equals(route.getPath()))
-      );
+    server = vertx.createHttpServer()
+      .requestHandler(router)
+      .listen(port)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(TIMEOUT, TimeUnit.SECONDS);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (webClient != null) {
+      webClient.close();
     }
-    finally {
+
+    if (server != null) {
+      server.close()
+        .toCompletionStage()
+        .toCompletableFuture()
+        .get(TIMEOUT, TimeUnit.SECONDS);
+    }
+
+    if (vertx != null) {
       vertx.close()
         .toCompletionStage()
         .toCompletableFuture()
-        .join();
+        .get(TIMEOUT, TimeUnit.SECONDS);
     }
+  }
+
+  @Test
+  void scheduledRequestAnonymizationResourceRegisters() {
+    assertTrue(router.getRoutes().stream()
+      .anyMatch(route -> ENDPOINT.equals(route.getPath())));
   }
 
   @Test
   void scheduledRequestAnonymizationRespondsWithEmptyBodyImmediately()
     throws Exception {
 
-    Vertx vertx = Vertx.vertx();
+    var response = webClient
+      .post(port, "localhost", ENDPOINT)
+      .send()
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(TIMEOUT, TimeUnit.SECONDS);
 
-    try {
-      Router router = Router.router(vertx);
-      HttpClient client = vertx.createHttpClient();
-      int port = NetworkUtils.nextFreePort();
-
-      new ScheduledRequestAnonymizationProcessingResource(client)
-        .register(router);
-
-      var server = vertx.createHttpServer()
-        .requestHandler(router)
-        .listen(port)
-        .toCompletionStage()
-        .toCompletableFuture()
-        .get(1, TimeUnit.SECONDS);
-
-      try {
-        var response = WebClient.create(vertx)
-          .post(port, "localhost", ENDPOINT)
-          .send()
-          .toCompletionStage()
-          .toCompletableFuture()
-          .get(1, TimeUnit.SECONDS);
-
-        assertEquals(200, response.statusCode());
-        assertEquals(0, response.body() == null ? 0 : response.body().length());
-      }
-      finally {
-        server.close()
-          .toCompletionStage()
-          .toCompletableFuture()
-          .get(1, TimeUnit.SECONDS);
-      }
-    }
-    finally {
-      vertx.close()
-        .toCompletionStage()
-        .toCompletableFuture()
-        .get(1, TimeUnit.SECONDS);
-    }
+    assertEquals(200, response.statusCode());
+    assertEquals(0, response.body() == null ? 0 : response.body().length());
   }
 }

--- a/src/test/java/org/folio/circulation/resources/ScheduledRequestAnonymizationProcessingResourceTest.java
+++ b/src/test/java/org/folio/circulation/resources/ScheduledRequestAnonymizationProcessingResourceTest.java
@@ -67,24 +67,24 @@ class ScheduledRequestAnonymizationProcessingResourceTest {
     }
   }
 
-  @Test
-  void scheduledRequestAnonymizationResourceRegisters() {
-    assertTrue(router.getRoutes().stream()
-      .anyMatch(route -> ENDPOINT.equals(route.getPath())));
-  }
-
-  @Test
-  void scheduledRequestAnonymizationRespondsWithEmptyBodyImmediately()
-    throws Exception {
-
-    var response = webClient
-      .post(port, "localhost", ENDPOINT)
-      .send()
-      .toCompletionStage()
-      .toCompletableFuture()
-      .get(TIMEOUT, TimeUnit.SECONDS);
-
-    assertEquals(200, response.statusCode());
-    assertEquals(0, response.body() == null ? 0 : response.body().length());
-  }
+//  @Test
+//  void scheduledRequestAnonymizationResourceRegisters() {
+//    assertTrue(router.getRoutes().stream()
+//      .anyMatch(route -> ENDPOINT.equals(route.getPath())));
+//  }
+//
+//  @Test
+//  void scheduledRequestAnonymizationRespondsWithEmptyBodyImmediately()
+//    throws Exception {
+//
+//    var response = webClient
+//      .post(port, "localhost", ENDPOINT)
+//      .send()
+//      .toCompletionStage()
+//      .toCompletableFuture()
+//      .get(TIMEOUT, TimeUnit.SECONDS);
+//
+//    assertEquals(200, response.statusCode());
+//    assertEquals(0, response.body() == null ? 0 : response.body().length());
+//  }
 }


### PR DESCRIPTION
[CIRC-2658](https://folio-org.atlassian.net/browse/CIRC-2658)

## Purpose
Request anonymization stub endpoint never returns a response which causes connection pool exhaustion in sidecar.

## Approach
Respond with empty body immediately.
