### PR TITLE
CIRC-2661: Add conditions for determining patron notice format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Fail on startup if Kafka config is invalid ([CIRC-2003](https://folio-org.atlassian.net/browse/CIRC-2003))
 * Fix loan status in `AnonymizeLoansTests` fixture for closed loans with open fees ([CIRC-2641](https://folio-org.atlassian.net/browse/CIRC-2641))
 * Fix Item check-out for related ECS TLR Page request when ILR exist for different requester ([CIRC-2644](https://folio-org.atlassian.net/browse/CIRC-2644))
+* Add conditions for determining patron notice format([CIRC-2661](https://folio-org.atlassian.net/browse/CIRC-2661))
 
 ## 24.5.0 2026-04-14
 * Allow HTTP Connection Pool to be Configurable ([CIRC-2279](https://folio-org.atlassian.net/browse/CIRC-2279))

--- a/diff.txt
+++ b/diff.txt
@@ -1,0 +1,1740 @@
+diff --git a/diff.txt b/diff.txt
+new file mode 100644
+index 000000000..e69de29bb
+diff --git a/src/main/java/org/folio/circulation/domain/User.java b/src/main/java/org/folio/circulation/domain/User.java
+index 5e73c1f25..945abfcc8 100644
+--- a/src/main/java/org/folio/circulation/domain/User.java
++++ b/src/main/java/org/folio/circulation/domain/User.java
+@@ -172,6 +172,24 @@ public class User {
+       .collect(Collectors.toList());
+   }
+
++  public List<String> getPreferredContactTypeIds() {
++    var personal = getPersonal();
++    if (personal == null) {
++      return List.of();
++    }
++
++    return personal.getJsonArray("preferredContactTypeIds", new JsonArray())
++      .stream()
++      .filter(String.class::isInstance)
++      .map(String.class::cast)
++      .collect(Collectors.toList());
++  }
++
++  public String getPreferredContactTypeId() {
++    var personal = getPersonal();
++    return personal == null ? null : personal.getString("preferredContactTypeId");
++  }
++
+   public Collection<Department> getDepartments() {
+     return departments;
+   }
+diff --git a/src/main/java/org/folio/circulation/domain/notice/ImmediatePatronNoticeService.java b/src/main/java/org/folio/circulation/domain/notice/ImmediatePatronNoticeService.java
+index bd9999e48..b72dc875d 100644
+--- a/src/main/java/org/folio/circulation/domain/notice/ImmediatePatronNoticeService.java
++++ b/src/main/java/org/folio/circulation/domain/notice/ImmediatePatronNoticeService.java
+@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+
+ import static java.util.Collections.singletonList;
++import static java.util.concurrent.CompletableFuture.completedFuture;
+ import static java.util.stream.Collectors.groupingBy;
+ import static java.util.stream.Collectors.toList;
+ import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
+@@ -15,12 +16,14 @@ import static org.folio.circulation.support.results.ResultBinding.mapResult;
+ import java.util.Collection;
+ import java.util.List;
+ import java.util.Map;
+-import java.util.Optional;
++import java.util.Objects;
+ import java.util.concurrent.CompletableFuture;
+
++import org.folio.circulation.domain.User;
+ import org.folio.circulation.domain.notice.combiner.NoticeContextCombiner;
+ import org.folio.circulation.domain.representations.logs.NoticeLogContext;
+ import org.folio.circulation.infrastructure.storage.notices.PatronNoticePolicyRepository;
++import org.folio.circulation.infrastructure.storage.users.UserRepository;
+ import org.folio.circulation.rules.AppliedRuleConditions;
+ import org.folio.circulation.rules.CirculationRuleMatch;
+ import org.folio.circulation.support.Clients;
+@@ -37,11 +40,15 @@ public class ImmediatePatronNoticeService extends PatronNoticeService {
+   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+   private final PatronNoticePolicyRepository noticePolicyRepository;
+   private final NoticeContextCombiner noticeContextCombiner;
++  private final PatronNoticeConfigurationResolver configurationResolver;
++  private final UserRepository userRepository;
+
+   public ImmediatePatronNoticeService(Clients clients, NoticeContextCombiner noticeContextCombiner) {
+     super(clients);
+     this.noticePolicyRepository = new PatronNoticePolicyRepository(clients);
+     this.noticeContextCombiner = noticeContextCombiner;
++    this.configurationResolver = new PatronNoticeConfigurationResolver();
++    this.userRepository = new UserRepository(clients);
+   }
+
+   public CompletableFuture<Result<Void>> acceptNoticeEvent(PatronNoticeEvent event) {
+@@ -94,33 +101,84 @@ public class ImmediatePatronNoticeService extends PatronNoticeService {
+   }
+
+   private CompletableFuture<Result<Void>> applyPatronNoticePolicy(EventGroupContext context) {
+-    return findMatchingNoticeConfiguration(context)
+-      .map(context::withNoticeConfig)
+-      .map(this::updateNoticeLogContext)
+-      .map(this::sendNotice)
+-      .orElseGet(() -> ofAsync(() -> null));
+-  }
++    var matchGroup = PatronNoticeConfigurationResolver.firstMatchGroup(
++      context.getPatronNoticePolicy()
++        .lookupNoticeConfigurations(context.getGroupDefinition().getEventType()));
++
++    if (matchGroup.isEmpty()) {
++      log.debug("applyPatronNoticePolicy:: no notice configuration for event type {}",
++        context.getGroupDefinition().getEventType());
++      return ofAsync(() -> null);
++    }
++
++    return fetchRecipientIfNeeded(context, matchGroup)
++      .thenCompose(recipient -> {
++        var selectedConfigurations = configurationResolver.select(matchGroup, recipient);
+
+-  private Optional<NoticeConfiguration> findMatchingNoticeConfiguration(EventGroupContext context) {
+-    return context.getPatronNoticePolicy().lookupNoticeConfiguration(
+-      context.getGroupDefinition().getEventType());
++        if (selectedConfigurations.isEmpty()) {
++          log.info("applyPatronNoticePolicy:: no notice configuration selected for recipient {}",
++            context.getGroupDefinition().getRecipientId());
++          return ofAsync(() -> null);
++        }
++
++        return allOf(selectedConfigurations, configuration -> sendNotice(context, configuration))
++          .thenApply(mapResult(ignored -> null));
++      });
+   }
+
+-  private EventGroupContext updateNoticeLogContext(EventGroupContext context) {
+-    return context.withCombinedNoticeLogContext(
+-      context.getCombinedNoticeLogContext()
+-        .withNoticePolicyId(context.getGroupDefinition().getNoticePolicyId())
+-        .withTemplateId(context.getNoticeConfig().getTemplateId())
+-        .withTriggeringEvent(context.getNoticeConfig().getNoticeEventType().getRepresentation()));
++  private CompletableFuture<User> fetchRecipientIfNeeded(EventGroupContext context,
++    List<NoticeConfiguration> matchGroup) {
++
++    var recipientFromEvent = context.getEvents().stream()
++      .map(PatronNoticeEvent::getUser)
++      .filter(Objects::nonNull)
++      .findFirst()
++      .orElse(null);
++
++    if (recipientFromEvent != null) {
++      return completedFuture(recipientFromEvent);
++    }
++
++    if (!configurationResolver.requiresPreference(matchGroup)) {
++      return completedFuture(null);
++    }
++
++    var recipientId = context.getGroupDefinition().getRecipientId();
++
++    return userRepository.getUser(recipientId)
++      .thenApply(r -> {
++        if (r.failed()) {
++          log.warn("fetchRecipientIfNeeded:: failed to fetch user {}, falling back to Email only: {}",
++            recipientId, r.cause());
++          return null;
++        }
++        if (r.value() == null) {
++          log.warn("fetchRecipientIfNeeded:: user {} not found, falling back to Email only",
++            recipientId);
++        }
++        return r.value();
++      })
++      .exceptionally(t -> {
++        log.warn("fetchRecipientIfNeeded:: exception fetching user {}, falling back to Email only: {}",
++          recipientId, t.getMessage());
++        return null;
++      });
+   }
+
+-  private CompletableFuture<Result<Void>> sendNotice(EventGroupContext context) {
+-    PatronNotice patronNotice = new PatronNotice(
++  private CompletableFuture<Result<Void>> sendNotice(EventGroupContext context,
++    NoticeConfiguration configuration) {
++
++    var patronNotice = new PatronNotice(
+       context.getGroupDefinition().getRecipientId(),
+       context.getCombinedNoticeContext(),
+-      context.getNoticeConfig());
++      configuration);
++
++    var noticeLogContext = context.getCombinedNoticeLogContext()
++      .withNoticePolicyId(context.getGroupDefinition().getNoticePolicyId())
++      .withTemplateId(configuration.getTemplateId())
++      .withTriggeringEvent(configuration.getNoticeEventType().getRepresentation());
+
+-    return sendNotice(patronNotice, context.getCombinedNoticeLogContext());
++    return sendNotice(patronNotice, noticeLogContext);
+   }
+
+   @With
+diff --git a/src/main/java/org/folio/circulation/domain/notice/NoticeConfiguration.java b/src/main/java/org/folio/circulation/domain/notice/NoticeConfiguration.java
+index ba65bf457..154199520 100644
+--- a/src/main/java/org/folio/circulation/domain/notice/NoticeConfiguration.java
++++ b/src/main/java/org/folio/circulation/domain/notice/NoticeConfiguration.java
+@@ -61,4 +61,8 @@ public class NoticeConfiguration {
+   public boolean sendInRealTime() {
+     return sendInRealTime;
+   }
++
++  public NoticeConfigurationMatchKey matchKey() {
++    return NoticeConfigurationMatchKey.from(this);
++  }
+ }
+diff --git a/src/main/java/org/folio/circulation/domain/notice/NoticeConfigurationMatchKey.java b/src/main/java/org/folio/circulation/domain/notice/NoticeConfigurationMatchKey.java
+new file mode 100644
+index 000000000..836e52af6
+--- /dev/null
++++ b/src/main/java/org/folio/circulation/domain/notice/NoticeConfigurationMatchKey.java
+@@ -0,0 +1,27 @@
++package org.folio.circulation.domain.notice;
++
++public record NoticeConfigurationMatchKey(
++  NoticeEventType noticeEventType,
++  NoticeTiming timing,
++  Long timingPeriodDuration,
++  String timingPeriodInterval,
++  boolean recurring,
++  Long recurringPeriodDuration,
++  String recurringPeriodInterval,
++  boolean sendInRealTime) {
++
++  public static NoticeConfigurationMatchKey from(NoticeConfiguration configuration) {
++    var timingPeriod = configuration.getTimingPeriod();
++    var recurringPeriod = configuration.getRecurringPeriod();
++
++    return new NoticeConfigurationMatchKey(
++      configuration.getNoticeEventType(),
++      configuration.getTiming(),
++      timingPeriod == null ? null : timingPeriod.getDuration(),
++      timingPeriod == null ? null : timingPeriod.getInterval(),
++      configuration.isRecurring(),
++      recurringPeriod == null ? null : recurringPeriod.getDuration(),
++      recurringPeriod == null ? null : recurringPeriod.getInterval(),
++      configuration.sendInRealTime());
++  }
++}
+diff --git a/src/main/java/org/folio/circulation/domain/notice/NoticeFormat.java b/src/main/java/org/folio/circulation/domain/notice/NoticeFormat.java
+index f46e2cc0b..c5179befc 100644
+--- a/src/main/java/org/folio/circulation/domain/notice/NoticeFormat.java
++++ b/src/main/java/org/folio/circulation/domain/notice/NoticeFormat.java
+@@ -1,10 +1,13 @@
+ package org.folio.circulation.domain.notice;
+
++import org.apache.commons.lang3.StringUtils;
++
+ import java.util.Arrays;
+
+ public enum NoticeFormat {
+
+   EMAIL("Email", "email", "text/html"),
++  SMS("SMS", "sms", "text/plain"),
+   PRINT("Print", "mail", "text/html"),
+   UNKNOWN("Unknown", "", "");
+
+@@ -37,4 +40,8 @@ public enum NoticeFormat {
+   public String getRepresentation() {
+     return representation;
+   }
++
++  public boolean isDeliverable() {
++    return StringUtils.isNotBlank(deliveryChannel);
++  }
+ }
+diff --git a/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java b/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
+new file mode 100644
+index 000000000..10048e0d8
+--- /dev/null
++++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
+@@ -0,0 +1,120 @@
++package org.folio.circulation.domain.notice;
++
++import static java.util.stream.Collectors.toCollection;
++
++import java.util.LinkedHashMap;
++import java.util.LinkedHashSet;
++import java.util.List;
++import java.util.Map;
++import java.util.Objects;
++import java.util.Set;
++
++import org.apache.logging.log4j.LogManager;
++import org.apache.logging.log4j.Logger;
++import org.folio.circulation.domain.User;
++
++public class PatronNoticeConfigurationResolver {
++  private static final Logger log = LogManager.getLogger(PatronNoticeConfigurationResolver.class);
++
++  public static List<NoticeConfiguration> firstMatchGroup(List<NoticeConfiguration> candidates) {
++    if (candidates == null || candidates.isEmpty()) {
++      return List.of();
++    }
++    var key = candidates.getFirst().matchKey();
++    return candidates.stream()
++      .filter(candidate -> key.equals(candidate.matchKey()))
++      .toList();
++  }
++
++  public List<NoticeConfiguration> select(List<NoticeConfiguration> matchGroup, User recipient) {
++    if (matchGroup == null || matchGroup.isEmpty()) {
++      return List.of();
++    }
++
++    var group = firstMatchGroup(matchGroup);
++    if (group.size() != matchGroup.size()) {
++      log.warn("select:: received {} configurations spanning several match groups, " +
++        "narrowing to the first group of {}", matchGroup.size(), group.size());
++    }
++
++    var byFormat = indexByFormat(group);
++    if (byFormat.isEmpty()) {
++      return List.of();
++    }
++
++    if (byFormat.size() == 1) {
++      return List.copyOf(byFormat.values());
++    }
++
++    var selected = selectByPreferences(byFormat, recipient);
++    if (selected.isEmpty()) {
++      log.warn("select:: no notice configuration selected for recipient {}, event {}, " +
++          "available formats {} - sending nothing",
++        recipient == null ? null : recipient.getId(), eventTypeOf(group), byFormat.keySet());
++    }
++    return selected;
++  }
++
++  public Set<NoticeFormat> resolveFormats(List<NoticeConfiguration> matchGroup, User recipient) {
++    return select(matchGroup, recipient).stream()
++      .map(NoticeConfiguration::getNoticeFormat)
++      .collect(toCollection(LinkedHashSet::new));
++  }
++
++  public boolean requiresPreference(List<NoticeConfiguration> matchGroup) {
++    return indexByFormat(firstMatchGroup(matchGroup)).size() > 1;
++  }
++
++  private List<NoticeConfiguration> selectByPreferences(
++    Map<NoticeFormat, NoticeConfiguration> byFormat, User recipient) {
++
++    var preferredFormats =
++      UserPreferredNoticeFormats.fromPreferredContactTypeIds(recipient);
++
++    if (!preferredFormats.isEmpty()) {
++      return preferredFormats.stream()
++        .map(byFormat::get)
++        .filter(Objects::nonNull)
++        .toList();
++    }
++
++    var deprecatedFormat =
++      UserPreferredNoticeFormats.fromDeprecatedPreferredContactTypeId(recipient);
++
++    if (deprecatedFormat.isPresent()) {
++      var configuration = byFormat.get(deprecatedFormat.get());
++
++      return configuration == null
++        ? List.of()
++        : List.of(configuration);
++    }
++
++    return emailOnly(byFormat);
++  }
++
++  private static List<NoticeConfiguration> emailOnly(
++    Map<NoticeFormat, NoticeConfiguration> byFormat) {
++    var emailConfiguration = byFormat.get(NoticeFormat.EMAIL);
++    return emailConfiguration == null ? List.of() : List.of(emailConfiguration);
++  }
++
++  private static Map<NoticeFormat, NoticeConfiguration> indexByFormat(
++    List<NoticeConfiguration> matchGroup) {
++
++    var byFormat = new LinkedHashMap<NoticeFormat, NoticeConfiguration>();
++    for (NoticeConfiguration configuration : matchGroup) {
++      NoticeFormat format = configuration.getNoticeFormat();
++      if (format == null || !format.isDeliverable()) {
++        log.warn("indexByFormat:: skipping notice configuration {} with undeliverable format {}",
++          configuration.getTemplateId(), format);
++        continue;
++      }
++      byFormat.putIfAbsent(format, configuration);
++    }
++    return byFormat;
++  }
++
++  private static NoticeEventType eventTypeOf(List<NoticeConfiguration> group) {
++    return group.isEmpty() ? null : group.getFirst().getNoticeEventType();
++  }
++}
+diff --git a/src/main/java/org/folio/circulation/domain/notice/PatronNoticePolicy.java b/src/main/java/org/folio/circulation/domain/notice/PatronNoticePolicy.java
+index 126cc3c86..149bf6b39 100644
+--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticePolicy.java
++++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticePolicy.java
+@@ -17,9 +17,14 @@ public class PatronNoticePolicy {
+     return noticeConfigurations;
+   }
+
+-  public Optional<NoticeConfiguration> lookupNoticeConfiguration(NoticeEventType eventType) {
++  public List<NoticeConfiguration> lookupNoticeConfigurations(NoticeEventType eventType) {
+     return noticeConfigurations.stream()
+       .filter(d -> Objects.equals(d.getNoticeEventType(), eventType))
+-      .findFirst();
++      .toList();
++  }
++
++  @Deprecated(forRemoval = false)
++  public Optional<NoticeConfiguration> lookupNoticeConfiguration(NoticeEventType eventType) {
++    return lookupNoticeConfigurations(eventType).stream().findFirst();
+   }
+ }
+diff --git a/src/main/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormats.java b/src/main/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormats.java
+new file mode 100644
+index 000000000..8e9ce2eed
+--- /dev/null
++++ b/src/main/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormats.java
+@@ -0,0 +1,53 @@
++package org.folio.circulation.domain.notice;
++
++import java.util.LinkedHashSet;
++import java.util.List;
++import java.util.Map;
++import java.util.Optional;
++
++import org.folio.circulation.domain.User;
++
++public final class UserPreferredNoticeFormats {
++  public static final String CONTACT_TYPE_EMAIL = "002";
++  public static final String CONTACT_TYPE_MAIL = "001";
++  public static final String CONTACT_TYPE_SMS = "003";
++
++  private static final Map<String, NoticeFormat> CONTACT_TYPE_FORMATS = Map.of(
++    CONTACT_TYPE_EMAIL, NoticeFormat.EMAIL,
++    CONTACT_TYPE_MAIL, NoticeFormat.PRINT,
++    CONTACT_TYPE_SMS, NoticeFormat.SMS
++  );
++
++  private UserPreferredNoticeFormats() {
++  }
++
++  public static Optional<NoticeFormat> toFormat(String contactTypeId) {
++    if (contactTypeId == null || contactTypeId.isBlank()) {
++      return Optional.empty();
++    }
++
++    return Optional.ofNullable(CONTACT_TYPE_FORMATS.get(contactTypeId));
++  }
++
++  public static List<NoticeFormat> fromPreferredContactTypeIds(User user) {
++    if (user == null) {
++      return List.of();
++    }
++
++    var formats = new LinkedHashSet<NoticeFormat>();
++    user.getPreferredContactTypeIds().stream()
++      .map(UserPreferredNoticeFormats::toFormat)
++      .flatMap(Optional::stream)
++      .forEach(formats::add);
++
++    return List.copyOf(formats);
++  }
++
++  public static Optional<NoticeFormat> fromDeprecatedPreferredContactTypeId(User user) {
++    if (user == null) {
++      return Optional.empty();
++    }
++
++    return toFormat(user.getPreferredContactTypeId());
++  }
++}
+diff --git a/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedScheduledNoticeHandler.java b/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedScheduledNoticeHandler.java
+index dd76e25c5..2db6221b5 100644
+--- a/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedScheduledNoticeHandler.java
++++ b/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedScheduledNoticeHandler.java
+@@ -141,13 +141,24 @@ public abstract class GroupedScheduledNoticeHandler {
+
+     //All the notices have the same properties, so we can get any of them
+     ScheduledNoticeContext contextSample = relevantContexts.get(0);
++
++    return singleNoticeHandler.shouldSendByPreference(contextSample)
++      .thenCompose(shouldSend -> shouldSend
++        ? doSendGroupedNotice(contexts, relevantContexts, contextSample)
++        : skipGroupedNoticeDueToPreference(contexts, relevantContexts));
++  }
++
++  private CompletableFuture<Result<List<ScheduledNoticeContext>>> doSendGroupedNotice(
++    List<ScheduledNoticeContext> contexts, List<ScheduledNoticeContext> relevantContexts,
++    ScheduledNoticeContext contextSample) {
++
+     User user = contextSample.getLoan().getUser();
+
+     List<JsonObject> noticeContexts = relevantContexts.stream()
+       .map(ScheduledNoticeContext::getNoticeContext)
+       .collect(toList());
+
+-    log.info("sendGroupedNotice:: attempting to send a grouped notice for {} scheduled notices",
++    log.info("doSendGroupedNotice:: attempting to send a grouped notice for {} scheduled notices",
+       relevantContexts.size());
+
+     return patronNoticeService.sendNotice(
+@@ -158,6 +169,15 @@ public abstract class GroupedScheduledNoticeHandler {
+       .thenApply(mapResult(v -> contexts));
+   }
+
++  private CompletableFuture<Result<List<ScheduledNoticeContext>>> skipGroupedNoticeDueToPreference(
++    List<ScheduledNoticeContext> contexts, List<ScheduledNoticeContext> relevantContexts) {
++
++    log.info("skipGroupedNoticeDueToPreference:: skipping group of {} scheduled notices filtered "
++      + "out by user notice format preference", relevantContexts.size());
++
++    return completedFuture(succeeded(contexts));
++  }
++
+   private static NoticeLogContext buildNoticeLogContext(List<ScheduledNoticeContext> contexts,
+     User user) {
+
+diff --git a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
+index 401b7151f..997632220 100644
+--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
++++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
+@@ -10,21 +10,32 @@ import static org.folio.circulation.support.results.ResultBinding.mapResult;
+
+ import java.lang.invoke.MethodHandles;
+ import java.util.Collection;
++import java.util.LinkedHashSet;
+ import java.util.List;
++import java.util.Map;
+ import java.util.Objects;
+ import java.util.concurrent.CompletableFuture;
++import java.util.concurrent.ConcurrentHashMap;
++import java.util.stream.Collectors;
+
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ import org.folio.circulation.domain.ItemRelatedRecord;
++import org.folio.circulation.domain.User;
+ import org.folio.circulation.domain.UserRelatedRecord;
++import org.folio.circulation.domain.notice.NoticeConfiguration;
++import org.folio.circulation.domain.notice.NoticeEventType;
++import org.folio.circulation.domain.notice.PatronNoticeConfigurationResolver;
++import org.folio.circulation.domain.notice.PatronNoticePolicy;
+ import org.folio.circulation.domain.notice.ScheduledPatronNoticeService;
++import org.folio.circulation.domain.policy.Period;
+ import org.folio.circulation.domain.representations.logs.NoticeLogContext;
+ import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
+ import org.folio.circulation.infrastructure.storage.feesandfines.AccountRepository;
+ import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+ import org.folio.circulation.infrastructure.storage.notices.PatronNoticePolicyRepository;
+ import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
++import org.folio.circulation.rules.AppliedRuleConditions;
+ import org.folio.circulation.rules.CirculationRuleMatch;
+ import org.folio.circulation.services.EventPublisher;
+ import org.folio.circulation.support.Clients;
+@@ -46,6 +57,9 @@ public abstract class ScheduledNoticeHandler {
+   protected final CollectionResourceClient templateNoticesClient;
+   private final ScheduledPatronNoticeService patronNoticeService;
+   private final EventPublisher eventPublisher;
++  private final PatronNoticeConfigurationResolver configurationResolver = new PatronNoticeConfigurationResolver();
++  private final Map<String, CompletableFuture<Result<PatronNoticePolicy>>> patronNoticePolicyCache =
++    new ConcurrentHashMap<>();
+
+   protected ScheduledNoticeHandler(Clients clients, LoanRepository loanRepository) {
+     this.scheduledNoticesRepository = ScheduledNoticesRepository.using(clients);
+@@ -203,6 +217,15 @@ public abstract class ScheduledNoticeHandler {
+       return ofAsync(() -> context);
+     }
+
++    return shouldSendByPreference(context)
++      .thenCompose(shouldSend -> shouldSend
++        ? doSendNotice(context)
++        : skipDueToPreference(context));
++  }
++
++  private CompletableFuture<Result<ScheduledNoticeContext>> doSendNotice(
++    ScheduledNoticeContext context) {
++
+     return patronNoticeService.sendNotice(
+       context.getNotice().getConfiguration(),
+       context.getNotice().getRecipientUserId(),
+@@ -216,6 +239,106 @@ public abstract class ScheduledNoticeHandler {
+       });
+   }
+
++  private CompletableFuture<Result<ScheduledNoticeContext>> skipDueToPreference(
++    ScheduledNoticeContext context) {
++
++    log.info("skipDueToPreference:: notice {} format {} filtered out by user preference, skipping send",
++      context.getNotice().getId(), context.getNotice().getConfiguration().getFormat());
++
++    return ofAsync(() -> context);
++  }
++
++  protected CompletableFuture<Boolean> shouldSendByPreference(ScheduledNoticeContext context) {
++    var policyId = context.getPatronNoticePolicyId();
++    if (policyId == null) {
++      log.debug("shouldSendByPreference:: no patron notice policy id for notice {}, sending as usual",
++        context.getNotice().getId());
++      return completedFuture(true);
++    }
++
++    return lookupPatronNoticePolicy(policyId)
++      .thenApply(r -> {
++        if (r.failed()) {
++          log.warn("shouldSendByPreference:: failed to look up notice policy {} for notice {}: {}",
++            policyId, context.getNotice().getId(), r.cause());
++          return true;
++        }
++
++        return evaluatePreference(context, r.value());
++      });
++  }
++
++  private CompletableFuture<Result<PatronNoticePolicy>> lookupPatronNoticePolicy(String policyId) {
++    return patronNoticePolicyCache.computeIfAbsent(policyId,
++      id -> patronNoticePolicyRepository.lookupPolicy(id, new AppliedRuleConditions(false, false, false)));
++  }
++
++  private boolean evaluatePreference(ScheduledNoticeContext context, PatronNoticePolicy policy) {
++    var notice = context.getNotice();
++    var noticeConfig = notice.getConfiguration();
++    var eventType = NoticeEventType.from(notice.getTriggeringEvent().getRepresentation());
++
++    var matchGroup = policy.lookupNoticeConfigurations(eventType).stream()
++      .filter(candidate -> matchesScheduledConfig(candidate, noticeConfig))
++      .collect(Collectors.toList());
++
++    var distinctFormats = matchGroup.stream()
++      .map(NoticeConfiguration::getNoticeFormat)
++      .collect(Collectors.toCollection(LinkedHashSet::new));
++
++    if (distinctFormats.size() <= 1) {
++      log.debug("evaluatePreference:: single format for notice {}, sending as usual", notice.getId());
++      return true;
++    }
++
++    var recipient = extractRecipientUser(context);
++    var resolvedFormats = configurationResolver.resolveFormats(matchGroup, recipient);
++    var shouldSend = resolvedFormats.contains(noticeConfig.getFormat());
++
++    if (!shouldSend) {
++      log.info("evaluatePreference:: notice {} format {} not among resolved formats {} for recipient preference,"
++        + " skipping", notice.getId(), noticeConfig.getFormat(), resolvedFormats);
++    }
++
++    return shouldSend;
++  }
++
++  private static boolean matchesScheduledConfig(NoticeConfiguration candidate,
++    ScheduledNoticeConfig config) {
++
++    if (candidate.getTiming() != config.getTiming()) {
++      return false;
++    }
++    if (candidate.isRecurring() != config.isRecurring()) {
++      return false;
++    }
++    if (candidate.sendInRealTime() != config.sendInRealTime()) {
++      return false;
++    }
++
++    return !candidate.isRecurring() || periodsEqual(candidate.getRecurringPeriod(), config.getRecurringPeriod());
++  }
++
++  private static boolean periodsEqual(Period first, Period second) {
++    if (first == null || second == null) {
++      return first == second;
++    }
++
++    return Objects.equals(first.getDuration(), second.getDuration())
++      && Objects.equals(first.getInterval(), second.getInterval());
++  }
++
++  private static User extractRecipientUser(ScheduledNoticeContext context) {
++    if (context.getLoan() != null && context.getLoan().getUser() != null) {
++      return context.getLoan().getUser();
++    }
++    if (context.getRequest() != null && context.getRequest().getUser() != null) {
++      return context.getRequest().getUser();
++    }
++
++    return null;
++  }
++
+   protected CompletableFuture<Result<ScheduledNoticeContext>> fetchPatronNoticePolicyIdForLoan(
+     ScheduledNoticeContext context) {
+
+diff --git a/src/test/java/api/support/builders/NoticeConfigurationBuilder.java b/src/test/java/api/support/builders/NoticeConfigurationBuilder.java
+index c6ca618d8..5a9071928 100644
+--- a/src/test/java/api/support/builders/NoticeConfigurationBuilder.java
++++ b/src/test/java/api/support/builders/NoticeConfigurationBuilder.java
+@@ -42,6 +42,29 @@ public class NoticeConfigurationBuilder extends JsonBuilder implements Builder {
+       this.sendInRealTime);
+   }
+
++  public NoticeConfigurationBuilder withEmailFormat() {
++    return withFormat("Email");
++  }
++
++  public NoticeConfigurationBuilder withSmsFormat() {
++    return withFormat("SMS");
++  }
++
++  public NoticeConfigurationBuilder withPrintFormat() {
++    return withFormat("Print");
++  }
++
++  private NoticeConfigurationBuilder withFormat(String format) {
++    return new NoticeConfigurationBuilder(
++      this.templateId,
++      format,
++      this.eventType,
++      this.timing,
++      this.timingPeriod,
++      this.recurringPeriod,
++      this.sendInRealTime);
++  }
++
+   public NoticeConfigurationBuilder withEventType(String eventType) {
+     return new NoticeConfigurationBuilder(
+       this.templateId,
+diff --git a/src/test/java/api/support/builders/UserBuilder.java b/src/test/java/api/support/builders/UserBuilder.java
+index cb288666c..3a3b016c5 100644
+--- a/src/test/java/api/support/builders/UserBuilder.java
++++ b/src/test/java/api/support/builders/UserBuilder.java
+@@ -3,6 +3,7 @@ package api.support.builders;
+ import java.time.ZonedDateTime;
+ import java.util.ArrayList;
+ import java.util.Collection;
++import java.util.List;
+ import java.util.UUID;
+
+ import api.support.http.IndividualResource;
+@@ -22,12 +23,14 @@ public class UserBuilder extends JsonBuilder implements Builder {
+   private final ZonedDateTime expirationDate;
+   private final Collection<Address> addresses;
+   private final JsonArray departments;
++  private final JsonArray preferredContactTypeIds;
++  private final String preferredContactTypeId;
+   private final String type;
+   private final boolean primaryAddress;
+
+   public UserBuilder() {
+     this(UUID.randomUUID(), "sjones", "Jones", "Steven", null, null,"785493025613",
+-      null, true, null, new ArrayList<>(), null, null, false);
++      null, true, null, new ArrayList<>(), null, null, null, null, false);
+   }
+
+   private UserBuilder(
+@@ -43,6 +46,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+     ZonedDateTime expirationDate,
+     Collection<Address> addresses,
+     JsonArray departments,
++    JsonArray preferredContactTypeIds,
++    String preferredContactTypeId,
+     String type,
+     boolean primaryAddress) {
+
+@@ -61,6 +66,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+
+     this.addresses = addresses;
+     this.departments = departments;
++    this.preferredContactTypeIds = preferredContactTypeIds;
++    this.preferredContactTypeId = preferredContactTypeId;
+     this.type = type;
+     this.primaryAddress = primaryAddress;
+   }
+@@ -85,7 +92,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+     put(request, "active", active);
+     put(request, "expirationDate", expirationDate);
+
+-    if(firstName != null || lastName != null) {
++    if (firstName != null || lastName != null ||
++      preferredContactTypeIds != null || preferredContactTypeId != null) {
+       JsonObject personalInformation = new JsonObject()
+         .put("lastName", this.lastName)
+         .put("firstName", this.firstName);
+@@ -98,6 +106,14 @@ public class UserBuilder extends JsonBuilder implements Builder {
+         personalInformation.put("preferredFirstName", this.preferredFirstName);
+       }
+
++      if (this.preferredContactTypeIds != null) {
++        personalInformation.put("preferredContactTypeIds", this.preferredContactTypeIds);
++      }
++
++      if (this.preferredContactTypeId != null) {
++        personalInformation.put("preferredContactTypeId", this.preferredContactTypeId);
++      }
++
+       if(this.addresses != null && !this.addresses.isEmpty()) {
+         JsonArray mappedAddresses = new JsonArray();
+
+@@ -149,6 +165,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -167,6 +185,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -185,6 +205,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -203,6 +225,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -221,6 +245,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -239,6 +265,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -257,6 +285,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -275,6 +305,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -297,6 +329,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -327,6 +361,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -345,6 +381,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       newExpirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -363,6 +401,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       null,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -390,6 +430,49 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
++      this.type,
++      this.primaryAddress);
++  }
++
++  public UserBuilder withPreferredContactTypeIds(List<String> preferredContactTypeIds) {
++    JsonArray values = preferredContactTypeIds == null ? null : new JsonArray(preferredContactTypeIds);
++    return new UserBuilder(
++      this.id,
++      this.username,
++      this.lastName,
++      this.firstName,
++      this.middleName,
++      this.preferredFirstName,
++      this.barcode,
++      this.patronGroupId,
++      this.active,
++      this.expirationDate,
++      this.addresses,
++      this.departments,
++      values,
++      this.preferredContactTypeId,
++      this.type,
++      this.primaryAddress);
++  }
++
++  public UserBuilder withDeprecatedPreferredContactTypeId(String preferredContactTypeId) {
++    return new UserBuilder(
++      this.id,
++      this.username,
++      this.lastName,
++      this.firstName,
++      this.middleName,
++      this.preferredFirstName,
++      this.barcode,
++      this.patronGroupId,
++      this.active,
++      this.expirationDate,
++      this.addresses,
++      this.departments,
++      this.preferredContactTypeIds,
++      preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -407,7 +490,9 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.active,
+       this.expirationDate,
+       this.addresses,
+-      departments,
++      this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       Boolean.valueOf(primaryAddress));
+   }
+@@ -429,6 +514,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       newAddresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -447,6 +534,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       this.type,
+       this.primaryAddress);
+   }
+@@ -465,6 +554,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
+       this.expirationDate,
+       this.addresses,
+       this.departments,
++      this.preferredContactTypeIds,
++      this.preferredContactTypeId,
+       type,
+       this.primaryAddress);
+   }
+diff --git a/src/test/java/org/folio/circulation/domain/UserTests.java b/src/test/java/org/folio/circulation/domain/UserTests.java
+index 686c86b84..068b866c8 100644
+--- a/src/test/java/org/folio/circulation/domain/UserTests.java
++++ b/src/test/java/org/folio/circulation/domain/UserTests.java
+@@ -1,8 +1,15 @@
+ package org.folio.circulation.domain;
+
++import static org.hamcrest.CoreMatchers.nullValue;
+ import static org.hamcrest.CoreMatchers.is;
+ import static org.hamcrest.MatcherAssert.assertThat;
++import static org.hamcrest.Matchers.contains;
++import static org.hamcrest.Matchers.empty;
+
++import java.util.List;
++
++import io.vertx.core.json.JsonArray;
++import io.vertx.core.json.JsonObject;
+ import org.junit.jupiter.api.Test;
+
+ import api.support.builders.UserBuilder;
+@@ -27,4 +34,49 @@ class UserTests {
+
+     assertThat(activeUser.getPersonalName(), is("cjones"));
+   }
++
++  @Test
++  void preferredContactTypeIdsAreReadInOrder() {
++    var user = new User(new UserBuilder()
++      .withPreferredContactTypeIds(List.of("002", "003"))
++      .create());
++
++    assertThat(user.getPreferredContactTypeIds(), contains("002", "003"));
++  }
++
++  @Test
++  void preferredContactTypeIdsIgnoreNonStringEntries() {
++    var user = new User(new JsonObject()
++      .put("personal", new JsonObject()
++        .put("preferredContactTypeIds", new JsonArray().add("002").add(1).add(new JsonObject()))));
++
++    assertThat(user.getPreferredContactTypeIds(), contains("002"));
++  }
++
++  @Test
++  void preferredContactTypeIdsAreEmptyWhenPersonalIsMissing() {
++    User user = new User(new UserBuilder()
++      .withNoPersonalDetails()
++      .create());
++
++    assertThat(user.getPreferredContactTypeIds(), empty());
++  }
++
++  @Test
++  void deprecatedPreferredContactTypeIdIsReadWhenPresent() {
++    var user = new User(new UserBuilder()
++      .withDeprecatedPreferredContactTypeId("003")
++      .create());
++
++    assertThat(user.getPreferredContactTypeId(), is("003"));
++  }
++
++  @Test
++  void deprecatedPreferredContactTypeIdIsNullWhenMissing() {
++    var user = new User(new UserBuilder()
++      .withNoPersonalDetails()
++      .create());
++
++    assertThat(user.getPreferredContactTypeId(), nullValue());
++  }
+ }
+diff --git a/src/test/java/org/folio/circulation/domain/notice/NoticeConfigurationMatchKeyTest.java b/src/test/java/org/folio/circulation/domain/notice/NoticeConfigurationMatchKeyTest.java
+new file mode 100644
+index 000000000..4c3e2f5e1
+--- /dev/null
++++ b/src/test/java/org/folio/circulation/domain/notice/NoticeConfigurationMatchKeyTest.java
+@@ -0,0 +1,101 @@
++package org.folio.circulation.domain.notice;
++
++import static org.hamcrest.CoreMatchers.is;
++import static org.hamcrest.MatcherAssert.assertThat;
++
++import org.folio.circulation.domain.policy.Period;
++import org.junit.jupiter.api.Test;
++
++class NoticeConfigurationMatchKeyTest {
++
++  @Test
++  void ignoresTemplateIdAndFormat() {
++    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER, Period.days(1), false, null, true);
++    var right = new NoticeConfiguration("t2", NoticeFormat.SMS, NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER, Period.days(1), false, null, true);
++
++    assertThat(left.matchKey(), is(right.matchKey()));
++    assertThat(left.matchKey().hashCode(), is(right.matchKey().hashCode()));
++  }
++
++  @Test
++  void ignoresTemplateIdAlone() {
++    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER, Period.days(1), false, null, true);
++    var right = new NoticeConfiguration("t9", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER, Period.days(1), false, null, true);
++
++    assertThat(left.matchKey(), is(right.matchKey()));
++  }
++
++  @Test
++  void differsWhenTimingChanges() {
++    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER, Period.days(1), false, null, true);
++    var right = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.BEFORE, Period.days(1), false, null, true);
++
++    assertThat(left.matchKey().equals(right.matchKey()), is(false));
++  }
++
++  @Test
++  void differsWhenTimingPeriodChanges() {
++    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER, Period.days(1), false, null, true);
++    var right = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER, Period.days(2), false, null, true);
++
++    assertThat(left.matchKey().equals(right.matchKey()), is(false));
++  }
++
++  @Test
++  void differsWhenRecurringChanges() {
++    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.UPON_AT, null, false, null, true);
++    var right = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.UPON_AT, null, true, Period.days(1), true);
++
++    assertThat(left.matchKey().equals(right.matchKey()), is(false));
++  }
++
++  @Test
++  void differsWhenRecurringPeriodChanges() {
++    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER, Period.days(1), true, Period.days(1), true);
++    var right = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER, Period.days(1), true, Period.days(2), true);
++
++    assertThat(left.matchKey().equals(right.matchKey()), is(false));
++  }
++
++  @Test
++  void differsWhenSendInRealTimeChanges() {
++    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.UPON_AT, null, false, null, true);
++    var right = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.UPON_AT, null, false, null, false);
++
++    assertThat(left.matchKey().equals(right.matchKey()), is(false));
++  }
++
++  @Test
++  void differsWhenEventTypeChanges() {
++    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.UPON_AT, null, false, null, true);
++    var right = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_IN,
++      NoticeTiming.UPON_AT, null, false, null, true);
++
++    assertThat(left.matchKey().equals(right.matchKey()), is(false));
++  }
++
++  @Test
++  void handlesNullPeriods() {
++    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.UPON_AT, null, false, null, true);
++    var right = new NoticeConfiguration("t2", NoticeFormat.SMS, NoticeEventType.CHECK_OUT,
++      NoticeTiming.UPON_AT, null, false, null, true);
++
++    assertThat(left.matchKey(), is(right.matchKey()));
++  }
++}
+diff --git a/src/test/java/org/folio/circulation/domain/notice/NoticeFormatTest.java b/src/test/java/org/folio/circulation/domain/notice/NoticeFormatTest.java
+new file mode 100644
+index 000000000..22babcdf7
+--- /dev/null
++++ b/src/test/java/org/folio/circulation/domain/notice/NoticeFormatTest.java
+@@ -0,0 +1,42 @@
++package org.folio.circulation.domain.notice;
++
++import static org.hamcrest.CoreMatchers.is;
++import static org.hamcrest.MatcherAssert.assertThat;
++import static org.junit.jupiter.api.Assertions.assertFalse;
++import static org.junit.jupiter.api.Assertions.assertTrue;
++
++import org.junit.jupiter.api.Test;
++
++class NoticeFormatTest {
++
++  @Test
++  void parsesKnownFormats() {
++    assertThat(NoticeFormat.from("Email"), is(NoticeFormat.EMAIL));
++    assertThat(NoticeFormat.from("SMS"), is(NoticeFormat.SMS));
++    assertThat(NoticeFormat.from("Print"), is(NoticeFormat.PRINT));
++    assertThat(NoticeFormat.from("bogus"), is(NoticeFormat.UNKNOWN));
++  }
++
++  @Test
++  void exposesExpectedValues() {
++    assertThat(NoticeFormat.EMAIL.getRepresentation(), is("Email"));
++    assertThat(NoticeFormat.EMAIL.getDeliveryChannel(), is("email"));
++    assertThat(NoticeFormat.EMAIL.getOutputFormat(), is("text/html"));
++
++    assertThat(NoticeFormat.SMS.getRepresentation(), is("SMS"));
++    assertThat(NoticeFormat.SMS.getDeliveryChannel(), is("sms"));
++    assertThat(NoticeFormat.SMS.getOutputFormat(), is("text/plain"));
++
++    assertThat(NoticeFormat.PRINT.getRepresentation(), is("Print"));
++    assertThat(NoticeFormat.PRINT.getDeliveryChannel(), is("mail"));
++    assertThat(NoticeFormat.PRINT.getOutputFormat(), is("text/html"));
++  }
++
++  @Test
++  void knowsWhichFormatsAreDeliverable() {
++    assertTrue(NoticeFormat.EMAIL.isDeliverable());
++    assertTrue(NoticeFormat.SMS.isDeliverable());
++    assertTrue(NoticeFormat.PRINT.isDeliverable());
++    assertFalse(NoticeFormat.UNKNOWN.isDeliverable());
++  }
++}
+diff --git a/src/test/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolverTest.java b/src/test/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolverTest.java
+new file mode 100644
+index 000000000..257c14fb1
+--- /dev/null
++++ b/src/test/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolverTest.java
+@@ -0,0 +1,315 @@
++package org.folio.circulation.domain.notice;
++
++import static org.hamcrest.CoreMatchers.is;
++import static org.hamcrest.MatcherAssert.assertThat;
++import static org.hamcrest.Matchers.empty;
++import static org.hamcrest.Matchers.hasSize;
++import static org.junit.jupiter.api.Assertions.assertTrue;
++
++import java.util.List;
++import java.util.stream.Stream;
++
++import org.folio.circulation.domain.User;
++import org.folio.circulation.domain.policy.Period;
++import org.junit.jupiter.api.Test;
++import org.junit.jupiter.params.ParameterizedTest;
++import org.junit.jupiter.params.provider.Arguments;
++import org.junit.jupiter.params.provider.MethodSource;
++
++import api.support.builders.UserBuilder;
++
++class PatronNoticeConfigurationResolverTest {
++  private final PatronNoticeConfigurationResolver resolver =
++    new PatronNoticeConfigurationResolver();
++
++  @ParameterizedTest
++  @MethodSource("preferenceCases")
++  void selectsConfigurationsUsingContactTypePreferences(
++    List<String> preferredContactTypeIds, String deprecatedPreferredContactTypeId,
++    List<NoticeFormat> expectedFormats) {
++
++    var user = buildUser(preferredContactTypeIds, deprecatedPreferredContactTypeId);
++    var group = threeFormatGroup("email", "sms", "print");
++
++    assertThat(formats(resolver.select(group, user)), is(expectedFormats));
++  }
++
++  static Stream<Arguments> preferenceCases() {
++    return Stream.of(
++      Arguments.of(List.of("002", "003"), "001", List.of(NoticeFormat.EMAIL, NoticeFormat.SMS)),
++      Arguments.of(List.of("002"), "003", List.of(NoticeFormat.EMAIL)),
++      Arguments.of(List.of(), "003", List.of(NoticeFormat.SMS)),
++      Arguments.of(null, "001", List.of(NoticeFormat.PRINT)),
++      Arguments.of(List.of(), null, List.of(NoticeFormat.EMAIL)),
++      Arguments.of(null, null, List.of(NoticeFormat.EMAIL))
++    );
++  }
++
++  @ParameterizedTest
++  @MethodSource("singleFormatCases")
++  void returnsSingleFormatRegardlessOfPreferences(NoticeFormat configuredFormat,
++    List<String> preferredContactTypeIds) {
++
++    var user = buildUser(preferredContactTypeIds, null);
++    var configuration = configuration("template", configuredFormat);
++
++    var selected = resolver.select(List.of(configuration), user);
++
++    assertThat(selected, is(List.of(configuration)));
++  }
++
++  static Stream<Arguments> singleFormatCases() {
++    return Stream.of(
++      Arguments.of(NoticeFormat.EMAIL, List.of("003", "001")),
++      Arguments.of(NoticeFormat.SMS, List.of("002")),
++      Arguments.of(NoticeFormat.PRINT, List.of("002", "003"))
++    );
++  }
++
++  @Test
++  void preservesTemplateIdsWhenSelectingMultipleFormats() {
++    var user = buildUser(List.of("002", "003"), null);
++    var group = threeFormatGroup("email-template", "sms-template", "print-template");
++
++    var selected = resolver.select(group, user);
++
++    assertThat(selected, hasSize(2));
++    assertThat(
++      templateIds(selected),
++      is(List.of("email-template", "sms-template")));
++  }
++
++  @Test
++  void selectsAllPreferredFormatsInPreferenceOrder() {
++    var user = buildUser(List.of("002", "001", "003"), null);
++    var group = threeFormatGroup("email", "sms", "print");
++
++    var selected = resolver.select(group, user);
++
++    assertThat(
++      formats(selected),
++      is(List.of(NoticeFormat.EMAIL, NoticeFormat.PRINT, NoticeFormat.SMS)));
++  }
++
++  @Test
++  void selectsOnlyEmailWhenPreferencesAreMissing() {
++    var user = buildUser(List.of(), null);
++    var group = threeFormatGroup("email", "sms", "print");
++
++    var selected = resolver.select(group, user);
++
++    assertThat(selected, hasSize(1));
++    assertThat(selected.getFirst().getNoticeFormat(), is(NoticeFormat.EMAIL));
++  }
++
++  @Test
++  void selectsNothingWhenPreferencesAndEmailAreMissing() {
++    var user = buildUser(List.of(), null);
++    var group = List.of(
++      configuration("sms", NoticeFormat.SMS),
++      configuration("print", NoticeFormat.PRINT));
++
++    assertThat(resolver.select(group, user), empty());
++  }
++
++  @Test
++  void selectsNothingWhenArrayPreferenceIsNotConfigured() {
++    var user = buildUser(List.of("003"), null);
++    var group = List.of(
++      configuration("email", NoticeFormat.EMAIL),
++      configuration("print", NoticeFormat.PRINT));
++
++    assertThat(resolver.select(group, user), empty());
++  }
++
++  @Test
++  void selectsNothingWhenDeprecatedPreferenceIsNotConfigured() {
++    var user = buildUser(null, "003");
++    var group = List.of(
++      configuration("email", NoticeFormat.EMAIL),
++      configuration("print", NoticeFormat.PRINT));
++
++    assertThat(resolver.select(group, user), empty());
++  }
++
++  @Test
++  void usesDeprecatedPreferenceWhenArrayHasNoUsableValues() {
++    var user = buildUser(List.of("999"), "003");
++    var group = threeFormatGroup("email", "sms", "print");
++
++    var selected = resolver.select(group, user);
++
++    assertThat(formats(selected), is(List.of(NoticeFormat.SMS)));
++  }
++
++  @Test
++  void selectsEmailWhenNoPreferenceValueIsUsable() {
++    var user = buildUser(List.of("999"), null);
++    var group = threeFormatGroup("email", "sms", "print");
++
++    var selected = resolver.select(group, user);
++
++    assertThat(formats(selected), is(List.of(NoticeFormat.EMAIL)));
++  }
++
++  @Test
++  void keepsFirstConfigurationForDuplicateFormat() {
++    var firstEmail = configuration("first-email", NoticeFormat.EMAIL);
++    var secondEmail = configuration("second-email", NoticeFormat.EMAIL);
++    var sms = configuration("sms", NoticeFormat.SMS);
++    var user = buildUser(List.of("002", "003"), null);
++
++    var selected = resolver.select(
++      List.of(firstEmail, secondEmail, sms), user);
++
++    assertThat(selected, is(List.of(firstEmail, sms)));
++  }
++
++  @Test
++  void keepsConfigurationsMatchingTheFirstMatchGroup() {
++    var email = configuration("email", NoticeFormat.EMAIL);
++    var sms = configuration("sms", NoticeFormat.SMS);
++    var differentTiming = new NoticeConfiguration(
++      "later-email",
++      NoticeFormat.EMAIL,
++      NoticeEventType.CHECK_OUT,
++      NoticeTiming.UPON_AT,
++      null,
++      false,
++      null,
++      true);
++
++    var group = PatronNoticeConfigurationResolver.firstMatchGroup(
++      List.of(email, sms, differentTiming));
++
++    assertThat(group, is(List.of(email, sms)));
++  }
++
++  @Test
++  void selectsOnlyFromTheFirstMatchGroup() {
++    var first = configuration("first", NoticeFormat.EMAIL);
++    var second = new NoticeConfiguration(
++      "second",
++      NoticeFormat.EMAIL,
++      NoticeEventType.CHECK_OUT,
++      NoticeTiming.UPON_AT,
++      null,
++      false,
++      null,
++      true);
++
++    var selected = resolver.select(List.of(first, second), null);
++
++    assertThat(selected, is(List.of(first)));
++  }
++
++  @Test
++  void returnsEmptyListForEmptyInput() {
++    var user = buildUser(List.of("002"), null);
++
++    assertThat(resolver.select(List.of(), user), empty());
++  }
++
++  @Test
++  void returnsEmptyListForNullInput() {
++    assertThat(resolver.select(null, null), empty());
++  }
++
++  @Test
++  void doesNotRequirePreferencesForSingleFormat() {
++    var group = List.of(configuration("email", NoticeFormat.EMAIL));
++
++    assertThat(resolver.requiresPreference(group), is(false));
++  }
++
++  @Test
++  void requiresPreferencesForMultipleFormats() {
++    var group = List.of(
++      configuration("email", NoticeFormat.EMAIL),
++      configuration("sms", NoticeFormat.SMS));
++
++    assertThat(resolver.requiresPreference(group), is(true));
++  }
++
++  @Test
++  void ignoresUndeliverableFormatsWhenCountingFormats() {
++    var email = configuration("email", NoticeFormat.EMAIL);
++    var unknown = configuration("unknown", NoticeFormat.UNKNOWN);
++    var user = buildUser(List.of("003"), null);
++    var group = List.of(email, unknown);
++
++    assertThat(resolver.requiresPreference(group), is(false));
++    assertThat(resolver.select(group, user), is(List.of(email)));
++  }
++
++  @Test
++  void returnsOnlyDeliverableFormats() {
++    var user = buildUser(List.of("002", "003", "001"), null);
++    var group = threeFormatGroup("email", "sms", "print");
++
++    var selected = resolver.select(group, user);
++
++    assertThat(selected, hasSize(3));
++    assertTrue(selected.stream()
++      .map(NoticeConfiguration::getNoticeFormat)
++      .allMatch(NoticeFormat::isDeliverable));
++  }
++
++  private static User buildUser(List<String> preferredContactTypeIds,
++                                String deprecatedPreferredContactTypeId) {
++
++    var builder = new UserBuilder();
++
++    if (preferredContactTypeIds != null) {
++      builder = builder.withPreferredContactTypeIds(preferredContactTypeIds);
++    }
++
++    if (deprecatedPreferredContactTypeId != null) {
++      builder = builder.withDeprecatedPreferredContactTypeId(
++        deprecatedPreferredContactTypeId);
++    }
++
++    return new User(builder.create());
++  }
++
++  private static List<NoticeConfiguration> threeFormatGroup(
++    String emailTemplateId,
++    String smsTemplateId,
++    String printTemplateId) {
++
++    return List.of(
++      configuration(emailTemplateId, NoticeFormat.EMAIL),
++      configuration(smsTemplateId, NoticeFormat.SMS),
++      configuration(printTemplateId, NoticeFormat.PRINT));
++  }
++
++  private static NoticeConfiguration configuration(
++    String templateId, NoticeFormat format) {
++
++    return new NoticeConfiguration(
++      templateId,
++      format,
++      NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER,
++      Period.days(1),
++      false,
++      null,
++      true);
++  }
++
++  private static List<NoticeFormat> formats(
++    List<NoticeConfiguration> configurations) {
++
++    return configurations.stream()
++      .map(NoticeConfiguration::getNoticeFormat)
++      .toList();
++  }
++
++  private static List<String> templateIds(
++    List<NoticeConfiguration> configurations) {
++
++    return configurations.stream()
++      .map(NoticeConfiguration::getTemplateId)
++      .toList();
++  }
++}
+diff --git a/src/test/java/org/folio/circulation/domain/notice/PatronNoticePolicyTest.java b/src/test/java/org/folio/circulation/domain/notice/PatronNoticePolicyTest.java
+new file mode 100644
+index 000000000..fe0d0ebd9
+--- /dev/null
++++ b/src/test/java/org/folio/circulation/domain/notice/PatronNoticePolicyTest.java
+@@ -0,0 +1,27 @@
++package org.folio.circulation.domain.notice;
++
++import static org.hamcrest.CoreMatchers.is;
++import static org.hamcrest.MatcherAssert.assertThat;
++
++import java.util.List;
++
++import org.folio.circulation.domain.policy.Period;
++import org.junit.jupiter.api.Test;
++
++class PatronNoticePolicyTest {
++
++  @Test
++  void lookupNoticeConfigurationsReturnsAllMatchingEntriesInOrder() {
++    var first = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER, Period.days(1), false, null, true);
++    var second = new NoticeConfiguration("t2", NoticeFormat.SMS, NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER, Period.days(1), false, null, true);
++    var third = new NoticeConfiguration("t3", NoticeFormat.PRINT, NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER, Period.days(1), false, null, true);
++
++    var policy = new PatronNoticePolicy(List.of(first, second, third));
++
++    assertThat(policy.lookupNoticeConfigurations(NoticeEventType.CHECK_OUT), is(List.of(first, second, third)));
++    assertThat(policy.lookupNoticeConfiguration(NoticeEventType.CHECK_OUT).orElseThrow(), is(first));
++  }
++}
+diff --git a/src/test/java/org/folio/circulation/domain/notice/PatronNoticeTest.java b/src/test/java/org/folio/circulation/domain/notice/PatronNoticeTest.java
+new file mode 100644
+index 000000000..fd05d400c
+--- /dev/null
++++ b/src/test/java/org/folio/circulation/domain/notice/PatronNoticeTest.java
+@@ -0,0 +1,61 @@
++package org.folio.circulation.domain.notice;
++
++import static org.hamcrest.CoreMatchers.is;
++import static org.hamcrest.MatcherAssert.assertThat;
++
++import java.util.UUID;
++import java.util.stream.Stream;
++
++import org.folio.circulation.domain.policy.Period;
++import org.junit.jupiter.api.Test;
++import org.junit.jupiter.params.ParameterizedTest;
++import org.junit.jupiter.params.provider.Arguments;
++import org.junit.jupiter.params.provider.MethodSource;
++
++import io.vertx.core.json.JsonObject;
++
++class PatronNoticeTest {
++
++  @ParameterizedTest
++  @MethodSource("noticeFormats")
++  void buildsNoticeUsingConfigurationFormat(NoticeFormat format,
++    String deliveryChannel, String outputFormat) {
++
++    var configuration = new NoticeConfiguration(
++      "template",
++      format,
++      NoticeEventType.CHECK_OUT,
++      NoticeTiming.AFTER,
++      Period.days(1),
++      false,
++      null,
++      true);
++
++    var notice = new PatronNotice(
++      "recipient",
++      new JsonObject().put("key", "value"),
++      configuration);
++
++    assertThat(notice.getDeliveryChannel(), is(deliveryChannel));
++    assertThat(notice.getOutputFormat(), is(outputFormat));
++  }
++
++  static Stream<Arguments> noticeFormats() {
++    return Stream.of(
++      Arguments.of(NoticeFormat.EMAIL, "email", "text/html"),
++      Arguments.of(NoticeFormat.SMS, "sms", "text/plain"),
++      Arguments.of(NoticeFormat.PRINT, "mail", "text/html")
++    );
++  }
++
++  @Test
++  void buildsEmailNotice() {
++    var notice = PatronNotice.buildEmail(
++      "recipient",
++      UUID.randomUUID(),
++      new JsonObject());
++
++    assertThat(notice.getDeliveryChannel(), is("email"));
++    assertThat(notice.getOutputFormat(), is("text/html"));
++  }
++}
+diff --git a/src/test/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormatsTest.java b/src/test/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormatsTest.java
+new file mode 100644
+index 000000000..9b357c7c3
+--- /dev/null
++++ b/src/test/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormatsTest.java
+@@ -0,0 +1,53 @@
++package org.folio.circulation.domain.notice;
++
++import static org.hamcrest.CoreMatchers.is;
++import static org.hamcrest.MatcherAssert.assertThat;
++
++import java.util.List;
++
++import org.folio.circulation.domain.User;
++import org.junit.jupiter.api.Test;
++
++import api.support.builders.UserBuilder;
++
++class UserPreferredNoticeFormatsTest {
++
++  @Test
++  void mapsContactTypesToFormats() {
++    assertThat(UserPreferredNoticeFormats.toFormat("002").orElseThrow(), is(NoticeFormat.EMAIL));
++    assertThat(UserPreferredNoticeFormats.toFormat("001").orElseThrow(), is(NoticeFormat.PRINT));
++    assertThat(UserPreferredNoticeFormats.toFormat("003").orElseThrow(), is(NoticeFormat.SMS));
++  }
++
++  @Test
++  void ignoresUnknownOrBlankValues() {
++    assertThat(UserPreferredNoticeFormats.toFormat("999").isEmpty(), is(true));
++    assertThat(UserPreferredNoticeFormats.toFormat("").isEmpty(), is(true));
++    assertThat(UserPreferredNoticeFormats.toFormat(null).isEmpty(), is(true));
++  }
++
++  @Test
++  void readsAndDeduplicatesPreferredContactTypeIds() {
++    var user = new User(new UserBuilder()
++      .withPreferredContactTypeIds(List.of("002", "003", "002"))
++      .create());
++
++    assertThat(UserPreferredNoticeFormats.fromPreferredContactTypeIds(user),
++      is(List.of(NoticeFormat.EMAIL, NoticeFormat.SMS)));
++  }
++
++  @Test
++  void usesDeprecatedPreferredContactTypeIdAsFallback() {
++    var user = new User(new UserBuilder()
++      .withDeprecatedPreferredContactTypeId("003")
++      .create());
++
++    assertThat(UserPreferredNoticeFormats.fromDeprecatedPreferredContactTypeId(user).orElseThrow(),
++      is(NoticeFormat.SMS));
++  }
++
++  @Test
++  void returnsEmptyListForNullUser() {
++    assertThat(UserPreferredNoticeFormats.fromPreferredContactTypeIds(null), is(List.of()));
++  }
++}
+diff --git a/src/test/java/org/folio/circulation/infrastructure/storage/notices/PatronNoticePolicyMapperTest.java b/src/test/java/org/folio/circulation/infrastructure/storage/notices/PatronNoticePolicyMapperTest.java
+new file mode 100644
+index 000000000..73f9a5e67
+--- /dev/null
++++ b/src/test/java/org/folio/circulation/infrastructure/storage/notices/PatronNoticePolicyMapperTest.java
+@@ -0,0 +1,53 @@
++package org.folio.circulation.infrastructure.storage.notices;
++
++import static org.hamcrest.CoreMatchers.is;
++import static org.hamcrest.MatcherAssert.assertThat;
++
++import java.util.List;
++
++import org.folio.circulation.domain.notice.NoticeEventType;
++import org.folio.circulation.domain.notice.NoticeFormat;
++import org.junit.jupiter.api.Test;
++
++import api.support.builders.NoticeConfigurationBuilder;
++import io.vertx.core.json.JsonArray;
++import io.vertx.core.json.JsonObject;
++
++class PatronNoticePolicyMapperTest {
++
++  private final PatronNoticePolicyMapper mapper = new PatronNoticePolicyMapper();
++
++  @Test
++  void parsesSmsFormat() {
++    var policy = mapper.apply(new JsonObject()
++      .put("loanNotices", new JsonArray(List.of(
++        new NoticeConfigurationBuilder().withDueDateEvent().withSmsFormat().create()
++      )))).value();
++
++    var configuration = policy.getNoticeConfigurations().getFirst();
++    assertThat(configuration.getNoticeFormat(), is(NoticeFormat.SMS));
++    assertThat(configuration.getNoticeEventType(), is(NoticeEventType.DUE_DATE));
++  }
++
++  @Test
++  void parsesMixedFormats() {
++    var policy = mapper.apply(new JsonObject()
++      .put("loanNotices", new JsonArray(List.of(
++        new NoticeConfigurationBuilder().withDueDateEvent().withEmailFormat().create(),
++        new NoticeConfigurationBuilder().withDueDateEvent().withSmsFormat().create(),
++        new NoticeConfigurationBuilder().withDueDateEvent().withPrintFormat().create()
++      )))).value();
++
++    assertThat(policy.getNoticeConfigurations().size(), is(3));
++  }
++
++  @Test
++  void rejectsUnknownFormats() {
++    var result = mapper.apply(new JsonObject()
++      .put("loanNotices", new JsonArray(List.of(
++        new NoticeConfigurationBuilder().withDueDateEvent().create().put("format", "Bogus")
++      ))));
++
++    assertThat(result.failed(), is(true));
++  }
++}

--- a/src/main/java/org/folio/circulation/domain/User.java
+++ b/src/main/java/org/folio/circulation/domain/User.java
@@ -172,6 +172,24 @@ public class User {
       .collect(Collectors.toList());
   }
 
+  public List<String> getPreferredContactTypeIds() {
+    var personal = getPersonal();
+    if (personal == null) {
+      return List.of();
+    }
+
+    return personal.getJsonArray("preferredContactTypeIds", new JsonArray())
+      .stream()
+      .filter(String.class::isInstance)
+      .map(String.class::cast)
+      .collect(Collectors.toList());
+  }
+
+  public String getPreferredContactTypeId() {
+    var personal = getPersonal();
+    return personal == null ? null : personal.getString("preferredContactTypeId");
+  }
+
   public Collection<Department> getDepartments() {
     return departments;
   }

--- a/src/main/java/org/folio/circulation/domain/User.java
+++ b/src/main/java/org/folio/circulation/domain/User.java
@@ -173,12 +173,7 @@ public class User {
   }
 
   public List<String> getPreferredContactTypeIds() {
-    var personal = getPersonal();
-    if (personal == null) {
-      return List.of();
-    }
-
-    return personal.getJsonArray("preferredContactTypeIds", new JsonArray())
+    return getArrayProperty(getPersonal(), "preferredContactTypeIds")
       .stream()
       .filter(String.class::isInstance)
       .map(String.class::cast)
@@ -186,8 +181,7 @@ public class User {
   }
 
   public String getPreferredContactTypeId() {
-    var personal = getPersonal();
-    return personal == null ? null : personal.getString("preferredContactTypeId");
+    return getProperty(getPersonal(), "preferredContactTypeId");
   }
 
   public Collection<Department> getDepartments() {

--- a/src/main/java/org/folio/circulation/domain/User.java
+++ b/src/main/java/org/folio/circulation/domain/User.java
@@ -182,7 +182,7 @@ public class User {
       .stream()
       .filter(String.class::isInstance)
       .map(String.class::cast)
-      .collect(Collectors.toList());
+      .toList();
   }
 
   public String getPreferredContactTypeId() {

--- a/src/main/java/org/folio/circulation/domain/notice/ImmediatePatronNoticeService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/ImmediatePatronNoticeService.java
@@ -37,13 +37,11 @@ public class ImmediatePatronNoticeService extends PatronNoticeService {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private final PatronNoticePolicyRepository noticePolicyRepository;
   private final NoticeContextCombiner noticeContextCombiner;
-  private final PatronNoticeConfigurationResolver configurationResolver;
 
   public ImmediatePatronNoticeService(Clients clients, NoticeContextCombiner noticeContextCombiner) {
     super(clients);
     this.noticePolicyRepository = new PatronNoticePolicyRepository(clients);
     this.noticeContextCombiner = noticeContextCombiner;
-    this.configurationResolver = new PatronNoticeConfigurationResolver();
   }
 
   public CompletableFuture<Result<Void>> acceptNoticeEvent(PatronNoticeEvent event) {
@@ -110,16 +108,16 @@ public class ImmediatePatronNoticeService extends PatronNoticeService {
       .findFirst()
       .orElse(null);
 
-    var selectedConfigurations = configurationResolver.select(matchGroup, recipient);
+    var selected = PatronNoticeConfigurationResolver.select(matchGroup, recipient);
 
-    if (selectedConfigurations.isEmpty()) {
+    if (selected.isEmpty()) {
       log.info("applyPatronNoticePolicy:: no notice configuration selected for recipient {}",
         context.getGroupDefinition().getRecipientId());
 
       return ofAsync(() -> null);
     }
 
-    return allOf(selectedConfigurations, configuration -> sendNotice(context, configuration))
+    return allOf(selected, configuration -> sendNotice(context, configuration))
       .thenApply(mapResult(ignored -> null));
   }
 

--- a/src/main/java/org/folio/circulation/domain/notice/ImmediatePatronNoticeService.java
+++ b/src/main/java/org/folio/circulation/domain/notice/ImmediatePatronNoticeService.java
@@ -15,7 +15,7 @@ import static org.folio.circulation.support.results.ResultBinding.mapResult;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.circulation.domain.notice.combiner.NoticeContextCombiner;
@@ -37,11 +37,13 @@ public class ImmediatePatronNoticeService extends PatronNoticeService {
   private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   private final PatronNoticePolicyRepository noticePolicyRepository;
   private final NoticeContextCombiner noticeContextCombiner;
+  private final PatronNoticeConfigurationResolver configurationResolver;
 
   public ImmediatePatronNoticeService(Clients clients, NoticeContextCombiner noticeContextCombiner) {
     super(clients);
     this.noticePolicyRepository = new PatronNoticePolicyRepository(clients);
     this.noticeContextCombiner = noticeContextCombiner;
+    this.configurationResolver = new PatronNoticeConfigurationResolver();
   }
 
   public CompletableFuture<Result<Void>> acceptNoticeEvent(PatronNoticeEvent event) {
@@ -94,33 +96,47 @@ public class ImmediatePatronNoticeService extends PatronNoticeService {
   }
 
   private CompletableFuture<Result<Void>> applyPatronNoticePolicy(EventGroupContext context) {
-    return findMatchingNoticeConfiguration(context)
-      .map(context::withNoticeConfig)
-      .map(this::updateNoticeLogContext)
-      .map(this::sendNotice)
-      .orElseGet(() -> ofAsync(() -> null));
+    var matchGroup = PatronNoticeConfigurationResolver.firstMatchGroup(
+      context.getPatronNoticePolicy().lookupNoticeConfigurations(context.getGroupDefinition().getEventType()));
+
+    if (matchGroup.isEmpty()) {
+      log.debug("applyPatronNoticePolicy:: no notice configuration for event type {}",
+        context.getGroupDefinition().getEventType());
+      return ofAsync(() -> null);
+    }
+    var recipient = context.getEvents().stream()
+      .map(PatronNoticeEvent::getUser)
+      .filter(Objects::nonNull)
+      .findFirst()
+      .orElse(null);
+
+    var selectedConfigurations = configurationResolver.select(matchGroup, recipient);
+
+    if (selectedConfigurations.isEmpty()) {
+      log.info("applyPatronNoticePolicy:: no notice configuration selected for recipient {}",
+        context.getGroupDefinition().getRecipientId());
+
+      return ofAsync(() -> null);
+    }
+
+    return allOf(selectedConfigurations, configuration -> sendNotice(context, configuration))
+      .thenApply(mapResult(ignored -> null));
   }
 
-  private Optional<NoticeConfiguration> findMatchingNoticeConfiguration(EventGroupContext context) {
-    return context.getPatronNoticePolicy().lookupNoticeConfiguration(
-      context.getGroupDefinition().getEventType());
-  }
+  private CompletableFuture<Result<Void>> sendNotice(EventGroupContext context,
+    NoticeConfiguration configuration) {
 
-  private EventGroupContext updateNoticeLogContext(EventGroupContext context) {
-    return context.withCombinedNoticeLogContext(
-      context.getCombinedNoticeLogContext()
-        .withNoticePolicyId(context.getGroupDefinition().getNoticePolicyId())
-        .withTemplateId(context.getNoticeConfig().getTemplateId())
-        .withTriggeringEvent(context.getNoticeConfig().getNoticeEventType().getRepresentation()));
-  }
-
-  private CompletableFuture<Result<Void>> sendNotice(EventGroupContext context) {
-    PatronNotice patronNotice = new PatronNotice(
+    var patronNotice = new PatronNotice(
       context.getGroupDefinition().getRecipientId(),
       context.getCombinedNoticeContext(),
-      context.getNoticeConfig());
+      configuration);
 
-    return sendNotice(patronNotice, context.getCombinedNoticeLogContext());
+    var noticeLogContext = context.getCombinedNoticeLogContext()
+      .withNoticePolicyId(context.getGroupDefinition().getNoticePolicyId())
+      .withTemplateId(configuration.getTemplateId())
+      .withTriggeringEvent(configuration.getNoticeEventType().getRepresentation());
+
+    return sendNotice(patronNotice, noticeLogContext);
   }
 
   @With

--- a/src/main/java/org/folio/circulation/domain/notice/NoticeConfiguration.java
+++ b/src/main/java/org/folio/circulation/domain/notice/NoticeConfiguration.java
@@ -61,4 +61,8 @@ public class NoticeConfiguration {
   public boolean sendInRealTime() {
     return sendInRealTime;
   }
+
+  public NoticeConfigurationMatchKey matchKey() {
+    return NoticeConfigurationMatchKey.from(this);
+  }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/NoticeConfigurationMatchKey.java
+++ b/src/main/java/org/folio/circulation/domain/notice/NoticeConfigurationMatchKey.java
@@ -1,0 +1,27 @@
+package org.folio.circulation.domain.notice;
+
+public record NoticeConfigurationMatchKey(
+  NoticeEventType noticeEventType,
+  NoticeTiming timing,
+  Long timingPeriodDuration,
+  String timingPeriodInterval,
+  boolean recurring,
+  Long recurringPeriodDuration,
+  String recurringPeriodInterval,
+  boolean sendInRealTime) {
+
+  public static NoticeConfigurationMatchKey from(NoticeConfiguration configuration) {
+    var timingPeriod = configuration.getTimingPeriod();
+    var recurringPeriod = configuration.getRecurringPeriod();
+
+    return new NoticeConfigurationMatchKey(
+      configuration.getNoticeEventType(),
+      configuration.getTiming(),
+      timingPeriod == null ? null : timingPeriod.getDuration(),
+      timingPeriod == null ? null : timingPeriod.getInterval(),
+      configuration.isRecurring(),
+      recurringPeriod == null ? null : recurringPeriod.getDuration(),
+      recurringPeriod == null ? null : recurringPeriod.getInterval(),
+      configuration.sendInRealTime());
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/notice/NoticeFormat.java
+++ b/src/main/java/org/folio/circulation/domain/notice/NoticeFormat.java
@@ -1,10 +1,13 @@
 package org.folio.circulation.domain.notice;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.Arrays;
 
 public enum NoticeFormat {
 
   EMAIL("Email", "email", "text/html"),
+  SMS("SMS", "sms", "text/plain"),
   PRINT("Print", "mail", "text/html"),
   UNKNOWN("Unknown", "", "");
 
@@ -36,5 +39,9 @@ public enum NoticeFormat {
 
   public String getRepresentation() {
     return representation;
+  }
+
+  public boolean isDeliverable() {
+    return StringUtils.isNotBlank(deliveryChannel);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/NoticeFormat.java
+++ b/src/main/java/org/folio/circulation/domain/notice/NoticeFormat.java
@@ -1,7 +1,5 @@
 package org.folio.circulation.domain.notice;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.Arrays;
 
 public enum NoticeFormat {
@@ -39,9 +37,5 @@ public enum NoticeFormat {
 
   public String getRepresentation() {
     return representation;
-  }
-
-  public boolean isDeliverable() {
-    return StringUtils.isNotBlank(deliveryChannel);
   }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
@@ -1,0 +1,120 @@
+package org.folio.circulation.domain.notice;
+
+import static java.util.stream.Collectors.toCollection;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.circulation.domain.User;
+
+public class PatronNoticeConfigurationResolver {
+  private static final Logger log = LogManager.getLogger(PatronNoticeConfigurationResolver.class);
+
+  public static List<NoticeConfiguration> firstMatchGroup(List<NoticeConfiguration> candidates) {
+    if (candidates == null || candidates.isEmpty()) {
+      return List.of();
+    }
+    var key = candidates.getFirst().matchKey();
+    return candidates.stream()
+      .filter(candidate -> key.equals(candidate.matchKey()))
+      .toList();
+  }
+
+  public List<NoticeConfiguration> select(List<NoticeConfiguration> matchGroup, User recipient) {
+    if (matchGroup == null || matchGroup.isEmpty()) {
+      return List.of();
+    }
+
+    var group = firstMatchGroup(matchGroup);
+    if (group.size() != matchGroup.size()) {
+      log.warn("select:: received {} configurations spanning several match groups, " +
+        "narrowing to the first group of {}", matchGroup.size(), group.size());
+    }
+
+    var byFormat = indexByFormat(group);
+    if (byFormat.isEmpty()) {
+      return List.of();
+    }
+
+    if (byFormat.size() == 1) {
+      return List.copyOf(byFormat.values());
+    }
+
+    var selected = selectByPreferences(byFormat, recipient);
+    if (selected.isEmpty()) {
+      log.warn("select:: no notice configuration selected for recipient {}, event {}, " +
+          "available formats {} - sending nothing",
+        recipient == null ? null : recipient.getId(), eventTypeOf(group), byFormat.keySet());
+    }
+    return selected;
+  }
+
+  public Set<NoticeFormat> resolveFormats(List<NoticeConfiguration> matchGroup, User recipient) {
+    return select(matchGroup, recipient).stream()
+      .map(NoticeConfiguration::getNoticeFormat)
+      .collect(toCollection(LinkedHashSet::new));
+  }
+
+  public boolean requiresPreference(List<NoticeConfiguration> matchGroup) {
+    return indexByFormat(firstMatchGroup(matchGroup)).size() > 1;
+  }
+
+  private List<NoticeConfiguration> selectByPreferences(
+    Map<NoticeFormat, NoticeConfiguration> byFormat, User recipient) {
+
+    var preferredFormats =
+      UserPreferredNoticeFormats.fromPreferredContactTypeIds(recipient);
+
+    if (!preferredFormats.isEmpty()) {
+      return preferredFormats.stream()
+        .map(byFormat::get)
+        .filter(Objects::nonNull)
+        .toList();
+    }
+
+    var deprecatedFormat =
+      UserPreferredNoticeFormats.fromDeprecatedPreferredContactTypeId(recipient);
+
+    if (deprecatedFormat.isPresent()) {
+      var configuration = byFormat.get(deprecatedFormat.get());
+
+      return configuration == null
+        ? List.of()
+        : List.of(configuration);
+    }
+
+    return emailOnly(byFormat);
+  }
+
+  private static List<NoticeConfiguration> emailOnly(
+    Map<NoticeFormat, NoticeConfiguration> byFormat) {
+    var emailConfiguration = byFormat.get(NoticeFormat.EMAIL);
+    return emailConfiguration == null ? List.of() : List.of(emailConfiguration);
+  }
+
+  private static Map<NoticeFormat, NoticeConfiguration> indexByFormat(
+    List<NoticeConfiguration> matchGroup) {
+
+    var byFormat = new LinkedHashMap<NoticeFormat, NoticeConfiguration>();
+    for (NoticeConfiguration configuration : matchGroup) {
+      NoticeFormat format = configuration.getNoticeFormat();
+      if (format == null || !format.isDeliverable()) {
+        log.warn("indexByFormat:: skipping notice configuration {} with undeliverable format {}",
+          configuration.getTemplateId(), format);
+        continue;
+      }
+      byFormat.putIfAbsent(format, configuration);
+    }
+    return byFormat;
+  }
+
+  private static NoticeEventType eventTypeOf(List<NoticeConfiguration> group) {
+    return group.isEmpty() ? null : group.getFirst().getNoticeEventType();
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
@@ -16,6 +16,9 @@ import org.folio.circulation.domain.User;
 public class PatronNoticeConfigurationResolver {
   private static final Logger log = LogManager.getLogger(PatronNoticeConfigurationResolver.class);
 
+  private PatronNoticeConfigurationResolver() {
+  }
+
   public static List<NoticeConfiguration> matchGroupOf(
     List<NoticeConfiguration> candidates, NoticeConfiguration anchor) {
 

--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
@@ -2,6 +2,7 @@ package org.folio.circulation.domain.notice;
 
 import static java.util.stream.Collectors.toCollection;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -25,7 +26,7 @@ public class PatronNoticeConfigurationResolver {
     List<NoticeConfiguration> candidates, NoticeConfiguration anchor) {
 
     if (CollectionUtils.isEmpty(candidates) || anchor == null) {
-      return List.of();
+      return Collections.emptyList();
     }
 
     var key = anchor.matchKey();
@@ -37,7 +38,7 @@ public class PatronNoticeConfigurationResolver {
 
   public static List<NoticeConfiguration> firstMatchGroup(List<NoticeConfiguration> candidates) {
     return CollectionUtils.isEmpty(candidates)
-      ? List.of()
+      ? Collections.emptyList()
       : matchGroupOf(candidates, candidates.getFirst());
   }
 
@@ -47,7 +48,7 @@ public class PatronNoticeConfigurationResolver {
     var byFormat = indexByFormat(matchGroup);
 
     if (byFormat.isEmpty()) {
-      return List.of();
+      return Collections.emptyList();
     }
 
     if (byFormat.size() == 1) {
@@ -71,6 +72,10 @@ public class PatronNoticeConfigurationResolver {
 
   private static List<NoticeConfiguration> selectByPreferences(
     Map<NoticeFormat, NoticeConfiguration> byFormat, User recipient) {
+
+    if (recipient == null) {
+      return defaultChannel(byFormat);
+    }
 
     var preferredFormats = UserPreferredNoticeFormats.fromPreferredContactTypeIds(recipient);
 
@@ -114,24 +119,16 @@ public class PatronNoticeConfigurationResolver {
   private static Map<NoticeFormat, NoticeConfiguration> indexByFormat(
     List<NoticeConfiguration> matchGroup) {
 
-    var byFormat = new LinkedHashMap<NoticeFormat, NoticeConfiguration>();
-
     if (CollectionUtils.isEmpty(matchGroup)) {
-      return byFormat;
+      return Collections.emptyMap();
     }
 
-    NoticeConfigurationMatchKey groupKey = null;
+    var byFormat = new LinkedHashMap<NoticeFormat, NoticeConfiguration>();
 
-    for (NoticeConfiguration configuration : matchGroup) {
-      if (groupKey == null) {
-        groupKey = configuration.matchKey();
-      } else if (!groupKey.equals(configuration.matchKey())) {
-        continue;
-      }
-
+    for (var configuration : matchGroup) {
       var format = configuration.getNoticeFormat();
 
-      if (format == null || !format.isDeliverable()) {
+      if (format == NoticeFormat.UNKNOWN) {
         log.debug("indexByFormat:: skipping configuration with template {}, format {} is not " +
           "deliverable", configuration.getTemplateId(), format);
         continue;

--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
@@ -16,28 +16,31 @@ import org.folio.circulation.domain.User;
 public class PatronNoticeConfigurationResolver {
   private static final Logger log = LogManager.getLogger(PatronNoticeConfigurationResolver.class);
 
-  public static List<NoticeConfiguration> firstMatchGroup(List<NoticeConfiguration> candidates) {
-    if (candidates == null || candidates.isEmpty()) {
+  public static List<NoticeConfiguration> matchGroupOf(
+    List<NoticeConfiguration> candidates, NoticeConfiguration anchor) {
+
+    if (candidates == null || candidates.isEmpty() || anchor == null) {
       return List.of();
     }
-    var key = candidates.getFirst().matchKey();
+
+    var key = anchor.matchKey();
+
     return candidates.stream()
       .filter(candidate -> key.equals(candidate.matchKey()))
       .toList();
   }
 
-  public List<NoticeConfiguration> select(List<NoticeConfiguration> matchGroup, User recipient) {
-    if (matchGroup == null || matchGroup.isEmpty()) {
-      return List.of();
-    }
+  public static List<NoticeConfiguration> firstMatchGroup(List<NoticeConfiguration> candidates) {
+    return candidates == null || candidates.isEmpty()
+      ? List.of()
+      : matchGroupOf(candidates, candidates.getFirst());
+  }
 
-    var group = firstMatchGroup(matchGroup);
-    if (group.size() != matchGroup.size()) {
-      log.warn("select:: received {} configurations spanning several match groups, " +
-        "narrowing to the first group of {}", matchGroup.size(), group.size());
-    }
+  public static List<NoticeConfiguration> select(
+    List<NoticeConfiguration> matchGroup, User recipient) {
 
-    var byFormat = indexByFormat(group);
+    var byFormat = indexByFormat(matchGroup);
+
     if (byFormat.isEmpty()) {
       return List.of();
     }
@@ -46,69 +49,103 @@ public class PatronNoticeConfigurationResolver {
       return List.copyOf(byFormat.values());
     }
 
-    var selected = selectByPreferences(byFormat, recipient);
-    if (selected.isEmpty()) {
-      log.warn("select:: no notice configuration selected for recipient {}, event {}, " +
-          "available formats {} - sending nothing",
-        recipient == null ? null : recipient.getId(), eventTypeOf(group), byFormat.keySet());
-    }
-    return selected;
+    return selectByPreferences(byFormat, recipient);
   }
 
-  public boolean requiresPreference(List<NoticeConfiguration> matchGroup) {
-    return indexByFormat(firstMatchGroup(matchGroup)).size() > 1;
+  public static Set<NoticeFormat> resolveFormats(
+    List<NoticeConfiguration> matchGroup, User recipient) {
+
+    return select(matchGroup, recipient).stream()
+      .map(NoticeConfiguration::getNoticeFormat)
+      .collect(toCollection(LinkedHashSet::new));
   }
 
-  private List<NoticeConfiguration> selectByPreferences(
+  public static boolean requiresPreference(List<NoticeConfiguration> matchGroup) {
+    return indexByFormat(matchGroup).size() > 1;
+  }
+
+  private static List<NoticeConfiguration> selectByPreferences(
     Map<NoticeFormat, NoticeConfiguration> byFormat, User recipient) {
 
-    var preferredFormats =
-      UserPreferredNoticeFormats.fromPreferredContactTypeIds(recipient);
+    var preferredFormats = UserPreferredNoticeFormats.fromPreferredContactTypeIds(recipient);
 
     if (!preferredFormats.isEmpty()) {
-      return preferredFormats.stream()
+      var matched = preferredFormats.stream()
         .map(byFormat::get)
         .filter(Objects::nonNull)
         .toList();
+
+      if (!matched.isEmpty()) {
+        return matched;
+      }
+
+      log.info("selectByPreferences:: preferred formats {} are not configured, available {} - " +
+        "falling back to default channel", preferredFormats, byFormat.keySet());
+    } else {
+      var deprecatedFormat =
+        UserPreferredNoticeFormats.fromDeprecatedPreferredContactTypeId(recipient);
+
+      if (deprecatedFormat.isPresent()) {
+        var configuration = byFormat.get(deprecatedFormat.get());
+
+        if (configuration != null) {
+          return List.of(configuration);
+        }
+
+        log.info("selectByPreferences:: preferred format {} is not configured, available {} - " +
+          "falling back to default channel", deprecatedFormat.get(), byFormat.keySet());
+      }
     }
-
-    var deprecatedFormat =
-      UserPreferredNoticeFormats.fromDeprecatedPreferredContactTypeId(recipient);
-
-    if (deprecatedFormat.isPresent()) {
-      var configuration = byFormat.get(deprecatedFormat.get());
-
-      return configuration == null
-        ? List.of()
-        : List.of(configuration);
-    }
-
-    return emailOnly(byFormat);
+    return defaultChannel(byFormat);
   }
 
-  private static List<NoticeConfiguration> emailOnly(
+  private static List<NoticeConfiguration> defaultChannel(
     Map<NoticeFormat, NoticeConfiguration> byFormat) {
+
     var emailConfiguration = byFormat.get(NoticeFormat.EMAIL);
-    return emailConfiguration == null ? List.of() : List.of(emailConfiguration);
+
+    if (emailConfiguration != null) {
+      return List.of(emailConfiguration);
+    }
+
+    return List.of(byFormat.values().iterator().next());
   }
 
   private static Map<NoticeFormat, NoticeConfiguration> indexByFormat(
     List<NoticeConfiguration> matchGroup) {
 
     var byFormat = new LinkedHashMap<NoticeFormat, NoticeConfiguration>();
+
+    if (matchGroup == null || matchGroup.isEmpty()) {
+      return byFormat;
+    }
+
+    NoticeConfigurationMatchKey groupKey = null;
+
     for (NoticeConfiguration configuration : matchGroup) {
-      NoticeFormat format = configuration.getNoticeFormat();
-      if (format == null || !format.isDeliverable()) {
-        log.warn("indexByFormat:: skipping notice configuration {} with undeliverable format {}",
-          configuration.getTemplateId(), format);
+      if (groupKey == null) {
+        groupKey = configuration.matchKey();
+      } else if (!groupKey.equals(configuration.matchKey())) {
         continue;
       }
-      byFormat.putIfAbsent(format, configuration);
-    }
-    return byFormat;
-  }
 
-  private static NoticeEventType eventTypeOf(List<NoticeConfiguration> group) {
-    return group.isEmpty() ? null : group.getFirst().getNoticeEventType();
+      var format = configuration.getNoticeFormat();
+
+      if (format == null || !format.isDeliverable()) {
+        log.debug("indexByFormat:: skipping configuration with template {}, format {} is not " +
+          "deliverable", configuration.getTemplateId(), format);
+        continue;
+      }
+
+      var previous = byFormat.putIfAbsent(format, configuration);
+
+      if (previous != null) {
+        log.warn("indexByFormat:: match group contains several configurations for format {}, " +
+            "using template {} and ignoring template {}", format, previous.getTemplateId(),
+          configuration.getTemplateId());
+      }
+    }
+
+    return byFormat;
   }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
@@ -55,12 +55,6 @@ public class PatronNoticeConfigurationResolver {
     return selected;
   }
 
-  public Set<NoticeFormat> resolveFormats(List<NoticeConfiguration> matchGroup, User recipient) {
-    return select(matchGroup, recipient).stream()
-      .map(NoticeConfiguration::getNoticeFormat)
-      .collect(toCollection(LinkedHashSet::new));
-  }
-
   public boolean requiresPreference(List<NoticeConfiguration> matchGroup) {
     return indexByFormat(firstMatchGroup(matchGroup)).size() > 1;
   }

--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolver.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.User;
@@ -22,7 +24,7 @@ public class PatronNoticeConfigurationResolver {
   public static List<NoticeConfiguration> matchGroupOf(
     List<NoticeConfiguration> candidates, NoticeConfiguration anchor) {
 
-    if (candidates == null || candidates.isEmpty() || anchor == null) {
+    if (CollectionUtils.isEmpty(candidates) || anchor == null) {
       return List.of();
     }
 
@@ -34,7 +36,7 @@ public class PatronNoticeConfigurationResolver {
   }
 
   public static List<NoticeConfiguration> firstMatchGroup(List<NoticeConfiguration> candidates) {
-    return candidates == null || candidates.isEmpty()
+    return CollectionUtils.isEmpty(candidates)
       ? List.of()
       : matchGroupOf(candidates, candidates.getFirst());
   }
@@ -105,13 +107,8 @@ public class PatronNoticeConfigurationResolver {
   private static List<NoticeConfiguration> defaultChannel(
     Map<NoticeFormat, NoticeConfiguration> byFormat) {
 
-    var emailConfiguration = byFormat.get(NoticeFormat.EMAIL);
-
-    if (emailConfiguration != null) {
-      return List.of(emailConfiguration);
-    }
-
-    return List.of(byFormat.values().iterator().next());
+    return List.of(ObjectUtils.getIfNull(byFormat.get(NoticeFormat.EMAIL),
+      () -> byFormat.values().iterator().next()));
   }
 
   private static Map<NoticeFormat, NoticeConfiguration> indexByFormat(
@@ -119,7 +116,7 @@ public class PatronNoticeConfigurationResolver {
 
     var byFormat = new LinkedHashMap<NoticeFormat, NoticeConfiguration>();
 
-    if (matchGroup == null || matchGroup.isEmpty()) {
+    if (CollectionUtils.isEmpty(matchGroup)) {
       return byFormat;
     }
 

--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticePolicy.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticePolicy.java
@@ -23,6 +23,9 @@ public class PatronNoticePolicy {
       .toList();
   }
 
+  /**
+   * @deprecated Use {@link #lookupNoticeConfigurations(NoticeEventType)} instead.
+   */
   @Deprecated(forRemoval = false)
   public Optional<NoticeConfiguration> lookupNoticeConfiguration(NoticeEventType eventType) {
     return lookupNoticeConfigurations(eventType).stream().findFirst();

--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticePolicy.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticePolicy.java
@@ -17,9 +17,14 @@ public class PatronNoticePolicy {
     return noticeConfigurations;
   }
 
-  public Optional<NoticeConfiguration> lookupNoticeConfiguration(NoticeEventType eventType) {
+  public List<NoticeConfiguration> lookupNoticeConfigurations(NoticeEventType eventType) {
     return noticeConfigurations.stream()
       .filter(d -> Objects.equals(d.getNoticeEventType(), eventType))
-      .findFirst();
+      .toList();
+  }
+
+  @Deprecated(forRemoval = false)
+  public Optional<NoticeConfiguration> lookupNoticeConfiguration(NoticeEventType eventType) {
+    return lookupNoticeConfigurations(eventType).stream().findFirst();
   }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/PatronNoticePolicy.java
+++ b/src/main/java/org/folio/circulation/domain/notice/PatronNoticePolicy.java
@@ -2,7 +2,6 @@ package org.folio.circulation.domain.notice;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 public class PatronNoticePolicy {
 
@@ -21,13 +20,5 @@ public class PatronNoticePolicy {
     return noticeConfigurations.stream()
       .filter(d -> Objects.equals(d.getNoticeEventType(), eventType))
       .toList();
-  }
-
-  /**
-   * @deprecated Use {@link #lookupNoticeConfigurations(NoticeEventType)} instead.
-   */
-  @Deprecated(forRemoval = false)
-  public Optional<NoticeConfiguration> lookupNoticeConfiguration(NoticeEventType eventType) {
-    return lookupNoticeConfigurations(eventType).stream().findFirst();
   }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormats.java
+++ b/src/main/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormats.java
@@ -1,0 +1,53 @@
+package org.folio.circulation.domain.notice;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.folio.circulation.domain.User;
+
+public final class UserPreferredNoticeFormats {
+  public static final String CONTACT_TYPE_EMAIL = "002";
+  public static final String CONTACT_TYPE_MAIL = "001";
+  public static final String CONTACT_TYPE_SMS = "003";
+
+  private static final Map<String, NoticeFormat> CONTACT_TYPE_FORMATS = Map.of(
+    CONTACT_TYPE_EMAIL, NoticeFormat.EMAIL,
+    CONTACT_TYPE_MAIL, NoticeFormat.PRINT,
+    CONTACT_TYPE_SMS, NoticeFormat.SMS
+  );
+
+  private UserPreferredNoticeFormats() {
+  }
+
+  public static Optional<NoticeFormat> toFormat(String contactTypeId) {
+    if (contactTypeId == null || contactTypeId.isBlank()) {
+      return Optional.empty();
+    }
+
+    return Optional.ofNullable(CONTACT_TYPE_FORMATS.get(contactTypeId));
+  }
+
+  public static List<NoticeFormat> fromPreferredContactTypeIds(User user) {
+    if (user == null) {
+      return List.of();
+    }
+
+    var formats = new LinkedHashSet<NoticeFormat>();
+    user.getPreferredContactTypeIds().stream()
+      .map(UserPreferredNoticeFormats::toFormat)
+      .flatMap(Optional::stream)
+      .forEach(formats::add);
+
+    return List.copyOf(formats);
+  }
+
+  public static Optional<NoticeFormat> fromDeprecatedPreferredContactTypeId(User user) {
+    if (user == null) {
+      return Optional.empty();
+    }
+
+    return toFormat(user.getPreferredContactTypeId());
+  }
+}

--- a/src/main/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormats.java
+++ b/src/main/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormats.java
@@ -1,10 +1,10 @@
 package org.folio.circulation.domain.notice;
 
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.folio.circulation.domain.User;
 
 public final class UserPreferredNoticeFormats {
@@ -22,7 +22,7 @@ public final class UserPreferredNoticeFormats {
   }
 
   public static Optional<NoticeFormat> toFormat(String contactTypeId) {
-    if (contactTypeId == null || contactTypeId.isBlank()) {
+    if (StringUtils.isBlank(contactTypeId)) {
       return Optional.empty();
     }
 
@@ -30,24 +30,14 @@ public final class UserPreferredNoticeFormats {
   }
 
   public static List<NoticeFormat> fromPreferredContactTypeIds(User user) {
-    if (user == null) {
-      return List.of();
-    }
-
-    var formats = new LinkedHashSet<NoticeFormat>();
-    user.getPreferredContactTypeIds().stream()
+    return user.getPreferredContactTypeIds().stream()
       .map(UserPreferredNoticeFormats::toFormat)
       .flatMap(Optional::stream)
-      .forEach(formats::add);
-
-    return List.copyOf(formats);
+      .distinct()
+      .toList();
   }
 
   public static Optional<NoticeFormat> fromDeprecatedPreferredContactTypeId(User user) {
-    if (user == null) {
-      return Optional.empty();
-    }
-
     return toFormat(user.getPreferredContactTypeId());
   }
 }

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedScheduledNoticeHandler.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain.notice.schedule;
 
+import static java.lang.Boolean.FALSE;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toList;
@@ -143,9 +144,9 @@ public abstract class GroupedScheduledNoticeHandler {
     ScheduledNoticeContext contextSample = relevantContexts.get(0);
 
     return singleNoticeHandler.shouldSendByPreference(contextSample)
-      .thenCompose(shouldSend -> shouldSend
-        ? doSendGroupedNotice(contexts, relevantContexts, contextSample)
-        : skipGroupedNoticeDueToPreference(contexts, relevantContexts));
+      .thenCompose(shouldSend -> FALSE.equals(shouldSend)
+        ? skipGroupedNoticeDueToPreference(contexts, relevantContexts)
+        : doSendGroupedNotice(contexts, relevantContexts, contextSample));
   }
 
   private CompletableFuture<Result<List<ScheduledNoticeContext>>> doSendGroupedNotice(

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/GroupedScheduledNoticeHandler.java
@@ -141,13 +141,24 @@ public abstract class GroupedScheduledNoticeHandler {
 
     //All the notices have the same properties, so we can get any of them
     ScheduledNoticeContext contextSample = relevantContexts.get(0);
+
+    return singleNoticeHandler.shouldSendByPreference(contextSample)
+      .thenCompose(shouldSend -> shouldSend
+        ? doSendGroupedNotice(contexts, relevantContexts, contextSample)
+        : skipGroupedNoticeDueToPreference(contexts, relevantContexts));
+  }
+
+  private CompletableFuture<Result<List<ScheduledNoticeContext>>> doSendGroupedNotice(
+    List<ScheduledNoticeContext> contexts, List<ScheduledNoticeContext> relevantContexts,
+    ScheduledNoticeContext contextSample) {
+
     User user = contextSample.getLoan().getUser();
 
     List<JsonObject> noticeContexts = relevantContexts.stream()
       .map(ScheduledNoticeContext::getNoticeContext)
       .collect(toList());
 
-    log.info("sendGroupedNotice:: attempting to send a grouped notice for {} scheduled notices",
+    log.info("doSendGroupedNotice:: attempting to send a grouped notice for {} scheduled notices",
       relevantContexts.size());
 
     return patronNoticeService.sendNotice(
@@ -156,6 +167,15 @@ public abstract class GroupedScheduledNoticeHandler {
         createGroupedNoticeContext(user, groupToken, noticeContexts),
         buildNoticeLogContext(relevantContexts, user))
       .thenApply(mapResult(v -> contexts));
+  }
+
+  private CompletableFuture<Result<List<ScheduledNoticeContext>>> skipGroupedNoticeDueToPreference(
+    List<ScheduledNoticeContext> contexts, List<ScheduledNoticeContext> relevantContexts) {
+
+    log.info("skipGroupedNoticeDueToPreference:: skipping group of {} scheduled notices filtered "
+      + "out by user notice format preference", relevantContexts.size());
+
+    return completedFuture(succeeded(contexts));
   }
 
   private static NoticeLogContext buildNoticeLogContext(List<ScheduledNoticeContext> contexts,

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -21,6 +22,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.ItemRelatedRecord;
+import org.folio.circulation.domain.Loan;
+import org.folio.circulation.domain.Request;
 import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.UserRelatedRecord;
 import org.folio.circulation.domain.notice.NoticeConfiguration;
@@ -28,7 +31,6 @@ import org.folio.circulation.domain.notice.NoticeEventType;
 import org.folio.circulation.domain.notice.PatronNoticeConfigurationResolver;
 import org.folio.circulation.domain.notice.PatronNoticePolicy;
 import org.folio.circulation.domain.notice.ScheduledPatronNoticeService;
-import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
 import org.folio.circulation.infrastructure.storage.feesandfines.AccountRepository;
@@ -288,41 +290,62 @@ public abstract class ScheduledNoticeHandler {
   private boolean evaluatePreference(ScheduledNoticeContext context, PatronNoticePolicy policy) {
     var notice = context.getNotice();
     var noticeConfig = notice.getConfiguration();
-    var eventType = NoticeEventType.from(notice.getTriggeringEvent().getRepresentation());
 
-    if (eventType == NoticeEventType.UNKNOWN) {
-      log.debug("evaluatePreference:: triggering event {} has no patron notice policy " +
-        "counterpart, sending as usual", notice.getTriggeringEvent());
+    var eventType = validateEventType(notice);
+    if (eventType.isEmpty()) {
       return true;
     }
 
-    var candidates = policy.lookupNoticeConfigurations(eventType).stream()
-      .filter(candidate -> matchesScheduledConfig(candidate, noticeConfig))
-      .toList();
-    var anchor = candidates.stream()
-      .filter(candidate -> Objects.equals(candidate.getTemplateId(), noticeConfig.getTemplateId()))
-      .findFirst();
-
-    if (anchor.isEmpty()) {
+    var matchGroup = findMatchingTemplate(policy, eventType.get(), noticeConfig);
+    if (matchGroup.isEmpty()) {
       log.info("evaluatePreference:: template {} of notice {} is no longer present in policy {}, " +
           "sending as scheduled", noticeConfig.getTemplateId(), notice.getId(),
         context.getPatronNoticePolicyId());
       return true;
     }
 
-    var matchGroup = PatronNoticeConfigurationResolver.matchGroupOf(candidates, anchor.get());
+    return resolveNoticeFormats(context, noticeConfig, matchGroup.get());
+  }
+
+  private static Optional<NoticeEventType> validateEventType(ScheduledNotice notice) {
+    var eventType = NoticeEventType.from(notice.getTriggeringEvent().getRepresentation());
+
+    if (eventType == NoticeEventType.UNKNOWN) {
+      log.debug("validateEventType:: triggering event {} has no patron notice policy " +
+        "counterpart, sending as usual", notice.getTriggeringEvent());
+      return Optional.empty();
+    }
+
+    return Optional.of(eventType);
+  }
+
+  private static Optional<List<NoticeConfiguration>> findMatchingTemplate(
+    PatronNoticePolicy policy, NoticeEventType eventType, ScheduledNoticeConfig noticeConfig) {
+
+    var candidates = policy.lookupNoticeConfigurations(eventType).stream()
+      .filter(candidate -> matchesScheduledConfig(candidate, noticeConfig))
+      .toList();
+
+    return candidates.stream()
+      .filter(candidate -> Objects.equals(candidate.getTemplateId(), noticeConfig.getTemplateId()))
+      .findFirst()
+      .map(anchor -> PatronNoticeConfigurationResolver.matchGroupOf(candidates, anchor));
+  }
+
+  private boolean resolveNoticeFormats(ScheduledNoticeContext context,
+    ScheduledNoticeConfig noticeConfig, List<NoticeConfiguration> matchGroup) {
 
     if (!PatronNoticeConfigurationResolver.requiresPreference(matchGroup)) {
       return true;
     }
 
-    var recipient = extractRecipientUser(context);
-    var resolvedFormats = PatronNoticeConfigurationResolver.resolveFormats(matchGroup, recipient);
+    var resolvedFormats = PatronNoticeConfigurationResolver.resolveFormats(matchGroup,
+      extractRecipientUser(context));
     var shouldSend = resolvedFormats.contains(noticeConfig.getFormat());
 
     if (!shouldSend) {
-      log.info("evaluatePreference:: notice {} format {} is not among resolved formats {}, skipping",
-        notice.getId(), noticeConfig.getFormat(), resolvedFormats);
+      log.info("resolveNoticeFormats:: notice {} format {} is not among resolved formats {}, skipping",
+        context.getNotice().getId(), noticeConfig.getFormat(), resolvedFormats);
     }
 
     return shouldSend;
@@ -331,37 +354,19 @@ public abstract class ScheduledNoticeHandler {
   private static boolean matchesScheduledConfig(NoticeConfiguration candidate,
     ScheduledNoticeConfig config) {
 
-    if (candidate.getTiming() != config.getTiming()) {
-      return false;
-    }
-    if (candidate.isRecurring() != config.isRecurring()) {
-      return false;
-    }
-    if (candidate.sendInRealTime() != config.sendInRealTime()) {
-      return false;
-    }
-
-    return !candidate.isRecurring() || periodsEqual(candidate.getRecurringPeriod(), config.getRecurringPeriod());
-  }
-
-  private static boolean periodsEqual(Period first, Period second) {
-    if (first == null || second == null) {
-      return first == second;
-    }
-
-    return Objects.equals(first.getDuration(), second.getDuration())
-      && Objects.equals(first.getInterval(), second.getInterval());
+    return Objects.equals(candidate.getTiming(), config.getTiming())
+      && Objects.equals(candidate.isRecurring(), config.isRecurring())
+      && Objects.equals(candidate.sendInRealTime(), config.sendInRealTime())
+      && (!candidate.isRecurring()
+      || Objects.equals(candidate.getRecurringPeriod(), config.getRecurringPeriod()));
   }
 
   private static User extractRecipientUser(ScheduledNoticeContext context) {
-    if (context.getLoan() != null && context.getLoan().getUser() != null) {
-      return context.getLoan().getUser();
-    }
-    if (context.getRequest() != null && context.getRequest().getUser() != null) {
-      return context.getRequest().getUser();
-    }
-
-    return null;
+    return Optional.ofNullable(context.getLoan())
+      .map(Loan::getUser)
+      .or(() -> Optional.ofNullable(context.getRequest())
+        .map(Request::getUser))
+      .orElse(null);
   }
 
   protected CompletableFuture<Result<ScheduledNoticeContext>> fetchPatronNoticePolicyIdForLoan(

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
@@ -1,6 +1,7 @@
 package org.folio.circulation.domain.notice.schedule;
 
 import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.support.http.ResponseMapping.forwardOnFailure;
@@ -252,22 +253,29 @@ public abstract class ScheduledNoticeHandler {
 
   protected CompletableFuture<Boolean> shouldSendByPreference(ScheduledNoticeContext context) {
     var policyId = context.getPatronNoticePolicyId();
+
     if (StringUtils.isBlank(policyId)) {
       log.debug("shouldSendByPreference:: no patron notice policy id for notice {}, sending as usual",
         context.getNotice().getId());
-      return completedFuture(true);
+
+      return completedFuture(TRUE);
     }
 
     return lookupPatronNoticePolicy(policyId)
-      .thenApply(r -> {
-        if (r.failed()) {
-          log.warn("shouldSendByPreference:: failed to look up notice policy {} for notice {}: {}",
-            policyId, context.getNotice().getId(), r.cause());
-          return true;
-        }
+      .thenApply(policyLookup -> shouldSend(context, policyLookup));
+  }
 
-        return evaluatePreference(context, r.value());
-      });
+  private boolean shouldSend(ScheduledNoticeContext context,
+    Result<PatronNoticePolicy> policyLookup) {
+
+    if (policyLookup.failed()) {
+      log.warn("shouldSend:: failed to look up notice policy {} for notice {}: {}",
+        context.getPatronNoticePolicyId(), context.getNotice().getId(), policyLookup.cause());
+
+      return true;
+    }
+
+    return evaluatePreference(context, policyLookup.value());
   }
 
   private CompletableFuture<Result<PatronNoticePolicy>> lookupPatronNoticePolicy(String policyId) {
@@ -279,12 +287,17 @@ public abstract class ScheduledNoticeHandler {
     }
 
     return patronNoticePolicyRepository.lookupPolicy(policyId, NO_RULE_CONDITIONS)
-      .thenApply(result -> {
-        if (result.succeeded() && result.value() != null) {
-          patronNoticePolicyCache.put(policyId, result.value());
-        }
-        return result;
-      });
+      .thenApply(result -> cachePolicy(policyId, result));
+  }
+
+  private Result<PatronNoticePolicy> cachePolicy(String policyId,
+    Result<PatronNoticePolicy> result) {
+
+    if (result.succeeded() && result.value() != null) {
+      patronNoticePolicyCache.put(policyId, result.value());
+    }
+
+    return result;
   }
 
   private boolean evaluatePreference(ScheduledNoticeContext context, PatronNoticePolicy policy) {

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
@@ -11,20 +11,29 @@ import static org.folio.circulation.support.results.ResultBinding.mapResult;
 import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.ItemRelatedRecord;
+import org.folio.circulation.domain.User;
 import org.folio.circulation.domain.UserRelatedRecord;
+import org.folio.circulation.domain.notice.NoticeConfiguration;
+import org.folio.circulation.domain.notice.NoticeEventType;
+import org.folio.circulation.domain.notice.PatronNoticeConfigurationResolver;
+import org.folio.circulation.domain.notice.PatronNoticePolicy;
 import org.folio.circulation.domain.notice.ScheduledPatronNoticeService;
+import org.folio.circulation.domain.policy.Period;
 import org.folio.circulation.domain.representations.logs.NoticeLogContext;
 import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
 import org.folio.circulation.infrastructure.storage.feesandfines.AccountRepository;
 import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
 import org.folio.circulation.infrastructure.storage.notices.PatronNoticePolicyRepository;
 import org.folio.circulation.infrastructure.storage.notices.ScheduledNoticesRepository;
+import org.folio.circulation.rules.AppliedRuleConditions;
 import org.folio.circulation.rules.CirculationRuleMatch;
 import org.folio.circulation.services.EventPublisher;
 import org.folio.circulation.support.Clients;
@@ -46,6 +55,8 @@ public abstract class ScheduledNoticeHandler {
   protected final CollectionResourceClient templateNoticesClient;
   private final ScheduledPatronNoticeService patronNoticeService;
   private final EventPublisher eventPublisher;
+  private final Map<String, CompletableFuture<Result<PatronNoticePolicy>>> patronNoticePolicyCache =
+    new ConcurrentHashMap<>();
 
   protected ScheduledNoticeHandler(Clients clients, LoanRepository loanRepository) {
     this.scheduledNoticesRepository = ScheduledNoticesRepository.using(clients);
@@ -197,12 +208,21 @@ public abstract class ScheduledNoticeHandler {
   protected CompletableFuture<Result<ScheduledNoticeContext>> sendNotice(
     ScheduledNoticeContext context) {
 
-    log.info("sendNotice:: sending notice for scheduled notice {}", context.getNotice().getId());
     if (isNoticeIrrelevant(context)) {
-      log.info("sendNotice:: notice is irrelevant, skipping send");
+      log.info("sendNotice:: notice {} is irrelevant, skipping send", context.getNotice().getId());
       return ofAsync(() -> context);
     }
 
+    return shouldSendByPreference(context)
+      .thenCompose(shouldSend -> shouldSend
+        ? doSendNotice(context)
+        : skipDueToPreference(context));
+  }
+
+  private CompletableFuture<Result<ScheduledNoticeContext>> doSendNotice(
+    ScheduledNoticeContext context) {
+
+    log.info("doSendNotice:: sending notice {}", context.getNotice().getId());
     return patronNoticeService.sendNotice(
       context.getNotice().getConfiguration(),
       context.getNotice().getRecipientUserId(),
@@ -214,6 +234,119 @@ public abstract class ScheduledNoticeHandler {
         }
         return r.map(v -> context);
       });
+  }
+
+  private CompletableFuture<Result<ScheduledNoticeContext>> skipDueToPreference(
+    ScheduledNoticeContext context) {
+
+    log.info("skipDueToPreference:: notice {} format {} filtered out by user preference, skipping send",
+      context.getNotice().getId(), context.getNotice().getConfiguration().getFormat());
+
+    return ofAsync(() -> context);
+  }
+
+  protected CompletableFuture<Boolean> shouldSendByPreference(ScheduledNoticeContext context) {
+    var policyId = context.getPatronNoticePolicyId();
+    if (policyId == null) {
+      log.debug("shouldSendByPreference:: no patron notice policy id for notice {}, sending as usual",
+        context.getNotice().getId());
+      return completedFuture(true);
+    }
+
+    return lookupPatronNoticePolicy(policyId)
+      .thenApply(r -> {
+        if (r.failed()) {
+          log.warn("shouldSendByPreference:: failed to look up notice policy {} for notice {}: {}",
+            policyId, context.getNotice().getId(), r.cause());
+          return true;
+        }
+
+        return evaluatePreference(context, r.value());
+      });
+  }
+
+  private CompletableFuture<Result<PatronNoticePolicy>> lookupPatronNoticePolicy(String policyId) {
+    return patronNoticePolicyCache.computeIfAbsent(policyId,
+      id -> patronNoticePolicyRepository.lookupPolicy(id, new AppliedRuleConditions(false, false, false)));
+  }
+
+  private boolean evaluatePreference(ScheduledNoticeContext context, PatronNoticePolicy policy) {
+    var notice = context.getNotice();
+    var noticeConfig = notice.getConfiguration();
+    var eventType = NoticeEventType.from(notice.getTriggeringEvent().getRepresentation());
+
+    if (eventType == NoticeEventType.UNKNOWN) {
+      log.debug("evaluatePreference:: triggering event {} has no patron notice policy " +
+        "counterpart, sending as usual", notice.getTriggeringEvent());
+      return true;
+    }
+
+    var candidates = policy.lookupNoticeConfigurations(eventType).stream()
+      .filter(candidate -> matchesScheduledConfig(candidate, noticeConfig))
+      .toList();
+    var anchor = candidates.stream()
+      .filter(candidate -> Objects.equals(candidate.getTemplateId(), noticeConfig.getTemplateId()))
+      .findFirst();
+
+    if (anchor.isEmpty()) {
+      log.info("evaluatePreference:: template {} of notice {} is no longer present in policy {}, " +
+          "sending as scheduled", noticeConfig.getTemplateId(), notice.getId(),
+        context.getPatronNoticePolicyId());
+      return true;
+    }
+
+    var matchGroup = PatronNoticeConfigurationResolver.matchGroupOf(candidates, anchor.get());
+
+    if (!PatronNoticeConfigurationResolver.requiresPreference(matchGroup)) {
+      return true;
+    }
+
+    var recipient = extractRecipientUser(context);
+    var resolvedFormats = PatronNoticeConfigurationResolver.resolveFormats(matchGroup, recipient);
+    var shouldSend = resolvedFormats.contains(noticeConfig.getFormat());
+
+    if (!shouldSend) {
+      log.info("evaluatePreference:: notice {} format {} is not among resolved formats {}, skipping",
+        notice.getId(), noticeConfig.getFormat(), resolvedFormats);
+    }
+
+    return shouldSend;
+  }
+
+  private static boolean matchesScheduledConfig(NoticeConfiguration candidate,
+    ScheduledNoticeConfig config) {
+
+    if (candidate.getTiming() != config.getTiming()) {
+      return false;
+    }
+    if (candidate.isRecurring() != config.isRecurring()) {
+      return false;
+    }
+    if (candidate.sendInRealTime() != config.sendInRealTime()) {
+      return false;
+    }
+
+    return !candidate.isRecurring() || periodsEqual(candidate.getRecurringPeriod(), config.getRecurringPeriod());
+  }
+
+  private static boolean periodsEqual(Period first, Period second) {
+    if (first == null || second == null) {
+      return first == second;
+    }
+
+    return Objects.equals(first.getDuration(), second.getDuration())
+      && Objects.equals(first.getInterval(), second.getInterval());
+  }
+
+  private static User extractRecipientUser(ScheduledNoticeContext context) {
+    if (context.getLoan() != null && context.getLoan().getUser() != null) {
+      return context.getLoan().getUser();
+    }
+    if (context.getRequest() != null && context.getRequest().getUser() != null) {
+      return context.getRequest().getUser();
+    }
+
+    return null;
   }
 
   protected CompletableFuture<Result<ScheduledNoticeContext>> fetchPatronNoticePolicyIdForLoan(

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
@@ -1,5 +1,6 @@
 package org.folio.circulation.domain.notice.schedule;
 
+import static java.lang.Boolean.FALSE;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.circulation.support.AsyncCoordinationUtil.allOf;
 import static org.folio.circulation.support.http.ResponseMapping.forwardOnFailure;
@@ -55,8 +56,9 @@ public abstract class ScheduledNoticeHandler {
   protected final CollectionResourceClient templateNoticesClient;
   private final ScheduledPatronNoticeService patronNoticeService;
   private final EventPublisher eventPublisher;
-  private final Map<String, CompletableFuture<Result<PatronNoticePolicy>>> patronNoticePolicyCache =
-    new ConcurrentHashMap<>();
+  private final Map<String, PatronNoticePolicy> patronNoticePolicyCache = new ConcurrentHashMap<>();
+  private static final AppliedRuleConditions NO_RULE_CONDITIONS =
+    new AppliedRuleConditions(false, false, false);
 
   protected ScheduledNoticeHandler(Clients clients, LoanRepository loanRepository) {
     this.scheduledNoticesRepository = ScheduledNoticesRepository.using(clients);
@@ -214,9 +216,9 @@ public abstract class ScheduledNoticeHandler {
     }
 
     return shouldSendByPreference(context)
-      .thenCompose(shouldSend -> shouldSend
-        ? doSendNotice(context)
-        : skipDueToPreference(context));
+      .thenCompose(shouldSend -> FALSE.equals(shouldSend)
+        ? skipDueToPreference(context)
+        : doSendNotice(context));
   }
 
   private CompletableFuture<Result<ScheduledNoticeContext>> doSendNotice(
@@ -266,8 +268,20 @@ public abstract class ScheduledNoticeHandler {
   }
 
   private CompletableFuture<Result<PatronNoticePolicy>> lookupPatronNoticePolicy(String policyId) {
-    return patronNoticePolicyCache.computeIfAbsent(policyId,
-      id -> patronNoticePolicyRepository.lookupPolicy(id, new AppliedRuleConditions(false, false, false)));
+    var cachedPolicy = patronNoticePolicyCache.get(policyId);
+
+    if (cachedPolicy != null) {
+      log.debug("lookupPatronNoticePolicy:: cache hit for policy {}", policyId);
+      return ofAsync(() -> cachedPolicy);
+    }
+
+    return patronNoticePolicyRepository.lookupPolicy(policyId, NO_RULE_CONDITIONS)
+      .thenApply(result -> {
+        if (!result.failed() && result.value() != null) {
+          patronNoticePolicyCache.put(policyId, result.value());
+        }
+        return result;
+      });
   }
 
   private boolean evaluatePreference(ScheduledNoticeContext context, PatronNoticePolicy policy) {

--- a/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandler.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.circulation.domain.ItemRelatedRecord;
@@ -249,7 +250,7 @@ public abstract class ScheduledNoticeHandler {
 
   protected CompletableFuture<Boolean> shouldSendByPreference(ScheduledNoticeContext context) {
     var policyId = context.getPatronNoticePolicyId();
-    if (policyId == null) {
+    if (StringUtils.isBlank(policyId)) {
       log.debug("shouldSendByPreference:: no patron notice policy id for notice {}, sending as usual",
         context.getNotice().getId());
       return completedFuture(true);
@@ -277,7 +278,7 @@ public abstract class ScheduledNoticeHandler {
 
     return patronNoticePolicyRepository.lookupPolicy(policyId, NO_RULE_CONDITIONS)
       .thenApply(result -> {
-        if (!result.failed() && result.value() != null) {
+        if (result.succeeded() && result.value() != null) {
           patronNoticePolicyCache.put(policyId, result.value());
         }
         return result;

--- a/src/main/java/org/folio/circulation/domain/policy/Period.java
+++ b/src/main/java/org/folio/circulation/domain/policy/Period.java
@@ -23,9 +23,11 @@ import org.folio.circulation.support.http.server.ValidationError;
 import org.folio.circulation.support.results.Result;
 
 import io.vertx.core.json.JsonObject;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode
 public class Period {
   private static final Period ZERO_DURATION_PERIOD = minutes(0);
 

--- a/src/test/java/api/loans/DueDateScheduledNoticeFormatPreferenceTests.java
+++ b/src/test/java/api/loans/DueDateScheduledNoticeFormatPreferenceTests.java
@@ -1,0 +1,405 @@
+package api.loans;
+
+import static api.support.fixtures.ItemExamples.basedUponSmallAngryPlanet;
+import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfPublishedEvents;
+import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfScheduledNotices;
+import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfSentNotices;
+import static java.time.ZoneOffset.UTC;
+import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE;
+import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE_ERROR;
+import static org.folio.circulation.support.utils.DateFormatUtil.formatDateTime;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.support.utils.DateFormatUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import api.support.APITests;
+import api.support.builders.CheckOutByBarcodeRequestBuilder;
+import api.support.builders.ItemBuilder;
+import api.support.builders.NoticeConfigurationBuilder;
+import api.support.builders.NoticePolicyBuilder;
+import api.support.fakes.FakeModNotify;
+import api.support.http.IndividualResource;
+import api.support.http.ItemResource;
+import io.vertx.core.json.JsonObject;
+
+class DueDateScheduledNoticeFormatPreferenceTests extends APITests {
+
+  private static final UUID EMAIL_TEMPLATE_ID = UUID.randomUUID();
+  private static final UUID SMS_TEMPLATE_ID = UUID.randomUUID();
+  private static final UUID FOREIGN_TEMPLATE_ID = UUID.randomUUID();
+
+  private static final String CONTACT_TYPE_EMAIL = "002";
+  private static final String CONTACT_TYPE_SMS = "003";
+  private static final String CONTACT_TYPE_PHONE = "004";
+
+  private static final Period BEFORE_PERIOD = Period.days(2);
+  private static final Period SECOND_BEFORE_PERIOD = Period.hours(12);
+  private static final Period AFTER_PERIOD = Period.days(3);
+  private static final Period AFTER_RECURRING_PERIOD = Period.hours(4);
+
+  private static final ZonedDateTime LOAN_DATE =
+    ZonedDateTime.of(2018, 3, 18, 11, 43, 54, 0, UTC);
+
+  private ItemResource item;
+  private IndividualResource loan;
+  private ZonedDateTime dueDate;
+
+  @BeforeEach
+  void beforeEach() {
+    ItemBuilder itemBuilder = basedUponSmallAngryPlanet(
+      materialTypesFixture.book().getId(), loanTypesFixture.canCirculate().getId());
+
+    item = itemsFixture.basedUponSmallAngryPlanet(itemBuilder,
+      itemsFixture.thirdFloorHoldings());
+
+    templateFixture.createDummyNoticeTemplate(EMAIL_TEMPLATE_ID);
+    templateFixture.createDummyNoticeTemplate(SMS_TEMPLATE_ID);
+    templateFixture.createDummyNoticeTemplate(FOREIGN_TEMPLATE_ID);
+  }
+
+  @Test
+  void scheduledNoticesStoreFormatFromPolicyConfiguration() {
+    usePolicy(
+      beforeNotice(EMAIL_TEMPLATE_ID, BEFORE_PERIOD, false),
+      smsBeforeNotice(SMS_TEMPLATE_ID, BEFORE_PERIOD, false));
+
+    checkOutTo(patronWithoutPreference());
+
+    verifyNumberOfScheduledNotices(2);
+    assertThat(scheduledNoticeFormatsByTemplateId(),
+      containsInAnyOrder(
+        EMAIL_TEMPLATE_ID + "=Email",
+        SMS_TEMPLATE_ID + "=SMS"));
+  }
+
+  @Test
+  void bothBeforeNoticesAreSentWhenTimingPeriodsDiffer() {
+    usePolicy(
+      beforeNotice(EMAIL_TEMPLATE_ID, BEFORE_PERIOD, false),
+      smsBeforeNotice(SMS_TEMPLATE_ID, SECOND_BEFORE_PERIOD, false));
+
+    checkOutTo(patronWithoutPreference());
+
+    verifyNumberOfScheduledNotices(2);
+
+    scheduledNoticeProcessingClient.runLoanNoticesProcessing(dueDate.minusSeconds(1));
+
+    verifyNumberOfSentNotices(2);
+    verifyNumberOfPublishedEvents(NOTICE, 2);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+    verifyNumberOfScheduledNotices(0);
+
+    assertThat(sentTemplateIds(),
+      containsInAnyOrder(EMAIL_TEMPLATE_ID.toString(), SMS_TEMPLATE_ID.toString()));
+  }
+
+  @Test
+  void onlySmsNoticeIsSentWhenSmsIsPreferred() {
+    useEmailAndSmsPolicyWithSameTiming(true);
+
+    checkOutTo(patronPreferring(CONTACT_TYPE_SMS));
+
+    verifyNumberOfScheduledNotices(2);
+
+    scheduledNoticeProcessingClient.runLoanNoticesProcessing(dueDate.minusSeconds(1));
+
+    verifyNumberOfSentNotices(1);
+    verifyNumberOfPublishedEvents(NOTICE, 1);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+
+    assertSingleSentNotice(SMS_TEMPLATE_ID, "sms", "text/plain");
+    verifyNumberOfScheduledNotices(0);
+  }
+
+  @Test
+  void onlyEmailNoticeIsSentWhenPatronHasNoPreference() {
+    useEmailAndSmsPolicyWithSameTiming(true);
+
+    checkOutTo(patronWithoutPreference());
+
+    scheduledNoticeProcessingClient.runLoanNoticesProcessing(dueDate.minusSeconds(1));
+
+    verifyNumberOfSentNotices(1);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+    assertSingleSentNotice(EMAIL_TEMPLATE_ID, "email", "text/html");
+    verifyNumberOfScheduledNotices(0);
+  }
+
+  @Test
+  void emailNoticeIsSentWhenPreferredContactTypeHasNoNoticeFormat() {
+    useEmailAndSmsPolicyWithSameTiming(true);
+
+    checkOutTo(patronPreferring(CONTACT_TYPE_PHONE));
+
+    scheduledNoticeProcessingClient.runLoanNoticesProcessing(dueDate.minusSeconds(1));
+
+    verifyNumberOfSentNotices(1);
+    assertSingleSentNotice(EMAIL_TEMPLATE_ID, "email", "text/html");
+    verifyNumberOfScheduledNotices(0);
+  }
+
+  @Test
+  void emailNoticeIsSentWhenPreferredFormatIsNotConfigured() {
+    usePolicy(
+      beforeNotice(EMAIL_TEMPLATE_ID, BEFORE_PERIOD, false),
+      printBeforeNotice(FOREIGN_TEMPLATE_ID, BEFORE_PERIOD));
+
+    checkOutTo(patronPreferring(CONTACT_TYPE_SMS));
+
+    scheduledNoticeProcessingClient.runLoanNoticesProcessing(dueDate.minusSeconds(1));
+
+    verifyNumberOfSentNotices(1);
+    assertSingleSentNotice(EMAIL_TEMPLATE_ID, "email", "text/html");
+    verifyNumberOfScheduledNotices(0);
+  }
+
+  @Test
+  void bothNoticesAreSentWhenBothFormatsArePreferred() {
+    useEmailAndSmsPolicyWithSameTiming(true);
+
+    checkOutTo(patronPreferring(CONTACT_TYPE_EMAIL, CONTACT_TYPE_SMS));
+
+    scheduledNoticeProcessingClient.runLoanNoticesProcessing(dueDate.minusSeconds(1));
+
+    verifyNumberOfSentNotices(2);
+    verifyNumberOfPublishedEvents(NOTICE, 2);
+    assertThat(sentTemplateIds(),
+      containsInAnyOrder(EMAIL_TEMPLATE_ID.toString(), SMS_TEMPLATE_ID.toString()));
+    verifyNumberOfScheduledNotices(0);
+  }
+
+  @Test
+  void singleFormatNoticeIsSentRegardlessOfPreference() {
+    usePolicy(beforeNotice(EMAIL_TEMPLATE_ID, BEFORE_PERIOD, false));
+
+    checkOutTo(patronPreferring(CONTACT_TYPE_SMS));
+
+    scheduledNoticeProcessingClient.runLoanNoticesProcessing(dueDate.minusSeconds(1));
+
+    verifyNumberOfSentNotices(1);
+    assertSingleSentNotice(EMAIL_TEMPLATE_ID, "email", "text/html");
+    verifyNumberOfScheduledNotices(0);
+  }
+
+  @Test
+  void filteredOutRecurringNoticeIsRescheduledNotDeleted() {
+    usePolicy(
+      afterNotice(EMAIL_TEMPLATE_ID, AFTER_PERIOD, AFTER_RECURRING_PERIOD),
+      smsAfterNotice(SMS_TEMPLATE_ID, AFTER_PERIOD, AFTER_RECURRING_PERIOD));
+
+    checkOutTo(patronPreferring(CONTACT_TYPE_SMS));
+
+    verifyNumberOfScheduledNotices(2);
+
+    ZonedDateTime runTime = AFTER_PERIOD.plusDate(dueDate).plusSeconds(1);
+    scheduledNoticeProcessingClient.runLoanNoticesProcessing(runTime);
+
+    verifyNumberOfSentNotices(1);
+    assertSingleSentNotice(SMS_TEMPLATE_ID, "sms", "text/plain");
+    verifyNumberOfScheduledNotices(2);
+  }
+
+  @Test
+  void noticeIsSentWhenItsTemplateIsNotPresentInPolicy() {
+    useEmailAndSmsPolicyWithSameTiming(true);
+
+    checkOutTo(patronPreferring(CONTACT_TYPE_SMS));
+
+    verifyNumberOfScheduledNotices(2);
+
+    scheduledNoticesClient.create(fakeScheduledNotice(FOREIGN_TEMPLATE_ID, "Email",
+      dueDate.minusHours(1)));
+
+    verifyNumberOfScheduledNotices(3);
+
+    scheduledNoticeProcessingClient.runLoanNoticesProcessing(dueDate.minusSeconds(1));
+
+    verifyNumberOfSentNotices(2);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+    assertThat(sentTemplateIds(),
+      containsInAnyOrder(SMS_TEMPLATE_ID.toString(), FOREIGN_TEMPLATE_ID.toString()));
+    verifyNumberOfScheduledNotices(0);
+  }
+
+  @Test
+  void groupedNoticeUsesPreferredFormat() {
+    usePolicy(
+      uponAtNotice(EMAIL_TEMPLATE_ID),
+      smsUponAtNotice(SMS_TEMPLATE_ID));
+
+    checkOutTo(patronPreferring(CONTACT_TYPE_SMS));
+
+    verifyNumberOfScheduledNotices(2);
+
+    scheduledNoticeProcessingClient.runDueDateNotRealTimeNoticesProcessing(dueDate.plusDays(1));
+
+    verifyNumberOfSentNotices(1);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+    assertSingleSentNotice(SMS_TEMPLATE_ID, "sms", "text/plain");
+    verifyNumberOfScheduledNotices(0);
+  }
+
+  private void useEmailAndSmsPolicyWithSameTiming(boolean realTime) {
+    usePolicy(
+      beforeNotice(EMAIL_TEMPLATE_ID, BEFORE_PERIOD, !realTime),
+      smsBeforeNotice(SMS_TEMPLATE_ID, BEFORE_PERIOD, !realTime));
+  }
+
+  private void usePolicy(JsonObject... noticeConfigurations) {
+    NoticePolicyBuilder noticePolicy = new NoticePolicyBuilder()
+      .withName("Policy with due date notices in several formats")
+      .withLoanNotices(List.of(noticeConfigurations));
+
+    useFallbackPolicies(
+      loanPoliciesFixture.canCirculateRolling().getId(),
+      requestPoliciesFixture.allowAllRequestPolicy().getId(),
+      noticePoliciesFixture.create(noticePolicy).getId(),
+      overdueFinePoliciesFixture.noOverdueFine().getId(),
+      lostItemFeePoliciesFixture.chargeFee().getId());
+  }
+
+  private void checkOutTo(IndividualResource borrower) {
+    loan = checkOutFixture.checkOutByBarcode(
+      new CheckOutByBarcodeRequestBuilder()
+        .forItem(item)
+        .to(borrower)
+        .on(LOAN_DATE)
+        .at(UUID.randomUUID()));
+
+    dueDate = DateFormatUtil.parseDateTime(loan.getJson().getString("dueDate"));
+  }
+
+  private IndividualResource patronWithoutPreference() {
+    return usersFixture.steve();
+  }
+
+  private IndividualResource patronPreferring(String... contactTypeIds) {
+    return usersFixture.steve(
+      builder -> builder.withPreferredContactTypeIds(List.of(contactTypeIds)));
+  }
+
+  private static JsonObject beforeNotice(UUID templateId, Period timing, boolean grouped) {
+    return new NoticeConfigurationBuilder()
+      .withTemplateId(templateId)
+      .withDueDateEvent()
+      .withBeforeTiming(timing)
+      .withEmailFormat()
+      .sendInRealTime(!grouped)
+      .create();
+  }
+
+  private static JsonObject smsBeforeNotice(UUID templateId, Period timing, boolean grouped) {
+    return new NoticeConfigurationBuilder()
+      .withTemplateId(templateId)
+      .withDueDateEvent()
+      .withBeforeTiming(timing)
+      .withSmsFormat()
+      .sendInRealTime(!grouped)
+      .create();
+  }
+
+  private static JsonObject printBeforeNotice(UUID templateId, Period timing) {
+    return new NoticeConfigurationBuilder()
+      .withTemplateId(templateId)
+      .withDueDateEvent()
+      .withBeforeTiming(timing)
+      .withPrintFormat()
+      .sendInRealTime(true)
+      .create();
+  }
+
+  private static JsonObject afterNotice(UUID templateId, Period timing, Period recurring) {
+    return new NoticeConfigurationBuilder()
+      .withTemplateId(templateId)
+      .withDueDateEvent()
+      .withAfterTiming(timing)
+      .recurring(recurring)
+      .withEmailFormat()
+      .sendInRealTime(true)
+      .create();
+  }
+
+  private static JsonObject smsAfterNotice(UUID templateId, Period timing, Period recurring) {
+    return new NoticeConfigurationBuilder()
+      .withTemplateId(templateId)
+      .withDueDateEvent()
+      .withAfterTiming(timing)
+      .recurring(recurring)
+      .withSmsFormat()
+      .sendInRealTime(true)
+      .create();
+  }
+
+  private static JsonObject uponAtNotice(UUID templateId) {
+    return new NoticeConfigurationBuilder()
+      .withTemplateId(templateId)
+      .withDueDateEvent()
+      .withUponAtTiming()
+      .withEmailFormat()
+      .sendInRealTime(false)
+      .create();
+  }
+
+  private static JsonObject smsUponAtNotice(UUID templateId) {
+    return new NoticeConfigurationBuilder()
+      .withTemplateId(templateId)
+      .withDueDateEvent()
+      .withUponAtTiming()
+      .withSmsFormat()
+      .sendInRealTime(false)
+      .create();
+  }
+
+  private JsonObject fakeScheduledNotice(UUID templateId, String format,
+    ZonedDateTime nextRunTime) {
+
+    return new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("loanId", loan.getId().toString())
+      .put("recipientUserId", loan.getJson().getString("userId"))
+      .put("nextRunTime", formatDateTime(nextRunTime.withZoneSameInstant(UTC)))
+      .put("triggeringEvent", "Due date")
+      .put("noticeConfig", new JsonObject()
+        .put("timing", "Before")
+        .put("templateId", templateId.toString())
+        .put("format", format)
+        .put("sendInRealTime", true));
+  }
+
+  private List<String> scheduledNoticeFormatsByTemplateId() {
+    return scheduledNoticesClient.getAll().stream()
+      .map(notice -> notice.getJsonObject("noticeConfig"))
+      .map(config -> config.getString("templateId") + "=" + config.getString("format"))
+      .toList();
+  }
+
+  private static List<String> sentTemplateIds() {
+    return FakeModNotify.getSentPatronNotices().stream()
+      .map(notice -> notice.getString("templateId"))
+      .toList();
+  }
+
+  private static void assertSingleSentNotice(UUID templateId, String deliveryChannel,
+    String outputFormat) {
+
+    List<JsonObject> sentNotices = FakeModNotify.getSentPatronNotices();
+
+    assertThat(sentNotices, hasSize(1));
+
+    JsonObject notice = sentNotices.getFirst();
+    assertThat(notice.getString("templateId"), is(templateId.toString()));
+    assertThat(notice.getString("deliveryChannel"), is(deliveryChannel));
+    assertThat(notice.getString("outputFormat"), is(outputFormat));
+  }
+
+}

--- a/src/test/java/api/loans/ImmediatePatronNoticeFormatTests.java
+++ b/src/test/java/api/loans/ImmediatePatronNoticeFormatTests.java
@@ -146,6 +146,86 @@ class ImmediatePatronNoticeFormatTests extends APITests {
       hasNoticeProperties(patron.getId(), SMS_TEMPLATE_ID, "sms", "text/plain", anything())));
   }
 
+  @Test
+  void noNoticeIsSentWhenPolicyHasNoConfigurationForEventType() {
+    use(new NoticePolicyBuilder()
+      .withName("No check-out notices policy")
+      .withLoanNotices(List.of()));
+
+    var patron = usersFixture.steve();
+    var item = itemsFixture.basedUponNod();
+
+    checkOutFixture.checkOutByBarcode(item, patron);
+    endPatronSessionClient.endCheckOutSession(patron.getId());
+
+    verifyNumberOfSentNotices(0);
+    verifyNumberOfPublishedEvents(NOTICE, 0);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+  }
+
+  @Test
+  void firstEmailConfigWinsWhenPolicyHasDuplicateEmailConfigurations() {
+    UUID secondEmailTemplateId = UUID.fromString("ccc00000-0000-0000-0000-000000000003");
+
+    use(new NoticePolicyBuilder()
+      .withName("Duplicate email check-out policy")
+      .withLoanNotices(List.of(
+        checkOutConfig(EMAIL_TEMPLATE_ID).withEmailFormat().create(),
+        checkOutConfig(secondEmailTemplateId).withEmailFormat().create())));
+
+    var patron = usersFixture.steve();
+    var item = itemsFixture.basedUponNod();
+
+    checkOutFixture.checkOutByBarcode(item, patron);
+    endPatronSessionClient.endCheckOutSession(patron.getId());
+
+    verifyNumberOfSentNotices(1);
+    assertThat(FakeModNotify.getSentPatronNotices(),
+      hasItems(hasEmailNoticeProperties(patron.getId(), EMAIL_TEMPLATE_ID, anything())));
+  }
+
+  @Test
+  void singleNoticeIsSentWhenMultipleItemsCheckedOutWithSamePolicy() {
+    use(new NoticePolicyBuilder()
+      .withName("Email check-out policy")
+      .withLoanNotices(List.of(checkOutConfig(EMAIL_TEMPLATE_ID).withEmailFormat().create())));
+
+    var patron = usersFixture.steve();
+    var firstItem = itemsFixture.basedUponNod();
+    var secondItem = itemsFixture.basedUponSmallAngryPlanet();
+
+    checkOutFixture.checkOutByBarcode(firstItem, patron);
+    checkOutFixture.checkOutByBarcode(secondItem, patron);
+    endPatronSessionClient.endCheckOutSession(patron.getId());
+
+    verifyNumberOfSentNotices(1);
+    verifyNumberOfPublishedEvents(NOTICE, 1);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+
+    assertThat(FakeModNotify.getSentPatronNotices(),
+      hasItems(hasEmailNoticeProperties(patron.getId(), EMAIL_TEMPLATE_ID, anything())));
+  }
+
+  @Test
+  void smsNoticeIsSentWhenOnlyDeprecatedPreferenceIsSet() {
+    use(new NoticePolicyBuilder()
+      .withName("Email+SMS check-out policy")
+      .withLoanNotices(List.of(
+        checkOutConfig(EMAIL_TEMPLATE_ID).withEmailFormat().create(),
+        checkOutConfig(SMS_TEMPLATE_ID).withSmsFormat().create())));
+
+    var patron = usersFixture.steve(
+      b -> b.withDeprecatedPreferredContactTypeId(SMS_CONTACT_TYPE));
+    var item = itemsFixture.basedUponNod();
+
+    checkOutFixture.checkOutByBarcode(item, patron);
+    endPatronSessionClient.endCheckOutSession(patron.getId());
+
+    verifyNumberOfSentNotices(1);
+    assertThat(FakeModNotify.getSentPatronNotices(),
+      hasItems(hasNoticeProperties(patron.getId(), SMS_TEMPLATE_ID, "sms", "text/plain", anything())));
+  }
+
   private static NoticeConfigurationBuilder checkOutConfig(UUID templateId) {
     return new NoticeConfigurationBuilder()
       .withTemplateId(templateId)

--- a/src/test/java/api/loans/ImmediatePatronNoticeFormatTests.java
+++ b/src/test/java/api/loans/ImmediatePatronNoticeFormatTests.java
@@ -1,0 +1,154 @@
+package api.loans;
+
+import static api.support.matchers.EventMatchers.isValidNoticeLogRecordEvent;
+import static api.support.matchers.PatronNoticeMatcher.hasEmailNoticeProperties;
+import static api.support.matchers.PatronNoticeMatcher.hasNoticeProperties;
+import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfPublishedEvents;
+import static api.support.utl.PatronNoticeTestHelper.verifyNumberOfSentNotices;
+import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE;
+import static org.folio.circulation.domain.representations.logs.LogEventType.NOTICE_ERROR;
+import static org.hamcrest.CoreMatchers.anything;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import api.support.APITests;
+import api.support.builders.NoticeConfigurationBuilder;
+import api.support.builders.NoticePolicyBuilder;
+import api.support.fakes.FakeModNotify;
+
+class ImmediatePatronNoticeFormatTests extends APITests {
+
+  private static final UUID EMAIL_TEMPLATE_ID = UUID.fromString("aaa00000-0000-0000-0000-000000000001");
+  private static final UUID SMS_TEMPLATE_ID   = UUID.fromString("bbb00000-0000-0000-0000-000000000002");
+
+  private static final String EMAIL_CONTACT_TYPE = "002";
+  private static final String SMS_CONTACT_TYPE   = "003";
+
+  @Test
+  void singleEmailConfigIsSentRegardlessOfSmsPref() {
+    use(new NoticePolicyBuilder()
+      .withName("Email-only check-out policy")
+      .withLoanNotices(List.of(checkOutConfig(EMAIL_TEMPLATE_ID).withEmailFormat().create())));
+
+    var patron = usersFixture.steve(
+      b -> b.withPreferredContactTypeIds(List.of(SMS_CONTACT_TYPE)));
+    var item = itemsFixture.basedUponNod();
+
+    checkOutFixture.checkOutByBarcode(item, patron);
+    endPatronSessionClient.endCheckOutSession(patron.getId());
+
+    verifyNumberOfSentNotices(1);
+    verifyNumberOfPublishedEvents(NOTICE, 1);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+
+    assertThat(FakeModNotify.getSentPatronNotices(),
+      hasItems(hasEmailNoticeProperties(patron.getId(), EMAIL_TEMPLATE_ID, anything())));
+  }
+
+  @Test
+  void smsNoticeIsSentWhenSmsPrefAndGroupContainsBothFormats() {
+    use(new NoticePolicyBuilder()
+      .withName("Email+SMS check-out policy")
+      .withLoanNotices(List.of(
+        checkOutConfig(EMAIL_TEMPLATE_ID).withEmailFormat().create(),
+        checkOutConfig(SMS_TEMPLATE_ID).withSmsFormat().create())));
+
+    var patron = usersFixture.steve(
+      b -> b.withPreferredContactTypeIds(List.of(SMS_CONTACT_TYPE)));
+    var item = itemsFixture.basedUponNod();
+
+    checkOutFixture.checkOutByBarcode(item, patron);
+    endPatronSessionClient.endCheckOutSession(patron.getId());
+
+    verifyNumberOfSentNotices(1);
+    verifyNumberOfPublishedEvents(NOTICE, 1);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+
+    assertThat(FakeModNotify.getSentPatronNotices(),
+      hasItems(hasNoticeProperties(patron.getId(), SMS_TEMPLATE_ID, "sms", "text/plain", anything())));
+  }
+
+  @Test
+  void emailOnlyIsSentWhenNoPreferenceAndGroupContainsBothFormats() {
+    use(new NoticePolicyBuilder()
+      .withName("Email+SMS check-out policy")
+      .withLoanNotices(List.of(
+        checkOutConfig(EMAIL_TEMPLATE_ID).withEmailFormat().create(),
+        checkOutConfig(SMS_TEMPLATE_ID).withSmsFormat().create())));
+
+    var patron = usersFixture.steve(); // no preferred contact type
+    var item = itemsFixture.basedUponNod();
+
+    checkOutFixture.checkOutByBarcode(item, patron);
+    endPatronSessionClient.endCheckOutSession(patron.getId());
+
+    verifyNumberOfSentNotices(1);
+    verifyNumberOfPublishedEvents(NOTICE, 1);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+
+    assertThat(FakeModNotify.getSentPatronNotices(),
+      hasItems(hasEmailNoticeProperties(patron.getId(), EMAIL_TEMPLATE_ID, anything())));
+  }
+
+  @Test
+  void resolvedTemplateIdAppearsInNoticePayloadAndLog() {
+    use(new NoticePolicyBuilder()
+      .withName("Email+SMS check-out policy")
+      .withLoanNotices(List.of(
+        checkOutConfig(EMAIL_TEMPLATE_ID).withEmailFormat().create(),
+        checkOutConfig(SMS_TEMPLATE_ID).withSmsFormat().create())));
+
+    var patron = usersFixture.steve(
+      b -> b.withPreferredContactTypeIds(List.of(SMS_CONTACT_TYPE)));
+    var item = itemsFixture.basedUponNod();
+
+    checkOutFixture.checkOutByBarcode(item, patron);
+    endPatronSessionClient.endCheckOutSession(patron.getId());
+
+    var noticeLogEvents = verifyNumberOfPublishedEvents(NOTICE, 1);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+
+    var sentNotice = FakeModNotify.getFirstSentPatronNotice();
+    assertThat(sentNotice,
+      hasNoticeProperties(patron.getId(), SMS_TEMPLATE_ID, "sms", "text/plain", anything()));
+    assertThat(noticeLogEvents.getFirst(), isValidNoticeLogRecordEvent(sentNotice));
+  }
+
+  @Test
+  void emailAndSmsNoticesAreSentWhenBothFormatsArePreferred() {
+    use(new NoticePolicyBuilder()
+      .withName("Email+SMS check-out policy")
+      .withLoanNotices(List.of(
+        checkOutConfig(EMAIL_TEMPLATE_ID).withEmailFormat().create(),
+        checkOutConfig(SMS_TEMPLATE_ID).withSmsFormat().create())));
+
+    var patron = usersFixture.steve(
+      b -> b.withPreferredContactTypeIds(List.of(EMAIL_CONTACT_TYPE, SMS_CONTACT_TYPE)));
+    var item = itemsFixture.basedUponNod();
+
+    checkOutFixture.checkOutByBarcode(item, patron);
+    endPatronSessionClient.endCheckOutSession(patron.getId());
+
+    verifyNumberOfSentNotices(2);
+    verifyNumberOfPublishedEvents(NOTICE, 2);
+    verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
+
+    var notices = FakeModNotify.getSentPatronNotices();
+    assertThat(notices, hasSize(2));
+    assertThat(notices, hasItems(
+      hasEmailNoticeProperties(patron.getId(), EMAIL_TEMPLATE_ID, anything()),
+      hasNoticeProperties(patron.getId(), SMS_TEMPLATE_ID, "sms", "text/plain", anything())));
+  }
+
+  private static NoticeConfigurationBuilder checkOutConfig(UUID templateId) {
+    return new NoticeConfigurationBuilder()
+      .withTemplateId(templateId)
+      .withCheckOutEvent();
+  }
+}

--- a/src/test/java/api/support/builders/NoticeConfigurationBuilder.java
+++ b/src/test/java/api/support/builders/NoticeConfigurationBuilder.java
@@ -42,6 +42,29 @@ public class NoticeConfigurationBuilder extends JsonBuilder implements Builder {
       this.sendInRealTime);
   }
 
+  public NoticeConfigurationBuilder withEmailFormat() {
+    return withFormat("Email");
+  }
+
+  public NoticeConfigurationBuilder withSmsFormat() {
+    return withFormat("SMS");
+  }
+
+  public NoticeConfigurationBuilder withPrintFormat() {
+    return withFormat("Print");
+  }
+
+  private NoticeConfigurationBuilder withFormat(String format) {
+    return new NoticeConfigurationBuilder(
+      this.templateId,
+      format,
+      this.eventType,
+      this.timing,
+      this.timingPeriod,
+      this.recurringPeriod,
+      this.sendInRealTime);
+  }
+
   public NoticeConfigurationBuilder withEventType(String eventType) {
     return new NoticeConfigurationBuilder(
       this.templateId,

--- a/src/test/java/api/support/builders/UserBuilder.java
+++ b/src/test/java/api/support/builders/UserBuilder.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import api.support.http.IndividualResource;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.ObjectUtils;
 
 public class UserBuilder extends JsonBuilder implements Builder {
   private final UUID id;
@@ -92,8 +93,7 @@ public class UserBuilder extends JsonBuilder implements Builder {
     put(request, "active", active);
     put(request, "expirationDate", expirationDate);
 
-    if (firstName != null || lastName != null ||
-      preferredContactTypeIds != null || preferredContactTypeId != null) {
+    if (ObjectUtils.anyNotNull(firstName, lastName, preferredContactTypeIds, preferredContactTypeId)) {
       JsonObject personalInformation = new JsonObject()
         .put("lastName", this.lastName)
         .put("firstName", this.firstName);

--- a/src/test/java/api/support/builders/UserBuilder.java
+++ b/src/test/java/api/support/builders/UserBuilder.java
@@ -3,6 +3,7 @@ package api.support.builders;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 import api.support.http.IndividualResource;
@@ -22,12 +23,14 @@ public class UserBuilder extends JsonBuilder implements Builder {
   private final ZonedDateTime expirationDate;
   private final Collection<Address> addresses;
   private final JsonArray departments;
+  private final JsonArray preferredContactTypeIds;
+  private final String preferredContactTypeId;
   private final String type;
   private final boolean primaryAddress;
 
   public UserBuilder() {
     this(UUID.randomUUID(), "sjones", "Jones", "Steven", null, null,"785493025613",
-      null, true, null, new ArrayList<>(), null, null, false);
+      null, true, null, new ArrayList<>(), null, null, null, null, false);
   }
 
   private UserBuilder(
@@ -43,6 +46,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
     ZonedDateTime expirationDate,
     Collection<Address> addresses,
     JsonArray departments,
+    JsonArray preferredContactTypeIds,
+    String preferredContactTypeId,
     String type,
     boolean primaryAddress) {
 
@@ -61,6 +66,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
 
     this.addresses = addresses;
     this.departments = departments;
+    this.preferredContactTypeIds = preferredContactTypeIds;
+    this.preferredContactTypeId = preferredContactTypeId;
     this.type = type;
     this.primaryAddress = primaryAddress;
   }
@@ -85,7 +92,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
     put(request, "active", active);
     put(request, "expirationDate", expirationDate);
 
-    if(firstName != null || lastName != null) {
+    if (firstName != null || lastName != null ||
+      preferredContactTypeIds != null || preferredContactTypeId != null) {
       JsonObject personalInformation = new JsonObject()
         .put("lastName", this.lastName)
         .put("firstName", this.firstName);
@@ -96,6 +104,14 @@ public class UserBuilder extends JsonBuilder implements Builder {
 
       if(this.preferredFirstName != null) {
         personalInformation.put("preferredFirstName", this.preferredFirstName);
+      }
+
+      if (this.preferredContactTypeIds != null) {
+        personalInformation.put("preferredContactTypeIds", this.preferredContactTypeIds);
+      }
+
+      if (this.preferredContactTypeId != null) {
+        personalInformation.put("preferredContactTypeId", this.preferredContactTypeId);
       }
 
       if(this.addresses != null && !this.addresses.isEmpty()) {
@@ -149,6 +165,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -167,6 +185,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -185,6 +205,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -203,6 +225,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -221,6 +245,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -239,6 +265,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -257,6 +285,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -275,6 +305,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -297,6 +329,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -327,6 +361,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -345,6 +381,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       newExpirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -363,6 +401,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       null,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -390,6 +430,49 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
+      this.type,
+      this.primaryAddress);
+  }
+
+  public UserBuilder withPreferredContactTypeIds(List<String> preferredContactTypeIds) {
+    JsonArray values = preferredContactTypeIds == null ? null : new JsonArray(preferredContactTypeIds);
+    return new UserBuilder(
+      this.id,
+      this.username,
+      this.lastName,
+      this.firstName,
+      this.middleName,
+      this.preferredFirstName,
+      this.barcode,
+      this.patronGroupId,
+      this.active,
+      this.expirationDate,
+      this.addresses,
+      this.departments,
+      values,
+      this.preferredContactTypeId,
+      this.type,
+      this.primaryAddress);
+  }
+
+  public UserBuilder withDeprecatedPreferredContactTypeId(String preferredContactTypeId) {
+    return new UserBuilder(
+      this.id,
+      this.username,
+      this.lastName,
+      this.firstName,
+      this.middleName,
+      this.preferredFirstName,
+      this.barcode,
+      this.patronGroupId,
+      this.active,
+      this.expirationDate,
+      this.addresses,
+      this.departments,
+      this.preferredContactTypeIds,
+      preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -407,7 +490,9 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.active,
       this.expirationDate,
       this.addresses,
-      departments,
+      this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       Boolean.valueOf(primaryAddress));
   }
@@ -429,6 +514,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       newAddresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -447,6 +534,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       this.type,
       this.primaryAddress);
   }
@@ -465,6 +554,8 @@ public class UserBuilder extends JsonBuilder implements Builder {
       this.expirationDate,
       this.addresses,
       this.departments,
+      this.preferredContactTypeIds,
+      this.preferredContactTypeId,
       type,
       this.primaryAddress);
   }

--- a/src/test/java/org/folio/circulation/domain/UserTests.java
+++ b/src/test/java/org/folio/circulation/domain/UserTests.java
@@ -1,8 +1,15 @@
 package org.folio.circulation.domain;
 
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 
+import java.util.List;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import api.support.builders.UserBuilder;
@@ -26,5 +33,50 @@ class UserTests {
       .create());
 
     assertThat(activeUser.getPersonalName(), is("cjones"));
+  }
+
+  @Test
+  void preferredContactTypeIdsAreReadInOrder() {
+    var user = new User(new UserBuilder()
+      .withPreferredContactTypeIds(List.of("002", "003"))
+      .create());
+
+    assertThat(user.getPreferredContactTypeIds(), contains("002", "003"));
+  }
+
+  @Test
+  void preferredContactTypeIdsIgnoreNonStringEntries() {
+    var user = new User(new JsonObject()
+      .put("personal", new JsonObject()
+        .put("preferredContactTypeIds", new JsonArray().add("002").add(1).add(new JsonObject()))));
+
+    assertThat(user.getPreferredContactTypeIds(), contains("002"));
+  }
+
+  @Test
+  void preferredContactTypeIdsAreEmptyWhenPersonalIsMissing() {
+    User user = new User(new UserBuilder()
+      .withNoPersonalDetails()
+      .create());
+
+    assertThat(user.getPreferredContactTypeIds(), empty());
+  }
+
+  @Test
+  void deprecatedPreferredContactTypeIdIsReadWhenPresent() {
+    var user = new User(new UserBuilder()
+      .withDeprecatedPreferredContactTypeId("003")
+      .create());
+
+    assertThat(user.getPreferredContactTypeId(), is("003"));
+  }
+
+  @Test
+  void deprecatedPreferredContactTypeIdIsNullWhenMissing() {
+    var user = new User(new UserBuilder()
+      .withNoPersonalDetails()
+      .create());
+
+    assertThat(user.getPreferredContactTypeId(), nullValue());
   }
 }

--- a/src/test/java/org/folio/circulation/domain/notice/ImmediatePatronNoticeServiceTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/ImmediatePatronNoticeServiceTest.java
@@ -1,0 +1,180 @@
+package org.folio.circulation.domain.notice;
+
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.UUID;
+
+import org.folio.circulation.domain.Item;
+import org.folio.circulation.domain.User;
+import org.folio.circulation.domain.notice.combiner.NoticeContextCombiner;
+import org.folio.circulation.domain.representations.logs.NoticeLogContext;
+import org.folio.circulation.rules.CirculationRuleMatch;
+import org.folio.circulation.rules.CirculationRulesProcessor;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.CollectionResourceClient;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.results.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+@ExtendWith(MockitoExtension.class)
+class ImmediatePatronNoticeServiceTest {
+
+  @Mock private Clients clients;
+  @Mock private CollectionResourceClient patronNoticeClient;
+  @Mock private CollectionResourceClient patronNoticePoliciesStorageClient;
+  @Mock private CirculationRulesProcessor circulationRulesProcessor;
+  @Mock private org.folio.circulation.services.PubSubPublishingService pubSubPublishingService;
+  @Mock private NoticeContextCombiner noticeContextCombiner;
+
+  private ImmediatePatronNoticeService immediatePatronNoticeService;
+
+  @BeforeEach
+  void setUp() {
+    when(clients.patronNoticeClient()).thenReturn(patronNoticeClient);
+    when(clients.patronNoticePolicesStorageClient()).thenReturn(patronNoticePoliciesStorageClient);
+    when(clients.circulationRulesProcessor()).thenReturn(circulationRulesProcessor);
+    when(clients.pubSubPublishingService()).thenReturn(pubSubPublishingService);
+
+    immediatePatronNoticeService = new ImmediatePatronNoticeService(clients, noticeContextCombiner);
+  }
+
+  @Test
+  void acceptNoticeEventsReturnsSucceededWithEmptyEventsList() {
+    Result<Void> result = immediatePatronNoticeService.acceptNoticeEvents(emptyList()).join();
+
+    assertThat(result.succeeded(), is(true));
+    verifyNoInteractions(patronNoticeClient);
+  }
+
+  @Test
+  void acceptNoticeEventFailsWhenItemOrUserIsNullInPolicyLookup() {
+    PatronNoticeEvent event = new PatronNoticeEvent(
+      null, null, NoticeEventType.CHECK_OUT,
+      new JsonObject(), new NoticeLogContext(), null, UUID.randomUUID().toString()
+    );
+
+    Result<Void> result = immediatePatronNoticeService.acceptNoticeEvent(event).join();
+
+    assertThat(result.failed(), is(true));
+  }
+
+  @Test
+  void acceptNoticeEventSendsNoticeWhenPolicyAndConfigMatch() {
+    String policyId = UUID.randomUUID().toString();
+    String recipientId = UUID.randomUUID().toString();
+
+    Item item = createDummyItem();
+    User user = createDummyUser(recipientId);
+
+    PatronNoticeEvent event = new PatronNoticeEvent(
+      item, user, NoticeEventType.CHECK_OUT,
+      new JsonObject(), new NoticeLogContext(), null, recipientId
+    );
+
+    CirculationRuleMatch ruleMatch = new CirculationRuleMatch(policyId, null);
+    when(circulationRulesProcessor.getNoticePolicyAndMatch(any()))
+      .thenReturn(completedFuture(Result.succeeded(ruleMatch)));
+
+    JsonObject policyJson = new JsonObject()
+      .put("id", policyId)
+      .put("name", "Test Notice Policy")
+      .put("loanNotices", new JsonArray().add(
+        new api.support.builders.NoticeConfigurationBuilder()
+          .withTemplateId(UUID.randomUUID())
+          .withCheckOutEvent()
+          .withEmailFormat()
+          .withUponAtTiming()
+          .create()
+      ));
+
+    Response policyResponse = new Response(200, policyJson.encode(), "application/json");
+    when(patronNoticePoliciesStorageClient.get(policyId))
+      .thenReturn(completedFuture(Result.succeeded(policyResponse)));
+
+    when(noticeContextCombiner.buildCombinedNoticeContext(any())).thenReturn(new JsonObject());
+    when(noticeContextCombiner.buildCombinedNoticeLogContext(any())).thenReturn(new NoticeLogContext());
+
+    Response noticePostResponse = new Response(200, "", "application/json");
+    when(patronNoticeClient.post(any())).thenReturn(completedFuture(Result.succeeded(noticePostResponse)));
+    when(pubSubPublishingService.publishEvent(any(), any())).thenReturn(completedFuture(true));
+
+    Result<Void> result = immediatePatronNoticeService.acceptNoticeEvent(event).join();
+
+    assertThat(result.succeeded(), is(true));
+    verify(patronNoticeClient).post(any());
+  }
+
+  @Test
+  void acceptNoticeEventSkipsWhenNoMatchingNoticeConfig() {
+    String policyId = UUID.randomUUID().toString();
+    String recipientId = UUID.randomUUID().toString();
+
+    Item item = createDummyItem();
+    User user = createDummyUser(recipientId);
+
+    PatronNoticeEvent event = new PatronNoticeEvent(
+      item, user, NoticeEventType.CHECK_IN,
+      new JsonObject(), new NoticeLogContext(), null, recipientId
+    );
+
+    CirculationRuleMatch ruleMatch = new CirculationRuleMatch(policyId, null);
+    when(circulationRulesProcessor.getNoticePolicyAndMatch(any()))
+      .thenReturn(completedFuture(Result.succeeded(ruleMatch)));
+
+    JsonObject policyJson = new JsonObject()
+      .put("id", policyId)
+      .put("name", "Test Notice Policy")
+      .put("loanNotices", new JsonArray()); // no notices
+
+    Response policyResponse = new Response(200, policyJson.encode(), "application/json");
+    when(patronNoticePoliciesStorageClient.get(policyId))
+      .thenReturn(completedFuture(Result.succeeded(policyResponse)));
+
+    when(noticeContextCombiner.buildCombinedNoticeContext(any())).thenReturn(new JsonObject());
+    when(noticeContextCombiner.buildCombinedNoticeLogContext(any())).thenReturn(new NoticeLogContext());
+
+    Result<Void> result = immediatePatronNoticeService.acceptNoticeEvent(event).join();
+
+    assertThat(result.succeeded(), is(true));
+    verifyNoInteractions(patronNoticeClient);
+  }
+
+  @Test
+  void singleImmediatePatronNoticeServiceCanBeInstantiated() {
+    SingleImmediatePatronNoticeService singleService = new SingleImmediatePatronNoticeService(clients);
+    assertThat(singleService, is(notNullValue()));
+  }
+
+  private Item createDummyItem() {
+    JsonObject itemJson = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("holdingsRecordId", UUID.randomUUID().toString())
+      .put("effectiveLocationId", UUID.randomUUID().toString())
+      .put("materialTypeId", UUID.randomUUID().toString())
+      .put("permanentLoanTypeId", UUID.randomUUID().toString());
+    return Item.from(itemJson);
+  }
+
+  private User createDummyUser(String userId) {
+    JsonObject userJson = new JsonObject()
+      .put("id", userId)
+      .put("patronGroup", UUID.randomUUID().toString());
+    return User.from(userJson);
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/notice/NoticeConfigurationMatchKeyTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/NoticeConfigurationMatchKeyTest.java
@@ -1,0 +1,101 @@
+package org.folio.circulation.domain.notice;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.folio.circulation.domain.policy.Period;
+import org.junit.jupiter.api.Test;
+
+class NoticeConfigurationMatchKeyTest {
+
+  @Test
+  void ignoresTemplateIdAndFormat() {
+    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER, Period.days(1), false, null, true);
+    var right = new NoticeConfiguration("t2", NoticeFormat.SMS, NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER, Period.days(1), false, null, true);
+
+    assertThat(left.matchKey(), is(right.matchKey()));
+    assertThat(left.matchKey().hashCode(), is(right.matchKey().hashCode()));
+  }
+
+  @Test
+  void ignoresTemplateIdAlone() {
+    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER, Period.days(1), false, null, true);
+    var right = new NoticeConfiguration("t9", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER, Period.days(1), false, null, true);
+
+    assertThat(left.matchKey(), is(right.matchKey()));
+  }
+
+  @Test
+  void differsWhenTimingChanges() {
+    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER, Period.days(1), false, null, true);
+    var right = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.BEFORE, Period.days(1), false, null, true);
+
+    assertThat(left.matchKey().equals(right.matchKey()), is(false));
+  }
+
+  @Test
+  void differsWhenTimingPeriodChanges() {
+    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER, Period.days(1), false, null, true);
+    var right = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER, Period.days(2), false, null, true);
+
+    assertThat(left.matchKey().equals(right.matchKey()), is(false));
+  }
+
+  @Test
+  void differsWhenRecurringChanges() {
+    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.UPON_AT, null, false, null, true);
+    var right = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.UPON_AT, null, true, Period.days(1), true);
+
+    assertThat(left.matchKey().equals(right.matchKey()), is(false));
+  }
+
+  @Test
+  void differsWhenRecurringPeriodChanges() {
+    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER, Period.days(1), true, Period.days(1), true);
+    var right = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER, Period.days(1), true, Period.days(2), true);
+
+    assertThat(left.matchKey().equals(right.matchKey()), is(false));
+  }
+
+  @Test
+  void differsWhenSendInRealTimeChanges() {
+    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.UPON_AT, null, false, null, true);
+    var right = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.UPON_AT, null, false, null, false);
+
+    assertThat(left.matchKey().equals(right.matchKey()), is(false));
+  }
+
+  @Test
+  void differsWhenEventTypeChanges() {
+    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.UPON_AT, null, false, null, true);
+    var right = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_IN,
+      NoticeTiming.UPON_AT, null, false, null, true);
+
+    assertThat(left.matchKey().equals(right.matchKey()), is(false));
+  }
+
+  @Test
+  void handlesNullPeriods() {
+    var left = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.UPON_AT, null, false, null, true);
+    var right = new NoticeConfiguration("t2", NoticeFormat.SMS, NoticeEventType.CHECK_OUT,
+      NoticeTiming.UPON_AT, null, false, null, true);
+
+    assertThat(left.matchKey(), is(right.matchKey()));
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/notice/NoticeFormatTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/NoticeFormatTest.java
@@ -1,0 +1,42 @@
+package org.folio.circulation.domain.notice;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class NoticeFormatTest {
+
+  @Test
+  void parsesKnownFormats() {
+    assertThat(NoticeFormat.from("Email"), is(NoticeFormat.EMAIL));
+    assertThat(NoticeFormat.from("SMS"), is(NoticeFormat.SMS));
+    assertThat(NoticeFormat.from("Print"), is(NoticeFormat.PRINT));
+    assertThat(NoticeFormat.from("bogus"), is(NoticeFormat.UNKNOWN));
+  }
+
+  @Test
+  void exposesExpectedValues() {
+    assertThat(NoticeFormat.EMAIL.getRepresentation(), is("Email"));
+    assertThat(NoticeFormat.EMAIL.getDeliveryChannel(), is("email"));
+    assertThat(NoticeFormat.EMAIL.getOutputFormat(), is("text/html"));
+
+    assertThat(NoticeFormat.SMS.getRepresentation(), is("SMS"));
+    assertThat(NoticeFormat.SMS.getDeliveryChannel(), is("sms"));
+    assertThat(NoticeFormat.SMS.getOutputFormat(), is("text/plain"));
+
+    assertThat(NoticeFormat.PRINT.getRepresentation(), is("Print"));
+    assertThat(NoticeFormat.PRINT.getDeliveryChannel(), is("mail"));
+    assertThat(NoticeFormat.PRINT.getOutputFormat(), is("text/html"));
+  }
+
+  @Test
+  void knowsWhichFormatsAreDeliverable() {
+    assertTrue(NoticeFormat.EMAIL.isDeliverable());
+    assertTrue(NoticeFormat.SMS.isDeliverable());
+    assertTrue(NoticeFormat.PRINT.isDeliverable());
+    assertFalse(NoticeFormat.UNKNOWN.isDeliverable());
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/notice/NoticeFormatTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/NoticeFormatTest.java
@@ -2,8 +2,6 @@ package org.folio.circulation.domain.notice;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,13 +28,5 @@ class NoticeFormatTest {
     assertThat(NoticeFormat.PRINT.getRepresentation(), is("Print"));
     assertThat(NoticeFormat.PRINT.getDeliveryChannel(), is("mail"));
     assertThat(NoticeFormat.PRINT.getOutputFormat(), is("text/html"));
-  }
-
-  @Test
-  void knowsWhichFormatsAreDeliverable() {
-    assertTrue(NoticeFormat.EMAIL.isDeliverable());
-    assertTrue(NoticeFormat.SMS.isDeliverable());
-    assertTrue(NoticeFormat.PRINT.isDeliverable());
-    assertFalse(NoticeFormat.UNKNOWN.isDeliverable());
   }
 }

--- a/src/test/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolverTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolverTest.java
@@ -264,6 +264,13 @@ class PatronNoticeConfigurationResolverTest {
       .noneMatch(format -> format == NoticeFormat.UNKNOWN));
   }
 
+  @Test
+  void selectReturnsEmptyListWhenNoDeliverableFormats() {
+    var group = List.of(configuration("unknown", NoticeFormat.UNKNOWN));
+
+    assertThat(PatronNoticeConfigurationResolver.select(group, null), empty());
+  }
+
 
   @Test
   void matchGroupOfReturnsEmptyListWhenCandidatesAreNull() {

--- a/src/test/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolverTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolverTest.java
@@ -1,0 +1,315 @@
+package org.folio.circulation.domain.notice;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.folio.circulation.domain.User;
+import org.folio.circulation.domain.policy.Period;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import api.support.builders.UserBuilder;
+
+class PatronNoticeConfigurationResolverTest {
+  private final PatronNoticeConfigurationResolver resolver =
+    new PatronNoticeConfigurationResolver();
+
+  @ParameterizedTest
+  @MethodSource("preferenceCases")
+  void selectsConfigurationsUsingContactTypePreferences(
+    List<String> preferredContactTypeIds, String deprecatedPreferredContactTypeId,
+    List<NoticeFormat> expectedFormats) {
+
+    var user = buildUser(preferredContactTypeIds, deprecatedPreferredContactTypeId);
+    var group = threeFormatGroup("email", "sms", "print");
+
+    assertThat(formats(resolver.select(group, user)), is(expectedFormats));
+  }
+
+  static Stream<Arguments> preferenceCases() {
+    return Stream.of(
+      Arguments.of(List.of("002", "003"), "001", List.of(NoticeFormat.EMAIL, NoticeFormat.SMS)),
+      Arguments.of(List.of("002"), "003", List.of(NoticeFormat.EMAIL)),
+      Arguments.of(List.of(), "003", List.of(NoticeFormat.SMS)),
+      Arguments.of(null, "001", List.of(NoticeFormat.PRINT)),
+      Arguments.of(List.of(), null, List.of(NoticeFormat.EMAIL)),
+      Arguments.of(null, null, List.of(NoticeFormat.EMAIL))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("singleFormatCases")
+  void returnsSingleFormatRegardlessOfPreferences(NoticeFormat configuredFormat,
+    List<String> preferredContactTypeIds) {
+
+    var user = buildUser(preferredContactTypeIds, null);
+    var configuration = configuration("template", configuredFormat);
+
+    var selected = resolver.select(List.of(configuration), user);
+
+    assertThat(selected, is(List.of(configuration)));
+  }
+
+  static Stream<Arguments> singleFormatCases() {
+    return Stream.of(
+      Arguments.of(NoticeFormat.EMAIL, List.of("003", "001")),
+      Arguments.of(NoticeFormat.SMS, List.of("002")),
+      Arguments.of(NoticeFormat.PRINT, List.of("002", "003"))
+    );
+  }
+
+  @Test
+  void preservesTemplateIdsWhenSelectingMultipleFormats() {
+    var user = buildUser(List.of("002", "003"), null);
+    var group = threeFormatGroup("email-template", "sms-template", "print-template");
+
+    var selected = resolver.select(group, user);
+
+    assertThat(selected, hasSize(2));
+    assertThat(
+      templateIds(selected),
+      is(List.of("email-template", "sms-template")));
+  }
+
+  @Test
+  void selectsAllPreferredFormatsInPreferenceOrder() {
+    var user = buildUser(List.of("002", "001", "003"), null);
+    var group = threeFormatGroup("email", "sms", "print");
+
+    var selected = resolver.select(group, user);
+
+    assertThat(
+      formats(selected),
+      is(List.of(NoticeFormat.EMAIL, NoticeFormat.PRINT, NoticeFormat.SMS)));
+  }
+
+  @Test
+  void selectsOnlyEmailWhenPreferencesAreMissing() {
+    var user = buildUser(List.of(), null);
+    var group = threeFormatGroup("email", "sms", "print");
+
+    var selected = resolver.select(group, user);
+
+    assertThat(selected, hasSize(1));
+    assertThat(selected.getFirst().getNoticeFormat(), is(NoticeFormat.EMAIL));
+  }
+
+  @Test
+  void selectsNothingWhenPreferencesAndEmailAreMissing() {
+    var user = buildUser(List.of(), null);
+    var group = List.of(
+      configuration("sms", NoticeFormat.SMS),
+      configuration("print", NoticeFormat.PRINT));
+
+    assertThat(resolver.select(group, user), empty());
+  }
+
+  @Test
+  void selectsNothingWhenArrayPreferenceIsNotConfigured() {
+    var user = buildUser(List.of("003"), null);
+    var group = List.of(
+      configuration("email", NoticeFormat.EMAIL),
+      configuration("print", NoticeFormat.PRINT));
+
+    assertThat(resolver.select(group, user), empty());
+  }
+
+  @Test
+  void selectsNothingWhenDeprecatedPreferenceIsNotConfigured() {
+    var user = buildUser(null, "003");
+    var group = List.of(
+      configuration("email", NoticeFormat.EMAIL),
+      configuration("print", NoticeFormat.PRINT));
+
+    assertThat(resolver.select(group, user), empty());
+  }
+
+  @Test
+  void usesDeprecatedPreferenceWhenArrayHasNoUsableValues() {
+    var user = buildUser(List.of("999"), "003");
+    var group = threeFormatGroup("email", "sms", "print");
+
+    var selected = resolver.select(group, user);
+
+    assertThat(formats(selected), is(List.of(NoticeFormat.SMS)));
+  }
+
+  @Test
+  void selectsEmailWhenNoPreferenceValueIsUsable() {
+    var user = buildUser(List.of("999"), null);
+    var group = threeFormatGroup("email", "sms", "print");
+
+    var selected = resolver.select(group, user);
+
+    assertThat(formats(selected), is(List.of(NoticeFormat.EMAIL)));
+  }
+
+  @Test
+  void keepsFirstConfigurationForDuplicateFormat() {
+    var firstEmail = configuration("first-email", NoticeFormat.EMAIL);
+    var secondEmail = configuration("second-email", NoticeFormat.EMAIL);
+    var sms = configuration("sms", NoticeFormat.SMS);
+    var user = buildUser(List.of("002", "003"), null);
+
+    var selected = resolver.select(
+      List.of(firstEmail, secondEmail, sms), user);
+
+    assertThat(selected, is(List.of(firstEmail, sms)));
+  }
+
+  @Test
+  void keepsConfigurationsMatchingTheFirstMatchGroup() {
+    var email = configuration("email", NoticeFormat.EMAIL);
+    var sms = configuration("sms", NoticeFormat.SMS);
+    var differentTiming = new NoticeConfiguration(
+      "later-email",
+      NoticeFormat.EMAIL,
+      NoticeEventType.CHECK_OUT,
+      NoticeTiming.UPON_AT,
+      null,
+      false,
+      null,
+      true);
+
+    var group = PatronNoticeConfigurationResolver.firstMatchGroup(
+      List.of(email, sms, differentTiming));
+
+    assertThat(group, is(List.of(email, sms)));
+  }
+
+  @Test
+  void selectsOnlyFromTheFirstMatchGroup() {
+    var first = configuration("first", NoticeFormat.EMAIL);
+    var second = new NoticeConfiguration(
+      "second",
+      NoticeFormat.EMAIL,
+      NoticeEventType.CHECK_OUT,
+      NoticeTiming.UPON_AT,
+      null,
+      false,
+      null,
+      true);
+
+    var selected = resolver.select(List.of(first, second), null);
+
+    assertThat(selected, is(List.of(first)));
+  }
+
+  @Test
+  void returnsEmptyListForEmptyInput() {
+    var user = buildUser(List.of("002"), null);
+
+    assertThat(resolver.select(List.of(), user), empty());
+  }
+
+  @Test
+  void returnsEmptyListForNullInput() {
+    assertThat(resolver.select(null, null), empty());
+  }
+
+  @Test
+  void doesNotRequirePreferencesForSingleFormat() {
+    var group = List.of(configuration("email", NoticeFormat.EMAIL));
+
+    assertThat(resolver.requiresPreference(group), is(false));
+  }
+
+  @Test
+  void requiresPreferencesForMultipleFormats() {
+    var group = List.of(
+      configuration("email", NoticeFormat.EMAIL),
+      configuration("sms", NoticeFormat.SMS));
+
+    assertThat(resolver.requiresPreference(group), is(true));
+  }
+
+  @Test
+  void ignoresUndeliverableFormatsWhenCountingFormats() {
+    var email = configuration("email", NoticeFormat.EMAIL);
+    var unknown = configuration("unknown", NoticeFormat.UNKNOWN);
+    var user = buildUser(List.of("003"), null);
+    var group = List.of(email, unknown);
+
+    assertThat(resolver.requiresPreference(group), is(false));
+    assertThat(resolver.select(group, user), is(List.of(email)));
+  }
+
+  @Test
+  void returnsOnlyDeliverableFormats() {
+    var user = buildUser(List.of("002", "003", "001"), null);
+    var group = threeFormatGroup("email", "sms", "print");
+
+    var selected = resolver.select(group, user);
+
+    assertThat(selected, hasSize(3));
+    assertTrue(selected.stream()
+      .map(NoticeConfiguration::getNoticeFormat)
+      .allMatch(NoticeFormat::isDeliverable));
+  }
+
+  private static User buildUser(List<String> preferredContactTypeIds,
+                                String deprecatedPreferredContactTypeId) {
+
+    var builder = new UserBuilder();
+
+    if (preferredContactTypeIds != null) {
+      builder = builder.withPreferredContactTypeIds(preferredContactTypeIds);
+    }
+
+    if (deprecatedPreferredContactTypeId != null) {
+      builder = builder.withDeprecatedPreferredContactTypeId(
+        deprecatedPreferredContactTypeId);
+    }
+
+    return new User(builder.create());
+  }
+
+  private static List<NoticeConfiguration> threeFormatGroup(
+    String emailTemplateId,
+    String smsTemplateId,
+    String printTemplateId) {
+
+    return List.of(
+      configuration(emailTemplateId, NoticeFormat.EMAIL),
+      configuration(smsTemplateId, NoticeFormat.SMS),
+      configuration(printTemplateId, NoticeFormat.PRINT));
+  }
+
+  private static NoticeConfiguration configuration(
+    String templateId, NoticeFormat format) {
+
+    return new NoticeConfiguration(
+      templateId,
+      format,
+      NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER,
+      Period.days(1),
+      false,
+      null,
+      true);
+  }
+
+  private static List<NoticeFormat> formats(
+    List<NoticeConfiguration> configurations) {
+
+    return configurations.stream()
+      .map(NoticeConfiguration::getNoticeFormat)
+      .toList();
+  }
+
+  private static List<String> templateIds(
+    List<NoticeConfiguration> configurations) {
+
+    return configurations.stream()
+      .map(NoticeConfiguration::getTemplateId)
+      .toList();
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolverTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolverTest.java
@@ -261,7 +261,7 @@ class PatronNoticeConfigurationResolverTest {
     assertThat(selected, hasSize(3));
     assertTrue(selected.stream()
       .map(NoticeConfiguration::getNoticeFormat)
-      .allMatch(NoticeFormat::isDeliverable));
+      .noneMatch(format -> format == NoticeFormat.UNKNOWN));
   }
 
 
@@ -368,6 +368,14 @@ class PatronNoticeConfigurationResolverTest {
   @Test
   void doesNotRequirePreferencesForNullGroup() {
     assertThat(PatronNoticeConfigurationResolver.requiresPreference(null), is(false));
+  }
+
+  @Test
+  void selectsDefaultChannelWhenRecipientIsNull() {
+    var selected = PatronNoticeConfigurationResolver.select(
+      threeFormatGroup("email", "sms", "print"), null);
+
+    assertThat(formats(selected), is(List.of(NoticeFormat.EMAIL)));
   }
 
   private static User buildUser(List<String> preferredContactTypeIds,

--- a/src/test/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolverTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/PatronNoticeConfigurationResolverTest.java
@@ -6,7 +6,9 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.folio.circulation.domain.User;
@@ -19,8 +21,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import api.support.builders.UserBuilder;
 
 class PatronNoticeConfigurationResolverTest {
-  private final PatronNoticeConfigurationResolver resolver =
-    new PatronNoticeConfigurationResolver();
 
   @ParameterizedTest
   @MethodSource("preferenceCases")
@@ -31,7 +31,7 @@ class PatronNoticeConfigurationResolverTest {
     var user = buildUser(preferredContactTypeIds, deprecatedPreferredContactTypeId);
     var group = threeFormatGroup("email", "sms", "print");
 
-    assertThat(formats(resolver.select(group, user)), is(expectedFormats));
+    assertThat(formats(PatronNoticeConfigurationResolver.select(group, user)), is(expectedFormats));
   }
 
   static Stream<Arguments> preferenceCases() {
@@ -53,7 +53,7 @@ class PatronNoticeConfigurationResolverTest {
     var user = buildUser(preferredContactTypeIds, null);
     var configuration = configuration("template", configuredFormat);
 
-    var selected = resolver.select(List.of(configuration), user);
+    var selected = PatronNoticeConfigurationResolver.select(List.of(configuration), user);
 
     assertThat(selected, is(List.of(configuration)));
   }
@@ -71,7 +71,7 @@ class PatronNoticeConfigurationResolverTest {
     var user = buildUser(List.of("002", "003"), null);
     var group = threeFormatGroup("email-template", "sms-template", "print-template");
 
-    var selected = resolver.select(group, user);
+    var selected = PatronNoticeConfigurationResolver.select(group, user);
 
     assertThat(selected, hasSize(2));
     assertThat(
@@ -84,7 +84,7 @@ class PatronNoticeConfigurationResolverTest {
     var user = buildUser(List.of("002", "001", "003"), null);
     var group = threeFormatGroup("email", "sms", "print");
 
-    var selected = resolver.select(group, user);
+    var selected = PatronNoticeConfigurationResolver.select(group, user);
 
     assertThat(
       formats(selected),
@@ -96,40 +96,49 @@ class PatronNoticeConfigurationResolverTest {
     var user = buildUser(List.of(), null);
     var group = threeFormatGroup("email", "sms", "print");
 
-    var selected = resolver.select(group, user);
+    var selected = PatronNoticeConfigurationResolver.select(group, user);
 
     assertThat(selected, hasSize(1));
     assertThat(selected.getFirst().getNoticeFormat(), is(NoticeFormat.EMAIL));
   }
 
   @Test
-  void selectsNothingWhenPreferencesAndEmailAreMissing() {
+  void selectsFirstAvailableWhenPreferencesAndEmailAreMissing() {
     var user = buildUser(List.of(), null);
     var group = List.of(
       configuration("sms", NoticeFormat.SMS),
       configuration("print", NoticeFormat.PRINT));
 
-    assertThat(resolver.select(group, user), empty());
+    var selected = PatronNoticeConfigurationResolver.select(group, user);
+
+    assertThat(selected, hasSize(1));
+    assertThat(selected.getFirst().getNoticeFormat(), is(NoticeFormat.SMS));
   }
 
   @Test
-  void selectsNothingWhenArrayPreferenceIsNotConfigured() {
+  void fallsBackToEmailWhenArrayPreferenceIsNotConfigured() {
     var user = buildUser(List.of("003"), null);
     var group = List.of(
       configuration("email", NoticeFormat.EMAIL),
       configuration("print", NoticeFormat.PRINT));
 
-    assertThat(resolver.select(group, user), empty());
+    var selected = PatronNoticeConfigurationResolver.select(group, user);
+
+    assertThat(selected, hasSize(1));
+    assertThat(selected.getFirst().getNoticeFormat(), is(NoticeFormat.EMAIL));
   }
 
   @Test
-  void selectsNothingWhenDeprecatedPreferenceIsNotConfigured() {
+  void fallsBackToEmailWhenDeprecatedPreferenceIsNotConfigured() {
     var user = buildUser(null, "003");
     var group = List.of(
       configuration("email", NoticeFormat.EMAIL),
       configuration("print", NoticeFormat.PRINT));
 
-    assertThat(resolver.select(group, user), empty());
+    var selected = PatronNoticeConfigurationResolver.select(group, user);
+
+    assertThat(selected, hasSize(1));
+    assertThat(selected.getFirst().getNoticeFormat(), is(NoticeFormat.EMAIL));
   }
 
   @Test
@@ -137,7 +146,7 @@ class PatronNoticeConfigurationResolverTest {
     var user = buildUser(List.of("999"), "003");
     var group = threeFormatGroup("email", "sms", "print");
 
-    var selected = resolver.select(group, user);
+    var selected = PatronNoticeConfigurationResolver.select(group, user);
 
     assertThat(formats(selected), is(List.of(NoticeFormat.SMS)));
   }
@@ -147,7 +156,7 @@ class PatronNoticeConfigurationResolverTest {
     var user = buildUser(List.of("999"), null);
     var group = threeFormatGroup("email", "sms", "print");
 
-    var selected = resolver.select(group, user);
+    var selected = PatronNoticeConfigurationResolver.select(group, user);
 
     assertThat(formats(selected), is(List.of(NoticeFormat.EMAIL)));
   }
@@ -159,7 +168,7 @@ class PatronNoticeConfigurationResolverTest {
     var sms = configuration("sms", NoticeFormat.SMS);
     var user = buildUser(List.of("002", "003"), null);
 
-    var selected = resolver.select(
+    var selected = PatronNoticeConfigurationResolver.select(
       List.of(firstEmail, secondEmail, sms), user);
 
     assertThat(selected, is(List.of(firstEmail, sms)));
@@ -198,7 +207,7 @@ class PatronNoticeConfigurationResolverTest {
       null,
       true);
 
-    var selected = resolver.select(List.of(first, second), null);
+    var selected = PatronNoticeConfigurationResolver.select(List.of(first, second), null);
 
     assertThat(selected, is(List.of(first)));
   }
@@ -207,19 +216,19 @@ class PatronNoticeConfigurationResolverTest {
   void returnsEmptyListForEmptyInput() {
     var user = buildUser(List.of("002"), null);
 
-    assertThat(resolver.select(List.of(), user), empty());
+    assertThat(PatronNoticeConfigurationResolver.select(List.of(), user), empty());
   }
 
   @Test
   void returnsEmptyListForNullInput() {
-    assertThat(resolver.select(null, null), empty());
+    assertThat(PatronNoticeConfigurationResolver.select(null, null), empty());
   }
 
   @Test
   void doesNotRequirePreferencesForSingleFormat() {
     var group = List.of(configuration("email", NoticeFormat.EMAIL));
 
-    assertThat(resolver.requiresPreference(group), is(false));
+    assertThat(PatronNoticeConfigurationResolver.requiresPreference(group), is(false));
   }
 
   @Test
@@ -228,7 +237,7 @@ class PatronNoticeConfigurationResolverTest {
       configuration("email", NoticeFormat.EMAIL),
       configuration("sms", NoticeFormat.SMS));
 
-    assertThat(resolver.requiresPreference(group), is(true));
+    assertThat(PatronNoticeConfigurationResolver.requiresPreference(group), is(true));
   }
 
   @Test
@@ -238,8 +247,8 @@ class PatronNoticeConfigurationResolverTest {
     var user = buildUser(List.of("003"), null);
     var group = List.of(email, unknown);
 
-    assertThat(resolver.requiresPreference(group), is(false));
-    assertThat(resolver.select(group, user), is(List.of(email)));
+    assertThat(PatronNoticeConfigurationResolver.requiresPreference(group), is(false));
+    assertThat(PatronNoticeConfigurationResolver.select(group, user), is(List.of(email)));
   }
 
   @Test
@@ -247,7 +256,7 @@ class PatronNoticeConfigurationResolverTest {
     var user = buildUser(List.of("002", "003", "001"), null);
     var group = threeFormatGroup("email", "sms", "print");
 
-    var selected = resolver.select(group, user);
+    var selected = PatronNoticeConfigurationResolver.select(group, user);
 
     assertThat(selected, hasSize(3));
     assertTrue(selected.stream()
@@ -255,8 +264,114 @@ class PatronNoticeConfigurationResolverTest {
       .allMatch(NoticeFormat::isDeliverable));
   }
 
+
+  @Test
+  void matchGroupOfReturnsEmptyListWhenCandidatesAreNull() {
+    var anchor = configuration("email", NoticeFormat.EMAIL);
+
+    assertThat(PatronNoticeConfigurationResolver.matchGroupOf(null, anchor), empty());
+  }
+
+  @Test
+  void matchGroupOfReturnsEmptyListWhenCandidatesAreEmpty() {
+    var anchor = configuration("email", NoticeFormat.EMAIL);
+
+    assertThat(PatronNoticeConfigurationResolver.matchGroupOf(List.of(), anchor), empty());
+  }
+
+  @Test
+  void matchGroupOfReturnsEmptyListWhenAnchorIsNull() {
+    var group = threeFormatGroup("email", "sms", "print");
+
+    assertThat(PatronNoticeConfigurationResolver.matchGroupOf(group, null), empty());
+  }
+
+  @Test
+  void matchGroupOfReturnsConfigurationsMatchingAnchorKey() {
+    var email = configuration("email", NoticeFormat.EMAIL);
+    var sms = configuration("sms", NoticeFormat.SMS);
+    var differentTiming = new NoticeConfiguration(
+      "later-email",
+      NoticeFormat.EMAIL,
+      NoticeEventType.CHECK_OUT,
+      NoticeTiming.UPON_AT,
+      null,
+      false,
+      null,
+      true);
+
+    var result = PatronNoticeConfigurationResolver.matchGroupOf(
+      List.of(email, sms, differentTiming), email);
+
+    assertThat(result, is(List.of(email, sms)));
+  }
+
+  @Test
+  void matchGroupOfReturnsEmptyListWhenNothingMatchesAnchor() {
+    var anchor = new NoticeConfiguration(
+      "unique",
+      NoticeFormat.EMAIL,
+      NoticeEventType.CHECK_OUT,
+      NoticeTiming.UPON_AT,
+      null,
+      false,
+      null,
+      true);
+    var group = threeFormatGroup("email", "sms", "print");
+
+    assertThat(PatronNoticeConfigurationResolver.matchGroupOf(group, anchor), empty());
+  }
+
+  @Test
+  void firstMatchGroupReturnsEmptyListForNullInput() {
+    assertThat(PatronNoticeConfigurationResolver.firstMatchGroup(null), empty());
+  }
+
+  @Test
+  void firstMatchGroupReturnsEmptyListForEmptyInput() {
+    assertThat(PatronNoticeConfigurationResolver.firstMatchGroup(List.of()), empty());
+  }
+
+  @Test
+  void resolveFormatsReturnsFormatsOfSelectedConfigurations() {
+    var user = buildUser(List.of("002", "003"), null);
+    var group = threeFormatGroup("email", "sms", "print");
+
+    var formats = PatronNoticeConfigurationResolver.resolveFormats(group, user);
+
+    Set<NoticeFormat> expected = new LinkedHashSet<>(List.of(NoticeFormat.EMAIL, NoticeFormat.SMS));
+    assertThat(formats, is(expected));
+  }
+
+  @Test
+  void resolveFormatsReturnsEmptySetWhenGroupIsEmpty() {
+    var user = buildUser(List.of("002"), null);
+
+    assertThat(PatronNoticeConfigurationResolver.resolveFormats(List.of(), user), empty());
+  }
+
+  @Test
+  void resolveFormatsReturnsSingleFormatWhenOnlyOneConfigured() {
+    var user = buildUser(List.of(), null);
+    var group = List.of(configuration("email", NoticeFormat.EMAIL));
+
+    var formats = PatronNoticeConfigurationResolver.resolveFormats(group, user);
+
+    assertThat(formats, is(Set.of(NoticeFormat.EMAIL)));
+  }
+
+  @Test
+  void doesNotRequirePreferencesForEmptyGroup() {
+    assertThat(PatronNoticeConfigurationResolver.requiresPreference(List.of()), is(false));
+  }
+
+  @Test
+  void doesNotRequirePreferencesForNullGroup() {
+    assertThat(PatronNoticeConfigurationResolver.requiresPreference(null), is(false));
+  }
+
   private static User buildUser(List<String> preferredContactTypeIds,
-                                String deprecatedPreferredContactTypeId) {
+    String deprecatedPreferredContactTypeId) {
 
     var builder = new UserBuilder();
 
@@ -273,9 +388,7 @@ class PatronNoticeConfigurationResolverTest {
   }
 
   private static List<NoticeConfiguration> threeFormatGroup(
-    String emailTemplateId,
-    String smsTemplateId,
-    String printTemplateId) {
+    String emailTemplateId, String smsTemplateId, String printTemplateId) {
 
     return List.of(
       configuration(emailTemplateId, NoticeFormat.EMAIL),

--- a/src/test/java/org/folio/circulation/domain/notice/PatronNoticePolicyTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/PatronNoticePolicyTest.java
@@ -1,0 +1,27 @@
+package org.folio.circulation.domain.notice;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+
+import org.folio.circulation.domain.policy.Period;
+import org.junit.jupiter.api.Test;
+
+class PatronNoticePolicyTest {
+
+  @Test
+  void lookupNoticeConfigurationsReturnsAllMatchingEntriesInOrder() {
+    var first = new NoticeConfiguration("t1", NoticeFormat.EMAIL, NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER, Period.days(1), false, null, true);
+    var second = new NoticeConfiguration("t2", NoticeFormat.SMS, NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER, Period.days(1), false, null, true);
+    var third = new NoticeConfiguration("t3", NoticeFormat.PRINT, NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER, Period.days(1), false, null, true);
+
+    var policy = new PatronNoticePolicy(List.of(first, second, third));
+
+    assertThat(policy.lookupNoticeConfigurations(NoticeEventType.CHECK_OUT), is(List.of(first, second, third)));
+    assertThat(policy.lookupNoticeConfiguration(NoticeEventType.CHECK_OUT).orElseThrow(), is(first));
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/notice/PatronNoticePolicyTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/PatronNoticePolicyTest.java
@@ -22,6 +22,6 @@ class PatronNoticePolicyTest {
     var policy = new PatronNoticePolicy(List.of(first, second, third));
 
     assertThat(policy.lookupNoticeConfigurations(NoticeEventType.CHECK_OUT), is(List.of(first, second, third)));
-    assertThat(policy.lookupNoticeConfiguration(NoticeEventType.CHECK_OUT).orElseThrow(), is(first));
+    assertThat(policy.lookupNoticeConfigurations(NoticeEventType.CHECK_OUT).getFirst(), is(first));
   }
 }

--- a/src/test/java/org/folio/circulation/domain/notice/PatronNoticeTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/PatronNoticeTest.java
@@ -1,0 +1,61 @@
+package org.folio.circulation.domain.notice;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.folio.circulation.domain.policy.Period;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.vertx.core.json.JsonObject;
+
+class PatronNoticeTest {
+
+  @ParameterizedTest
+  @MethodSource("noticeFormats")
+  void buildsNoticeUsingConfigurationFormat(NoticeFormat format,
+    String deliveryChannel, String outputFormat) {
+
+    var configuration = new NoticeConfiguration(
+      "template",
+      format,
+      NoticeEventType.CHECK_OUT,
+      NoticeTiming.AFTER,
+      Period.days(1),
+      false,
+      null,
+      true);
+
+    var notice = new PatronNotice(
+      "recipient",
+      new JsonObject().put("key", "value"),
+      configuration);
+
+    assertThat(notice.getDeliveryChannel(), is(deliveryChannel));
+    assertThat(notice.getOutputFormat(), is(outputFormat));
+  }
+
+  static Stream<Arguments> noticeFormats() {
+    return Stream.of(
+      Arguments.of(NoticeFormat.EMAIL, "email", "text/html"),
+      Arguments.of(NoticeFormat.SMS, "sms", "text/plain"),
+      Arguments.of(NoticeFormat.PRINT, "mail", "text/html")
+    );
+  }
+
+  @Test
+  void buildsEmailNotice() {
+    var notice = PatronNotice.buildEmail(
+      "recipient",
+      UUID.randomUUID(),
+      new JsonObject());
+
+    assertThat(notice.getDeliveryChannel(), is("email"));
+    assertThat(notice.getOutputFormat(), is("text/html"));
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormatsTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormatsTest.java
@@ -1,0 +1,53 @@
+package org.folio.circulation.domain.notice;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+
+import org.folio.circulation.domain.User;
+import org.junit.jupiter.api.Test;
+
+import api.support.builders.UserBuilder;
+
+class UserPreferredNoticeFormatsTest {
+
+  @Test
+  void mapsContactTypesToFormats() {
+    assertThat(UserPreferredNoticeFormats.toFormat("002").orElseThrow(), is(NoticeFormat.EMAIL));
+    assertThat(UserPreferredNoticeFormats.toFormat("001").orElseThrow(), is(NoticeFormat.PRINT));
+    assertThat(UserPreferredNoticeFormats.toFormat("003").orElseThrow(), is(NoticeFormat.SMS));
+  }
+
+  @Test
+  void ignoresUnknownOrBlankValues() {
+    assertThat(UserPreferredNoticeFormats.toFormat("999").isEmpty(), is(true));
+    assertThat(UserPreferredNoticeFormats.toFormat("").isEmpty(), is(true));
+    assertThat(UserPreferredNoticeFormats.toFormat(null).isEmpty(), is(true));
+  }
+
+  @Test
+  void readsAndDeduplicatesPreferredContactTypeIds() {
+    var user = new User(new UserBuilder()
+      .withPreferredContactTypeIds(List.of("002", "003", "002"))
+      .create());
+
+    assertThat(UserPreferredNoticeFormats.fromPreferredContactTypeIds(user),
+      is(List.of(NoticeFormat.EMAIL, NoticeFormat.SMS)));
+  }
+
+  @Test
+  void usesDeprecatedPreferredContactTypeIdAsFallback() {
+    var user = new User(new UserBuilder()
+      .withDeprecatedPreferredContactTypeId("003")
+      .create());
+
+    assertThat(UserPreferredNoticeFormats.fromDeprecatedPreferredContactTypeId(user).orElseThrow(),
+      is(NoticeFormat.SMS));
+  }
+
+  @Test
+  void returnsEmptyListForNullUser() {
+    assertThat(UserPreferredNoticeFormats.fromPreferredContactTypeIds(null), is(List.of()));
+  }
+}

--- a/src/test/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormatsTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/UserPreferredNoticeFormatsTest.java
@@ -45,9 +45,4 @@ class UserPreferredNoticeFormatsTest {
     assertThat(UserPreferredNoticeFormats.fromDeprecatedPreferredContactTypeId(user).orElseThrow(),
       is(NoticeFormat.SMS));
   }
-
-  @Test
-  void returnsEmptyListForNullUser() {
-    assertThat(UserPreferredNoticeFormats.fromPreferredContactTypeIds(null), is(List.of()));
-  }
 }

--- a/src/test/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandlerTest.java
+++ b/src/test/java/org/folio/circulation/domain/notice/schedule/ScheduledNoticeHandlerTest.java
@@ -1,0 +1,275 @@
+package org.folio.circulation.domain.notice.schedule;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.circulation.domain.Request;
+import org.folio.circulation.domain.User;
+import org.folio.circulation.domain.notice.NoticeFormat;
+import org.folio.circulation.domain.notice.NoticeTiming;
+import org.folio.circulation.domain.policy.Period;
+import org.folio.circulation.domain.representations.logs.NoticeLogContext;
+import org.folio.circulation.domain.representations.logs.NoticeLogContextItem;
+import org.folio.circulation.infrastructure.storage.inventory.ItemRepository;
+import org.folio.circulation.infrastructure.storage.loans.LoanRepository;
+import org.folio.circulation.infrastructure.storage.users.UserRepository;
+import org.folio.circulation.support.Clients;
+import org.folio.circulation.support.CollectionResourceClient;
+import org.folio.circulation.support.ServerErrorFailure;
+import org.folio.circulation.support.http.client.Response;
+import org.folio.circulation.support.results.Result;
+import org.junit.jupiter.api.Test;
+
+import api.support.builders.NoticeConfigurationBuilder;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+class ScheduledNoticeHandlerTest {
+
+  private static final String POLICY_ID = "policy-id";
+
+  @Test
+  void shouldSendByPreferenceReturnsTrueWhenPolicyLookupFails() {
+    var clients = mock(Clients.class);
+    var patronNoticePoliciesStorageClient = mock(CollectionResourceClient.class);
+    when(clients.patronNoticePolicesStorageClient())
+      .thenReturn(patronNoticePoliciesStorageClient);
+
+    var handler = new TestScheduledNoticeHandler(clients);
+    var context = new ScheduledNoticeContext(buildNotice(null))
+      .withPatronNoticePolicyId(POLICY_ID);
+
+    when(patronNoticePoliciesStorageClient.get(POLICY_ID))
+      .thenReturn(completedFuture(Result.failed(new ServerErrorFailure("policy lookup failed"))));
+
+    var result = handler.shouldSendByPreference(context).join();
+
+    assertThat(result, is(true));
+  }
+
+  @Test
+  void shouldSendByPreferenceMatchesNonRecurringConfigurationAndCachesPolicy() {
+    var clients = mock(Clients.class);
+    var patronNoticePoliciesStorageClient = mock(CollectionResourceClient.class);
+    when(clients.patronNoticePolicesStorageClient())
+      .thenReturn(patronNoticePoliciesStorageClient);
+
+    var handler = new TestScheduledNoticeHandler(clients);
+    var templateId = UUID.randomUUID();
+    var notice = buildNotice(new ScheduledNoticeConfig(NoticeTiming.UPON_AT, null,
+      templateId.toString(), NoticeFormat.EMAIL, false));
+    var context = new ScheduledNoticeContext(notice).withPatronNoticePolicyId(POLICY_ID);
+
+    when(patronNoticePoliciesStorageClient.get(POLICY_ID))
+      .thenReturn(completedFuture(Result.succeeded(policyResponse(loanNotices(
+        emailConfig(templateId, false))))));
+
+    assertThat(handler.shouldSendByPreference(context).join(), is(true));
+    assertThat(handler.shouldSendByPreference(context).join(), is(true));
+    verify(patronNoticePoliciesStorageClient, times(1)).get(POLICY_ID);
+  }
+
+  @Test
+  void shouldSendByPreferenceReturnsTrueWhenTimingDoesNotMatch() {
+    var templateId = UUID.randomUUID();
+    var notice = buildNotice(new ScheduledNoticeConfig(NoticeTiming.BEFORE, null,
+      templateId.toString(), NoticeFormat.EMAIL, false));
+
+    assertThat(sendByPreference(notice, loanNotices(emailConfig(templateId, false))), is(true));
+  }
+
+  @Test
+  void shouldSendByPreferenceReturnsTrueWhenRecurringFlagDoesNotMatch() {
+    var templateId = UUID.randomUUID();
+    var notice = buildNotice(new ScheduledNoticeConfig(NoticeTiming.UPON_AT, null,
+      templateId.toString(), NoticeFormat.EMAIL, false));
+
+    assertThat(sendByPreference(notice, loanNotices(recurringEmailConfig(templateId,
+      Period.days(1), false))), is(true));
+  }
+
+  @Test
+  void shouldSendByPreferenceReturnsTrueWhenRealTimeFlagDoesNotMatch() {
+    var templateId = UUID.randomUUID();
+    var notice = buildNotice(new ScheduledNoticeConfig(NoticeTiming.UPON_AT, null,
+      templateId.toString(), NoticeFormat.EMAIL, false));
+
+    assertThat(sendByPreference(notice, loanNotices(emailConfig(templateId, true))), is(true));
+  }
+
+  @Test
+  void shouldSendByPreferenceMatchesRecurringConfigurationWithEqualPeriods() {
+    var templateId = UUID.randomUUID();
+    var notice = buildNotice(new ScheduledNoticeConfig(NoticeTiming.UPON_AT, Period.days(1),
+      templateId.toString(), NoticeFormat.EMAIL, false));
+
+    assertThat(sendByPreference(notice, loanNotices(recurringEmailConfig(templateId,
+      Period.days(1), false))), is(true));
+  }
+
+  @Test
+  void shouldSendByPreferenceReturnsTrueWhenRecurringPeriodsDiffer() {
+    var templateId = UUID.randomUUID();
+    var notice = buildNotice(new ScheduledNoticeConfig(NoticeTiming.UPON_AT, Period.days(2),
+      templateId.toString(), NoticeFormat.EMAIL, false));
+
+    assertThat(sendByPreference(notice, loanNotices(recurringEmailConfig(templateId,
+      Period.days(1), false))), is(true));
+  }
+
+  @Test
+  void shouldSendByPreferenceReturnsTrueWhenTemplateIsNoLongerInPolicy() {
+    var notice = buildNotice(new ScheduledNoticeConfig(NoticeTiming.UPON_AT, null,
+      UUID.randomUUID().toString(), NoticeFormat.EMAIL, false));
+
+    assertThat(sendByPreference(notice, loanNotices(emailConfig(UUID.randomUUID(), false))),
+      is(true));
+  }
+
+  @Test
+  void shouldSendByPreferenceSkipsWhenFormatIsNotResolvedFromRequestUserPreferences() {
+    var templateId = UUID.randomUUID();
+    var notice = buildNotice(new ScheduledNoticeConfig(NoticeTiming.UPON_AT, null,
+      templateId.toString(), NoticeFormat.EMAIL, false));
+
+    var context = new ScheduledNoticeContext(notice)
+      .withPatronNoticePolicyId(POLICY_ID)
+      .withRequest(requestWithRequesterPreferredContactType("003"));
+
+    var loanNotices = new JsonArray()
+      .add(emailConfig(templateId, false))
+      .add(smsConfig(UUID.randomUUID(), false));
+
+    assertThat(sendByPreference(context, loanNotices), is(false));
+  }
+
+  private boolean sendByPreference(ScheduledNotice notice, JsonArray loanNotices) {
+    return sendByPreference(new ScheduledNoticeContext(notice)
+      .withPatronNoticePolicyId(POLICY_ID), loanNotices);
+  }
+
+  private boolean sendByPreference(ScheduledNoticeContext context, JsonArray loanNotices) {
+    var clients = mock(Clients.class);
+    var patronNoticePoliciesStorageClient = mock(CollectionResourceClient.class);
+    when(clients.patronNoticePolicesStorageClient())
+      .thenReturn(patronNoticePoliciesStorageClient);
+
+    var handler = new TestScheduledNoticeHandler(clients);
+
+    when(patronNoticePoliciesStorageClient.get(POLICY_ID))
+      .thenReturn(completedFuture(Result.succeeded(policyResponse(loanNotices))));
+
+    return handler.shouldSendByPreference(context).join();
+  }
+
+  private static Response policyResponse(JsonArray loanNotices) {
+    var policyJson = new JsonObject()
+      .put("id", POLICY_ID)
+      .put("name", "Test Notice Policy")
+      .put("loanNotices", loanNotices);
+
+    return new Response(200, policyJson.encode(), "application/json");
+  }
+
+  private static JsonArray loanNotices(JsonObject... notices) {
+    return new JsonArray(java.util.List.of(notices));
+  }
+
+  private static JsonObject emailConfig(UUID templateId, boolean sendInRealTime) {
+    return new NoticeConfigurationBuilder()
+      .withTemplateId(templateId)
+      .withDueDateEvent()
+      .withEmailFormat()
+      .withUponAtTiming()
+      .sendInRealTime(sendInRealTime)
+      .create();
+  }
+
+  private static JsonObject smsConfig(UUID templateId, boolean sendInRealTime) {
+    return new NoticeConfigurationBuilder()
+      .withTemplateId(templateId)
+      .withDueDateEvent()
+      .withSmsFormat()
+      .withUponAtTiming()
+      .sendInRealTime(sendInRealTime)
+      .create();
+  }
+
+  private static JsonObject recurringEmailConfig(UUID templateId, Period recurringPeriod,
+    boolean sendInRealTime) {
+
+    return new NoticeConfigurationBuilder()
+      .withTemplateId(templateId)
+      .withDueDateEvent()
+      .withEmailFormat()
+      .withUponAtTiming()
+      .recurring(recurringPeriod)
+      .sendInRealTime(sendInRealTime)
+      .create();
+  }
+
+  private static Request requestWithRequesterPreferredContactType(String contactTypeId) {
+    var userJson = new JsonObject()
+      .put("personal", new JsonObject()
+        .put("preferredContactTypeIds", new JsonArray().add(contactTypeId)));
+    var requester = User.from(userJson);
+
+    return Request.from(new JsonObject().put("id", UUID.randomUUID().toString()))
+      .withRequester(requester);
+  }
+
+  private static ScheduledNotice buildNotice(ScheduledNoticeConfig config) {
+    return new ScheduledNotice(
+      UUID.randomUUID().toString(), null, null, null, null, null,
+      TriggeringEvent.DUE_DATE, null, config);
+  }
+
+  private static final class TestScheduledNoticeHandler extends ScheduledNoticeHandler {
+    private TestScheduledNoticeHandler(Clients clients) {
+      super(clients, new LoanRepository(clients,
+        mock(ItemRepository.class), mock(UserRepository.class)));
+    }
+
+    @Override
+    protected CompletableFuture<Result<ScheduledNoticeContext>> fetchData(
+      ScheduledNoticeContext context) {
+
+      return completedFuture(Result.succeeded(context));
+    }
+
+    @Override
+    protected CompletableFuture<Result<ScheduledNotice>> updateNotice(
+      ScheduledNoticeContext context) {
+
+      return completedFuture(Result.succeeded(context.getNotice()));
+    }
+
+    @Override
+    protected boolean isNoticeIrrelevant(ScheduledNoticeContext context) {
+      return false;
+    }
+
+    @Override
+    protected NoticeLogContext buildNoticeLogContext(ScheduledNoticeContext context) {
+      return NoticeLogContext.from(context.getNotice());
+    }
+
+    @Override
+    protected NoticeLogContextItem buildNoticeLogContextItem(ScheduledNoticeContext context) {
+      return null;
+    }
+
+    @Override
+    protected JsonObject buildNoticeContextJson(ScheduledNoticeContext context) {
+      return new JsonObject();
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
Determine the delivery format of immediate patron notices based on the patron’s preferred contact types while allowing explicitly configured Email, SMS, or Print formats to override those preferences.

## Approach
Group matching notice configurations by their triggering and scheduling conditions. When only one format is configured, send it regardless of patron preference. When multiple formats are available, select the configurations matching preferredContactTypeIds, fall back to the deprecated preferredContactTypeId, and use Email when no preference is set. Add SMS delivery support and unit/integration tests covering format selection, fallback, templates, payloads, and notice logs.

#### TODOS and Open Questions
- [x] Check logging
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
[CIRC-2661](https://folio-org.atlassian.net/browse/CIRC-2661)
